### PR TITLE
Add macOS Shortcuts deep-link support for start/stop recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,79 @@
 - **System audio capture** - Record mic + system audio simultaneously for virtual meetings with headphones
 - **macOS desktop app** with intuitive interface
 
+## macOS Shortcuts (Optional)
+
+<details>
+<summary>Expand setup and calendar automation guide</summary>
+
+StenoAI supports Apple Shortcuts via deep links using the `stenoai://` URL scheme.
+
+- Start recording: `stenoai://record/start?name=Daily%20Standup`
+- Stop recording: `stenoai://record/stop`
+
+### How to set it up
+
+1. Open the **Shortcuts** app on macOS.
+2. Create a new shortcut (for example: "Start StenoAI Recording").
+3. Add the **Open URLs** action.
+4. Use one of the URLs above.
+5. (Optional) Add a keyboard shortcut from the shortcut settings.
+
+### Calendar event naming (optional)
+
+If you want calendar-based names, resolve the event title in your Shortcut workflow and pass it as the `name` query value in the start URL.
+
+Example:
+
+`stenoai://record/start?name=Weekly%20Product%20Sync`
+
+### Calendar event start automation (via Rules bridge)
+
+macOS Shortcuts **cannot natively trigger** exactly at Calendar event start.  
+To run this automatically on event timing, a third-party automation app is required.
+
+This addon uses:
+
+- **Apple Shortcuts**: builds the `stenoai://record/start?...` action.
+- **Rules – Calendar Automation**: watches Calendar events and triggers the shortcut.
+
+#### Architecture overview
+
+1. Rules App monitors upcoming Calendar events.
+2. Rules checks the event note/body for a marker keyword (for example `stenoai`).
+3. If matched, Rules runs a Shortcut.
+4. The Shortcut gets the next event title and opens:
+   - `stenoai://record/start?name={calendar_event_title}`
+5. StenoAI receives the URL and starts recording with that name.
+
+#### Step-by-step setup
+
+1. Install **Rules – Calendar Automation** on macOS.
+2. Create a Shortcut in Apple Shortcuts (example name: `StenoAI Start From Calendar Event`).
+3. In that Shortcut, add actions in this order:
+   - `Find Calendar Events` (limit to `1`, sorted by start date ascending, upcoming only)
+   - Extract the event title from the found event
+   - `URL Encode` the title
+   - `Open URLs` with:
+     - `stenoai://record/start?name=<encoded title>`
+4. Open Rules and create a calendar-trigger rule:
+   - Source: your target calendar(s)
+   - Trigger window: event start (or preferred offset)
+   - Condition: event note contains `stenoai`
+   - Action: run Shortcut `StenoAI Start From Calendar`
+5. In your Calendar event notes, add the word `stenoai` for meetings that should auto-start recording.
+6. Test with a near-future event:
+   - create event with `stenoai` in notes,
+   - wait for trigger,
+   - confirm StenoAI starts and uses the event title as session name.
+
+#### Notes
+
+- Without Rules (or another automation bridge), this cannot be fully event-driven from Calendar start time.
+- Keep using regular manual shortcuts (`Open URLs`) for non-automated scenarios.
+
 Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu) to chat with the community.
+</details>
 
 ## Models & Performance
 

--- a/app/index.html
+++ b/app/index.html
@@ -5900,9 +5900,21 @@ Session started - waiting for activity...
                 
                 // Do maintenance tasks in parallel
                 const maintenancePromise = Promise.all([
-                    ipcRenderer.invoke('clear-state').catch(err =>
-                        log(`State clear failed: ${err.message}`)
-                    ),
+                    (async () => {
+                        try {
+                            const queueStatus = await ipcRenderer.invoke('get-queue-status');
+                            if (queueStatus.success && queueStatus.hasRecording) {
+                                log('Skipping clear-state: recording is active');
+                                return;
+                            }
+                        } catch (err) {
+                            log(`Queue status check failed before clear-state: ${err.message}`);
+                        }
+
+                        return ipcRenderer.invoke('clear-state').catch(err =>
+                            log(`State clear failed: ${err.message}`)
+                        );
+                    })(),
                     checkInitialStatus().catch(err =>
                         log(`Status check failed: ${err.message}`)
                     ),
@@ -6432,6 +6444,52 @@ Session started - waiting for activity...
         ipcRenderer.on('debug-log', (event, message) => {
             debugLog(message);
         });
+
+        // Listen for macOS shortcut start action
+        ipcRenderer.on('shortcut-start-recording', (event, payload = {}) => {
+            const shortcutName = typeof payload.sessionName === 'string'
+                ? payload.sessionName.trim()
+                : '';
+
+            log('Shortcut received: start recording');
+            if (uiState !== 'ready') {
+                log(`Shortcut start ignored in UI state: ${uiState}`);
+                return;
+            }
+
+            if (shortcutName) {
+                sessionNameInput.value = shortcutName;
+            }
+
+            startBtn.click();
+        });
+
+        // Listen for macOS shortcut stop action
+        ipcRenderer.on('shortcut-stop-recording', async () => {
+            log('Shortcut received: stop recording');
+
+            if (uiState === 'recording' || uiState === 'paused') {
+                stopBtn.click();
+                return;
+            }
+
+            // UI can still be in "ready" right after hidden-window startup while backend
+            // is already recording. In that case, allow stop based on backend truth.
+            try {
+                const statusResult = await ipcRenderer.invoke('get-status');
+                if (statusResult.success && statusResult.status.includes('RECORDING')) {
+                    log('Shortcut stop proceeding based on backend recording status');
+                    stopBtn.click();
+                } else {
+                    log(`Shortcut stop ignored in UI state: ${uiState}`);
+                }
+            } catch (error) {
+                log(`Shortcut stop status check failed: ${error.message}`);
+            }
+        });
+
+        // Signal to main process that shortcut listeners are attached
+        ipcRenderer.send('shortcut-renderer-ready');
 
         // Listen for global hotkey toggle recording
         ipcRenderer.on('toggle-recording-hotkey', () => {
@@ -8115,7 +8173,13 @@ Session started - waiting for activity...
 
         // Initialize
         initializeApp().then(() => {
-            runStartupCheck().then(() => {
+            runStartupCheck().then(async () => {
+                // Final status sync after startup/setup checks to avoid stale READY UI
+                // when recording was started while window was hidden.
+                await checkInitialStatus().catch(err =>
+                    log(`Final status sync failed: ${err.message}`)
+                );
+
                 // Check for announcements and updates after app initialization
                 setTimeout(() => {
                     runAnnouncementChecks();

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, Notification } = require('electron');
 const path = require('path');
 const { spawn, exec } = require('child_process');
 const fs = require('fs');
@@ -17,6 +17,48 @@ let mainWindow;
 let pythonProcess;
 let tray = null;
 let isQuitting = false;
+let shortcutQueue = [];
+let pendingShortcutUrls = [];
+let rendererShortcutReady = false;
+let launchedByShortcut = false;
+
+const SHORTCUT_PROTOCOL = 'stenoai';
+const SHORTCUT_HOST = 'record';
+const SHORTCUT_SESSION_NAME_MAX_LENGTH = 120;
+
+function sanitizeShortcutSessionName(rawValue) {
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+
+  // Keep user-visible names readable while stripping unsafe/path-like characters.
+  // Preserve Unicode letters (including diacritics) and common punctuation.
+  const sanitized = rawValue
+    .replace(/[/\\:*?"<>|]/g, ' ')
+    .replace(/[^\p{L}\p{M}\p{N}_\s.,()@&'!+#-]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, SHORTCUT_SESSION_NAME_MAX_LENGTH);
+
+  return sanitized || null;
+}
+
+function registerShortcutProtocolClient() {
+  if (process.platform !== 'darwin') {
+    return false;
+  }
+
+  // In development (electron .), macOS protocol registration needs executable + app args.
+  if (!app.isPackaged) {
+    return app.setAsDefaultProtocolClient(
+      SHORTCUT_PROTOCOL,
+      process.execPath,
+      [path.resolve(process.argv[1])]
+    );
+  }
+
+  return app.setAsDefaultProtocolClient(SHORTCUT_PROTOCOL);
+}
 
 // Backend executable path - always use bundled stenoai
 function getBackendPath() {
@@ -35,6 +77,160 @@ function getBackendCwd() {
   } else {
     return path.join(__dirname, '..', 'dist', 'stenoai');
   }
+}
+
+function parseShortcutUrl(incomingUrl) {
+  try {
+    const parsed = new URL(incomingUrl);
+    if (parsed.protocol !== `${SHORTCUT_PROTOCOL}:`) {
+      return { type: 'invalid', reason: 'invalid-protocol' };
+    }
+
+    if (parsed.hostname !== SHORTCUT_HOST) {
+      return { type: 'invalid', reason: 'invalid-host' };
+    }
+
+    const cleanPath = (parsed.pathname || '').replace(/\/+$/, '');
+    if (cleanPath === '/start') {
+      const sessionName = sanitizeShortcutSessionName(parsed.searchParams.get('name') || '');
+      return {
+        type: 'start',
+        sessionName
+      };
+    }
+
+    if (cleanPath === '/stop') {
+      return { type: 'stop' };
+    }
+
+    return { type: 'invalid', reason: 'invalid-path' };
+  } catch (error) {
+    return { type: 'invalid', reason: 'parse-error' };
+  }
+}
+
+function ensureMainWindow() {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    createWindow();
+  }
+}
+
+function dispatchShortcutAction(action) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return false;
+  }
+
+  if (action.type === 'start') {
+    mainWindow.webContents.send('shortcut-start-recording', {
+      sessionName: action.sessionName || null
+    });
+    return true;
+  }
+
+  if (action.type === 'stop') {
+    mainWindow.webContents.send('shortcut-stop-recording');
+    return true;
+  }
+
+  return false;
+}
+
+function flushShortcutQueue() {
+  if (!rendererShortcutReady || !mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  while (shortcutQueue.length > 0) {
+    const nextAction = shortcutQueue.shift();
+    const dispatched = dispatchShortcutAction(nextAction);
+    if (!dispatched) {
+      shortcutQueue.unshift(nextAction);
+      break;
+    }
+  }
+}
+
+function enqueueShortcutAction(action) {
+  shortcutQueue.push(action);
+  flushShortcutQueue();
+}
+
+async function shouldShowShortcutNotifications() {
+  try {
+    const settings = await handleGetNotifications();
+    if (!settings.success) {
+      return true;
+    }
+    return settings.notifications_enabled !== false;
+  } catch (error) {
+    return true;
+  }
+}
+
+async function showShortcutNotification(body) {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  try {
+    const enabled = await shouldShowShortcutNotifications();
+    if (!enabled || !Notification.isSupported()) {
+      return;
+    }
+
+    new Notification({
+      title: 'StenoAI Shortcuts',
+      body
+    }).show();
+  } catch (error) {
+    console.error('Failed to show shortcut notification:', error.message);
+  }
+}
+
+async function isBackendRecording() {
+  try {
+    const status = await handleGetStatus();
+    if (!status.success) {
+      return false;
+    }
+    return status.status.includes('STATUS: RECORDING');
+  } catch (error) {
+    console.error('Error checking recording status for shortcut action:', error.message);
+    return false;
+  }
+}
+
+async function handleShortcutUrl(incomingUrl) {
+  const parsedAction = parseShortcutUrl(incomingUrl);
+
+  if (parsedAction.type === 'invalid') {
+    console.warn(`Ignored invalid shortcut URL (${parsedAction.reason}): ${incomingUrl}`);
+    await showShortcutNotification('Invalid shortcut URL');
+    return;
+  }
+
+  const recording = await isBackendRecording();
+
+  if (parsedAction.type === 'start') {
+    if (recording) {
+      await showShortcutNotification('Recording already in progress');
+      return;
+    }
+
+    ensureMainWindow();
+    enqueueShortcutAction(parsedAction);
+    await showShortcutNotification('Start recording requested');
+    return;
+  }
+
+  if (!recording) {
+    await showShortcutNotification('Recording already stopped');
+    return;
+  }
+
+  ensureMainWindow();
+  enqueueShortcutAction(parsedAction);
+  await showShortcutNotification('Stop recording requested');
 }
 
 // Telemetry state
@@ -196,6 +392,7 @@ function validateSafeFilePath(filepath, allowedBaseDirs) {
 }
 
 function createWindow() {
+  rendererShortcutReady = false;
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -212,6 +409,9 @@ function createWindow() {
   mainWindow.loadFile('index.html');
   
   mainWindow.once('ready-to-show', () => {
+    if (launchedByShortcut) {
+      return;
+    }
     mainWindow.show();
   });
 
@@ -225,6 +425,7 @@ function createWindow() {
 
   mainWindow.on('closed', () => {
     mainWindow = null;
+    rendererShortcutReady = false;
     if (pythonProcess) {
       pythonProcess.kill();
     }
@@ -371,6 +572,23 @@ app.on('before-quit', async (event) => {
   }
 });
 
+app.on('open-url', (event, incomingUrl) => {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  event.preventDefault();
+  console.log(`Received shortcut URL via open-url: ${incomingUrl}`);
+  launchedByShortcut = true;
+
+  if (!app.isReady()) {
+    pendingShortcutUrls.push(incomingUrl);
+    return;
+  }
+
+  void handleShortcutUrl(incomingUrl);
+});
+
 app.whenReady().then(async () => {
   // Set application menu with Help > Learn More
   const appMenu = Menu.buildFromTemplate([
@@ -401,6 +619,8 @@ app.whenReady().then(async () => {
 
   createWindow();
   createTray();
+  const protocolRegistered = registerShortcutProtocolClient();
+  console.log(`Protocol handler registration (${SHORTCUT_PROTOCOL}): ${protocolRegistered}`);
 
   // Initialize telemetry and track app open
   await initTelemetry();
@@ -432,7 +652,25 @@ app.whenReady().then(async () => {
   } else {
     console.error(`Failed to register global hotkey: ${hotkeyModifier}`);
   }
+
+  if (pendingShortcutUrls.length > 0) {
+    const urlsToProcess = [...pendingShortcutUrls];
+    pendingShortcutUrls = [];
+
+    for (const shortcutUrl of urlsToProcess) {
+      await handleShortcutUrl(shortcutUrl);
+    }
+  }
 });
+
+// Fallback for launch contexts where deep-link may arrive via argv instead of open-url.
+if (process.platform === 'darwin') {
+  const argvShortcutUrl = process.argv.find(arg => typeof arg === 'string' && arg.startsWith(`${SHORTCUT_PROTOCOL}://`));
+  if (argvShortcutUrl) {
+    pendingShortcutUrls.push(argvShortcutUrl);
+    launchedByShortcut = true;
+  }
+}
 
 app.on('will-quit', async () => {
   globalShortcut.unregisterAll();
@@ -459,8 +697,12 @@ app.on('window-all-closed', () => {
 
 app.on('activate', () => {
   if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore();
     mainWindow.show();
+    mainWindow.focus();
+    launchedByShortcut = false;
   } else {
+    launchedByShortcut = false;
     createWindow();
   }
 });
@@ -472,6 +714,11 @@ ipcMain.on('focus-window', () => {
         mainWindow.show();
         mainWindow.focus();
     }
+});
+
+ipcMain.on('shortcut-renderer-ready', () => {
+  rendererShortcutReady = true;
+  flushShortcutQueue();
 });
 
 // Microphone permission handlers
@@ -561,6 +808,34 @@ function runPythonScript(script, args = [], silent = false, extraEnv = {}) {
   });
 }
 
+async function getBackendStatusInternal(silent = true) {
+  const result = await runPythonScript('simple_recorder.py', ['status'], silent);
+  return { success: true, status: result };
+}
+
+async function handleGetStatus() {
+  try {
+    return await getBackendStatusInternal(true); // Silent mode
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+}
+
+async function handleGetNotifications() {
+  try {
+    const result = await runPythonScript('simple_recorder.py', ['get-notifications']);
+    const jsonData = JSON.parse(result);
+
+    return {
+      success: true,
+      ...jsonData
+    };
+  } catch (error) {
+    sendDebugLog(`Error getting notification settings: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+}
+
 // IPC Handlers - Separate start/stop with better error handling
 ipcMain.handle('start-recording', async (event, sessionName) => {
   try {
@@ -603,14 +878,7 @@ ipcMain.handle('stop-recording', async () => {
   }
 });
 
-ipcMain.handle('get-status', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['status'], true); // Silent mode
-    return { success: true, status: result };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
+ipcMain.handle('get-status', handleGetStatus);
 
 ipcMain.handle('process-recording', async (event, audioFile, sessionName) => {
   try {
@@ -2108,20 +2376,7 @@ ipcMain.handle('set-model', async (event, modelName) => {
   }
 });
 
-ipcMain.handle('get-notifications', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-notifications']);
-    const jsonData = JSON.parse(result);
-
-    return {
-      success: true,
-      ...jsonData
-    };
-  } catch (error) {
-    sendDebugLog(`Error getting notification settings: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
+ipcMain.handle('get-notifications', handleGetNotifications);
 
 ipcMain.handle('set-notifications', async (event, enabled) => {
   try {
@@ -2746,7 +3001,6 @@ ipcMain.handle('open-release-page', async (event, url) => {
     return { success: false, error: error.message };
   }
 });
-
 // ── Google Calendar: Token Storage ──────────────────────────────────────
 
 function getTokenFilePath() {

--- a/app/package.json
+++ b/app/package.json
@@ -49,6 +49,14 @@
   "build": {
     "appId": "com.stenoai.recorder",
     "productName": "StenoAI",
+    "protocols": [
+      {
+        "name": "StenoAI Shortcut Links",
+        "schemes": [
+          "stenoai"
+        ]
+      }
+    ],
     "directories": {
       "output": "dist",
       "buildResources": "build"


### PR DESCRIPTION
## Description

This PR adds Apple macOS Shortcuts integration via `stenoai://` deep links, allowing recording to be controlled from Shortcuts and automation flows.

### What changed

#### `app/main.js`
- Added protocol handling for:
  - `stenoai://record/start?name=...`
  - `stenoai://record/stop`
- Added macOS `open-url` handling with startup queueing so links work on cold and warm launch
- Added dev-safe protocol registration and `argv` fallback for deep-link delivery
- Added renderer-ready handshake to prevent startup race conditions
- Added idempotent shortcut behavior (`already recording` / `already stopped`)
- Added quiet-launch behavior and Dock activate recovery
- Added shortcut notifications (respecting existing notifications setting)

#### `app/index.html`
- Added shortcut IPC listeners:
  - `shortcut-start-recording` -> reuses existing `startBtn.click()`
  - `shortcut-stop-recording` -> reuses existing `stopBtn.click()`
- Added `shortcut-renderer-ready` handshake event

#### `app/package.json`
- Added `build.protocols` registration for the `stenoai` URL scheme

#### `README.md`
- Added `macOS Shortcuts` section with setup and URL examples
- Added calendar automation documentation using **Rules – Calendar Automation** bridge
- Clearly documented that macOS Shortcuts cannot natively trigger on Calendar event start

### Why

Enable reliable macOS Shortcut and calendar-driven automation control for recording, without changing existing recording business logic.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

### Manual test scenarios

1. Warm launch deep link start:
   - `stenoai://record/start?name=Daily%20Standup`
2. Warm launch deep link stop:
   - `stenoai://record/stop`
3. Cold launch via deep link with hidden-window behavior
4. Idempotent responses for repeated start/stop triggers
5. Existing `Cmd+Shift+R` global hotkey unchanged
6. Re-open from Dock after background shortcut start and verify UI shows active recording

## Additional Notes

- Recording start/stop backend logic was not modified; shortcuts are routed into existing renderer button handlers.
- No Python backend changes.
- `app/package-lock.json` intentionally not modified.
- I have read the CLA Document and I hereby sign the CLA