### PR TITLE
fix: detect incompatible macOS version before starting Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu)
 
 ## Installation
 
-Download the latest release for your Mac:
+Download the latest release for your Mac (**requires macOS 14 Sonoma or later**):
 
 - [Apple Silicon (M1-M5)](https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg)
 - [Intel Macs](https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-x64.dmg) Performance on Intel Macs is limited due to lack of dedicated AI inference capabilities on these older chips.

--- a/app/main.js
+++ b/app/main.js
@@ -1962,6 +1962,16 @@ ipcMain.handle('setup-ollama-and-model', async () => {
       sendDebugLog(`Could not read AI provider, proceeding with local setup: ${e.message}`);
     }
 
+    // Check macOS version — bundled Ollama requires macOS 14 (Sonoma) or later
+    const macosRelease = os.release(); // e.g. "23.1.0" for macOS 14.1
+    const darwinMajor = parseInt(macosRelease.split('.')[0], 10);
+    // Darwin 23 = macOS 14 (Sonoma), Darwin 22 = macOS 13 (Ventura), etc.
+    if (darwinMajor < 23) {
+      const macosVersion = darwinMajor >= 22 ? '13 (Ventura)' : darwinMajor >= 21 ? '12 (Monterey)' : `(Darwin ${darwinMajor})`;
+      sendDebugLog(`macOS ${macosVersion} detected — Ollama requires macOS 14 (Sonoma) or later`);
+      return { success: false, error: 'StenoAI requires macOS 14 (Sonoma) or later for local AI summarization. Please update your macOS or use a remote Ollama server in Settings.' };
+    }
+
     sendDebugLog('Locating bundled Ollama...');
     const finalOllamaPath = await findOllamaExecutable();
     if (!finalOllamaPath) {
@@ -1975,6 +1985,7 @@ ipcMain.handle('setup-ollama-and-model', async () => {
     sendDebugLog(`$ ${finalOllamaPath} serve`);
     let ollamaExited = false;
     let ollamaExitCode = null;
+    let ollamaDyldError = false;
     ollamaProcess = spawn(finalOllamaPath, ['serve'], { detached: true, stdio: ['ignore', 'ignore', 'pipe'], env: getOllamaEnv() });
     ollamaPid = ollamaProcess.pid;
     // Write PID file so quit handler can find the process
@@ -1982,6 +1993,7 @@ ipcMain.handle('setup-ollama-and-model', async () => {
     ollamaProcess.stderr.on('data', (data) => {
       const msg = data.toString().trim();
       if (msg) sendDebugLog(`Ollama: ${msg}`);
+      if (msg.includes('Symbol not found') || msg.includes('dyld')) ollamaDyldError = true;
     });
     ollamaProcess.on('exit', (code) => {
       ollamaExited = true;
@@ -2024,6 +2036,9 @@ ipcMain.handle('setup-ollama-and-model', async () => {
 
     if (!ready) {
       if (ollamaExited) {
+        if (ollamaDyldError) {
+          return { success: false, error: 'Ollama crashed due to incompatible macOS version. StenoAI requires macOS 14 (Sonoma) or later for local AI. Please update macOS or use a remote Ollama server in Settings.' };
+        }
         return { success: false, error: `Ollama failed to start (exit code: ${ollamaExitCode}). Check debug logs for details.` };
       }
       sendDebugLog('Warning: Ollama may not be fully ready, attempting pull anyway...');
@@ -2427,6 +2442,13 @@ async function ensureOllamaRunning() {
     }
 
     // Service not running, try to start it
+    // Check macOS version — bundled Ollama requires macOS 14 (Sonoma) or later
+    const macRelease = os.release();
+    if (parseInt(macRelease.split('.')[0], 10) < 23) {
+      sendDebugLog('macOS version too old for bundled Ollama — requires macOS 14 (Sonoma) or later');
+      return false;
+    }
+
     const ollamaPath = await findOllamaExecutable();
     if (!ollamaPath) {
       return false;


### PR DESCRIPTION
## Summary

- Ollama v0.17.5 requires macOS 14 (Sonoma)+. On older versions (Ventura, Monterey), the binary crashes with a `dyld Symbol not found: _cblas_sgemm$NEWLAPACK$ILP64` error
- Added early macOS version check (Darwin major < 23) in both the setup wizard and regular Ollama startup paths, logging a clear error message
- Added stderr monitoring for `dyld`/`Symbol not found` as a fallback, with a specific error message if the crash is detected
- Updated README to note macOS 14 Sonoma minimum requirement

## Test plan
- [x] Verify on macOS 14+ that Ollama starts normally (no regression)
- [x] If possible, test on macOS 13 to confirm the clear error appears in debug logs instead of the cryptic dyld crash