### PR TITLE
fix: shortcut stop not working for system audio recordings

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -209,7 +209,8 @@ async function handleShortcutUrl(incomingUrl) {
     return;
   }
 
-  const recording = await isBackendRecording();
+  const backendRecording = await isBackendRecording();
+  const recording = backendRecording || systemAudioRecordingActive;
 
   if (parsedAction.type === 'start') {
     if (recording) {


### PR DESCRIPTION
## Summary
- The `stenoai://record/stop` deep link was silently dropped when a system audio recording was active
- Root cause: `handleShortcutUrl` only checked the Python backend status via `isBackendRecording()`, but system audio recordings run entirely in the Electron renderer (WebAudio + MediaRecorder) — so the backend always reported `STATUS: READY`
- Fix: also check the `systemAudioRecordingActive` flag that's already tracked in `main.js` for the quit dialog and tray icon

## Test plan
- [x] Start a system audio recording via `open "stenoai://record/start?name=Test"`
- [x] Stop it via `open "stenoai://record/stop"` — should stop and trigger transcription pipeline
- [x] Verify mic-only recordings also stop correctly via deep link
- [x] Verify duplicate start is still rejected when already recording

Fixes the stop bug reported in #59.