### PR TITLE
fix: recording indicator stuck after stop

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4200,6 +4200,11 @@ Session started - waiting for activity...
         }
         
         function startRecordingTimer(resume = false) {
+            // Clear any existing timer to prevent leaked intervals
+            if (recordingTimer) {
+                clearInterval(recordingTimer);
+                recordingTimer = null;
+            }
             // If resuming, adjust start time to account for already elapsed time
             if (resume && pausedElapsedTime > 0) {
                 recordingStartTime = Date.now() - (pausedElapsedTime * 1000);
@@ -5583,6 +5588,12 @@ Session started - waiting for activity...
         // Check initial recording status once
         async function checkInitialStatus() {
             try {
+                // Don't override processing state — backend may still briefly
+                // report RECORDING while the pipeline is winding down
+                if (uiState === 'processing') {
+                    log('Skipping status check — currently processing');
+                    return;
+                }
                 const result = await ipcRenderer.invoke('get-status');
                 if (result.success && result.status.includes('RECORDING')) {
                     log('Found active recording session - syncing UI state');


### PR DESCRIPTION
## Summary
- Recording indicator ("Recording... 29557044:43") stayed visible after stopping a recording
- Root cause: `checkInitialStatus()` could re-trigger `setUIState('recording')` while in `processing` state, since the backend briefly still reports RECORDING during pipeline wind-down
- Introduced by the waveform animation PR (#54), which added `AudioVisualizer.start()` calls inside `setUIState('recording')`

## Fix
- Skip `checkInitialStatus()` when UI is already in `processing` state
- Clear any existing timer interval in `startRecordingTimer()` before creating a new one, preventing leaked intervals

## Test plan
- [x] Start a recording, stop it, verify the indicator clears and shows "Processing..." then "Ready"
- [x] Pause and resume a recording, verify timer continuity
- [x] Stop a recording and immediately check that waveform animation stops