### PR TITLE
feat: stereo channel diarisation (You vs Others)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5125,8 +5125,48 @@ Session started - waiting for activity...
                 detailActionItems.innerHTML = '<li style="color: var(--text-muted);">No action items identified</li>';
             }
             
-            // Transcript
-            detailTranscript.textContent = selectedMeeting.transcript || 'No transcript available';
+            // Transcript — render diarised view if available
+            if (selectedMeeting.is_diarised && selectedMeeting.diarised_text) {
+                detailTranscript.innerHTML = '';
+                // Override pre-wrap on container so block elements render properly
+                detailTranscript.style.whiteSpace = 'normal';
+                const blocks = selectedMeeting.diarised_text.split(/(?=\[You\]|\[Others\])/);
+                blocks.forEach(block => {
+                    const trimmed = block.trim();
+                    if (!trimmed) return;
+                    const div = document.createElement('div');
+                    div.style.cssText = 'margin-bottom:12px;padding:8px 12px;border-radius:6px;white-space:normal;';
+                    if (trimmed.startsWith('[You]')) {
+                        div.style.borderLeft = '3px solid var(--accent-primary, #818cf8)';
+                        div.style.background = 'rgba(129, 140, 248, 0.06)';
+                        const label = document.createElement('div');
+                        label.textContent = 'You';
+                        label.style.cssText = 'display:inline-block;font-size:11px;font-weight:600;color:var(--accent-primary,#818cf8);background:rgba(129,140,248,0.12);padding:1px 6px;border-radius:3px;margin-bottom:6px;';
+                        div.appendChild(label);
+                        const text = document.createElement('div');
+                        text.style.cssText = 'margin:0;line-height:1.7;';
+                        text.textContent = trimmed.replace('[You]', '').trim();
+                        div.appendChild(text);
+                    } else if (trimmed.startsWith('[Others]')) {
+                        div.style.borderLeft = '3px solid var(--text-muted, #888)';
+                        div.style.background = 'rgba(136, 136, 136, 0.06)';
+                        const label = document.createElement('div');
+                        label.textContent = 'Others';
+                        label.style.cssText = 'display:inline-block;font-size:11px;font-weight:600;color:var(--text-muted,#888);background:rgba(136,136,136,0.12);padding:1px 6px;border-radius:3px;margin-bottom:6px;';
+                        div.appendChild(label);
+                        const text = document.createElement('div');
+                        text.style.cssText = 'margin:0;line-height:1.7;';
+                        text.textContent = trimmed.replace('[Others]', '').trim();
+                        div.appendChild(text);
+                    } else {
+                        div.textContent = trimmed;
+                    }
+                    detailTranscript.appendChild(div);
+                });
+            } else {
+                detailTranscript.style.whiteSpace = 'pre-wrap';
+                detailTranscript.textContent = selectedMeeting.transcript || 'No transcript available';
+            }
             
             // Set reprocess button state based on whether this meeting is currently processing
             const isCurrentlyProcessing = processingMeeting && processingMeeting.session_info?.summary_file === selectedMeeting.session_info?.summary_file;
@@ -5198,15 +5238,18 @@ Session started - waiting for activity...
 
                 _systemAudioStreams = [loopbackStream, micStream];
 
-                // Mix both streams via Web Audio API
+                // Route mic and system audio to separate stereo channels
+                // Left channel = mic (You), Right channel = system audio (Others)
                 _systemAudioContext = new AudioContext();
                 const dest = _systemAudioContext.createMediaStreamDestination();
 
                 const loopbackSource = _systemAudioContext.createMediaStreamSource(loopbackStream);
-                loopbackSource.connect(dest);
-
                 const micSource = _systemAudioContext.createMediaStreamSource(micStream);
-                micSource.connect(dest);
+
+                const merger = _systemAudioContext.createChannelMerger(2);
+                micSource.connect(merger, 0, 0);        // mic → left channel
+                loopbackSource.connect(merger, 0, 1);   // system → right channel
+                merger.connect(dest);
 
                 // Attach analyser for waveform visualization
                 _systemAudioAnalyser = _systemAudioContext.createAnalyser();
@@ -6270,12 +6313,18 @@ Session started - waiting for activity...
         // Copy transcript to clipboard
         copyTranscriptBtn.addEventListener('click', async () => {
             try {
-                const transcriptText = detailTranscript.textContent || '';
+                // Prefer diarised text for copy if available
+                let transcriptText;
+                if (selectedMeeting && selectedMeeting.is_diarised && selectedMeeting.diarised_text) {
+                    transcriptText = selectedMeeting.diarised_text;
+                } else {
+                    transcriptText = detailTranscript.textContent || '';
+                }
                 if (!transcriptText || transcriptText === 'No transcript available') {
                     log('❌ No transcript available to copy');
                     return;
                 }
-                
+
                 await navigator.clipboard.writeText(transcriptText);
                 
                 // Visual feedback

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -190,8 +190,8 @@ class SimpleRecorder:
         config = get_config()
         configured_language = config.get_language()
 
-        # Transcribe (pass Path object, not string)
-        transcript_result = self.transcriber.transcribe_audio(audio_path, language=configured_language)
+        # Transcribe with diarisation support (stereo → [You]/[Others])
+        transcript_result = self.transcriber.transcribe_diarised(audio_path, language=configured_language)
 
         # Handle different return types
         duration_seconds = None
@@ -207,14 +207,22 @@ class SimpleRecorder:
         else:
             transcript_text = str(transcript_result)
 
+        # Extract diarisation fields
+        is_diarised = False
+        diarised_text = None
+        if isinstance(transcript_result, dict):
+            is_diarised = transcript_result.get("is_diarised", False)
+            diarised_text = transcript_result.get("diarised_text")
+
         output_language = self._resolve_output_language(configured_language, detected_language)
         detected_language_name = (
             config.get_language_name(detected_language)
             if detected_language in config.SUPPORTED_LANGUAGES else (detected_language or "Unknown")
         )
 
-        # Save transcript
+        # Save transcript (use diarised text if available for the saved file)
         transcript_path = self.transcripts_dir / f"{audio_path.stem}_transcript.txt"
+        saved_transcript = diarised_text if diarised_text else transcript_text
         transcript_content = f"""Session: {session_name}
 File: {audio_path.name}
 Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
@@ -224,7 +232,7 @@ Summary output language: {config.get_language_name(output_language)}
 
 {'='*60}
 
-{transcript_text}
+{saved_transcript}
 """
 
         with open(transcript_path, 'w') as f:
@@ -240,6 +248,8 @@ Summary output language: {config.get_language_name(output_language)}
             "duration_seconds": duration_seconds,
             "configured_language": configured_language,
             "detected_language": detected_language,
+            "is_diarised": is_diarised,
+            "diarised_text": diarised_text,
             "output_language": output_language,
         }
 
@@ -347,9 +357,10 @@ Transcript:
             duration_minutes = 0
             print("⚠️ Could not determine audio duration")
 
-        # Step 2: Summarize with actual duration
+        # Step 2: Summarize — prefer diarised text so LLM sees speaker labels
+        text_for_summary = transcript_data.get("diarised_text") or transcript_data["transcript_text"]
         summary_data = await self.summarize_transcript(
-            transcript_data["transcript_text"],
+            text_for_summary,
             session_name,
             duration_minutes,
             language=transcript_data.get("output_language")
@@ -391,7 +402,9 @@ Transcript:
             "discussion_areas": summary_data.get("discussion_areas", []) or [],
             "key_points": summary_data.get("key_points", []) or [],
             "action_items": summary_data.get("action_items", []) or [],
-            "transcript": transcript_data["transcript_text"]
+            "transcript": transcript_data["transcript_text"],
+            "is_diarised": transcript_data.get("is_diarised", False),
+            "diarised_text": transcript_data.get("diarised_text"),
         }
         
         with open(summary_path, 'w') as f:
@@ -914,6 +927,8 @@ def list_meetings():
                     "key_points": data.get("key_points", []),
                     "action_items": data.get("action_items", []),
                     "transcript": data.get("transcript", ""),
+                    "is_diarised": data.get("is_diarised", False),
+                    "diarised_text": data.get("diarised_text"),
                     "folders": data.get("folders", [])
                 }
                 meetings.append(essential_meeting)

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -372,7 +372,16 @@ class OllamaSummarizer:
         else:
             language_instruction = ""
 
-        return f"""You are a helpful meeting assistant. Summarise this meeting transcript into participants, discussion areas, key points and any next steps mentioned. Only base your summary on what was explicitly discussed in the transcript.
+        # Add speaker label context when diarised transcript is provided
+        diarisation_note = ""
+        if "[You]" in transcript and "[Others]" in transcript:
+            diarisation_note = """NOTE: This transcript has speaker labels. [You] is the person who recorded
+the meeting. [Others] are remote participants heard through system audio.
+Attribute statements to speakers in your summary where relevant.
+
+"""
+
+        return f"""{diarisation_note}You are a helpful meeting assistant. Summarise this meeting transcript into participants, discussion areas, key points and any next steps mentioned. Only base your summary on what was explicitly discussed in the transcript.
 
 IMPORTANT: Do not infer or assume information that wasn't directly mentioned.
 

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -11,8 +11,9 @@ whisper.cpp is preferred as it's 10x smaller and 2-4x faster.
 import logging
 import os
 import subprocess
+import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -360,6 +361,183 @@ class WhisperTranscriber:
             "detected_language": result.get("language"),
             "detected_language_probability": None,
         }
+
+    def _split_stereo_to_channels(self, audio_filepath: Path) -> Tuple[Optional[Path], Optional[Path], Optional[float]]:
+        """Detect if audio is stereo and split into separate channel files.
+
+        Returns:
+            (mic_path, system_path, duration_seconds) if stereo,
+            (None, None, None) if mono or detection fails.
+        """
+        # Detect channel count via ffprobe
+        try:
+            probe = subprocess.run(
+                ['ffprobe', '-v', 'error', '-select_streams', 'a:0',
+                 '-show_entries', 'stream=channels,duration',
+                 '-of', 'csv=p=0', str(audio_filepath)],
+                capture_output=True, timeout=15, text=True
+            )
+            if probe.returncode != 0:
+                logger.warning(f"ffprobe failed: {probe.stderr}")
+                return None, None, None
+
+            parts = probe.stdout.strip().split(',')
+            channels = int(parts[0])
+            # Duration may be 'N/A' for container formats like WebM
+            duration = None
+            if len(parts) > 1 and parts[1] and parts[1].strip() != 'N/A':
+                try:
+                    duration = float(parts[1])
+                except ValueError:
+                    pass
+
+            if channels < 2:
+                logger.info("Audio is mono, skipping stereo split")
+                return None, None, None
+
+            logger.info(f"Stereo audio detected ({channels} channels), splitting")
+        except Exception as e:
+            logger.warning(f"Channel detection failed: {e}")
+            return None, None, None
+
+        # Split channels into temp files
+        temp_dir = tempfile.gettempdir()
+        mic_path = Path(temp_dir) / f"stenoai_ch0_{audio_filepath.stem}.wav"
+        system_path = Path(temp_dir) / f"stenoai_ch1_{audio_filepath.stem}.wav"
+
+        try:
+            for ch_idx, out_path in [(0, mic_path), (1, system_path)]:
+                result = subprocess.run(
+                    ['ffmpeg', '-y', '-i', str(audio_filepath),
+                     '-af', f'pan=mono|c0=c{ch_idx}',
+                     '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le',
+                     str(out_path)],
+                    capture_output=True, timeout=120
+                )
+                if result.returncode != 0:
+                    logger.error(f"Channel {ch_idx} extraction failed: {result.stderr.decode()}")
+                    return None, None, None
+
+            logger.info("Stereo channels split successfully")
+            return mic_path, system_path, duration
+        except Exception as e:
+            logger.error(f"Channel splitting error: {e}")
+            return None, None, None
+
+    def _check_rms_energy(self, audio_path: Path, threshold: float = 0.005) -> bool:
+        """Check if an audio file has enough energy to contain speech.
+
+        Args:
+            audio_path: Path to 16kHz mono WAV file
+            threshold: RMS energy threshold below which the channel is silent
+
+        Returns:
+            True if the audio has speech-level energy
+        """
+        try:
+            import wave
+            import struct
+            import math
+
+            with wave.open(str(audio_path), 'rb') as wf:
+                n_frames = wf.getnframes()
+                if n_frames == 0:
+                    return False
+                # Read up to 5 seconds of audio for the check
+                sample_frames = min(n_frames, 16000 * 5)
+                raw = wf.readframes(sample_frames)
+
+            samples = struct.unpack(f'<{sample_frames}h', raw)
+            # Normalise int16 to [-1, 1]
+            float_samples = [s / 32768.0 for s in samples]
+            rms = math.sqrt(sum(s * s for s in float_samples) / len(float_samples))
+            logger.info(f"RMS energy for {audio_path.name}: {rms:.6f} (threshold {threshold})")
+            return rms >= threshold
+        except Exception as e:
+            logger.warning(f"RMS check failed for {audio_path}: {e}")
+            # If we can't check, assume it has audio
+            return True
+
+    def transcribe_diarised(self, audio_filepath: Path, language: str = "en") -> Optional[dict]:
+        """Transcribe audio with stereo channel diarisation.
+
+        If the audio is stereo (left=mic, right=system), each channel is
+        transcribed separately and labelled as [You] and [Others].
+
+        Falls back to normal transcription for mono audio.
+
+        Args:
+            audio_filepath: Path to the audio file
+            language: Language code
+
+        Returns:
+            Dict with text, diarised_text, is_diarised, plus standard fields
+        """
+        # Try stereo split
+        mic_path, system_path, duration = self._split_stereo_to_channels(audio_filepath)
+
+        if mic_path is None:
+            # Mono audio — use standard transcription
+            result = self.transcribe_audio(audio_filepath, language)
+            if result:
+                result['is_diarised'] = False
+                result['diarised_text'] = None
+            return result
+
+        try:
+            mic_has_audio = self._check_rms_energy(mic_path)
+            system_has_audio = self._check_rms_energy(system_path)
+
+            mic_text = ""
+            system_text = ""
+
+            if mic_has_audio:
+                logger.info("Transcribing mic channel (You)...")
+                mic_result = self.transcribe_audio(mic_path, language)
+                if mic_result and mic_result.get("text"):
+                    mic_text = mic_result["text"]
+            else:
+                logger.info("Mic channel is silent, skipping")
+
+            if system_has_audio:
+                logger.info("Transcribing system channel (Others)...")
+                sys_result = self.transcribe_audio(system_path, language)
+                if sys_result and sys_result.get("text"):
+                    system_text = sys_result["text"]
+            else:
+                logger.info("System channel is silent, skipping")
+
+            # Build combined plain text and labelled text
+            plain_parts = []
+            labelled_parts = []
+
+            if mic_text:
+                plain_parts.append(mic_text)
+                labelled_parts.append(f"[You] {mic_text}")
+            if system_text:
+                plain_parts.append(system_text)
+                labelled_parts.append(f"[Others] {system_text}")
+
+            plain_text = "\n\n".join(plain_parts) if plain_parts else "No speech detected in audio"
+            diarised_text = "\n\n".join(labelled_parts) if labelled_parts else None
+            is_diarised = bool(diarised_text)
+
+            return {
+                "text": plain_text,
+                "diarised_text": diarised_text,
+                "is_diarised": is_diarised,
+                "duration_seconds": duration,
+                "detected_language": None,
+                "detected_language_probability": None,
+            }
+        finally:
+            # Clean up temp channel files
+            for p in (mic_path, system_path):
+                if p and p.exists():
+                    try:
+                        p.unlink()
+                    except Exception:
+                        pass
 
     def transcribe_with_timestamps(self, audio_filepath: Path) -> Optional[dict]:
         """


### PR DESCRIPTION
## Summary
- Routes mic and system audio to separate stereo channels (left=You, right=Others) via Web Audio API `ChannelMergerNode` instead of mono mixing
- Backend detects stereo via ffprobe, splits channels with ffmpeg, skips silent channels (RMS energy check), and transcribes each independently with `[You]`/`[Others]` labels
- Summarizer prompt updated to attribute statements to speakers when diarised labels are present
- UI renders diarised transcripts with styled speaker badges (indigo for You, neutral for Others) and colored left borders; "Copy Transcript" copies the labelled format
- Mono recordings (mic-only, dropped files) fall through to existing path with no changes

## Files changed
- `app/index.html` — stereo routing in Web Audio API + diarised transcript rendering
- `src/transcriber.py` — `_split_stereo_to_channels()`, `_check_rms_energy()`, `transcribe_diarised()`
- `simple_recorder.py` — pipeline wiring, output JSON fields, `list-meetings` whitelist
- `src/summarizer.py` — speaker-aware prompt injection

## Test plan
- [x] Enable "Record system audio", record with headphones, verify `[You]`/`[Others]` labels in transcript
- [x] Verify styled speaker badges render in transcript UI
- [x] Verify "Copy Transcript" copies labelled text
- [x] Verify summary references speakers
- [x] Test mic-only recording still works (mono fallback, no regression)
- [x] Test with a dropped audio file (mono fallback)
- [x] Verify old meetings without diarisation still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)