### PR TITLE
fix: announcement banner buttons not clickable

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -104,6 +104,11 @@
 
         .header.with-announcement-banner {
             padding-top: 76px;
+            -webkit-app-region: no-drag;
+        }
+
+        .announcement-visible .drag-area {
+            display: none;
         }
 
         .brand {
@@ -4882,12 +4887,14 @@ Session started - waiting for activity...
             }
 
             document.querySelector('.header').classList.add('with-announcement-banner');
+            document.body.classList.add('announcement-visible');
             log(`Showing announcement: [${ann.type}] ${ann.title}`);
         }
 
         function hideAnnouncementBanner() {
             announcementBanner.className = 'announcement-banner';
             document.querySelector('.header').classList.remove('with-announcement-banner');
+            document.body.classList.remove('announcement-visible');
 
             if (currentAnnouncement) {
                 dismissAnnouncement(currentAnnouncement.id);

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AI-powered meeting transcription and analysis for Mac",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",


### PR DESCRIPTION
## Summary

- Fix announcement banner dismiss and action buttons not receiving click events due to Electron drag region overlap
- Disable drag region on header and hide drag area when banner is visible
- Bump version to 0.2.1

## Test plan

- [x] Show announcement banner (Settings > General > Check)
- [x] Click dismiss button (X) -- banner should close
- [x] Click action button (Download Update / GitHub) -- should open link
- [x] After dismissing, banner should not reappear on reload
- [x] Window dragging still works when banner is not visible

Generated with [Claude Code](https://claude.com/claude-code)