### PR TITLE
fix: show clear error on summarization failure

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6177,8 +6177,13 @@ Session started - waiting for activity...
 
                 setStatus('ready', 'Processing failed');
                 setTimeout(() => setStatus('ready', 'Ready'), 5000);
-                log(`Processing failed: ${data.error}`);
+                log(`Processing failed: ${data.message || data.error || 'Unknown error'}`);
                 filterMeetings();
+
+                showDesktopNotification('StenoAI - Processing Failed', {
+                    body: data.message || data.error || 'Summarization failed. Check that Ollama and a model are available.',
+                    requireInteraction: false
+                });
             }
         });
         

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -430,13 +430,13 @@ def start(session_name):
                             print("📝 Transcribing...")
                             result = loop.run_until_complete(recorder.process_recording(final_path, session_name))
                             
-                            print("✅ Complete processing finished!")
-                            print(f"📄 Transcript: {result['session_info']['transcript_file']}")  
+                            print("✅ Complete processing finished!", flush=True)
+                            print(f"📄 Transcript: {result['session_info']['transcript_file']}")
                             print(f"📋 Summary: {result['session_info']['summary_file']}")
                             print(f"📊 Meeting: {result['session_info']['name']}")
-                            
+
                         except Exception as e:
-                            print(f"❌ Processing pipeline failed: {e}")
+                            print(f"❌ Processing pipeline failed: {e}", flush=True)
                             import traceback
                             traceback.print_exc()
                     else:
@@ -447,10 +447,10 @@ def start(session_name):
                 print(f"❌ Error during signal handling: {e}")
                 import traceback
                 traceback.print_exc()
-        
+
         print("🏁 Recording session ended")
         sys.exit(0)
-    
+
     # Register signal handlers for graceful shutdown
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
@@ -665,13 +665,13 @@ def record(duration, session_name):
                             print("📝 Starting transcription...")
                             result = loop.run_until_complete(recorder.process_recording(final_path, session_name))
                             
-                            print("✅ Complete processing finished!")
-                            print(f"📄 Transcript: {result['session_info']['transcript_file']}")  
+                            print("✅ Complete processing finished!", flush=True)
+                            print(f"📄 Transcript: {result['session_info']['transcript_file']}")
                             print(f"📋 Summary: {result['session_info']['summary_file']}")
                             print(f"📊 Meeting: {result['session_info']['name']}")
-                            
+
                         except Exception as e:
-                            print(f"❌ Processing pipeline failed: {e}")
+                            print(f"❌ Processing pipeline failed: {e}", flush=True)
                             import traceback
                             traceback.print_exc()
                     else:


### PR DESCRIPTION
## Summary
- Detect processing failures in Electron (explicit error output + process exit without success message) and send `processing-complete` with `success: false`
- Show desktop notification on failure, mirroring the existing success notification pattern
- Add `flush=True` to critical print statements so errors reach Electron immediately instead of being buffered

Fixes the issue where summarization failure (e.g. missing Ollama/model) results in indefinite "processing in background" with no feedback.

## Test plan
- [x] Kill Ollama before stopping a recording -- verify desktop notification appears with error message
- [x] Normal recording flow still shows "Meeting Notes Ready" notification on success
- [x] Force-kill the Python process during processing -- verify fallback notification fires