### PR TITLE
fix: reprocess with streaming summaries and user notes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6272,35 +6272,14 @@ Session started - waiting for activity...
             log(`🔄 Reprocessing meeting: ${meetingBeingProcessed.session_info?.name}`);
             
             try {
-                // Call main process to reprocess the meeting
-                const result = await ipcRenderer.invoke('reprocess-meeting', summaryFile, regenerateTitle);
-                
-                if (result.success) {
-                    log('✅ Meeting reprocessed successfully');
-                    
-                    // Send notification for reprocessing completion
-                    showDesktopNotification('StenoAI - Reprocessing Complete', {
-                        body: `"${meetingBeingProcessed.session_info?.name || 'Meeting'}" has been reanalyzed`,
-                        requireInteraction: false
-                    }, () => {
-                        const idx = filteredMeetings.findIndex(m => m.session_info?.summary_file === summaryFile);
-                        if (idx !== -1) selectMeeting(idx);
-                    });
-                    
-                    // Reload meetings to show updated data
-                    await loadMeetings(true);
-                    // Re-select the current meeting to show updated content
-                    const updatedMeetingIndex = filteredMeetings.findIndex(m => 
-                        m.session_info?.summary_file === summaryFile
-                    );
-                    if (updatedMeetingIndex !== -1) {
-                        selectMeeting(updatedMeetingIndex);
-                    }
-                } else {
-                    log(`❌ Reprocessing failed: ${result.error}`);
+                // Kick off streaming reprocess (events will handle UI updates)
+                const result = await ipcRenderer.invoke('reprocess-meeting', summaryFile, regenerateTitle, meetingName);
+
+                if (!result.success) {
+                    log(`Reprocessing failed: ${result.error}`);
                 }
             } catch (error) {
-                log(`❌ Reprocessing error: ${error.message}`);
+                log(`Reprocessing error: ${error.message}`);
             } finally {
                 // Clear processing tracker
                 processingMeeting = null;
@@ -6308,13 +6287,11 @@ Session started - waiting for activity...
                     processingMeetings.delete(meetingName);
                     renderMeetingsList();
                 }
-                
-                // Reset button state only if we're still viewing the same meeting
-                if (selectedMeeting && selectedMeeting.session_info?.summary_file === summaryFile) {
-                    reprocessBtn.disabled = false;
-                    reprocessBtn.classList.remove('processing');
-                    reprocessBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>';
-                }
+
+                // Reset button state
+                reprocessBtn.disabled = false;
+                reprocessBtn.classList.remove('processing');
+                reprocessBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>';
             }
         });
 
@@ -7273,10 +7250,14 @@ Session started - waiting for activity...
                         }
                         // Keep sections hidden — streaming view IS the meeting view
                         document.querySelectorAll('#meeting-detail .meeting-section').forEach(s => s.style.display = 'none');
-                        // Show action buttons
+                        // Show action buttons and reset reprocess button state
                         document.getElementById('ask-ai-btn').style.display = '';
                         document.getElementById('copy-notes-btn').style.display = '';
-                        document.getElementById('reprocess-btn').style.display = '';
+                        const rpBtn = document.getElementById('reprocess-btn');
+                        rpBtn.style.display = '';
+                        rpBtn.disabled = false;
+                        rpBtn.classList.remove('processing');
+                        rpBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>';
                         streamingActive = false;
                         // Store selectedMeeting for Ask Steno etc.
                         const meetingIdx = filteredMeetings.findIndex(m =>

--- a/app/main.js
+++ b/app/main.js
@@ -1058,7 +1058,7 @@ ipcMain.handle('clear-state', async () => {
   }
 });
 
-ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle) => {
+ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, sessionName) => {
   try {
     const args = ['reprocess', summaryFile];
     if (regenerateTitle) args.push('--regenerate-title');
@@ -1067,11 +1067,80 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle) 
     sendDebugLog(`$ stenoai ${args.join(' ')}`);
 
     const cloudKey = loadCloudApiKey();
-    const env = cloudKey ? { STENOAI_CLOUD_API_KEY: cloudKey } : {};
-    const result = await runPythonScript('simple_recorder.py', args, false, env);
+    const reprocessEnv = cloudKey ? { ...require('process').env, STENOAI_CLOUD_API_KEY: cloudKey } : undefined;
+
+    await new Promise((resolve, reject) => {
+      const proc = spawn(getBackendPath(), args, {
+        cwd: getBackendCwd(),
+        env: reprocessEnv
+      });
+
+      let stderrBuf = '';
+
+      const procTimeout = setTimeout(() => {
+        console.error('reprocess timed out after 30 minutes, killing');
+        proc.kill();
+      }, 30 * 60 * 1000);
+
+      proc.on('error', (err) => {
+        clearTimeout(procTimeout);
+        reject(new Error(`reprocess spawn error: ${err.message}`));
+      });
+
+      proc.stdout.on('data', (data) => {
+        const text = data.toString();
+        text.split('\n').forEach(line => {
+          if (line.startsWith('CHUNK:')) {
+            try {
+              const encoded = line.slice(6);
+              const chunk = Buffer.from(encoded, 'base64').toString('utf-8');
+              if (mainWindow && !mainWindow.isDestroyed()) {
+                mainWindow.webContents.send('summary-chunk', { chunk, sessionName });
+              }
+            } catch (e) { console.log('CHUNK decode error:', e.message); }
+          } else if (line.startsWith('TITLE:')) {
+            const title = line.slice(6);
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('summary-title', { title, sessionName });
+            }
+          } else if (line === 'STREAM_COMPLETE') {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('summary-complete', { success: true, sessionName });
+            }
+          } else if (line.trim()) {
+            sendDebugLog(line.trim());
+          }
+        });
+      });
+
+      proc.stderr.on('data', (data) => {
+        const msg = data.toString().trim();
+        if (msg) {
+          stderrBuf += msg + '\n';
+          sendDebugLog(`STDERR: ${msg}`);
+        }
+      });
+
+      proc.on('close', (code) => {
+        clearTimeout(procTimeout);
+        if (code === 0) {
+          console.log(`✅ Completed reprocessing: ${sessionName}`);
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('processing-complete', {
+              success: true,
+              sessionName,
+              message: 'Reprocessing completed successfully'
+            });
+          }
+          resolve();
+        } else {
+          reject(new Error(`reprocess exited with code ${code}: ${stderrBuf.slice(-500)}`));
+        }
+      });
+    });
 
     sendDebugLog('✅ Meeting reprocessed successfully');
-    return { success: true, message: result };
+    return { success: true };
   } catch (error) {
     sendDebugLog(`❌ Reprocessing failed: ${error.message}`);
     return { success: false, error: error.message };

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1398,144 +1398,144 @@ def reprocess(summary_file, regenerate_title):
     import json
     from pathlib import Path
 
-    async def run_reprocess():
-        recorder = SimpleRecorder()
-        summary_path = Path(summary_file)
+    import base64
 
-        if not summary_path.exists():
-            print(f"ERROR: Summary file not found: {summary_file}")
+    recorder = SimpleRecorder()
+    summary_path = Path(summary_file)
+
+    if not summary_path.exists():
+        print(f"ERROR: Summary file not found: {summary_file}")
+        sys.exit(1)
+
+    try:
+        # Load existing summary file (JSON or MD)
+        if summary_path.suffix == '.md':
+            existing_data = _parse_meeting_markdown(summary_path)
+        else:
+            with open(summary_path, 'r') as f:
+                existing_data = json.load(f)
+
+        # Get transcript from the data
+        transcript = existing_data.get('transcript', '')
+        if not transcript:
+            print("ERROR: No transcript found in summary file")
             sys.exit(1)
 
-        try:
-            # Load existing summary file (JSON or MD)
-            if summary_path.suffix == '.md':
-                existing_data = _parse_meeting_markdown(summary_path)
-            else:
-                with open(summary_path, 'r') as f:
-                    existing_data = json.load(f)
+        session_name = existing_data.get('session_info', {}).get('name', 'Reprocessed')
+        duration_minutes = existing_data.get('session_info', {}).get('duration_minutes', 10)
+        if duration_minutes is None:
+            ds = existing_data.get('session_info', {}).get('duration_seconds')
+            duration_minutes = int(ds / 60) if ds else 10
 
-            # Get transcript from the data
-            transcript = existing_data.get('transcript', '')
-            if not transcript:
-                print("ERROR: No transcript found in summary file")
-                sys.exit(1)
+        # Load user notes from the meeting data
+        notes_text = existing_data.get('user_notes')
 
-            session_name = existing_data.get('session_info', {}).get('name', 'Reprocessed')
-            duration_minutes = existing_data.get('session_info', {}).get('duration_minutes', 10)
-            if duration_minutes is None:
-                ds = existing_data.get('session_info', {}).get('duration_seconds')
-                duration_minutes = int(ds / 60) if ds else 10
+        print(f"Reprocessing summary for: {session_name}")
+        print(f"Transcript length: {len(transcript)} characters")
+        if notes_text:
+            print(f"User notes: {len(notes_text)} characters")
 
-            print(f"🔄 Reprocessing summary for: {session_name}")
-            print(f"📝 Transcript length: {len(transcript)} characters")
-
-            # Re-run summarization
-            existing_session_info = existing_data.get("session_info", {})
-            output_language = existing_session_info.get("output_language")
-            if not output_language:
-                configured_language = existing_session_info.get("configured_language")
-                if not configured_language:
-                    from src.config import get_config
-                    configured_language = get_config().get_language()
-                output_language = recorder._resolve_output_language(
-                    configured_language,
-                    existing_session_info.get("detected_language")
-                )
-
-            summary_data = await recorder.summarize_transcript(
-                transcript,
-                session_name,
-                duration_minutes,
-                language=output_language
+        # Resolve output language
+        existing_session_info = existing_data.get("session_info", {})
+        output_language = existing_session_info.get("output_language")
+        if not output_language:
+            configured_language = existing_session_info.get("configured_language")
+            if not configured_language:
+                from src.config import get_config
+                configured_language = get_config().get_language()
+            output_language = recorder._resolve_output_language(
+                configured_language,
+                existing_session_info.get("detected_language")
             )
 
-            # Update the existing data with new summary
-            existing_data.update({
-                "summary": summary_data.get("summary", "") or "",
-                "participants": summary_data.get("participants", []) or [],
-                "discussion_areas": summary_data.get("discussion_areas", []) or [],
-                "key_points": summary_data.get("key_points", []) or [],
-                "action_items": summary_data.get("action_items", []) or [],
-            })
+        # Use streaming summarization (same as new recordings)
+        if recorder.summarizer is None:
+            from src.summarizer import OllamaSummarizer
+            recorder.summarizer = OllamaSummarizer()
 
-            # Regenerate title if requested
-            if regenerate_title:
-                try:
-                    generated_title = recorder.summarizer.generate_title(
-                        summary_data.get("summary", ""),
-                        transcript,
-                        language=output_language
-                    )
-                    if generated_title:
-                        existing_data["session_info"]["name"] = generated_title
-                        print(f"Auto-generated title: {generated_title}")
-                except Exception as e:
-                    print(f"Title regeneration skipped: {e}")
+        print("Generating summary...", flush=True)
+        streamed_chunks = []
+        for chunk in recorder.summarizer.summarize_transcript_streaming(
+            transcript, duration_minutes, output_language, notes_text
+        ):
+            encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
+            sys.stdout.write(f"CHUNK:{encoded}\n")
+            sys.stdout.flush()
+            streamed_chunks.append(chunk)
+        streamed_md = ''.join(streamed_chunks)
 
-            # Add reprocess timestamp
-            existing_data["session_info"]["reprocessed_at"] = datetime.now().isoformat()
+        print("STREAM_COMPLETE", flush=True)
 
-            # Save updated summary (format matches input file)
-            if summary_path.suffix == '.md':
-                session_name = existing_data.get('session_info', {}).get('name', 'Reprocessed')
-                md_lines = ['---']
-                md_meta = {
-                    'title': session_name,
-                    'date': existing_data.get('session_info', {}).get('processed_at', datetime.now().isoformat()),
-                    'duration_seconds': existing_data.get('session_info', {}).get('duration_seconds'),
-                    'language': output_language,
-                    'is_diarised': existing_data.get('is_diarised', False),
-                }
-                for k, v in md_meta.items():
-                    if v is None:
-                        md_lines.append(f'{k}: null')
-                    elif isinstance(v, bool):
-                        md_lines.append(f'{k}: {"true" if v else "false"}')
-                    elif isinstance(v, int):
-                        md_lines.append(f'{k}: {v}')
-                    else:
-                        escaped = str(v).replace('\\', '\\\\').replace('"', '\\"')
-                        md_lines.append(f'{k}: "{escaped}"')
-                md_lines.append('---')
+        # Regenerate title if requested
+        if regenerate_title:
+            try:
+                generated_title = recorder.summarizer.generate_title(
+                    streamed_md, transcript, language=output_language
+                )
+                if generated_title:
+                    session_name = generated_title
+                    existing_data["session_info"]["name"] = generated_title
+                    print(f"TITLE:{session_name}", flush=True)
+                    print(f"Auto-generated title: {session_name}")
+            except Exception as e:
+                print(f"Title regeneration skipped: {e}")
+
+        # Add reprocess timestamp
+        existing_data["session_info"]["reprocessed_at"] = datetime.now().isoformat()
+
+        # Save updated summary
+        if summary_path.suffix == '.md':
+            session_name = existing_data.get('session_info', {}).get('name', 'Reprocessed')
+            md_lines = ['---']
+            md_meta = {
+                'title': session_name,
+                'date': existing_data.get('session_info', {}).get('processed_at', datetime.now().isoformat()),
+                'duration_seconds': existing_data.get('session_info', {}).get('duration_seconds'),
+                'language': output_language,
+                'is_diarised': existing_data.get('is_diarised', False),
+            }
+            for k, v in md_meta.items():
+                if v is None:
+                    md_lines.append(f'{k}: null')
+                elif isinstance(v, bool):
+                    md_lines.append(f'{k}: {"true" if v else "false"}')
+                elif isinstance(v, int):
+                    md_lines.append(f'{k}: {v}')
+                else:
+                    escaped = str(v).replace('\\', '\\\\').replace('"', '\\"')
+                    md_lines.append(f'{k}: "{escaped}"')
+            md_lines.append('---')
+            md_lines.append('')
+            # Write the raw streamed markdown (preserves LLM formatting)
+            md_lines.append(streamed_md)
+            md_lines.append('')
+            md_lines.append('## Transcript')
+            md_lines.append('')
+            md_lines.append(transcript)
+            if notes_text:
                 md_lines.append('')
-                # Rebuild markdown from structured data
-                md_lines.append(f"## Summary\n{existing_data.get('summary', '')}")
-                participants = existing_data.get('participants', [])
-                if participants:
-                    md_lines.append(f"\n## Participants\n{', '.join(participants)}")
-                areas = existing_data.get('discussion_areas', [])
-                if areas:
-                    md_lines.append('\n## Key Topics')
-                    for a in areas:
-                        md_lines.append(f"### {a.get('title', '')}\n{a.get('analysis', '')}")
-                points = existing_data.get('key_points', [])
-                if points:
-                    md_lines.append('\n## Key Points')
-                    for p in points:
-                        md_lines.append(f"- {p}")
-                items = existing_data.get('action_items', [])
-                if items:
-                    md_lines.append('\n## Action Items')
-                    for i in items:
-                        md_lines.append(f"- {i}")
-                if transcript:
-                    md_lines.append(f"\n## Transcript\n{transcript}")
-                notes = existing_data.get('user_notes')
-                if notes:
-                    md_lines.append(f"\n## User Notes\n{notes}")
-                summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
-            else:
-                with open(summary_path, 'w') as f:
-                    json.dump(existing_data, f, indent=2)
+                md_lines.append('## User Notes')
+                md_lines.append('')
+                md_lines.append(notes_text)
+            summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
+        else:
+            # JSON format: parse streamed markdown into structured fields
+            parsed = recorder._parse_streamed_markdown(streamed_md)
+            existing_data.update({
+                "summary": parsed.get("summary", "") or "",
+                "participants": parsed.get("participants", []) or [],
+                "discussion_areas": parsed.get("discussion_areas", []) or [],
+                "key_points": parsed.get("key_points", []) or [],
+                "action_items": parsed.get("action_items", []) or [],
+            })
+            with open(summary_path, 'w') as f:
+                json.dump(existing_data, f, indent=2)
 
-            print(f"✅ Summary reprocessed successfully: {summary_path}")
-            print(f"📋 New summary: {existing_data['summary'][:100]}...")
+        print(f"Summary reprocessed successfully: {summary_path}")
 
-        except Exception as e:
-            print(f"ERROR: Failed to reprocess summary: {e}")
-            sys.exit(1)
-
-    asyncio.run(run_reprocess())
+    except Exception as e:
+        print(f"ERROR: Failed to reprocess summary: {e}")
+        sys.exit(1)
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- Reprocess command now uses streaming summarization (same as new recordings) instead of the non-streaming path
- User notes from `.md` files are passed to the LLM prompt during reprocess
- Electron handler uses spawn with `CHUNK:`/`STREAM_COMPLETE`/`TITLE:` protocol for live UI streaming
- Saves raw streamed markdown instead of lossy parse-then-reconstruct
- Fixes reprocess button stuck in "Processing..." state after completion

## Test plan
- [x] Record a meeting with user notes, then reprocess — verify notes influence the new summary
- [x] Reprocess a meeting and verify streaming output appears in the UI
- [x] Verify reprocess button resets to normal state after completion
- [x] Verify normal recording + processing still works end-to-end
- [x] Test reprocess on older JSON-format meetings still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches reprocess to streaming summarization with live updates and support for user notes. Saves the raw streamed markdown and fixes the reprocess button getting stuck.

- **New Features**
  - Reprocess now uses the streaming path and forwards `CHUNK:`, `STREAM_COMPLETE`, and `TITLE:` events from a spawned backend process.
  - Includes user notes from `.md` files in the prompt; can regenerate the title from streamed output.
  - Writes raw streamed markdown for `.md`; for `.json`, parses it into structured fields.

- **Bug Fixes**
  - Reprocess button reliably resets and reappears after completion.

<sup>Written for commit 83942d145ebcec641da7430e7633750a38dbe7fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

