### PR TITLE
fix: correct quit dialog message for active recordings

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -327,7 +327,7 @@ app.on('before-quit', async (event) => {
       defaultId: 0,
       cancelId: 0,
       title: 'Recording in Progress',
-      message: 'A recording is still in progress. Quitting will stop the recording and process it in the background.',
+      message: 'A recording is still in progress. Quitting will stop and save the recording.',
     });
     if (response === 1) {
       // Stop recording gracefully then quit


### PR DESCRIPTION
## Summary
- Fix misleading quit dialog that claimed recordings would be "processed in the background" — the app quits before processing can complete
- Updated message to accurately state the recording will be stopped and saved

## Test plan
- [x] Start a recording, attempt to quit — verify dialog shows "Quitting will stop and save the recording."