### PR TITLE
fix: handle storage path permission failures gracefully

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -175,6 +175,8 @@ class Config:
         Returns:
             True if saved successfully, False otherwise.
         """
+        if storage_path is None:
+            storage_path = ""
         storage_path = storage_path.strip()
 
         if storage_path:
@@ -182,9 +184,14 @@ class Config:
             if not sp.is_absolute():
                 logger.error(f"Storage path must be absolute: {storage_path}")
                 return False
-            # Create subdirectories at the new location
-            for subdir in ("recordings", "transcripts", "output"):
-                (sp / subdir).mkdir(parents=True, exist_ok=True)
+            # Create subdirectories at the new location. If this fails
+            # (for example due to permissions), keep existing config unchanged.
+            try:
+                for subdir in ("recordings", "transcripts", "output"):
+                    (sp / subdir).mkdir(parents=True, exist_ok=True)
+            except Exception as e:
+                logger.error(f"Failed to initialize storage path {storage_path}: {e}")
+                return False
 
         self._config["storage_path"] = storage_path
         return self._save()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.config import Config
+
+
+class ConfigStoragePathTests(unittest.TestCase):
+    def test_set_storage_path_handles_permission_errors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertEqual(config.get_storage_path(), "")
+
+            with patch("pathlib.Path.mkdir", side_effect=PermissionError("no access")):
+                success = config.set_storage_path("/System/Library")
+
+            self.assertFalse(success)
+            self.assertEqual(config.get_storage_path(), "")
+
+    def test_set_storage_path_accepts_none_as_reset(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            success = config.set_storage_path(None)
+            self.assertTrue(success)
+            self.assertEqual(config.get_storage_path(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes a crash when users choose an unwritable storage location in Settings.

Previously, `set_storage_path` attempted to create `recordings/`, `transcripts/`, and `output/` without handling filesystem permission errors. On protected paths (e.g. `/System/Library`), this raised `PermissionError` and crashed the backend command.

## Changes
- Catch directory initialization errors in `Config.set_storage_path`.
- Return `False` (graceful failure) instead of propagating exceptions.
- Keep existing config unchanged on failure.
- Accept `None` as an empty reset value defensively.
- Added unit tests for:
  - permission-error handling
  - `None` reset behavior

## Testing
- `python3 -m unittest -q tests/test_config.py`
- Manual check:
  - `python3 simple_recorder.py set-storage-path /System/Library`
  - Now returns structured failure JSON instead of traceback.
