### PR TITLE
Update test_transcriber.py

### DIFF
--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -42,6 +42,22 @@ class WhisperTranscriberAutoLanguageTests(unittest.TestCase):
         self.assertIsNone(result["detected_language"])
         self.assertNotIn("language", model.transcribe.call_args.kwargs)
 
+    def test_explicit_language_skips_auto_detection(self):
+        model = Mock()
+        segment = Mock()
+        segment.text = " Bonjour "
+        model.transcribe.return_value = [segment]
+
+        transcriber = self._build_transcriber(model)
+        result = transcriber._transcribe_whisper_cpp(
+            Path("/tmp/stenoai-test.wav"),
+            language="fr",
+        )
+
+        self.assertEqual(result["text"], "Bonjour")
+        self.assertIsNone(result["detected_language"])
+        model.auto_detect_language.assert_not_called()
+        self.assertEqual(model.transcribe.call_args.kwargs.get("language"), "fr")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Added one additional test for French with `Bonjour `.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test to verify explicit language handling. When language='fr', the transcriber skips auto detection, passes 'fr' to model.transcribe, trims ' Bonjour ' to 'Bonjour', and leaves detected_language unset.

<sup>Written for commit a9fa6edd0107cfcecf50d14c56b5f07b0a2d1d86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

