### PR TITLE
Fix multiprocessing freeze and check bundled ffmpeg first

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1282,10 +1282,13 @@ ipcMain.handle('setup-system-check', async () => {
 ipcMain.handle('setup-ffmpeg', async () => {
   try {
     sendDebugLog('$ Checking for existing ffmpeg installation...');
-    sendDebugLog('$ Checking: ffmpeg -version, /opt/homebrew/bin/ffmpeg, /usr/local/bin/ffmpeg');
 
-    // Check if ffmpeg is already installed - try multiple common paths
-    const ffmpegPaths = ['ffmpeg', '/opt/homebrew/bin/ffmpeg', '/usr/local/bin/ffmpeg'];
+    // Check bundled ffmpeg first (shipped with the app), then system paths
+    const bundledFfmpeg = app.isPackaged
+      ? path.join(process.resourcesPath, 'stenoai', 'ffmpeg')
+      : path.join(__dirname, '..', 'dist', 'stenoai', 'ffmpeg');
+    const ffmpegPaths = [bundledFfmpeg, 'ffmpeg', '/opt/homebrew/bin/ffmpeg', '/usr/local/bin/ffmpeg'];
+    sendDebugLog(`$ Checking: ${ffmpegPaths.join(', ')}`);
     let ffmpegPath = null;
 
     for (const testPath of ffmpegPaths) {

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1772,4 +1772,6 @@ def pull_model(model_name):
 
 
 if __name__ == '__main__':
+    import multiprocessing
+    multiprocessing.freeze_support()
     cli()


### PR DESCRIPTION
## Summary
- Add `multiprocessing.freeze_support()` call before CLI entry point to prevent freezing issues in PyInstaller-bundled builds
- Check bundled ffmpeg (shipped with the app) before falling back to system paths, ensuring the app works without a system ffmpeg installation

## Test plan
- [x] Verify PyInstaller build completes without multiprocessing-related errors
- [x] Verify ffmpeg setup finds bundled binary in packaged app
- [x] Verify fallback to system ffmpeg still works when bundled binary is absent