### PR TITLE
Real sound capture waveform animation

### DIFF
--- a/app/audio-visualizer.js
+++ b/app/audio-visualizer.js
@@ -1,14 +1,20 @@
 // ── AudioVisualizer ──
-// Drives .waveform-bar heights from live audio input.
+// Drives .waveform-bar via transform:scaleY() from live audio input.
 // Mic-only mode: opens its own getUserMedia stream for visualization only
 // (Python backend records independently via sounddevice).
 // System audio mode: reuses the existing AudioContext analyser.
+//
+// Expects exactly 8 .waveform-bar elements in the DOM (see index.html #waveform).
 window.AudioVisualizer = {
     _animFrame: null,
     _stream: null,
     _ctx: null,
     _lastFrame: 0,
     _abort: null,
+
+    _log(msg) {
+        (typeof log === 'function' ? log : console.log)(msg);
+    },
 
     // Open a new mic stream purely for visualization.
     async start(bars) {
@@ -31,7 +37,7 @@ window.AudioVisualizer = {
             const dataArray = new Uint8Array(analyser.frequencyBinCount);
             this._loop(bars, analyser, dataArray);
         } catch (e) {
-            log(`Visualizer start error: ${e.message}`);
+            this._log(`Visualizer start error: ${e.message}`);
         }
     },
 
@@ -57,7 +63,25 @@ window.AudioVisualizer = {
             this._stream.getTracks().forEach(t => t.stop());
             this._stream = null;
         }
+        // Reset bars to baseline so they don't freeze mid-waveform
+        document.querySelectorAll('#waveform .waveform-bar').forEach(bar => {
+            bar.style.transform = '';
+        });
     },
+
+    // 8 log-spaced octave bands — must match the 8 .waveform-bar elements in index.html
+    _binGroups: [
+        [0],
+        [1, 2],
+        [3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12, 13, 14, 15, 16, 17],
+        [18, 19, 20, 21, 22, 23, 24, 25, 26,
+         27, 28, 29, 30, 31, 32, 33, 34],
+        [35, 36, 37, 38, 39, 40, 41, 42],
+        [43, 44, 45, 46, 47, 48, 49, 50, 51,
+         52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+    ],
 
     _loop(bars, analyser, dataArray) {
         // Throttle DOM writes to ~20fps — rAF still drives the loop so it
@@ -67,23 +91,13 @@ window.AudioVisualizer = {
             this._lastFrame = now;
             analyser.getByteFrequencyData(dataArray);
             // fftSize=256 → 128 bins at ~187.5 Hz/bin (48 kHz)
-            // 8 log-spaced octave bands across the speech range (~0-12000 Hz)
-            const binGroups = [
-                [0],
-                [1, 2],
-                [3, 4],
-                [5, 6, 7, 8],
-                [9, 10, 11, 12, 13, 14, 15, 16, 17],
-                [18, 19, 20, 21, 22, 23, 24, 25, 26,
-                 27, 28, 29, 30, 31, 32, 33, 34],
-                [35, 36, 37, 38, 39, 40, 41, 42],
-                [43, 44, 45, 46, 47, 48, 49, 50, 51,
-                 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
-            ];
+            const binGroups = this._binGroups;
             bars.forEach((bar, i) => {
                 const group = binGroups[i];
+                if (!group) return;
                 const avg = group.reduce((sum, b) => sum + (dataArray[b] || 0), 0) / group.length;
-                bar.style.height = `${Math.max(4, Math.round(4 + (avg / 255) * 16))}px`;
+                // scaleY 0.2 (min 4px visual) to 1.0 (full 20px) — no layout reflow
+                bar.style.transform = `scaleY(${Math.max(0.2, avg / 255)})`;
             });
         }
         this._animFrame = requestAnimationFrame(() => this._loop(bars, analyser, dataArray));

--- a/app/index.html
+++ b/app/index.html
@@ -270,12 +270,15 @@
             display: flex;
         }
 
+        /* 8 bars — must match the 8 binGroups in audio-visualizer.js */
         .waveform-bar {
             width: 3px;
             background: var(--recording-red);
             border-radius: 2px;
-            height: 4px;
-            transition: height 0.05s ease;
+            height: 20px;
+            transform-origin: bottom;
+            transform: scaleY(0.2);
+            transition: transform 0.05s ease;
         }
         
         .btn {
@@ -3175,6 +3178,7 @@
             <div class="status" id="status-container">
                 <div class="status-dot ready" id="status-dot"></div>
                 <span id="status-text" style="font-size: 13px; color: var(--text-secondary);">Ready</span>
+                <!-- 8 bars — must match the 8 binGroups in audio-visualizer.js -->
                 <div class="waveform" id="waveform">
                     <div class="waveform-bar"></div>
                     <div class="waveform-bar"></div>
@@ -4239,6 +4243,15 @@ Session started - waiting for activity...
                     pauseBtn.disabled = false;
                     // Check if resuming from paused state (pausedElapsedTime > 0)
                     startRecordingTimer(pausedElapsedTime > 0);
+                    // Restart visualizer if resuming from pause or recovering
+                    if (!AudioVisualizer._animFrame) {
+                        const bars = Array.from(document.querySelectorAll('#waveform .waveform-bar'));
+                        if (_systemAudioAnalyser) {
+                            AudioVisualizer.startFromAnalyser(bars, _systemAudioAnalyser);
+                        } else {
+                            AudioVisualizer.start(bars);
+                        }
+                    }
                     break;
 
                 case 'paused':
@@ -4250,6 +4263,7 @@ Session started - waiting for activity...
                     sessionNameInput.disabled = true;
                     stopBtn.disabled = false;
                     pauseBtn.disabled = false;
+                    AudioVisualizer.stop();
                     pauseRecordingTimer();
                     // Show paused status with the frozen time
                     const minutes = Math.floor(pausedElapsedTime / 60);
@@ -5140,6 +5154,7 @@ Session started - waiting for activity...
         let _systemAudioChunks = [];
         let _systemAudioStreams = [];  // Track streams for cleanup
         let _systemAudioContext = null;
+        let _systemAudioAnalyser = null;
 
         async function startSystemAudioRecording() {
             const { getLoopbackAudioMediaStream } = require('electron-audio-loopback');
@@ -5167,10 +5182,10 @@ Session started - waiting for activity...
                 micSource.connect(dest);
 
                 // Attach analyser for waveform visualization
-                const vizAnalyser = _systemAudioContext.createAnalyser();
-                vizAnalyser.fftSize = 256;
-                loopbackSource.connect(vizAnalyser);
-                micSource.connect(vizAnalyser);
+                _systemAudioAnalyser = _systemAudioContext.createAnalyser();
+                _systemAudioAnalyser.fftSize = 256;
+                loopbackSource.connect(_systemAudioAnalyser);
+                micSource.connect(_systemAudioAnalyser);
 
                 // Start recording the mixed stream
                 _systemAudioChunks = [];
@@ -5190,7 +5205,7 @@ Session started - waiting for activity...
 
                 // Start waveform visualization from the mixed analyser
                 const vizBars = Array.from(document.querySelectorAll('#waveform .waveform-bar'));
-                AudioVisualizer.startFromAnalyser(vizBars, vizAnalyser);
+                AudioVisualizer.startFromAnalyser(vizBars, _systemAudioAnalyser);
 
                 log('System audio recording started (mic + system audio)');
             } catch (error) {
@@ -5205,6 +5220,7 @@ Session started - waiting for activity...
                 if (_systemAudioContext) {
                     _systemAudioContext.close().catch(() => {});
                     _systemAudioContext = null;
+                    _systemAudioAnalyser = null;
                 }
                 throw error;
             }


### PR DESCRIPTION
## Description

Brief description of what this PR does and why it's needed.

The waveform animation when recording was not accurate to the sound being captured. This change amend this to use calculate it based off the captured sound.

## Type of Change

- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

## Additional Notes

Any additional context about this change.