### PR TITLE
fix: ensure debug messages are shown in correct order and not delayed by buffering

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -560,7 +560,7 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
     const actualSessionName = sessionName || 'Meeting';
     
     // Start background recording with 60-minute limit
-    currentRecordingProcess = spawn(pythonPath, [scriptPath, 'record', '3600', actualSessionName], {
+    currentRecordingProcess = spawn(pythonPath, ['-u', scriptPath, 'record', '3600', actualSessionName], {
       cwd: path.join(__dirname, '..')
     });
 


### PR DESCRIPTION
## Description

I noticed that some of the debug logs were appearing out of order:

```
[14:36:07] Starting recording process: Meeting-B4NL6U
[14:36:07] $ python simple_recorder.py record 3600
[14:36:09] STDERR: 2026-01-17 14:36:09,286 - INFO - Creating recording thread...
[14:36:09] STDERR: 2026-01-17 14:36:09,286 - INFO - Starting audio stream with sample_rate=44100, channels=1
[14:36:09] STDERR: 2026-01-17 14:36:09,286 - INFO - Started recording thread
[14:36:09] STDERR: 2026-01-17 14:36:09,341 - INFO - Audio stream started successfully
[14:36:09] STDERR: 2026-01-17 14:36:09,487 - INFO - Recording appears to be active
[14:37:35] STDERR: 2026-01-17 14:37:35,956 - INFO - Recording loop ended
[14:37:36] STDERR: 2026-01-17 14:37:36,065 - INFO - Audio stream closed
[14:37:36] STDERR: 2026-01-17 14:37:36,065 - INFO - Stopped recording
[14:37:36] STDERR: 2026-01-17 14:37:36,583 - INFO - Audio saved to recordings/20260117_143609_Meeting-B4NL6U.wav
[14:37:36] STDERR: 2026-01-17 14:37:36,673 - INFO - ffmpeg found in PATH
[14:37:36] STDERR: 2026-01-17 14:37:36,673 - INFO - Loading Whisper model: small
[14:37:38] STDERR: 2026-01-17 14:37:38,302 - INFO - Whisper model loaded successfully
[14:37:38] STDERR: 2026-01-17 14:37:38,302 - INFO - Transcribing audio file: recordings/20260117_143609_Meeting-B4NL6U.wav
[14:37:38] STDERR: 2026-01-17 14:37:38,302 - INFO - Audio file size: 7454.0 KB
[14:37:38] 🎤 Recording 3600 seconds of audio for 'Meeting-B4NL6U'...
[14:37:38] 🎤 Starting recording: Meeting-B4NL6U
[14:37:38] 📁 File: recordings/20260117_143609_Meeting-B4NL6U.wav
[14:37:38] 📁 Recording to: recordings/20260117_143609_Meeting-B4NL6U.wav
[14:37:38] 📢 Speak into your microphone now!
[14:37:38] 3600...
[14:37:38] 3599...
[14:37:38] 3598...   
```                                                                                                                                                                                                                              

You can see that we start recording at 14:36:07, but only when we stop the recording do we see the debug logs from the recording thread appear.

The fix is to simply add the -u flag (unbuffered) when creating the recording thread, to ensure we are immediately writing all STDOUT logs rather than buffering and flushing at the end.

Only real risk of setting the -u flag is if there was a very high volume of log-writing, which is not really the case here.

## Type of Change

- [x] Bug fix

## Testing

- [x] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

Confirmed that after the fix, the logs all appear in the order you would expect. ✅ 

## Additional Notes

Might also want to consider removing the seconds counter that counts down from 3600, 3599, 3598 etc. - quite spammy in the debug logs and probably not necessary (or could be changed to count down in minutes rather than seconds).