### PR TITLE
fix: find bundled ffmpeg in setup-check and transcriber

### DIFF
--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -76,12 +76,18 @@ class WhisperTranscriber:
         # Check bundled ffmpeg first (PyInstaller bundle)
         if getattr(sys, 'frozen', False):
             # Running from PyInstaller bundle
-            bundle_dir = Path(sys._MEIPASS) if hasattr(sys, '_MEIPASS') else Path(sys.executable).parent
-            bundled_ffmpeg = bundle_dir / 'ffmpeg'
-            if bundled_ffmpeg.exists():
-                possible_ffmpeg_paths.append(str(bundled_ffmpeg))
-            # Also check _internal directory
-            internal_ffmpeg = Path(sys.executable).parent / '_internal' / 'ffmpeg'
+            # stenoai.spec places ffmpeg at '.' (bundle root, next to executable)
+            exe_dir = Path(sys.executable).parent
+            root_ffmpeg = exe_dir / 'ffmpeg'
+            if root_ffmpeg.exists():
+                possible_ffmpeg_paths.append(str(root_ffmpeg))
+            # Also check _MEIPASS (_internal) in case layout changes
+            if hasattr(sys, '_MEIPASS'):
+                meipass_ffmpeg = Path(sys._MEIPASS) / 'ffmpeg'
+                if meipass_ffmpeg.exists():
+                    possible_ffmpeg_paths.append(str(meipass_ffmpeg))
+            # Also check _internal subdirectory
+            internal_ffmpeg = exe_dir / '_internal' / 'ffmpeg'
             if internal_ffmpeg.exists():
                 possible_ffmpeg_paths.append(str(internal_ffmpeg))
         else:


### PR DESCRIPTION
## Summary
- **Setup-check** now checks bundled ffmpeg paths (`_internal/`, bundle root) before falling back to system paths. Previously it only checked system PATH, causing a false `❌ ffmpeg not found` and "Setup incomplete" warning for users without Homebrew ffmpeg.
- **Transcriber** ffmpeg path lookup cleaned up to explicitly check bundle root, `_MEIPASS`, and `_internal/` for resilience against future PyInstaller layout changes.

## Context
A user reported seeing `❌ ffmpeg not found` and "Setup incomplete" despite ffmpeg being bundled in the app at `_internal/ffmpeg`. The setup-check was only looking at system paths (`/opt/homebrew/bin/ffmpeg`, etc.), not the PyInstaller bundle.

## Test plan
- [x] Built PyInstaller bundle, verified `setup-check` shows `✅ ffmpeg bundled`
- [x] Confirmed ffmpeg binary exists at `dist/stenoai/_internal/ffmpeg`
- [x] Full setup-check passes: "System check passed! Ready to record meetings."