### PR TITLE
feat: notes generation animation, inline title editing, and UI polish

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1094,7 +1094,7 @@
         
         /* Sidebar with meetings list */
         .sidebar {
-            width: 320px;
+            width: 250px;
             background: var(--bg-primary);
             border-right: 1px solid var(--border-subtle);
             display: flex;
@@ -1130,7 +1130,7 @@
 
         .sidebar-toggle {
             position: fixed;
-            left: 319px;
+            left: 249px;
             top: 50%;
             transform: translateY(-50%);
             width: 24px;

--- a/app/index.html
+++ b/app/index.html
@@ -8435,6 +8435,8 @@ Session started - waiting for activity...
                     hideAiQueryPopup();
                 } else if (settingsVisible) {
                     toggleSettings();
+                } else if (activeQueryId) {
+                    askBarStop.click();
                 }
             }
         });
@@ -9133,10 +9135,7 @@ Session started - waiting for activity...
         // ── Streaming Summary Rendering ──
         let streamedMarkdown = '';
         let streamingActive = false;
-
-        function escapeHtml(str) {
-            return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-        }
+        let scannerRafPending = false;
 
         function renderStreamingMarkdown(md) {
             const container = document.getElementById('streaming-output');
@@ -9186,7 +9185,16 @@ Session started - waiting for activity...
             const scanner = document.getElementById('generation-scanner');
             if (scanner) {
                 scanner.style.display = 'flex';
-                scanner.style.top = (container.scrollHeight - 14) + 'px';
+                if (!scannerRafPending) {
+                    scannerRafPending = true;
+                    requestAnimationFrame(() => {
+                        scannerRafPending = false;
+                        const s = document.getElementById('generation-scanner');
+                        if (s && s.style.display !== 'none') {
+                            s.style.top = Math.max(0, container.scrollHeight - 40) + 'px';
+                        }
+                    });
+                }
             }
 
             const detailPanel = document.getElementById('meeting-detail');
@@ -9195,6 +9203,7 @@ Session started - waiting for activity...
 
         function stopStreamingRenderer() {
             streamingActive = false;
+            scannerRafPending = false;
             const scanner = document.getElementById('generation-scanner');
             if (scanner) scanner.style.display = 'none';
         }

--- a/app/index.html
+++ b/app/index.html
@@ -155,10 +155,12 @@
             background: transparent;
             border: 1px solid var(--border-subtle);
             color: var(--text-muted);
-            padding: 8px 12px;
+            padding: 6px 10px;
             border-radius: 8px;
             cursor: pointer;
-            font-size: 16px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
             transition: all 0.2s ease;
         }
 
@@ -1183,7 +1185,7 @@
         }
 
         .search-input {
-            background: var(--bg-surface);
+            background: var(--bg-elevated);
             border: 1px solid var(--border-subtle);
             color: var(--text-primary);
             padding: 7px 12px 7px 30px;
@@ -1197,12 +1199,15 @@
 
         .search-input:focus {
             border-color: var(--accent-primary);
-            background: var(--bg-elevated);
-            box-shadow: 0 0 0 3px var(--accent-glow);
+            box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.18);
         }
 
         .search-input::placeholder {
             color: var(--text-muted);
+        }
+
+        [data-theme="light"] .search-input {
+            background: var(--bg-deep);
         }
         
         .sidebar-header p {
@@ -1920,6 +1925,28 @@
             position: relative;
         }
 
+        .generation-scanner {
+            display: none;
+            align-items: center;
+            padding: 0 12px;
+            position: absolute;
+            left: -12px;
+            right: -12px;
+            height: 44px;
+            background: var(--bg-primary);
+            border-radius: 8px;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15), 0 1px 4px rgba(0, 0, 0, 0.08);
+            pointer-events: none;
+            transition: top 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+            z-index: 2;
+        }
+
+        .generation-scanner-label {
+            font-size: 12px;
+            color: var(--text-primary);
+        }
+
+
         .notes-content {
             outline: none;
             font-size: 15px;
@@ -1954,9 +1981,9 @@
             font-family: Charter, 'Iowan Old Style', Georgia, 'Times New Roman', serif;
             color: var(--text-primary);
             margin: 0;
-            flex: 1;
             letter-spacing: -0.02em;
             line-height: 1.25;
+            display: inline;
         }
         
         .reprocess-btn {
@@ -1991,19 +2018,8 @@
             opacity: 0.5;
         }
 
-        .reprocess-btn.processing {
-            background: var(--warning-amber);
-            color: var(--bg-deep);
-            border-color: var(--warning-amber);
-        }
-        
-        .reprocess-spinner {
-            width: 14px;
-            height: 14px;
-            border: 2px solid transparent;
-            border-top: 2px solid currentColor;
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
+        .reprocess-btn.processing svg {
+            animation: spin 0.8s linear infinite;
         }
         
         #transcript-section {
@@ -2075,21 +2091,9 @@
         }
 
         .meeting-title-container {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            flex: 0;
-            max-width: fit-content;
+            flex: 1;
         }
 
-        .meeting-title {
-            margin: 0;
-            color: var(--text-primary);
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            max-width: 600px;
-        }
 
         .meeting-title-input {
             background: var(--bg-elevated);
@@ -2108,28 +2112,9 @@
             background: var(--bg-surface);
         }
 
-        .edit-title-btn {
-            background: transparent;
-            border: 1px solid var(--border-default);
-            color: var(--text-muted);
-            padding: 6px;
-            border-radius: 4px;
-            cursor: pointer;
-            transition: all 0.2s;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            opacity: 0;
-        }
-
-        .meeting-title-container:hover .edit-title-btn {
-            opacity: 1;
-        }
-
-        .edit-title-btn:hover {
-            background: var(--bg-surface);
-            border-color: var(--border-default);
-            color: var(--text-primary);
+        .meeting-title[contenteditable] {
+            cursor: text;
+            outline: none;
         }
 
         .title-edit-actions {
@@ -3281,7 +3266,7 @@
             position: sticky;
             bottom: 0;
             z-index: 10;
-            padding: 16px 0 24px;
+            padding: 16px 32px 24px;
         }
 
         .ask-bar::before {
@@ -4331,13 +4316,7 @@
                 <div class="meeting-header">
                     <div class="meeting-header-top">
                         <div class="meeting-title-container">
-                            <h1 class="meeting-title" id="detail-title">Meeting Title</h1>
-                            <button class="edit-title-btn" id="edit-title-btn" title="Edit meeting name">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-                                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-                                </svg>
-                            </button>
+                            <h1 class="meeting-title" id="detail-title" contenteditable="true" spellcheck="false">Meeting Title</h1>
                         </div>
                         <div style="display: flex; gap: 8px; align-items: center;">
                             <button class="ask-ai-btn" id="ask-ai-btn" title="Ask Steno about this meeting">
@@ -4379,6 +4358,10 @@ Ask Steno
                     <div class="notes-content" id="notes-content" contenteditable="true" spellcheck="true"
                          data-placeholder="Type your notes here..."></div>
                     <div class="streaming-output" id="streaming-output" style="display: none;"></div>
+                    <div class="generation-scanner" id="generation-scanner">
+                        <div class="meeting-item-spinner" style="margin-right:7px;"></div>
+                        <span class="generation-scanner-label" id="generation-scanner-label">Analyzing transcript</span>
+                    </div>
                 </div>
 
                 <div class="meeting-section">
@@ -5230,7 +5213,6 @@ Session started - waiting for activity...
         const reprocessBtn = document.getElementById('reprocess-btn');
         const copyTranscriptBtn = document.getElementById('copy-transcript-btn');
         const copyNotesBtn = document.getElementById('copy-notes-btn');
-        const editTitleBtn = document.getElementById('edit-title-btn');
 
         // AI Query elements
         const askAiBtn = document.getElementById('ask-ai-btn');
@@ -7487,10 +7469,24 @@ Session started - waiting for activity...
                 renderMeetingsList();
             }
 
-            // Show processing state
+            // Show processing state — spin the icon, clear existing notes immediately
             reprocessBtn.disabled = true;
             reprocessBtn.classList.add('processing');
-            reprocessBtn.innerHTML = '<div class="reprocess-spinner"></div>Processing...';
+
+            streamedMarkdown = '';
+            document.getElementById('streaming-output').textContent = '';
+            document.querySelectorAll('#meeting-detail .meeting-section').forEach(s => s.style.display = 'none');
+            document.getElementById('notes-editor').style.display = 'block';
+            document.getElementById('streaming-output').style.display = 'block';
+
+            // Show scanner immediately in "analyzing" state
+            const scannerEl = document.getElementById('generation-scanner');
+            const scannerLabel = document.getElementById('generation-scanner-label');
+            if (scannerEl) {
+                scannerEl.style.display = 'flex';
+                scannerEl.style.top = '0px';
+            }
+            if (scannerLabel) scannerLabel.textContent = 'Analyzing transcript';
 
             const meetingBeingProcessed = selectedMeeting; // Capture the meeting being processed
             log(`🔄 Reprocessing meeting: ${meetingBeingProcessed.session_info?.name}`);
@@ -7515,7 +7511,6 @@ Session started - waiting for activity...
                 // Reset button state
                 reprocessBtn.disabled = false;
                 reprocessBtn.classList.remove('processing');
-                reprocessBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>';
             }
         });
 
@@ -8463,101 +8458,66 @@ Session started - waiting for activity...
         setupCopyLogBtn('copy-setup-log-btn', 'debug-console');
         setupCopyLogBtn('copy-debug-log-btn', 'debug-console-panel');
 
-        // Edit meeting title - define as a reusable function
-        function startEditingTitle() {
-            if (!selectedMeeting) return;
-
+        // Inline contenteditable title editing
+        (function setupTitleEditing() {
             const titleElement = document.getElementById('detail-title');
-            const editBtn = document.getElementById('edit-title-btn');
-            const currentTitle = titleElement.textContent;
+            let originalTitle = '';
+            let pendingTitle = '';
+            let editingMeeting = null;
 
-            // Hide title and edit button
-            titleElement.style.display = 'none';
-            editBtn.style.display = 'none';
+            titleElement.addEventListener('focus', () => {
+                if (!selectedMeeting) { titleElement.blur(); return; }
+                editingMeeting = selectedMeeting;
+                originalTitle = titleElement.textContent;
+                pendingTitle = originalTitle;
+            });
 
-            // Create input and buttons
-            const titleContainer = document.querySelector('.meeting-title-container');
-            const inputHTML = `
-                <input type="text" class="meeting-title-input" id="title-input" value="${currentTitle}">
-                <div class="title-edit-actions">
-                    <button class="save-title-btn" id="save-title-btn">Save</button>
-                    <button class="cancel-title-btn" id="cancel-title-btn">Cancel</button>
-                </div>
-            `;
-            titleContainer.insertAdjacentHTML('beforeend', inputHTML);
+            // Track edits as they happen so blur always has the latest value
+            titleElement.addEventListener('input', () => {
+                pendingTitle = titleElement.textContent;
+            });
 
-            const titleInput = document.getElementById('title-input');
-            const saveTitleBtn = document.getElementById('save-title-btn');
-            const cancelTitleBtn = document.getElementById('cancel-title-btn');
-
-            // Focus and select the input
-            titleInput.focus();
-            titleInput.select();
-
-            // Save on Enter key
-            titleInput.addEventListener('keydown', (e) => {
+            titleElement.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter') {
-                    saveTitleBtn.click();
+                    e.preventDefault();
+                    titleElement.blur();
                 } else if (e.key === 'Escape') {
-                    cancelTitleBtn.click();
+                    pendingTitle = originalTitle;
+                    titleElement.textContent = originalTitle;
+                    titleElement.blur();
                 }
             });
 
-            // Cancel function
-            const cancelEdit = () => {
-                titleInput.remove();
-                document.querySelector('.title-edit-actions').remove();
-                titleElement.style.display = '';
-                editBtn.style.display = '';
-            };
+            titleElement.addEventListener('blur', async () => {
+                if (!editingMeeting) return;
+                const meeting = editingMeeting;
+                const newTitle = pendingTitle.trim();
+                editingMeeting = null;
+                pendingTitle = '';
 
-            // Save function
-            const saveTitle = async () => {
-                const newTitle = titleInput.value.trim();
-                if (!newTitle || newTitle === currentTitle) {
-                    cancelEdit();
+                if (!newTitle || newTitle === originalTitle) {
+                    if (!newTitle) titleElement.textContent = originalTitle;
                     return;
                 }
-
                 try {
                     const result = await ipcRenderer.invoke('update-meeting',
-                        selectedMeeting.session_info.summary_file,
+                        meeting.session_info.summary_file,
                         { name: newTitle }
                     );
-
                     if (result.success) {
-                        // Update local data
-                        selectedMeeting.session_info.name = newTitle;
-
-                        // Update the SAME title element (keeps detailTitle reference valid)
-                        titleElement.textContent = newTitle;
-
-                        // Remove input and show title again
-                        titleInput.remove();
-                        document.querySelector('.title-edit-actions').remove();
-                        titleElement.style.display = '';
-                        editBtn.style.display = '';
-
-                        // Reload meetings list to show updated name
+                        meeting.session_info.name = newTitle;
                         await loadMeetings(true);
-
                         log(`✏️ Meeting name updated to: ${newTitle}`);
                     } else {
+                        titleElement.textContent = originalTitle;
                         log(`❌ Failed to update meeting name: ${result.error}`);
-                        cancelEdit();
                     }
                 } catch (error) {
+                    titleElement.textContent = originalTitle;
                     log(`❌ Error updating meeting name: ${error.message}`);
-                    cancelEdit();
                 }
-            };
-
-            cancelTitleBtn.addEventListener('click', cancelEdit);
-            saveTitleBtn.addEventListener('click', saveTitle);
-        }
-
-        // Attach the initial event listener
-        editTitleBtn.addEventListener('click', startEditingTitle);
+            });
+        })();
 
         // Listen for debug messages from backend
         ipcRenderer.on('debug-log', (event, message) => {
@@ -9059,6 +9019,9 @@ Session started - waiting for activity...
                 } else if (line.startsWith('### ')) {
                     if (inList) { html += '</ul>'; inList = false; }
                     html += `<h3 style="font-size:15px;font-weight:600;color:var(--text-primary);margin:16px 0 4px;">${escapeHtml(line.slice(4))}</h3>`;
+                } else if (line.startsWith('#### ')) {
+                    if (inList) { html += '</ul>'; inList = false; }
+                    html += `<h4 style="font-size:14px;font-weight:600;color:var(--text-primary);margin:12px 0 2px;">${escapeHtml(line.slice(5))}</h4>`;
                 } else if (line.startsWith('- ')) {
                     if (!inList) { html += '<ul style="list-style:none;padding:0;">'; inList = true; }
                     const safe = escapeHtml(line.slice(2));
@@ -9069,24 +9032,30 @@ Session started - waiting for activity...
                 } else {
                     if (inList) { html += '</ul>'; inList = false; }
                     const safe = escapeHtml(line);
-                    const text = safe.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+                    // If the entire line is bold (**text**), render as plain text to avoid heavy weight
+                    const isFully = safe.startsWith('**') && safe.endsWith('**') && safe.indexOf('**', 2) === safe.length - 2;
+                    const text = isFully ? safe.slice(2, -2) : safe.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
                     html += `<p style="color:var(--text-secondary);line-height:1.7;font-size:15px;margin:4px 0;">${text}</p>`;
                 }
             }
             if (inList) html += '</ul>';
 
-            container.innerHTML = html + '<p style="color:var(--accent-primary);font-size:13px;margin-top:16px;opacity:0.7;">Generating summary...</p>';
+            container.innerHTML = html; // html is built from escapeHtml-sanitized input
+
+            const scanner = document.getElementById('generation-scanner');
+            if (scanner) {
+                scanner.style.display = 'flex';
+                scanner.style.top = (container.scrollHeight - 14) + 'px';
+            }
+
+            const detailPanel = document.getElementById('meeting-detail');
+            if (detailPanel) detailPanel.scrollTop = detailPanel.scrollHeight;
         }
 
         function stopStreamingRenderer() {
             streamingActive = false;
-            const container = document.getElementById('streaming-output');
-            if (container) {
-                const indicator = container.querySelector('p:last-child');
-                if (indicator && indicator.textContent.includes('Generating')) {
-                    indicator.remove();
-                }
-            }
+            const scanner = document.getElementById('generation-scanner');
+            if (scanner) scanner.style.display = 'none';
         }
 
         ipcRenderer.on('summary-chunk', (event, data) => {
@@ -9101,6 +9070,9 @@ Session started - waiting for activity...
                 document.getElementById('ask-bar').style.display = '';
                 const editor = document.getElementById('notes-editor');
                 if (editor) editor.style.display = 'block';
+                // Switch scanner label now that streaming has started
+                const lbl = document.getElementById('generation-scanner-label');
+                if (lbl) lbl.textContent = 'Generating notes';
             }
             streamedMarkdown += data.chunk;
             renderStreamingMarkdown(streamedMarkdown);
@@ -9163,7 +9135,8 @@ Session started - waiting for activity...
                         rpBtn.style.display = '';
                         rpBtn.disabled = false;
                         rpBtn.classList.remove('processing');
-                        rpBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>';
+                        const scanner = document.getElementById('generation-scanner');
+                        if (scanner) scanner.style.display = 'none';
                         streamingActive = false;
                         // Store selectedMeeting for Ask Steno etc.
                         const meetingIdx = filteredMeetings.findIndex(m =>

--- a/app/index.html
+++ b/app/index.html
@@ -7626,7 +7626,7 @@ Session started - waiting for activity...
         ipcRenderer.invoke('load-chat-sessions').then(result => {
             if (result?.success && Array.isArray(result.data)) {
                 for (const [key, sessions] of result.data) {
-                    meetingChats.set(key, sessions);
+                    if (!meetingChats.has(key)) meetingChats.set(key, sessions);
                 }
             }
         }).catch(() => {});

--- a/app/index.html
+++ b/app/index.html
@@ -3761,19 +3761,8 @@
             transform: scaleY(0.15);
             transition: transform 0.3s ease;
         }
-        .controls-pill .bar-pause-btn {
-            background: none;
-            border: none;
-            color: var(--text-secondary);
-            font-size: 13px;
-            font-weight: 500;
-            font-family: inherit;
-            cursor: pointer;
-            padding: 4px 6px;
-            border-radius: 4px;
-            transition: color 0.15s ease, background 0.15s ease;
-        }
-
+        /* base .bar-pause-btn + :hover rules live in the top of this file;
+           the controls-pill version inherits, with only the hover tint differing */
         .controls-pill .bar-pause-btn:hover {
             color: var(--text-primary);
         }
@@ -6799,6 +6788,7 @@ Session started - waiting for activity...
                     log(`System audio start error: ${error.message}`);
                     hideNotesEditor();
                     setUIState('ready');
+                    removeLiveMeeting(sessionName);
                 }
             } else {
                 log(`Starting recording: ${sessionName}`);
@@ -6818,12 +6808,14 @@ Session started - waiting for activity...
                         AudioVisualizer.stop();
                         hideNotesEditor();
                         setUIState('ready');
+                        removeLiveMeeting(sessionName);
                     }
                 } catch (error) {
                     log(`Start error: ${error.message}`);
                     AudioVisualizer.stop();
                     hideNotesEditor();
                     setUIState('ready');
+                    removeLiveMeeting(sessionName);
                 }
             }
         });
@@ -7884,8 +7876,13 @@ Session started - waiting for activity...
 
             document.getElementById('ask-bar-chat-title').textContent = session.title;
 
+            // Exclude the currently-streaming AI message — the chunk handler
+            // owns its DOM element (streamingEl) and appends it separately.
+            // Rendering it here would produce a duplicate bubble.
+            const streamingMsg = activeQueryId ? activeQueryAiMsg : null;
             askBarMessages.replaceChildren(
                 ...session.messages
+                    .filter(msg => msg !== streamingMsg)
                     .filter(msg => msg.role !== 'ai' || msg.content.trim() !== '')
                     .map(msg => {
                         const el = document.createElement('div');
@@ -8043,16 +8040,30 @@ Session started - waiting for activity...
             finishQuery(session, aiMsg, sessionId);
         });
 
+        // Tracked so showChatWindow can cancel a pending hide's animationend
+        // before it gets a chance to rip `.show` back off a just-opened panel.
+        let _chatHideAnimHandler = null;
+
         function hideChatWindow() {
             if (!askBarChatWindow.classList.contains('show')) return;
+            if (_chatHideAnimHandler) {
+                askBarChatWindow.removeEventListener('animationend', _chatHideAnimHandler);
+            }
             askBarChatWindow.classList.add('hiding');
-            askBarChatWindow.addEventListener('animationend', () => {
+            _chatHideAnimHandler = () => {
                 askBarChatWindow.classList.remove('show', 'hiding');
-            }, { once: true });
+                _chatHideAnimHandler = null;
+            };
+            askBarChatWindow.addEventListener('animationend', _chatHideAnimHandler, { once: true });
         }
 
         function showChatWindow() {
-            // Cancel any in-progress hide animation so its animationend doesn't remove .show
+            // Cancel any pending hide animation + its listener so a late animationend
+            // doesn't strip `.show` right after the panel finishes opening.
+            if (_chatHideAnimHandler) {
+                askBarChatWindow.removeEventListener('animationend', _chatHideAnimHandler);
+                _chatHideAnimHandler = null;
+            }
             askBarChatWindow.classList.remove('hiding');
             // Instantly clear the transcript so both panels never occupy space simultaneously
             const transcript = document.getElementById('ask-bar-transcript');
@@ -8204,10 +8215,15 @@ Session started - waiting for activity...
             renameBtn.addEventListener('click', (ev) => {
                 ev.stopPropagation();
                 closeItemContextMenu();
+                // Re-query the current title span from the item — the reference
+                // captured by the outer closure goes stale after the first rename
+                // (we replace it with a brand-new span on commit).
+                const currentTitleSpan = itemEl.querySelector('.ask-bar-history-item-title') || titleSpan;
+                if (!currentTitleSpan.isConnected) return;
                 const input = document.createElement('input');
                 input.value = session.title;
                 input.style.cssText = 'flex:1;background:none;border:none;outline:none;font-size:13px;color:var(--text-primary);font-family:inherit;min-width:0;';
-                titleSpan.replaceWith(input);
+                currentTitleSpan.replaceWith(input);
                 input.focus();
                 input.select();
                 const commit = () => {
@@ -8659,11 +8675,18 @@ Session started - waiting for activity...
                         await loadMeetings(true);
                         log(`✏️ Meeting name updated to: ${newTitle}`);
                     } else {
-                        titleElement.textContent = originalTitle;
+                        // Only revert the visible title if the user is still on this
+                        // meeting; otherwise we'd overwrite whichever meeting they
+                        // switched to mid-save with this one's original title.
+                        if (selectedMeeting === meeting) {
+                            titleElement.textContent = originalTitle;
+                        }
                         log(`❌ Failed to update meeting name: ${result.error}`);
                     }
                 } catch (error) {
-                    titleElement.textContent = originalTitle;
+                    if (selectedMeeting === meeting) {
+                        titleElement.textContent = originalTitle;
+                    }
                     log(`❌ Error updating meeting name: ${error.message}`);
                 }
             });

--- a/app/index.html
+++ b/app/index.html
@@ -1442,6 +1442,18 @@
             opacity: 0.5;
         }
 
+        .meeting-item.recording .meeting-dot {
+            background: #ef4444;
+            box-shadow: 0 0 8px rgba(239, 68, 68, 0.6);
+            opacity: 1;
+            animation: pulse 1.2s infinite;
+        }
+
+        .meeting-item.recording .meeting-line-date {
+            color: #ef4444;
+            font-weight: 600;
+        }
+
         .meeting-item.active .meeting-line-title {
             color: var(--text-primary);
             font-weight: 600;
@@ -6171,21 +6183,32 @@ Session started - waiting for activity...
             }
 
             meetingsList.innerHTML = filteredMeetings.map((meeting, index) => {
-                const isProcessing = processingMeetings.has(meeting.session_info?.name);
+                const isRecording = !!meeting.is_recording;
+                const isProcessing = !isRecording && processingMeetings.has(meeting.session_info?.name);
                 const actionCount = (meeting.action_items || []).length;
                 const title = meeting.session_info?.name || 'Untitled Meeting';
-                const date = formatShortDate(meeting.session_info?.processed_at);
+                const date = isRecording ? 'Recording' : formatShortDate(meeting.session_info?.processed_at);
+                const classes = ['meeting-item'];
+                if (isRecording) classes.push('recording');
+                if (isProcessing) classes.push('processing');
+                // Live entries shouldn't be draggable/renamable/deletable — the real
+                // entry (with all those affordances) shows up once processing finishes.
+                const draggable = isRecording ? '' : 'draggable="true"';
+                const contextMenu = isRecording ? '' : `oncontextmenu="showMeetingContextMenu(event, ${index})"`;
+                const dragStart = isRecording ? '' : `ondragstart="handleMeetingDragStart(event, ${index})"`;
+                const rename = isRecording ? '' : `ondblclick="event.stopPropagation(); renameMeeting(${index}, this)"`;
+                const deleteBtn = isRecording ? '' : `<button class="meeting-delete" onclick="deleteMeeting(${index}, event)" title="Delete meeting">✕</button>`;
                 return `
-                <div class="meeting-item ${isProcessing ? 'processing' : ''}" data-index="${index}" draggable="true" oncontextmenu="showMeetingContextMenu(event, ${index})" ondragstart="handleMeetingDragStart(event, ${index})">
+                <div class="${classes.join(' ')}" data-index="${index}" ${draggable} ${contextMenu} ${dragStart}>
                     <span class="meeting-dot"></span>
                     <div class="meeting-line-body">
-                        <span class="meeting-line-title" ondblclick="event.stopPropagation(); renameMeeting(${index}, this)">${escapeHtml(title)}</span>
+                        <span class="meeting-line-title" ${rename}>${escapeHtml(title)}</span>
                         ${isProcessing ? '<span class="meeting-item-spinner"></span>' : ''}
                         <span class="meeting-line-meta">
                             <span class="meeting-line-date">${date}</span>
                         </span>
                     </div>
-                    <button class="meeting-delete" onclick="deleteMeeting(${index}, event)" title="Delete meeting">✕</button>
+                    ${deleteBtn}
                 </div>
                 `;
             }).join('');
@@ -6248,6 +6271,33 @@ Session started - waiting for activity...
         function selectMeeting(index) {
             selectedMeeting = filteredMeetings[index];
             if (!selectedMeeting) return;
+
+            // Live recording: restore the in-progress notes editor view WITHOUT
+            // re-initializing (showNotesEditor would wipe the user's typed notes).
+            // The recording is already running — we just un-hide what's already in
+            // the DOM from the initial start.
+            if (selectedMeeting.is_recording) {
+                document.querySelectorAll('.meeting-item').forEach((item, i) => {
+                    item.classList.toggle('active', i === index);
+                });
+                selectedCalendarEvent = null;
+                document.getElementById('calendar-event-detail').classList.remove('show');
+                renderCalendarSidebar();
+                emptyState.style.display = 'none';
+                meetingDetail.classList.add('show');
+                document.getElementById('home-btn').style.display = '';
+                detailTitle.textContent = selectedMeeting.session_info?.name || 'Untitled';
+                // Show notes editor, hide processed-meeting sections
+                document.querySelectorAll('#meeting-detail .meeting-section').forEach(s => s.style.display = 'none');
+                document.getElementById('notes-editor').style.display = 'block';
+                // Keep action buttons hidden (they appear after processing)
+                document.getElementById('ask-ai-btn').style.display = 'none';
+                document.getElementById('copy-notes-btn').style.display = 'none';
+                document.getElementById('reprocess-btn').style.display = 'none';
+                document.getElementById('ask-bar').style.display = '';
+                return;
+            }
+
             activeChatSessionId = null;
             if (typeof meetingChats !== 'undefined') {
                 const mid = selectedMeeting?.session_info?.name || selectedMeeting?.session_info?.summary_file || selectedMeeting?.id;
@@ -6425,6 +6475,33 @@ Session started - waiting for activity...
 
         let _notesInputHandler = null;  // Track listener to avoid duplicates
         let _notesSaveTimeout = null;   // Debounce timeout for auto-save
+
+        // --- Live recording sidebar entry -----------------------------------
+        // Ephemeral entry shown at the top of the meetings list while a recording
+        // is active so the user can navigate away and click back. Replaced by the
+        // real .md entry once processing finishes (loadMeetings refresh).
+        function upsertLiveMeeting(sessionName) {
+            meetings = meetings.filter(m => !(m.is_recording && m.session_info?.name === sessionName));
+            meetings.unshift({
+                is_recording: true,
+                session_info: {
+                    name: sessionName,
+                    processed_at: new Date().toISOString(),
+                    duration_seconds: null,
+                },
+                summary: '',
+                key_points: [],
+                action_items: [],
+                transcript: '',
+            });
+            filterMeetings();
+        }
+
+        function removeLiveMeeting(sessionName) {
+            const before = meetings.length;
+            meetings = meetings.filter(m => !(m.is_recording && m.session_info?.name === sessionName));
+            if (meetings.length !== before) filterMeetings();
+        }
 
         function showNotesEditor(sessionName) {
             currentNotesSessionName = sessionName;
@@ -6692,10 +6769,10 @@ Session started - waiting for activity...
                 return;
             }
 
-            // Generate session name if empty or use Meeting-HASH format
+            // Generate session name if empty or already in the auto-Note/Meeting-HASH format
             let sessionName = sessionNameInput.value.trim();
-            if (!sessionName || sessionName === 'Meeting' || /^Meeting-[A-Z0-9]{6}$/.test(sessionName)) {
-                sessionName = `Meeting-${generateMeetingHash()}`;
+            if (!sessionName || sessionName === 'Meeting' || sessionName === 'Note' || /^(Meeting|Note)-[A-Z0-9]{6}$/.test(sessionName)) {
+                sessionName = `Note-${generateMeetingHash()}`;
                 sessionNameInput.value = sessionName;
             }
 
@@ -6707,6 +6784,10 @@ Session started - waiting for activity...
             } catch (e) {
                 // Fall back to mic-only
             }
+
+            // Surface a "Recording…" entry in the sidebar immediately so the user
+            // can click away to another note and return without losing the session.
+            upsertLiveMeeting(sessionName);
 
             if (useSystemAudio) {
                 log(`Starting recording (mic + system audio): ${sessionName}`);
@@ -6756,6 +6837,10 @@ Session started - waiting for activity...
             // Add current session to processing list immediately
             const currentSessionName = sessionNameInput.value.trim() || 'Meeting';
             processingMeetings.add(currentSessionName);
+
+            // Drop the live-recording sidebar entry (if any) before inserting
+            // the processing temp — otherwise we'd end up with two entries.
+            meetings = meetings.filter(m => !(m.is_recording && m.session_info?.name === currentSessionName));
 
             // Add a temporary meeting entry to show processing
             const tempMeeting = {

--- a/app/index.html
+++ b/app/index.html
@@ -8620,6 +8620,13 @@ Session started - waiting for activity...
                 pendingTitle = titleElement.textContent;
             });
 
+            titleElement.addEventListener('paste', (e) => {
+                e.preventDefault();
+                const text = (e.clipboardData || window.clipboardData).getData('text/plain');
+                const cleaned = text.replace(/[\r\n]+/g, ' ').trim();
+                document.execCommand('insertText', false, cleaned);
+            });
+
             titleElement.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter') {
                     e.preventDefault();
@@ -8634,7 +8641,7 @@ Session started - waiting for activity...
             titleElement.addEventListener('blur', async () => {
                 if (!editingMeeting) return;
                 const meeting = editingMeeting;
-                const newTitle = pendingTitle.trim();
+                const newTitle = pendingTitle.replace(/[\r\n]+/g, ' ').trim();
                 editingMeeting = null;
                 pendingTitle = '';
 

--- a/app/index.html
+++ b/app/index.html
@@ -1913,6 +1913,7 @@
         .meeting-detail {
             height: 100%;
             overflow-y: auto;
+            scrollbar-gutter: stable;
             display: none;
         }
 
@@ -3312,60 +3313,278 @@
             z-index: -1;
         }
 
-        .ask-bar-response {
+        .ask-bar-chat-window {
+            display: none;
+            flex-direction: column;
             background: var(--bg-elevated);
             border: 1px solid var(--border-subtle);
-            border-radius: 18px 18px 6px 6px;
-            padding: 14px 18px;
-            margin: 0 auto 8px;
+            border-radius: 22px;
             max-width: 680px;
-            display: none;
-            font-size: 14px;
-            line-height: 1.7;
-            color: var(--text-primary);
-            max-height: 240px;
-            overflow-y: auto;
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+            margin: 0 auto 8px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22), 0 2px 6px rgba(0, 0, 0, 0.08);
+            backdrop-filter: saturate(160%) blur(10px);
+            -webkit-backdrop-filter: saturate(160%) blur(10px);
+            overflow: hidden;
         }
 
-        .ask-bar-response.show {
-            display: block;
+        .ask-bar-chat-window.show {
+            display: flex;
+            animation: chatWindowIn 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards;
         }
+
+        .ask-bar-chat-window.hiding {
+            animation: chatWindowOut 0.15s ease-in forwards;
+        }
+
+        @keyframes chatWindowIn {
+            from { opacity: 0; transform: translateY(10px) scale(0.98); }
+            to   { opacity: 1; transform: translateY(0) scale(1); }
+        }
+
+        @keyframes chatWindowOut {
+            from { opacity: 1; transform: translateY(0) scale(1); }
+            to   { opacity: 0; transform: translateY(6px) scale(0.98); }
+        }
+
+        .ask-bar-chat-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 10px 14px;
+            border-bottom: 1px solid var(--border-subtle);
+            flex-shrink: 0;
+        }
+
+        .ask-bar-chat-title-group {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .ask-bar-chat-title-btn {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text-primary);
+            padding: 4px 8px;
+            border-radius: 8px;
+            font-family: inherit;
+        }
+
+        .ask-bar-chat-title-btn:hover { background: var(--bg-surface); }
+
+        .ask-bar-chat-chevron {
+            width: 14px;
+            height: 14px;
+            color: var(--text-muted);
+            flex-shrink: 0;
+            transition: transform 0.15s ease;
+        }
+
+        .ask-bar-chat-title-btn.open .ask-bar-chat-chevron { transform: rotate(180deg); }
+
+        .ask-bar-new-chat-btn {
+            background: none;
+            border: 1px solid var(--border-subtle);
+            border-radius: 8px;
+            padding: 4px 10px;
+            font-size: 12px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            font-family: inherit;
+            transition: background 0.15s ease, color 0.15s ease;
+        }
+
+        .ask-bar-new-chat-btn:hover { background: var(--bg-surface); color: var(--text-primary); }
+
+        .ask-bar-chat-history-menu {
+            display: none;
+            position: absolute;
+            top: calc(100% + 4px);
+            left: 0;
+            background: var(--bg-elevated);
+            border: 1px solid var(--border-subtle);
+            border-radius: 12px;
+            min-width: 240px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+            z-index: 30;
+            overflow: hidden;
+            padding: 6px;
+        }
+
+        .ask-bar-chat-history-menu.show { display: block; }
+
+        .ask-bar-history-group-label {
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--text-muted);
+            padding: 4px 8px 2px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        .ask-bar-history-menu-item {
+            display: flex;
+            align-items: center;
+            padding: 7px 10px;
+            font-size: 13px;
+            color: var(--text-secondary);
+            border-radius: 8px;
+            cursor: pointer;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            transition: background 0.1s ease, color 0.1s ease;
+        }
+        .ask-bar-history-menu-item:hover { background: var(--bg-surface); color: var(--text-primary); }
+        .ask-bar-history-menu-item.active { background: var(--bg-surface); color: var(--text-primary); font-weight: 500; }
+        .ask-bar-history-item-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .ask-bar-history-item-actions { display: flex; align-items: center; gap: 2px; margin-left: auto; flex-shrink: 0; opacity: 0; transition: opacity 0.1s ease; }
+        .ask-bar-history-menu-item:hover .ask-bar-history-item-actions { opacity: 1; }
+        .ask-bar-history-item-more {
+            background: none; border: none; cursor: pointer; color: var(--text-muted);
+            width: 24px; height: 24px; border-radius: 6px;
+            display: flex; align-items: center; justify-content: center;
+            transition: background 0.1s, color 0.1s;
+        }
+        .ask-bar-history-item-more:hover { background: var(--bg-deep); color: var(--text-primary); }
+        .ask-bar-item-context-menu {
+            position: fixed; z-index: 200;
+            background: var(--bg-elevated); border: 1px solid var(--border-subtle);
+            border-radius: 10px; padding: 4px;
+            box-shadow: 0 8px 24px rgba(0,0,0,0.22);
+            min-width: 140px;
+        }
+        .ask-bar-item-context-menu button {
+            display: flex; align-items: center; gap: 8px;
+            width: 100%; background: none; border: none; cursor: pointer;
+            padding: 7px 10px; border-radius: 7px; font-size: 13px; font-family: inherit;
+            color: var(--text-secondary); transition: background 0.1s, color 0.1s;
+        }
+        .ask-bar-item-context-menu button:hover { background: var(--bg-surface); color: var(--text-primary); }
+        .ask-bar-item-context-menu button.danger { color: #f87171; }
+        .ask-bar-item-context-menu button.danger:hover { background: rgba(248,113,113,0.1); color: #f87171; }
+        .ask-bar-history-item-thinking { display: inline-flex; align-items: center; gap: 3px; margin-left: auto; padding-right: 4px; }
+        .ask-bar-history-item-thinking span {
+            display: inline-block; width: 4px; height: 4px; border-radius: 50%;
+            background: var(--text-muted);
+            animation: thinking-bounce 1.2s infinite ease-in-out;
+        }
+        .ask-bar-history-item-thinking span:nth-child(2) { animation-delay: 0.2s; }
+        .ask-bar-history-item-thinking span:nth-child(3) { animation-delay: 0.4s; }
+
+        .ask-bar-messages {
+            height: 280px;
+            overflow-y: auto;
+            overscroll-behavior: contain;
+            padding: 14px 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            max-height: 380px;
+            min-height: 60px;
+        }
+
+        .ask-bar-msg-user {
+            align-self: flex-end;
+            background: var(--bg-surface);
+            border: 1px solid var(--border-subtle);
+            border-radius: 18px 18px 4px 18px;
+            padding: 8px 14px;
+            font-size: 14px;
+            color: var(--text-primary);
+            max-width: 75%;
+        }
+
+        .ask-bar-msg-ai {
+            align-self: flex-start;
+            font-size: 14px;
+            color: var(--text-primary);
+            line-height: 1.7;
+            max-width: 90%;
+        }
+
+        .ask-bar-msg-ai ul, .ask-bar-msg-ai ol { margin: 4px 0; padding-left: 20px; }
+        .ask-bar-msg-ai li { margin: 2px 0; }
+
+        .ask-bar-msg-thinking {
+            align-self: flex-start;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 0;
+        }
+
+        .ask-bar-thinking-dots { display: flex; align-items: center; gap: 4px; }
+
+        .ask-bar-thinking-label {
+            font-size: 13px;
+            color: var(--text-muted);
+        }
+
+        .ask-bar-thinking-dots span {
+            display: inline-block;
+            width: 5px;
+            height: 5px;
+            border-radius: 50%;
+            background: var(--text-muted);
+            animation: thinking-bounce 1.2s infinite ease-in-out;
+        }
+
+        .ask-bar-thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+        .ask-bar-thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+        @keyframes thinking-bounce {
+            0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
+            40% { transform: scale(1); opacity: 1; }
+        }
+
+        [data-theme="light"] .ask-bar-chat-window,
+        [data-theme="light"] .ask-bar-chat-header,
+        [data-theme="light"] .ask-bar-chat-history-menu { background: var(--bg-deep); }
 
         .ask-bar-transcript {
             background: var(--bg-elevated);
             border: 1px solid var(--border-subtle);
-            border-radius: 18px 18px 6px 6px;
-            margin: 0 auto 8px;
+            border-radius: 22px;
             max-width: 680px;
+            margin: 0 auto 8px;
             display: none;
-            max-height: 280px;
-            overflow-y: auto;
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+            overflow: hidden;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22), 0 2px 6px rgba(0, 0, 0, 0.08);
+            backdrop-filter: saturate(160%) blur(10px);
+            -webkit-backdrop-filter: saturate(160%) blur(10px);
         }
 
         .ask-bar-transcript.show {
             display: block;
+            animation: chatWindowIn 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+        }
+
+        .ask-bar-transcript.hiding {
+            animation: chatWindowOut 0.15s ease-in forwards;
         }
 
         .ask-bar-transcript-header {
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 8px 12px;
+            padding: 10px 14px;
             border-bottom: 1px solid var(--border-subtle);
-            position: sticky;
-            top: 0;
             background: var(--bg-elevated);
-            z-index: 1;
+            flex-shrink: 0;
         }
 
         .ask-bar-transcript-header span {
-            font-size: 12px;
+            font-size: 13px;
             font-weight: 600;
-            color: var(--text-secondary);
-            text-transform: uppercase;
-            letter-spacing: 0.03em;
+            color: var(--text-primary);
+            padding: 4px 8px;
         }
 
         .ask-bar-transcript-header button {
@@ -3373,8 +3592,8 @@
             border: none;
             color: var(--text-muted);
             cursor: pointer;
-            padding: 2px 4px;
-            border-radius: 4px;
+            padding: 4px 6px;
+            border-radius: 6px;
             display: flex;
             align-items: center;
         }
@@ -3385,45 +3604,28 @@
         }
 
         .ask-bar-transcript-body {
-            padding: 12px 14px;
+            padding: 14px 16px;
             font-size: 13px;
             line-height: 1.7;
             color: var(--text-secondary);
             white-space: pre-wrap;
             word-wrap: break-word;
+            height: 280px;
+            max-height: 380px;
+            overflow-y: auto;
+            overscroll-behavior: contain;
         }
 
-        .ask-bar-transcript.show + .ask-bar-response.show + .ask-bar-inner,
-        .ask-bar-transcript.show + .ask-bar-inner {
-            border-radius: 999px;
-        }
 
         [data-theme="light"] .ask-bar-transcript,
         [data-theme="light"] .ask-bar-transcript-header {
             background: var(--bg-deep);
         }
 
-        .ask-bar-response.loading {
-            color: var(--text-muted);
-        }
-
-        .ask-bar-response.error {
-            color: #ef4444;
-        }
-
-        .ask-bar-response ul {
-            margin: 6px 0;
-            padding-left: 20px;
-        }
-
-        .ask-bar-response li {
-            margin: 2px 0;
-        }
-
         /* Bottom bar row: controls pill (left) + ask pill (right) */
         .ask-bar-row {
             display: flex;
-            align-items: center;
+            align-items: stretch;
             justify-content: center;
             gap: 8px;
             max-width: 680px;
@@ -3434,19 +3636,43 @@
         .controls-pill {
             display: none;
             align-items: center;
+            justify-content: center;
             gap: 2px;
             background: var(--bg-elevated);
             border: 1px solid var(--border-subtle);
-            border-radius: 999px;
+            border-radius: 22px;
             padding: 6px 12px;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22), 0 2px 6px rgba(0, 0, 0, 0.08);
             backdrop-filter: saturate(160%) blur(10px);
             -webkit-backdrop-filter: saturate(160%) blur(10px);
             flex-shrink: 0;
+            align-self: stretch;
+            position: relative;
         }
 
         .controls-pill.show {
             display: flex;
+            cursor: pointer;
+        }
+
+        .controls-pill.show::before {
+            content: '';
+            position: absolute;
+            inset: 3px;
+            border-radius: 18px;
+            background: var(--bg-surface);
+            opacity: 0;
+            transition: opacity 0.15s ease;
+            pointer-events: none;
+        }
+
+        .controls-pill.show:hover::before {
+            opacity: 1;
+        }
+
+        .controls-pill > * {
+            position: relative;
+            z-index: 1;
         }
 
         .controls-pill button {
@@ -3458,12 +3684,11 @@
             display: flex;
             align-items: center;
             border-radius: 4px;
-            transition: color 0.15s ease, background 0.15s ease;
+            transition: color 0.15s ease;
         }
 
-        .controls-pill button:hover {
+        .controls-pill:hover button {
             color: var(--text-primary);
-            background: var(--bg-surface);
         }
 
         .controls-pill button svg {
@@ -3474,6 +3699,21 @@
         .controls-pill .bar-transcript-btn svg {
             width: 18px;
             height: 18px;
+        }
+
+        .controls-pill .bar-chevron {
+            width: 14px;
+            height: 14px;
+            flex-shrink: 0;
+            transition: transform 0.2s ease;
+        }
+
+        .controls-pill .bar-chevron.open {
+            transform: rotate(180deg);
+        }
+
+        .controls-pill .bar-transcript-btn {
+            gap: 6px;
         }
 
         /* Toggle between static SVG icon and live mini waveform */
@@ -3540,7 +3780,6 @@
 
         .controls-pill .bar-pause-btn:hover {
             color: var(--text-primary);
-            background: var(--bg-surface);
         }
 
         [data-theme="light"] .controls-pill {
@@ -3550,15 +3789,147 @@
 
         .ask-bar-inner {
             display: flex;
-            align-items: center;
+            flex-direction: column;
+            align-items: stretch;
             background: var(--bg-elevated);
             border: 1px solid var(--border-subtle);
-            border-radius: 999px;
+            border-radius: 22px;
             flex: 1;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22), 0 2px 6px rgba(0, 0, 0, 0.08);
             backdrop-filter: saturate(160%) blur(10px);
             -webkit-backdrop-filter: saturate(160%) blur(10px);
             transition: border-color 0.15s ease, box-shadow 0.15s ease;
+            position: relative;
+        }
+
+        .ask-bar-inner::before {
+            content: '';
+            position: absolute;
+            inset: 3px;
+            border-radius: 18px;
+            background: var(--bg-surface);
+            opacity: 0;
+            transition: opacity 0.15s ease;
+            pointer-events: none;
+        }
+
+        .ask-bar-inner:hover:not(.expanded)::before {
+            opacity: 1;
+        }
+
+        [data-theme="light"] .ask-bar-inner:hover:not(.expanded)::before {
+            opacity: 0;
+        }
+
+        .ask-bar-inner > * {
+            position: relative;
+            z-index: 1;
+        }
+
+        .ask-bar-row:has(.ask-bar-inner.expanded) .controls-pill {
+            display: none;
+        }
+
+        .ask-bar-expanded-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            padding: 0 16px;
+            max-height: 0;
+            overflow: hidden;
+            opacity: 0;
+            transition: max-height 0.25s cubic-bezier(0.4, 0, 0.2, 1), padding 0.25s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease;
+        }
+
+        .ask-bar-inner.expanded .ask-bar-expanded-panel {
+            max-height: 200px;
+            padding: 14px 16px 4px;
+            opacity: 1;
+        }
+
+        .ask-bar-input-row {
+            display: flex;
+            align-items: center;
+        }
+
+        .ask-bar-history-wrap {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .ask-bar-history-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--text-muted);
+            padding: 4px 6px;
+            border-radius: 6px;
+            display: flex;
+            align-items: center;
+            transition: color 0.15s ease, background 0.15s ease;
+        }
+
+        .ask-bar-history-btn:hover {
+            color: var(--text-primary);
+            background: var(--bg-surface);
+        }
+
+        .ask-bar-history-dropdown {
+            display: none;
+            position: absolute;
+            top: calc(100% + 4px);
+            left: 0;
+            background: var(--bg-elevated);
+            border: 1px solid var(--border-subtle);
+            border-radius: 10px;
+            min-width: 260px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+            z-index: 20;
+            overflow: hidden;
+        }
+
+        .ask-bar-history-dropdown.show {
+            display: block;
+        }
+
+        .ask-bar-history-item {
+            padding: 8px 14px;
+            font-size: 13px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            transition: background 0.1s ease, color 0.1s ease;
+        }
+
+        .ask-bar-history-item:hover {
+            background: var(--bg-surface);
+            color: var(--text-primary);
+        }
+
+        .ask-bar-prompts {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .ask-bar-prompt-chip {
+            background: none;
+            border: 1px solid var(--border-subtle);
+            border-radius: 8px;
+            padding: 4px 10px;
+            font-size: 12px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            font-family: inherit;
+            transition: background 0.15s ease, color 0.15s ease;
+        }
+
+        .ask-bar-prompt-chip:hover {
+            background: var(--bg-surface);
+            color: var(--text-primary);
         }
 
         .ask-bar-left {
@@ -3600,10 +3971,6 @@
             transform: rotate(180deg);
         }
 
-        .ask-bar-response.show + .ask-bar-inner {
-            border-radius: 999px;
-        }
-
         .ask-bar-inner:focus-within {
             border-color: var(--accent-primary);
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24), 0 0 0 3px rgba(129, 140, 248, 0.18);
@@ -3622,36 +3989,64 @@
 
         .ask-bar-input::placeholder {
             color: var(--text-muted);
+            transition: color 0.15s ease;
         }
 
-        .ask-bar-submit {
-            background: none;
-            border: none;
-            padding: 10px 18px 10px 12px;
-            cursor: pointer;
+        .ask-bar-inner:hover:not(.expanded) .ask-bar-input::placeholder {
+            color: var(--text-primary);
+        }
+
+        [data-theme="light"] .ask-bar-inner:hover:not(.expanded) .ask-bar-input::placeholder {
             color: var(--text-muted);
+        }
+
+        .ask-bar-submit,
+        .ask-bar-stop {
+            background: var(--text-muted);
+            border: none;
+            border-radius: 50%;
+            width: 28px;
+            height: 28px;
+            margin: 0 8px 0 4px;
+            cursor: pointer;
+            color: var(--bg-deep);
             display: flex;
             align-items: center;
-            transition: color 0.15s ease;
+            justify-content: center;
+            transition: background 0.15s ease, transform 0.1s ease;
             flex-shrink: 0;
         }
 
-        .ask-bar-submit:hover {
-            color: var(--accent-primary);
-        }
-
         .ask-bar-submit:disabled {
-            opacity: 0.3;
+            background: var(--border-subtle);
             cursor: default;
         }
 
-        .ask-bar-submit svg {
-            width: 16px;
-            height: 16px;
+        .ask-bar-submit:not(:disabled):hover {
+            background: var(--accent-primary);
+            transform: scale(1.05);
         }
 
-        [data-theme="light"] .ask-bar-inner,
-        [data-theme="light"] .ask-bar-response {
+        .ask-bar-inner.has-text .ask-bar-submit:not(:disabled) {
+            background: var(--accent-primary);
+        }
+
+        .ask-bar-stop {
+            background: var(--accent-primary);
+        }
+
+        .ask-bar-stop:hover {
+            background: #a5b4fc;
+            transform: scale(1.05);
+        }
+
+        .ask-bar-submit svg,
+        .ask-bar-stop svg {
+            width: 14px;
+            height: 14px;
+        }
+
+        [data-theme="light"] .ask-bar-inner {
             background: var(--bg-deep);
             border-color: #c4c4cc;
         }
@@ -4078,10 +4473,9 @@ Ask Steno
                                       <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
                                   </svg>
                               </button>
-                              <button id="ask-bar-transcript-close" title="Close">
+                              <button id="ask-bar-transcript-close" title="Minimise">
                                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                                      <line x1="18" y1="6" x2="6" y2="18"></line>
-                                      <line x1="6" y1="6" x2="18" y2="18"></line>
+                                      <line x1="5" y1="12" x2="19" y2="12"></line>
                                   </svg>
                               </button>
                           </div>
@@ -4106,7 +4500,21 @@ Ask Steno
                       </div>
                       <div class="ask-bar-transcript-body" id="ask-bar-transcript-body"></div>
                   </div>
-                  <div class="ask-bar-response" id="ask-bar-response"></div>
+                  <div class="ask-bar-chat-window" id="ask-bar-chat-window">
+                      <div class="ask-bar-chat-header">
+                          <div class="ask-bar-chat-title-group">
+                              <button class="ask-bar-chat-title-btn" id="ask-bar-chat-title-btn">
+                                  <span id="ask-bar-chat-title">New chat</span>
+                                  <svg class="ask-bar-chat-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                                      <polyline points="6 9 12 15 18 9"></polyline>
+                                  </svg>
+                              </button>
+                              <div class="ask-bar-chat-history-menu" id="ask-bar-chat-history-menu"></div>
+                          </div>
+                          <button class="ask-bar-new-chat-btn" id="ask-bar-new-chat-btn">New chat</button>
+                      </div>
+                      <div class="ask-bar-messages" id="ask-bar-messages"></div>
+                  </div>
                   <div class="ask-bar-row">
                       <!-- Separate controls pill (visible during recording + on meetings) -->
                       <div class="controls-pill" id="controls-pill">
@@ -4127,10 +4535,9 @@ Ask Steno
                                   <div class="mini-waveform-bar"></div>
                                   <div class="mini-waveform-bar"></div>
                               </div>
-                          </button>
-                          <button class="bar-chevron" id="bar-chevron" title="Show transcript">
-                              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                                  <polyline points="6 9 12 15 18 9"></polyline>
+                              <!-- Chevron (points up; rotates down when transcript is open) -->
+                              <svg class="bar-chevron" id="bar-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                                  <polyline points="6 15 12 9 18 15"></polyline>
                               </svg>
                           </button>
                           <button class="bar-pause-btn" id="bar-pause-btn" style="display: none;">Pause</button>
@@ -4143,14 +4550,29 @@ Ask Steno
                       <div id="ask-bar-rec-controls" style="display:none;"></div>
                       <div id="ask-bar-rec-divider" style="display:none;"></div>
                       <!-- Main ask input pill -->
-                      <div class="ask-bar-inner">
-                          <input type="text" class="ask-bar-input" id="ask-bar-input" placeholder="Ask anything" autocomplete="off">
-                          <button class="ask-bar-submit" id="ask-bar-submit" title="Ask">
-                              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <line x1="22" y1="2" x2="11" y2="13"></line>
-                                  <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-                              </svg>
-                          </button>
+                      <div class="ask-bar-inner" id="ask-bar-inner">
+                          <!-- Expanded panel: hidden by default, shown on focus -->
+                          <div class="ask-bar-expanded-panel" id="ask-bar-expanded-panel">
+                              <div class="ask-bar-prompts">
+                                  <button class="ask-bar-prompt-chip" data-prompt="Summarize the key decisions made">Summarize key decisions</button>
+                                  <button class="ask-bar-prompt-chip" data-prompt="What action items were discussed?">Action items</button>
+                                  <button class="ask-bar-prompt-chip" data-prompt="What were the main topics covered?">Main topics</button>
+                              </div>
+                          </div>
+                          <!-- Input row -->
+                          <div class="ask-bar-input-row">
+                              <input type="text" class="ask-bar-input" id="ask-bar-input" placeholder="Ask anything" autocomplete="off">
+                              <button class="ask-bar-submit" id="ask-bar-submit" title="Ask" disabled>
+                                  <svg viewBox="0 0 24 24" fill="currentColor">
+                                      <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z" transform="rotate(-90 12 12)"/>
+                                  </svg>
+                              </button>
+                              <button class="ask-bar-stop" id="ask-bar-stop" title="Stop" style="display:none;">
+                                  <svg viewBox="0 0 24 24" fill="currentColor">
+                                      <rect x="6" y="6" width="12" height="12" rx="2"/>
+                                  </svg>
+                              </button>
+                          </div>
                       </div>
                   </div>
               </div>
@@ -5832,6 +6254,15 @@ Session started - waiting for activity...
         function selectMeeting(index) {
             selectedMeeting = filteredMeetings[index];
             if (!selectedMeeting) return;
+            activeChatSessionId = null;
+            if (typeof meetingChats !== 'undefined') {
+                const mid = selectedMeeting?.session_info?.name || selectedMeeting?.session_info?.summary_file || selectedMeeting?.id;
+                const sessions = meetingChats.get(mid);
+                if (sessions && sessions.length > 0) activeChatSessionId = sessions[0].id;
+            }
+            if (typeof hideChatWindow === 'function') hideChatWindow(); else if (typeof askBarChatWindow !== 'undefined') askBarChatWindow.classList.remove('show');
+            if (typeof askBarInner !== 'undefined') askBarInner.classList.remove('expanded');
+            if (typeof updateInputPlaceholder === 'function') updateInputPlaceholder();
 
             // Show home button when inside a note
             document.getElementById('home-btn').style.display = '';
@@ -5962,6 +6393,9 @@ Session started - waiting for activity...
             // TEMPORARY: Show reprocess button for all meetings (for testing)
             reprocessBtn.style.display = 'flex';
             document.getElementById('ask-bar').style.display = '';
+            controlsPill.classList.add('show');
+            controlsPill.classList.remove('recording');
+            controlsPill.classList.remove('paused');
             
             /* ORIGINAL LOGIC (commented out for testing):
             // Show/hide reprocess button based on meeting quality
@@ -6447,11 +6881,13 @@ Session started - waiting for activity...
         });
 
         // Ask bar recording controls — wire to existing handlers
-        barPauseBtn.addEventListener('click', () => {
+        barPauseBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
             pauseBtn.click();
         });
 
-        barStopBtn.addEventListener('click', () => {
+        barStopBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
             stopBtn.click();
         });
 
@@ -7217,39 +7653,574 @@ Session started - waiting for activity...
         // Bottom bar inline query
         const askBarInput = document.getElementById('ask-bar-input');
         const askBarSubmit = document.getElementById('ask-bar-submit');
-        const askBarResponse = document.getElementById('ask-bar-response');
+        const askBarStop = document.getElementById('ask-bar-stop');
+        const askBarInner = document.getElementById('ask-bar-inner');
+        const askBarChatWindow = document.getElementById('ask-bar-chat-window');
+        const askBarMessages = document.getElementById('ask-bar-messages');
 
-        async function submitBarQuery() {
-            const question = askBarInput.value.trim();
-            if (!question) return;
-            if (!selectedMeeting) return;
+        // Chat session data: meetingId -> [{id, title, messages: [{role, content}]}]
+        const meetingChats = new Map();
+        let activeChatSessionId = null;
 
-            const summaryFile = selectedMeeting.session_info?.summary_file;
-            if (!summaryFile) return;
+        function saveChatSessions() {
+            const data = Array.from(meetingChats.entries());
+            ipcRenderer.invoke('save-chat-sessions', data).catch(() => {});
+        }
 
-            askBarSubmit.disabled = true;
-            askBarResponse.className = 'ask-bar-response show loading';
-            askBarResponse.textContent = 'Thinking...';
-
-            try {
-                const result = await ipcRenderer.invoke('query-transcript', summaryFile, question);
-                askBarResponse.classList.remove('loading');
-                if (result.success) {
-                    askBarResponse.innerHTML = formatAiResponse(result.answer);
-                } else {
-                    askBarResponse.classList.add('error');
-                    askBarResponse.textContent = result.error || 'Failed to get response';
+        ipcRenderer.invoke('load-chat-sessions').then(result => {
+            if (result?.success && Array.isArray(result.data)) {
+                for (const [key, sessions] of result.data) {
+                    meetingChats.set(key, sessions);
                 }
-            } catch (error) {
-                askBarResponse.classList.remove('loading');
-                askBarResponse.classList.add('error');
-                askBarResponse.textContent = 'Failed: ' + error.message;
-            } finally {
-                askBarSubmit.disabled = false;
+            }
+        }).catch(() => {});
+
+        function getActiveMeetingId() {
+            return selectedMeeting?.session_info?.name
+                || selectedMeeting?.session_info?.summary_file
+                || selectedMeeting?.id;
+        }
+
+        function getOrCreateSession(meetingId) {
+            if (!meetingChats.has(meetingId)) meetingChats.set(meetingId, []);
+            const sessions = meetingChats.get(meetingId);
+            if (!activeChatSessionId || !sessions.find(s => s.id === activeChatSessionId)) {
+                return createNewChatSession(meetingId);
+            }
+            return sessions.find(s => s.id === activeChatSessionId);
+        }
+
+        function createNewChatSession(meetingId) {
+            if (!meetingChats.has(meetingId)) meetingChats.set(meetingId, []);
+            const id = Date.now().toString();
+            const session = { id, title: 'New chat', messages: [] };
+            meetingChats.get(meetingId).unshift(session);
+            activeChatSessionId = id;
+            return session;
+        }
+
+        // Render formatted AI text as safe DOM nodes (no innerHTML needed)
+        function appendFormattedText(el, text) {
+            const parts = text.split(/\*\*(.+?)\*\*/);
+            parts.forEach((part, i) => {
+                if (i % 2 === 1) {
+                    const strong = document.createElement('strong');
+                    strong.textContent = part;
+                    el.appendChild(strong);
+                } else if (part) {
+                    el.appendChild(document.createTextNode(part));
+                }
+            });
+        }
+
+        function renderFormattedContent(container, text) {
+            container.replaceChildren();
+            const lines = text.split('\n');
+            let currentUl = null;
+            let currentOl = null;
+            for (const line of lines) {
+                const bulletMatch = line.match(/^[\*\-]\s+(.+)$/);
+                const numberedMatch = line.match(/^(\d+)[.)]\s+(.+)$/);
+                const headingMatch = line.match(/^#{1,3}\s+(.+)$/);
+                if (bulletMatch) {
+                    currentOl = null;
+                    if (!currentUl) {
+                        currentUl = document.createElement('ul');
+                        container.appendChild(currentUl);
+                    }
+                    const li = document.createElement('li');
+                    appendFormattedText(li, bulletMatch[1]);
+                    currentUl.appendChild(li);
+                } else if (numberedMatch) {
+                    currentUl = null;
+                    if (!currentOl) {
+                        currentOl = document.createElement('ol');
+                        container.appendChild(currentOl);
+                    }
+                    const li = document.createElement('li');
+                    appendFormattedText(li, numberedMatch[2]);
+                    currentOl.appendChild(li);
+                } else if (headingMatch) {
+                    currentUl = null; currentOl = null;
+                    const h = document.createElement('strong');
+                    h.style.display = 'block';
+                    h.style.marginTop = '6px';
+                    appendFormattedText(h, headingMatch[1]);
+                    container.appendChild(h);
+                } else {
+                    currentUl = null; currentOl = null;
+                    if (line.trim() === '') {
+                        container.appendChild(document.createElement('br'));
+                    } else {
+                        const span = document.createElement('span');
+                        span.style.display = 'block';
+                        appendFormattedText(span, line);
+                        container.appendChild(span);
+                    }
+                }
             }
         }
 
+        function updateInputPlaceholder() {
+            const meetingId = getActiveMeetingId();
+            const sessions = meetingId ? (meetingChats.get(meetingId) || []) : [];
+            const session = sessions.find(s => s.id === activeChatSessionId);
+            askBarInput.placeholder = (session && session.messages.length > 0)
+                ? 'Continue chat'
+                : 'Ask anything';
+        }
+
+        function renderChatWindow() {
+            const meetingId = getActiveMeetingId();
+            if (!meetingId) {
+                hideChatWindow();
+                return;
+            }
+            const sessions = meetingChats.get(meetingId) || [];
+            const session = sessions.find(s => s.id === activeChatSessionId);
+            if (!session) {
+                hideChatWindow();
+                updateInputPlaceholder();
+                return;
+            }
+            if (session.messages.length === 0) {
+                askBarMessages.replaceChildren();
+                document.getElementById('ask-bar-chat-title').textContent = session.title;
+                updateInputPlaceholder();
+                return;
+            }
+
+            document.getElementById('ask-bar-chat-title').textContent = session.title;
+
+            askBarMessages.replaceChildren(
+                ...session.messages
+                    .filter(msg => msg.role !== 'ai' || msg.content.trim() !== '')
+                    .map(msg => {
+                        const el = document.createElement('div');
+                        el.className = msg.role === 'user' ? 'ask-bar-msg-user' : 'ask-bar-msg-ai';
+                        if (msg.role === 'ai') {
+                            renderFormattedContent(el, msg.content);
+                        } else {
+                            el.textContent = msg.content;
+                        }
+                        return el;
+                    })
+            );
+
+            if (session.pending) appendThinking();
+
+            showChatWindow();
+            askBarMessages.scrollTop = askBarMessages.scrollHeight;
+            updateInputPlaceholder();
+        }
+
+        function appendThinking() {
+            const el = document.createElement('div');
+            el.className = 'ask-bar-msg-thinking';
+            el.id = 'ask-bar-thinking-msg';
+            const dots = document.createElement('span');
+            dots.className = 'ask-bar-thinking-dots';
+            for (let i = 0; i < 3; i++) dots.appendChild(document.createElement('span'));
+            const label = document.createElement('span');
+            label.className = 'ask-bar-thinking-label';
+            label.textContent = 'Thinking';
+            el.appendChild(dots);
+            el.appendChild(label);
+            askBarMessages.appendChild(el);
+            askBarMessages.scrollTop = askBarMessages.scrollHeight;
+        }
+
+        function removeThinking() {
+            document.getElementById('ask-bar-thinking-msg')?.remove();
+        }
+
+        let activeQueryId = null;
+        let activeQuerySession = null;
+        let activeQueryAiMsg = null;
+        let activeQueryChunkHandler = null;
+        let activeQueryDoneHandler = null;
+
+        function setQueryPending(isPending) {
+            askBarSubmit.style.display = isPending ? 'none' : 'flex';
+            askBarStop.style.display = isPending ? 'flex' : 'none';
+        }
+
+        function finishQuery(session, aiMsg, sessionId) {
+            ipcRenderer.removeListener('query-chunk', activeQueryChunkHandler);
+            ipcRenderer.removeListener('query-done', activeQueryDoneHandler);
+            activeQueryId = null;
+            activeQuerySession = null;
+            activeQueryAiMsg = null;
+            activeQueryChunkHandler = null;
+            activeQueryDoneHandler = null;
+            session.pending = false;
+            setQueryPending(false);
+            refreshHistoryMenuDots();
+            saveChatSessions();
+            if (activeChatSessionId === sessionId) {
+                removeThinking();
+                renderChatWindow();
+                askBarInner.classList.add('expanded');
+            }
+        }
+
+        function submitBarQuery() {
+            if (activeQueryId) return;
+            const question = askBarInput.value.trim();
+            if (!question) return;
+            if (!selectedMeeting) return;
+            const summaryFile = selectedMeeting.session_info?.summary_file;
+            if (!summaryFile) return;
+
+            const meetingId = getActiveMeetingId();
+            const session = getOrCreateSession(meetingId);
+
+            // Add user message and show immediately
+            session.messages.push({ role: 'user', content: question });
+            if (session.messages.length === 1) {
+                session.title = question.length > 40 ? question.slice(0, 40) + '\u2026' : question;
+            }
+            askBarInput.value = '';
+            askBarInner.classList.remove('has-text');
+            askBarSubmit.disabled = true;
+
+            // Create empty AI message placeholder for streaming
+            const aiMsg = { role: 'ai', content: '' };
+            session.messages.push(aiMsg);
+            session.pending = true;
+            renderChatWindow();
+            refreshHistoryMenuDots();
+            showChatWindow();
+            setQueryPending(true);
+
+            const queryId = Date.now().toString();
+            activeQueryId = queryId;
+            activeQuerySession = session;
+            activeQueryAiMsg = aiMsg;
+
+            const sessionId = session.id;
+            let streamingEl = null;
+
+            activeQueryChunkHandler = (_e, { queryId: id, chunk }) => {
+                if (id !== queryId) return;
+                aiMsg.content += chunk;
+                if (activeChatSessionId !== sessionId) return;
+                removeThinking();
+                // Append a fresh AI bubble at the end of the messages container.
+                // Don't reuse prior AI messages from history — appending always keeps
+                // the new response below the just-sent user message.
+                if (!streamingEl || !streamingEl.isConnected) {
+                    streamingEl = document.createElement('div');
+                    streamingEl.className = 'ask-bar-msg-ai';
+                    askBarMessages.appendChild(streamingEl);
+                }
+                renderFormattedContent(streamingEl, aiMsg.content);
+                askBarMessages.scrollTop = askBarMessages.scrollHeight;
+            };
+
+            activeQueryDoneHandler = (_e, { queryId: id, success, error }) => {
+                if (id !== queryId) return;
+                if (!success && !aiMsg.content) {
+                    aiMsg.content = error || 'Failed to get response';
+                }
+                finishQuery(session, aiMsg, sessionId);
+            };
+
+            ipcRenderer.on('query-chunk', activeQueryChunkHandler);
+            ipcRenderer.on('query-done', activeQueryDoneHandler);
+            ipcRenderer.send('query-transcript-stream', queryId, summaryFile, question);
+        }
+
         askBarSubmit.addEventListener('click', submitBarQuery);
+
+        askBarStop.addEventListener('click', () => {
+            if (!activeQueryId) return;
+            const queryId = activeQueryId;
+            const session = activeQuerySession;
+            const aiMsg = activeQueryAiMsg;
+            const sessionId = session?.id;
+            // Keep focus in the input so the chat stays expanded after the stop button is hidden.
+            askBarInput.focus();
+            suppressChatCollapse = true;
+            ipcRenderer.send('query-cancel', queryId);
+            if (aiMsg && !aiMsg.content) {
+                aiMsg.content = 'Stopped';
+            } else if (aiMsg) {
+                aiMsg.content += '\n\n*Stopped*';
+            }
+            finishQuery(session, aiMsg, sessionId);
+        });
+
+        function hideChatWindow() {
+            if (!askBarChatWindow.classList.contains('show')) return;
+            askBarChatWindow.classList.add('hiding');
+            askBarChatWindow.addEventListener('animationend', () => {
+                askBarChatWindow.classList.remove('show', 'hiding');
+            }, { once: true });
+        }
+
+        function showChatWindow() {
+            // Cancel any in-progress hide animation so its animationend doesn't remove .show
+            askBarChatWindow.classList.remove('hiding');
+            // Instantly clear the transcript so both panels never occupy space simultaneously
+            const transcript = document.getElementById('ask-bar-transcript');
+            if (transcript && transcript.classList.contains('show')) {
+                transcript.classList.remove('show', 'hiding');
+                document.getElementById('bar-chevron')?.classList.remove('open');
+            }
+            askBarChatWindow.classList.add('show');
+        }
+
+        // Prevent scroll from propagating to background notes. stopPropagation() alone
+        // doesn't stop native scroll chaining — when .ask-bar-messages isn't scrollable
+        // (content fits) or hits a boundary, the browser chains the scroll up to
+        // .meeting-detail. Take over scrolling manually to fully prevent that.
+        askBarChatWindow.addEventListener('wheel', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            askBarMessages.scrollTop += e.deltaY;
+        }, { passive: false });
+
+        // mousedown on the chat window, prompt chips, or stop button prevents blur from collapsing everything
+        let suppressChatCollapse = false;
+        askBarChatWindow.addEventListener('mousedown', () => { suppressChatCollapse = true; });
+        document.getElementById('ask-bar-expanded-panel').addEventListener('mousedown', () => { suppressChatCollapse = true; });
+        askBarStop.addEventListener('mousedown', () => { suppressChatCollapse = true; });
+
+        // Expand panel on focus; restore chat window if session has messages
+        askBarInput.addEventListener('focus', () => {
+            askBarInner.classList.add('expanded');
+            renderChatWindow();
+        });
+
+        // Collapse when focus leaves both the input and chat window
+        askBarInner.addEventListener('focusout', () => {
+            setTimeout(() => {
+                // If focus is back inside the chat UI, don't collapse — regardless of flag
+                const active = document.activeElement;
+                if (active && (askBarInner.contains(active) || askBarChatWindow.contains(active))) {
+                    suppressChatCollapse = false;
+                    return;
+                }
+                if (suppressChatCollapse) {
+                    suppressChatCollapse = false;
+                    return;
+                }
+                const meetingId = getActiveMeetingId();
+                const sessions = meetingId ? (meetingChats.get(meetingId) || []) : [];
+                const activeSession = sessions.find(s => s.id === activeChatSessionId);
+                askBarInner.classList.remove('expanded');
+                hideChatWindow();
+            }, 0);
+        });
+
+        // Show/hide submit button based on input content
+        askBarInput.addEventListener('input', () => {
+            const hasText = askBarInput.value.trim().length > 0;
+            askBarInner.classList.toggle('has-text', hasText);
+            askBarSubmit.disabled = !hasText;
+        });
+
+        // Prompt chip clicks
+        document.querySelectorAll('.ask-bar-prompt-chip').forEach(chip => {
+            chip.addEventListener('click', () => {
+                askBarInput.value = chip.dataset.prompt;
+                askBarInner.classList.add('has-text');
+                submitBarQuery();
+            });
+        });
+
+        // Chat history title button + dropdown
+        const askBarChatTitleBtn = document.getElementById('ask-bar-chat-title-btn');
+        const askBarChatHistoryMenu = document.getElementById('ask-bar-chat-history-menu');
+
+        function renderHistoryMenu() {
+            const meetingId = getActiveMeetingId();
+            const sessions = meetingId ? (meetingChats.get(meetingId) || []) : [];
+            if (sessions.length === 0) {
+                askBarChatHistoryMenu.classList.remove('show');
+                askBarChatTitleBtn.classList.remove('open');
+                return;
+            }
+
+            const label = document.createElement('div');
+            label.className = 'ask-bar-history-group-label';
+            label.textContent = 'Today';
+
+            const items = sessions.map(s => {
+                const item = document.createElement('div');
+                item.className = 'ask-bar-history-menu-item' + (s.id === activeChatSessionId ? ' active' : '');
+
+                const titleSpan = document.createElement('span');
+                titleSpan.className = 'ask-bar-history-item-title';
+                titleSpan.textContent = s.title;
+                item.appendChild(titleSpan);
+
+                if (s.pending) {
+                    const dots = document.createElement('span');
+                    dots.className = 'ask-bar-history-item-thinking';
+                    for (let i = 0; i < 3; i++) dots.appendChild(document.createElement('span'));
+                    item.appendChild(dots);
+                }
+
+                const actions = document.createElement('div');
+                actions.className = 'ask-bar-history-item-actions';
+                const moreBtn = document.createElement('button');
+                moreBtn.className = 'ask-bar-history-item-more';
+                moreBtn.title = 'More options';
+                moreBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg>';
+                actions.appendChild(moreBtn);
+                item.appendChild(actions);
+
+                moreBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    openChatItemMenu(e, s, item, titleSpan);
+                });
+
+                item.addEventListener('click', () => {
+                    activeChatSessionId = s.id;
+                    renderChatWindow();
+                    askBarChatHistoryMenu.classList.remove('show');
+                    askBarChatTitleBtn.classList.remove('open');
+                });
+                return item;
+            });
+
+            askBarChatHistoryMenu.replaceChildren(label, ...items);
+            askBarChatHistoryMenu.classList.toggle('show');
+            askBarChatTitleBtn.classList.toggle('open');
+        }
+
+        let activeItemContextMenu = null;
+
+        function closeItemContextMenu() {
+            if (activeItemContextMenu) {
+                activeItemContextMenu.remove();
+                activeItemContextMenu = null;
+            }
+        }
+
+        function openChatItemMenu(e, session, itemEl, titleSpan) {
+            closeItemContextMenu();
+            const meetingId = getActiveMeetingId();
+            const menu = document.createElement('div');
+            menu.className = 'ask-bar-item-context-menu';
+            activeItemContextMenu = menu;
+
+            const renameBtn = document.createElement('button');
+            renameBtn.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg> Rename';
+            renameBtn.addEventListener('click', (ev) => {
+                ev.stopPropagation();
+                closeItemContextMenu();
+                const input = document.createElement('input');
+                input.value = session.title;
+                input.style.cssText = 'flex:1;background:none;border:none;outline:none;font-size:13px;color:var(--text-primary);font-family:inherit;min-width:0;';
+                titleSpan.replaceWith(input);
+                input.focus();
+                input.select();
+                const commit = () => {
+                    const newTitle = input.value.trim() || session.title;
+                    session.title = newTitle;
+                    saveChatSessions();
+                    const span = document.createElement('span');
+                    span.className = 'ask-bar-history-item-title';
+                    span.textContent = newTitle;
+                    input.replaceWith(span);
+                    if (activeChatSessionId === session.id) {
+                        document.getElementById('ask-bar-chat-title').textContent = newTitle;
+                    }
+                };
+                input.addEventListener('blur', commit);
+                input.addEventListener('keydown', (k) => { if (k.key === 'Enter') input.blur(); if (k.key === 'Escape') { input.value = session.title; input.blur(); } });
+            });
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.className = 'danger';
+            deleteBtn.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg> Delete';
+            deleteBtn.addEventListener('click', (ev) => {
+                ev.stopPropagation();
+                closeItemContextMenu();
+                if (!meetingId) return;
+                const sessions = meetingChats.get(meetingId) || [];
+                const idx = sessions.findIndex(s => s.id === session.id);
+                if (idx !== -1) sessions.splice(idx, 1);
+                if (activeChatSessionId === session.id) {
+                    activeChatSessionId = sessions.length > 0 ? sessions[0].id : null;
+                    if (sessions.length === 0) {
+                        createNewChatSession(meetingId);
+                        activeChatSessionId = meetingChats.get(meetingId)[0].id;
+                    }
+                    renderChatWindow();
+                }
+                saveChatSessions();
+                askBarChatHistoryMenu.classList.remove('show');
+                askBarChatTitleBtn.classList.remove('open');
+            });
+
+            menu.appendChild(renameBtn);
+            menu.appendChild(deleteBtn);
+            document.body.appendChild(menu);
+
+            const rect = e.currentTarget.getBoundingClientRect();
+            menu.style.top = (rect.bottom + 4) + 'px';
+            menu.style.left = rect.left + 'px';
+            // Clamp to viewport
+            requestAnimationFrame(() => {
+                const mr = menu.getBoundingClientRect();
+                if (mr.right > window.innerWidth - 8) menu.style.left = (window.innerWidth - mr.width - 8) + 'px';
+                if (mr.bottom > window.innerHeight - 8) menu.style.top = (rect.top - mr.height - 4) + 'px';
+            });
+        }
+
+        document.addEventListener('click', () => closeItemContextMenu());
+
+        function refreshHistoryMenuDots() {
+            if (!askBarChatHistoryMenu.classList.contains('show')) return;
+            const meetingId = getActiveMeetingId();
+            const sessions = meetingId ? (meetingChats.get(meetingId) || []) : [];
+            const items = askBarChatHistoryMenu.querySelectorAll('.ask-bar-history-menu-item');
+            items.forEach((item, i) => {
+                const s = sessions[i];
+                if (!s) return;
+                const existing = item.querySelector('.ask-bar-history-item-thinking');
+                if (s.pending && !existing) {
+                    const dots = document.createElement('span');
+                    dots.className = 'ask-bar-history-item-thinking';
+                    for (let j = 0; j < 3; j++) dots.appendChild(document.createElement('span'));
+                    item.appendChild(dots);
+                } else if (!s.pending && existing) {
+                    existing.remove();
+                }
+            });
+        }
+
+        askBarChatTitleBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            renderHistoryMenu();
+        });
+
+        document.getElementById('ask-bar-new-chat-btn').addEventListener('click', () => {
+            const meetingId = getActiveMeetingId();
+            if (!meetingId) return;
+            const sessions = meetingChats.get(meetingId) || [];
+            const current = sessions.find(s => s.id === activeChatSessionId);
+            if (current && current.messages.length === 0) return;
+            createNewChatSession(meetingId);
+            renderChatWindow();
+            showChatWindow();
+            askBarInner.classList.add('expanded');
+            askBarInput.focus();
+        });
+
+        document.addEventListener('click', (e) => {
+            askBarChatHistoryMenu?.classList.remove('show');
+            askBarChatTitleBtn?.classList.remove('open');
+            const askBar = document.getElementById('ask-bar');
+            if (askBar && !askBar.contains(e.target)) {
+                askBarInner.classList.remove('expanded');
+                hideChatWindow();
+            }
+        });
 
         askBarInput.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
@@ -7258,7 +8229,7 @@ Session started - waiting for activity...
             }
             if (e.key === 'Escape') {
                 askBarInput.blur();
-                askBarResponse.classList.remove('show');
+                askBarInner.classList.remove('expanded', 'has-text');
                 if (askBarTranscript) {
                     askBarTranscript.classList.remove('show');
                     if (barChevron) barChevron.classList.remove('open');
@@ -7273,10 +8244,18 @@ Session started - waiting for activity...
         const askBarTranscript = document.getElementById('ask-bar-transcript');
         const askBarTranscriptBody = document.getElementById('ask-bar-transcript-body');
 
+        function hideTranscript() {
+            if (!askBarTranscript.classList.contains('show')) return;
+            askBarTranscript.classList.add('hiding');
+            askBarTranscript.addEventListener('animationend', () => {
+                askBarTranscript.classList.remove('show', 'hiding');
+            }, { once: true });
+        }
+
         function toggleTranscriptPanel() {
             const isOpen = askBarTranscript.classList.contains('show');
             if (isOpen) {
-                askBarTranscript.classList.remove('show');
+                hideTranscript();
                 barChevron.classList.remove('open');
             } else {
                 // During recording/paused, no transcript available yet
@@ -7300,11 +8279,10 @@ Session started - waiting for activity...
             }
         }
 
-        barChevron.addEventListener('click', toggleTranscriptPanel);
-        barTranscriptBtn.addEventListener('click', toggleTranscriptPanel);
+        controlsPill.addEventListener('click', toggleTranscriptPanel);
         document.getElementById('ask-bar-transcript-close').addEventListener('click', (e) => {
             e.stopPropagation();
-            askBarTranscript.classList.remove('show');
+            hideTranscript();
             barChevron.classList.remove('open');
         });
         document.getElementById('ask-bar-transcript-copy').addEventListener('click', (e) => {
@@ -7320,15 +8298,11 @@ Session started - waiting for activity...
             }
         });
 
-        // Close response/transcript when clicking outside the ask bar
+        // Close transcript when clicking outside its panel
         document.addEventListener('click', (e) => {
-            const askBar = document.getElementById('ask-bar');
-            if (askBar && !askBar.contains(e.target)) {
-                if (askBarResponse.classList.contains('show')) {
-                    askBarResponse.classList.remove('show');
-                }
-                if (askBarTranscript.classList.contains('show')) {
-                    askBarTranscript.classList.remove('show');
+            if (askBarTranscript.classList.contains('show')) {
+                if (!askBarTranscript.contains(e.target) && !controlsPill.contains(e.target)) {
+                    hideTranscript();
                     barChevron.classList.remove('open');
                 }
             }
@@ -8226,6 +9200,9 @@ Session started - waiting for activity...
                         document.getElementById('ask-ai-btn').style.display = '';
                         document.getElementById('copy-notes-btn').style.display = '';
                         document.getElementById('ask-bar').style.display = '';
+                        controlsPill.classList.add('show');
+                        controlsPill.classList.remove('recording');
+                        controlsPill.classList.remove('paused');
                         const rpBtn = document.getElementById('reprocess-btn');
                         rpBtn.style.display = '';
                         rpBtn.disabled = false;

--- a/app/index.html
+++ b/app/index.html
@@ -418,23 +418,6 @@
             display: block;
         }
 
-        .bar-pause-btn {
-            background: none;
-            border: none;
-            color: var(--text-secondary);
-            font-size: 13px;
-            font-weight: 500;
-            font-family: inherit;
-            cursor: pointer;
-            padding: 4px 6px;
-            border-radius: 4px;
-            transition: color 0.15s ease, background 0.15s ease;
-        }
-
-        .bar-pause-btn:hover {
-            color: var(--text-primary);
-            background: var(--bg-surface);
-        }
 
         .bar-stop-btn {
             background: none;
@@ -3765,22 +3748,7 @@
             transition: transform 0.3s ease;
         }
 
-        .controls-pill .bar-pause-btn {
-            background: none;
-            border: none;
-            color: var(--text-secondary);
-            font-size: 13px;
-            font-weight: 500;
-            font-family: inherit;
-            cursor: pointer;
-            padding: 4px 6px;
-            border-radius: 4px;
-            transition: color 0.15s ease, background 0.15s ease;
-        }
 
-        .controls-pill .bar-pause-btn:hover {
-            color: var(--text-primary);
-        }
 
         [data-theme="light"] .controls-pill {
             background: var(--bg-deep);
@@ -4540,7 +4508,6 @@ Ask Steno
                                   <polyline points="6 15 12 9 18 15"></polyline>
                               </svg>
                           </button>
-                          <button class="bar-pause-btn" id="bar-pause-btn" style="display: none;">Pause</button>
                           <button class="bar-stop-btn" id="bar-stop-btn" title="Stop recording" style="display: none;">
                               <svg viewBox="0 0 16 16" fill="currentColor"><rect x="2" y="2" width="12" height="12" rx="2"/></svg>
                           </button>
@@ -5231,7 +5198,7 @@ Session started - waiting for activity...
         const stopBtn = document.getElementById('stop-btn');
         const pauseBtn = document.getElementById('pause-btn');
         const newNoteBtn = document.getElementById('new-note-btn');
-        const barPauseBtn = document.getElementById('bar-pause-btn');
+
         const barStopBtn = document.getElementById('bar-stop-btn');
         const barRecControls = document.getElementById('ask-bar-rec-controls');
         const barRecDivider = document.getElementById('ask-bar-rec-divider');
@@ -5392,7 +5359,6 @@ Session started - waiting for activity...
                     controlsPill.classList.remove('recording');
                     controlsPill.classList.remove('paused');
                     barStopBtn.style.display = 'none';
-                    barPauseBtn.style.display = 'none';
                     // Restore transcript body
                     document.getElementById('ask-bar-transcript-body').style.display = '';
                     break;
@@ -5405,13 +5371,11 @@ Session started - waiting for activity...
                     newNoteBtn.style.display = 'none';
                     document.getElementById('status-dot').style.display = '';
                     document.getElementById('status-text').style.display = '';
-                    // Controls pill: show with live waveform + pause + stop
+                    // Controls pill: show with live waveform + stop
                     controlsPill.classList.add('show');
                     controlsPill.classList.add('recording');
                     controlsPill.classList.remove('paused');
                     barStopBtn.style.display = '';
-                    barPauseBtn.style.display = '';
-                    barPauseBtn.textContent = 'Pause';
                     // Show ask bar
                     document.getElementById('ask-bar').style.display = '';
                     // Start visualizer targeting mini waveform bars in the button.
@@ -5446,8 +5410,6 @@ Session started - waiting for activity...
                     controlsPill.classList.remove('recording');
                     controlsPill.classList.add('paused');
                     barStopBtn.style.display = '';
-                    barPauseBtn.style.display = '';
-                    barPauseBtn.textContent = 'Resume';
                     const minutes = Math.floor(pausedElapsedTime / 60);
                     const seconds = pausedElapsedTime % 60;
                     const timeStr = `${minutes}:${seconds.toString().padStart(2, '0')}`;
@@ -5469,7 +5431,6 @@ Session started - waiting for activity...
                     controlsPill.classList.remove('recording');
                     controlsPill.classList.remove('paused');
                     barStopBtn.style.display = 'none';
-                    barPauseBtn.style.display = 'none';
                     // Restore transcript body
                     document.getElementById('ask-bar-transcript-body').style.display = '';
                     document.getElementById('ask-bar-transcript').classList.remove('show');
@@ -6700,7 +6661,7 @@ Session started - waiting for activity...
 
             // Generate session name if empty or use Meeting-HASH format
             let sessionName = sessionNameInput.value.trim();
-            if (!sessionName || sessionName === 'Meeting') {
+            if (!sessionName || sessionName === 'Meeting' || /^Meeting-[A-Z0-9]{6}$/.test(sessionName)) {
                 sessionName = `Meeting-${generateMeetingHash()}`;
                 sessionNameInput.value = sessionName;
             }
@@ -6881,11 +6842,6 @@ Session started - waiting for activity...
         });
 
         // Ask bar recording controls — wire to existing handlers
-        barPauseBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            pauseBtn.click();
-        });
-
         barStopBtn.addEventListener('click', (e) => {
             e.stopPropagation();
             stopBtn.click();

--- a/app/index.html
+++ b/app/index.html
@@ -5382,10 +5382,10 @@ Session started - waiting for activity...
                     startBtn.disabled = true;
                     sessionNameInput.disabled = true;
                     startRecordingTimer(pausedElapsedTime > 0);
-                    // Header
+                    // Header: status indicator hidden — bottom pill conveys state + time
                     newNoteBtn.style.display = 'none';
-                    document.getElementById('status-dot').style.display = '';
-                    document.getElementById('status-text').style.display = '';
+                    document.getElementById('status-dot').style.display = 'none';
+                    document.getElementById('status-text').style.display = 'none';
                     // Controls pill: show with live waveform + pause + stop
                     controlsPill.classList.add('show');
                     controlsPill.classList.add('recording');
@@ -5418,10 +5418,10 @@ Session started - waiting for activity...
                     sessionNameInput.disabled = true;
                     AudioVisualizer.stop();
                     pauseRecordingTimer();
-                    // Header
+                    // Header: status indicator hidden — bottom pill conveys state
                     newNoteBtn.style.display = 'none';
-                    document.getElementById('status-dot').style.display = '';
-                    document.getElementById('status-text').style.display = '';
+                    document.getElementById('status-dot').style.display = 'none';
+                    document.getElementById('status-text').style.display = 'none';
                     // Controls pill: show with resume + stop, grey waveform
                     controlsPill.classList.add('show');
                     controlsPill.classList.remove('recording');
@@ -5439,12 +5439,11 @@ Session started - waiting for activity...
                     startBtn.disabled = true;
                     sessionNameInput.disabled = true;
                     stopRecordingTimer();
-                    setStatus('processing', 'Processing...');
                     AudioVisualizer.stop();
-                    // Header
+                    // Header: status indicator hidden — the scanner inside the note carries the state
                     newNoteBtn.style.display = 'none';
-                    document.getElementById('status-dot').style.display = '';
-                    document.getElementById('status-text').style.display = '';
+                    document.getElementById('status-dot').style.display = 'none';
+                    document.getElementById('status-text').style.display = 'none';
                     // Controls pill: show (for transcript) but hide rec controls
                     controlsPill.classList.add('show');
                     controlsPill.classList.remove('recording');
@@ -5455,6 +5454,20 @@ Session started - waiting for activity...
                     document.getElementById('ask-bar-transcript-body').style.display = '';
                     document.getElementById('ask-bar-transcript').classList.remove('show');
                     document.getElementById('bar-chevron').classList.remove('open');
+                    // Surface the analysis scanner at the top of the notes editor while the
+                    // backend transcribes — it will slide down + relabel to "Generating notes"
+                    // once the first summary chunk arrives (see `summary-chunk` handler).
+                    {
+                        const editor = document.getElementById('notes-editor');
+                        if (editor) editor.style.display = 'block';
+                        const scanner = document.getElementById('generation-scanner');
+                        if (scanner) {
+                            scanner.style.display = 'flex';
+                            scanner.style.top = '0px';
+                        }
+                        const lbl = document.getElementById('generation-scanner-label');
+                        if (lbl) lbl.textContent = 'Analyzing transcript';
+                    }
                     break;
             }
         }

--- a/app/index.html
+++ b/app/index.html
@@ -420,6 +420,23 @@
             display: block;
         }
 
+        .bar-pause-btn {
+            background: none;
+            border: none;
+            color: var(--text-secondary);
+            font-size: 13px;
+            font-weight: 500;
+            font-family: inherit;
+            cursor: pointer;
+            padding: 4px 6px;
+            border-radius: 4px;
+            transition: color 0.15s ease, background 0.15s ease;
+        }
+
+        .bar-pause-btn:hover {
+            color: var(--text-primary);
+            background: var(--bg-surface);
+        }
 
         .bar-stop-btn {
             background: none;
@@ -3732,8 +3749,22 @@
             transform: scaleY(0.15);
             transition: transform 0.3s ease;
         }
+        .controls-pill .bar-pause-btn {
+            background: none;
+            border: none;
+            color: var(--text-secondary);
+            font-size: 13px;
+            font-weight: 500;
+            font-family: inherit;
+            cursor: pointer;
+            padding: 4px 6px;
+            border-radius: 4px;
+            transition: color 0.15s ease, background 0.15s ease;
+        }
 
-
+        .controls-pill .bar-pause-btn:hover {
+            color: var(--text-primary);
+        }
 
         [data-theme="light"] .controls-pill {
             background: var(--bg-deep);
@@ -4491,6 +4522,7 @@ Ask Steno
                                   <polyline points="6 15 12 9 18 15"></polyline>
                               </svg>
                           </button>
+                          <button class="bar-pause-btn" id="bar-pause-btn" style="display: none;">Pause</button>
                           <button class="bar-stop-btn" id="bar-stop-btn" title="Stop recording" style="display: none;">
                               <svg viewBox="0 0 16 16" fill="currentColor"><rect x="2" y="2" width="12" height="12" rx="2"/></svg>
                           </button>
@@ -5181,7 +5213,7 @@ Session started - waiting for activity...
         const stopBtn = document.getElementById('stop-btn');
         const pauseBtn = document.getElementById('pause-btn');
         const newNoteBtn = document.getElementById('new-note-btn');
-
+        const barPauseBtn = document.getElementById('bar-pause-btn');
         const barStopBtn = document.getElementById('bar-stop-btn');
         const barRecControls = document.getElementById('ask-bar-rec-controls');
         const barRecDivider = document.getElementById('ask-bar-rec-divider');
@@ -5341,6 +5373,7 @@ Session started - waiting for activity...
                     controlsPill.classList.remove('recording');
                     controlsPill.classList.remove('paused');
                     barStopBtn.style.display = 'none';
+                    barPauseBtn.style.display = 'none';
                     // Restore transcript body
                     document.getElementById('ask-bar-transcript-body').style.display = '';
                     break;
@@ -5353,11 +5386,13 @@ Session started - waiting for activity...
                     newNoteBtn.style.display = 'none';
                     document.getElementById('status-dot').style.display = '';
                     document.getElementById('status-text').style.display = '';
-                    // Controls pill: show with live waveform + stop
+                    // Controls pill: show with live waveform + pause + stop
                     controlsPill.classList.add('show');
                     controlsPill.classList.add('recording');
                     controlsPill.classList.remove('paused');
                     barStopBtn.style.display = '';
+                    barPauseBtn.style.display = '';
+                    barPauseBtn.textContent = 'Pause';
                     // Show ask bar
                     document.getElementById('ask-bar').style.display = '';
                     // Start visualizer targeting mini waveform bars in the button.
@@ -5392,6 +5427,8 @@ Session started - waiting for activity...
                     controlsPill.classList.remove('recording');
                     controlsPill.classList.add('paused');
                     barStopBtn.style.display = '';
+                    barPauseBtn.style.display = '';
+                    barPauseBtn.textContent = 'Resume';
                     const minutes = Math.floor(pausedElapsedTime / 60);
                     const seconds = pausedElapsedTime % 60;
                     const timeStr = `${minutes}:${seconds.toString().padStart(2, '0')}`;
@@ -5413,6 +5450,7 @@ Session started - waiting for activity...
                     controlsPill.classList.remove('recording');
                     controlsPill.classList.remove('paused');
                     barStopBtn.style.display = 'none';
+                    barPauseBtn.style.display = 'none';
                     // Restore transcript body
                     document.getElementById('ask-bar-transcript-body').style.display = '';
                     document.getElementById('ask-bar-transcript').classList.remove('show');
@@ -6824,6 +6862,11 @@ Session started - waiting for activity...
         });
 
         // Ask bar recording controls — wire to existing handlers
+        barPauseBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            pauseBtn.click();
+        });
+
         barStopBtn.addEventListener('click', (e) => {
             e.stopPropagation();
             stopBtn.click();

--- a/app/main.js
+++ b/app/main.js
@@ -1238,7 +1238,11 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
           chunkCount++;
           if (chunkCount === 1) console.log(`[QUERY] First chunk received (queryId=${queryId})`);
           if (!event.sender.isDestroyed()) event.sender.send('query-chunk', { queryId, chunk });
-          else console.log(`[QUERY] Sender destroyed, cannot send chunk`);
+          else {
+            console.log(`[QUERY] Sender destroyed, killing process queryId=${queryId}`);
+            proc.kill();
+            activeQueryProcs.delete(queryId);
+          }
         } catch (e) { console.log(`[QUERY] Chunk decode error: ${e.message}`); }
       } else if (line === 'CHAT_STREAM_COMPLETE' || line === 'STREAM_COMPLETE') {
         console.log(`[QUERY] STREAM_COMPLETE received, ${chunkCount} chunks sent`);

--- a/app/main.js
+++ b/app/main.js
@@ -1224,6 +1224,12 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
   }
 
   activeQueryProcs.set(queryId, proc);
+  event.sender.once('destroyed', () => {
+    if (activeQueryProcs.has(queryId)) {
+      proc.kill();
+      activeQueryProcs.delete(queryId);
+    }
+  });
   let buf = '';
   let chunkCount = 0;
   proc.stdout.on('data', (data) => {

--- a/app/main.js
+++ b/app/main.js
@@ -1224,12 +1224,16 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
   }
 
   activeQueryProcs.set(queryId, proc);
-  event.sender.once('destroyed', () => {
+  // Kill the spawned proc if the renderer sender goes away before the query
+  // finishes. Keep a reference so we can remove the listener on normal close
+  // (otherwise repeated queries on a long-lived sender leak one-time listeners).
+  const onSenderDestroyed = () => {
     if (activeQueryProcs.has(queryId)) {
       proc.kill();
       activeQueryProcs.delete(queryId);
     }
-  });
+  };
+  event.sender.once('destroyed', onSenderDestroyed);
   let buf = '';
   let chunkCount = 0;
   proc.stdout.on('data', (data) => {
@@ -1269,6 +1273,9 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
 
   proc.on('close', (code) => {
     activeQueryProcs.delete(queryId);
+    if (!event.sender.isDestroyed()) {
+      event.sender.removeListener('destroyed', onSenderDestroyed);
+    }
     console.log(`[QUERY] Process closed, code=${code}, chunks=${chunkCount}, bufRemainder=${buf.length > 0 ? JSON.stringify(buf.substring(0, 100)) : 'empty'}`);
     if (buf.trim() === 'CHAT_STREAM_COMPLETE' || buf.trim() === 'STREAM_COMPLETE') {
       console.log(`[QUERY] STREAM_COMPLETE was in buf remainder — sending done now`);

--- a/app/main.js
+++ b/app/main.js
@@ -1355,7 +1355,10 @@ ipcMain.handle('update-meeting', async (event, summaryFilePath, updates) => {
       // .md format: update YAML frontmatter fields
       let updatedContent = fileContent;
       if (updates.name !== undefined) {
-        const escapedName = updates.name.replace(/"/g, '\\"');
+        if (updates.name.includes('\n') || updates.name.includes('\r')) {
+          return { success: false, error: 'Title cannot contain newlines' };
+        }
+        const escapedName = updates.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         updatedContent = updatedContent.replace(
           /^title:\s*".*"$/m,
           `title: "${escapedName}"`

--- a/app/main.js
+++ b/app/main.js
@@ -1194,6 +1194,108 @@ ipcMain.handle('query-transcript', async (event, summaryFile, question) => {
   }
 });
 
+const activeQueryProcs = new Map();
+
+ipcMain.on('query-cancel', (_event, queryId) => {
+  const proc = activeQueryProcs.get(queryId);
+  if (proc) {
+    console.log(`[QUERY] Cancelling queryId=${queryId}`);
+    proc.kill();
+    activeQueryProcs.delete(queryId);
+  }
+});
+
+ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) => {
+  console.log(`[QUERY] IPC received: question="${question.substring(0, 50)}" file="${summaryFile}"`);
+  sendDebugLog(`🤖 Streaming query: ${question.substring(0, 50)}...`);
+  const cloudKey = loadCloudApiKey();
+  const env = cloudKey ? { ...process.env, STENOAI_CLOUD_API_KEY: cloudKey } : process.env;
+
+  let proc;
+  try {
+    const backendPath = getBackendPath();
+    proc = require('child_process').spawn(backendPath, ['query-streaming', summaryFile, '-q', question], {
+      env,
+      cwd: getBackendCwd(),
+    });
+  } catch (err) {
+    event.sender.send('query-done', { queryId, success: false, error: err.message });
+    return;
+  }
+
+  activeQueryProcs.set(queryId, proc);
+  let buf = '';
+  let chunkCount = 0;
+  proc.stdout.on('data', (data) => {
+    buf += data.toString();
+    const lines = buf.split('\n');
+    buf = lines.pop();
+    for (const line of lines) {
+      if (line.startsWith('CHAT_CHUNK:') || line.startsWith('CHUNK:')) {
+        const prefixLen = line.startsWith('CHAT_CHUNK:') ? 11 : 6;
+        try {
+          const chunk = Buffer.from(line.slice(prefixLen), 'base64').toString('utf-8');
+          chunkCount++;
+          if (chunkCount === 1) console.log(`[QUERY] First chunk received (queryId=${queryId})`);
+          if (!event.sender.isDestroyed()) event.sender.send('query-chunk', { queryId, chunk });
+          else console.log(`[QUERY] Sender destroyed, cannot send chunk`);
+        } catch (e) { console.log(`[QUERY] Chunk decode error: ${e.message}`); }
+      } else if (line === 'CHAT_STREAM_COMPLETE' || line === 'STREAM_COMPLETE') {
+        console.log(`[QUERY] STREAM_COMPLETE received, ${chunkCount} chunks sent`);
+        if (!event.sender.isDestroyed()) event.sender.send('query-done', { queryId, success: true });
+        else console.log(`[QUERY] Sender destroyed at STREAM_COMPLETE`);
+      } else if (line.startsWith('CHAT_STREAM_ERROR:') || line.startsWith('STREAM_ERROR:')) {
+        const errMsg = line.startsWith('CHAT_STREAM_ERROR:') ? line.slice(18) : line.slice(13);
+        console.log(`[QUERY] STREAM_ERROR: ${errMsg}`);
+        if (!event.sender.isDestroyed()) event.sender.send('query-done', { queryId, success: false, error: errMsg });
+      }
+    }
+  });
+
+  proc.stderr.on('data', (data) => {
+    const msg = data.toString().trim();
+    if (msg) console.log(`[QUERY stderr] ${msg.substring(0, 200)}`);
+  });
+
+  proc.on('close', (code) => {
+    activeQueryProcs.delete(queryId);
+    console.log(`[QUERY] Process closed, code=${code}, chunks=${chunkCount}, bufRemainder=${buf.length > 0 ? JSON.stringify(buf.substring(0, 100)) : 'empty'}`);
+    if (buf.trim() === 'CHAT_STREAM_COMPLETE' || buf.trim() === 'STREAM_COMPLETE') {
+      console.log(`[QUERY] STREAM_COMPLETE was in buf remainder — sending done now`);
+      if (!event.sender.isDestroyed()) event.sender.send('query-done', { queryId, success: true });
+    } else if (code !== 0 && code !== null && !event.sender.isDestroyed()) {
+      // code === null means killed (cancelled) — renderer already handles that case
+      event.sender.send('query-done', { queryId, success: false, error: `Process exited with code ${code}` });
+    }
+  });
+
+  proc.on('error', (err) => {
+    activeQueryProcs.delete(queryId);
+    if (!event.sender.isDestroyed()) event.sender.send('query-done', { queryId, success: false, error: err.message });
+  });
+});
+
+ipcMain.handle('save-chat-sessions', async (event, data) => {
+  try {
+    const filePath = path.join(app.getPath('userData'), 'chat_sessions.json');
+    fs.writeFileSync(filePath, JSON.stringify(data), 'utf-8');
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('load-chat-sessions', async () => {
+  try {
+    const filePath = path.join(app.getPath('userData'), 'chat_sessions.json');
+    if (!fs.existsSync(filePath)) return { success: true, data: null };
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return { success: true, data: JSON.parse(raw) };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
 ipcMain.handle('save-meeting-notes', async (event, sessionName, notes) => {
   try {
     const outputDir = path.join(getBackendCwd(), '_internal', 'output');

--- a/app/main.js
+++ b/app/main.js
@@ -1343,37 +1343,36 @@ ipcMain.handle('update-meeting', async (event, summaryFilePath, updates) => {
       };
     }
 
-    const data = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+    const fileContent = fs.readFileSync(absolutePath, 'utf8');
 
-    // Update fields - only update fields that are provided
-    if (updates.name !== undefined) {
-      data.session_info.name = updates.name;
+    if (absolutePath.endsWith('.md')) {
+      // .md format: update YAML frontmatter fields
+      let updatedContent = fileContent;
+      if (updates.name !== undefined) {
+        const escapedName = updates.name.replace(/"/g, '\\"');
+        updatedContent = updatedContent.replace(
+          /^title:\s*".*"$/m,
+          `title: "${escapedName}"`
+        );
+      }
+      fs.writeFileSync(absolutePath, updatedContent, 'utf8');
+    } else {
+      // .json format: update structured fields
+      const data = JSON.parse(fileContent);
+      if (updates.name !== undefined) data.session_info.name = updates.name;
+      if (updates.summary !== undefined) data.summary = updates.summary;
+      if (updates.participants !== undefined) data.participants = updates.participants;
+      if (updates.key_points !== undefined) data.key_points = updates.key_points;
+      if (updates.action_items !== undefined) data.action_items = updates.action_items;
+      data.session_info.updated_at = new Date().toISOString();
+      fs.writeFileSync(absolutePath, JSON.stringify(data, null, 2), 'utf8');
     }
-    if (updates.summary !== undefined) {
-      data.summary = updates.summary;
-    }
-    if (updates.participants !== undefined) {
-      data.participants = updates.participants;
-    }
-    if (updates.key_points !== undefined) {
-      data.key_points = updates.key_points;
-    }
-    if (updates.action_items !== undefined) {
-      data.action_items = updates.action_items;
-    }
-
-    // Add updated timestamp
-    data.session_info.updated_at = new Date().toISOString();
-
-    // Write back to file
-    fs.writeFileSync(absolutePath, JSON.stringify(data, null, 2), 'utf8');
 
     console.log(`Updated meeting: ${absolutePath}`);
 
     return {
       success: true,
-      message: 'Meeting updated successfully',
-      updatedData: data
+      message: 'Meeting updated successfully'
     };
   } catch (error) {
     console.error('Update meeting error:', error);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -677,7 +677,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -863,6 +862,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -882,6 +882,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -904,6 +905,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -919,7 +921,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -927,6 +930,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1173,6 +1177,7 @@
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1552,6 +1557,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1652,6 +1658,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1665,6 +1672,7 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -1823,8 +1831,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dir-compare": {
       "version": "3.3.0",
@@ -1867,7 +1874,6 @@
       "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "builder-util": "24.13.1",
@@ -2005,7 +2011,6 @@
       "integrity": "sha512-HZtZg8EHsDGnswFt0QeV8If8B+et63uD6RJ7I4/xhcXqmTIbI08GoubX/wm+HdY0DwcuPe1/xsgqpmYvjdjRoA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -2060,6 +2065,7 @@
       "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "archiver": "^5.3.1",
@@ -2073,6 +2079,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2088,6 +2095,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2101,6 +2109,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2575,7 +2584,8 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -3079,7 +3089,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -3210,6 +3221,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3223,6 +3235,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3238,7 +3251,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3246,6 +3260,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3262,14 +3277,16 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3282,7 +3299,8 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -3296,14 +3314,16 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -3502,6 +3522,7 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3714,7 +3735,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -3888,6 +3910,7 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3903,6 +3926,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -3982,7 +4006,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4227,6 +4252,7 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4366,6 +4392,7 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4561,7 +4588,8 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/verror": {
       "version": "1.10.1",
@@ -4739,6 +4767,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -4754,6 +4783,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1222,7 +1222,10 @@ def _parse_meeting_markdown(md_path):
             for line in parts[1].strip().split('\n'):
                 if ':' in line:
                     key, _, value = line.partition(':')
-                    value = value.strip().strip('"')
+                    value = value.strip()
+                    if value.startswith('"') and value.endswith('"'):
+                        import re as _re
+                        value = _re.sub(r'\\(.)', lambda m: m.group(1), value[1:-1])
                     if value == 'null':
                         value = None
                     elif value == 'true':

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -436,7 +436,7 @@ Transcript:
         )
 
         # Step 2b: Auto-generate title for auto-named meetings
-        if re.match(r'^Meeting-[A-Z0-9]{6}$', session_name):
+        if re.match(r'^(Meeting|Note)-[A-Z0-9]{6}$', session_name):
             try:
                 language = transcript_data.get("output_language")
                 generated_title = self.summarizer.generate_title(
@@ -556,7 +556,7 @@ Transcript:
         print("STREAM_COMPLETE", flush=True)
 
         # Step 3: Generate title
-        if re.match(r'^Meeting-[A-Z0-9]{6}$', session_name):
+        if re.match(r'^(Meeting|Note)-[A-Z0-9]{6}$', session_name):
             try:
                 generated_title = self.summarizer.generate_title(
                     streamed_md, transcript_text, language=output_language
@@ -889,7 +889,7 @@ def process_streaming(audio_file, name, notes):
 
         # Step 3: Generate title
         session_name = name
-        if re.match(r'^Meeting-[A-Z0-9]{6}$', name):
+        if re.match(r'^(Meeting|Note)-[A-Z0-9]{6}$', name):
             try:
                 generated_title = recorder.summarizer.generate_title(
                     streamed_md, transcript_text, language=output_language

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1629,6 +1629,84 @@ def query(transcript_file, question):
         print(json.dumps({"success": False, "error": f"Query failed: {e}"}))
 
 
+@cli.command(name='query-streaming')
+@click.argument('transcript_file')
+@click.option('--question', '-q', required=True, help='Question to ask about the transcript')
+def query_streaming(transcript_file, question):
+    """Query a transcript with streaming output. Emits CHUNK:base64 lines then STREAM_COMPLETE."""
+    import sys
+    import base64
+    from pathlib import Path
+
+    transcript_path = Path(transcript_file)
+    language = None
+
+    if transcript_file.endswith('.json'):
+        if not transcript_path.exists():
+            print(f"STREAM_ERROR:File not found: {transcript_file}", flush=True)
+            return
+        try:
+            with open(transcript_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                transcript_text = data.get('transcript', '')
+                if not transcript_text:
+                    print("STREAM_ERROR:No transcript found in summary file", flush=True)
+                    return
+                session_info = data.get("session_info", {})
+                language = session_info.get("output_language")
+        except Exception as e:
+            print(f"STREAM_ERROR:Failed to read file: {e}", flush=True)
+            return
+    elif transcript_file.endswith('.md'):
+        if not transcript_path.exists():
+            print(f"STREAM_ERROR:File not found: {transcript_file}", flush=True)
+            return
+        try:
+            meeting_data = _parse_meeting_markdown(transcript_path)
+            parts = []
+            if meeting_data.get('summary'):
+                parts.append(f"SUMMARY:\n{meeting_data['summary']}")
+            if meeting_data.get('discussion_areas'):
+                topics = '\n'.join(f"- {d['title']}: {d['analysis']}" for d in meeting_data['discussion_areas'])
+                parts.append(f"KEY TOPICS:\n{topics}")
+            if meeting_data.get('key_points'):
+                points = '\n'.join(f"- {p}" for p in meeting_data['key_points'])
+                parts.append(f"KEY POINTS:\n{points}")
+            if meeting_data.get('transcript'):
+                parts.append(f"TRANSCRIPT:\n{meeting_data['transcript']}")
+            transcript_text = '\n\n'.join(parts)
+            session_info = meeting_data.get("session_info", {})
+            language = session_info.get("output_language")
+        except Exception as e:
+            print(f"STREAM_ERROR:Failed to read file: {e}", flush=True)
+            return
+    else:
+        if not transcript_path.exists():
+            print(f"STREAM_ERROR:File not found: {transcript_file}", flush=True)
+            return
+        try:
+            transcript_text = transcript_path.read_text(encoding='utf-8')
+        except Exception as e:
+            print(f"STREAM_ERROR:Failed to read file: {e}", flush=True)
+            return
+
+    if not language:
+        from src.config import get_config
+        language = get_config().get_language()
+    if language == "auto":
+        language = "en"
+
+    try:
+        summarizer = OllamaSummarizer()
+        for chunk in summarizer.query_transcript_streaming(transcript_text, question, language=language):
+            encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
+            sys.stdout.write(f"CHAT_CHUNK:{encoded}\n")
+            sys.stdout.flush()
+        print("CHAT_STREAM_COMPLETE", flush=True)
+    except Exception as e:
+        print(f"CHAT_STREAM_ERROR:{e}", flush=True)
+
+
 @cli.command()
 def list_failed():
     """List summary files that failed processing (have fallback summaries)"""

--- a/src/config.py
+++ b/src/config.py
@@ -136,12 +136,12 @@ class Config:
             config_path: Path to config file. If None, uses default location.
         """
         if config_path is None:
-            # Use same directory logic as recorder state
-            if "StenoAI.app" in str(Path(__file__)) or "Applications" in str(Path(__file__)):
-                # Production: ~/Library/Application Support/stenoai
+            import sys as _sys
+            if getattr(_sys, 'frozen', False) or "StenoAI.app" in str(Path(__file__)) or "Applications" in str(Path(__file__)):
+                # Bundled (PyInstaller dev or production): ~/Library/Application Support/stenoai
                 base_dir = Path.home() / "Library" / "Application Support" / "stenoai"
             else:
-                # Development: project root
+                # Source dev: project root
                 base_dir = Path(__file__).parent.parent
 
             base_dir.mkdir(parents=True, exist_ok=True)
@@ -471,12 +471,13 @@ def get_data_dirs() -> Dict[str, Path]:
     config = get_config()
     custom = config.get_storage_path()
 
+    import sys as _sys
     if custom:
         base = Path(custom)
-    elif "StenoAI.app" in str(Path(__file__)) or "Applications" in str(Path(__file__)):
+    elif getattr(_sys, 'frozen', False) or "StenoAI.app" in str(Path(__file__)) or "Applications" in str(Path(__file__)):
         base = Path.home() / "Library" / "Application Support" / "stenoai"
     else:
-        base = Path(__file__).parent.parent  # project root in dev
+        base = Path(__file__).parent.parent  # project root in dev (source)
 
     dirs = {
         "recordings": base / "recordings",

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -930,6 +930,23 @@ TITLE:"""
             logger.warning(f"Failed to generate meeting title: {e}")
             return None
 
+    def _build_query_prompt(self, transcript: str, question: str, language: str = "en") -> str:
+        if language and language not in ("en", "auto"):
+            from .config import get_config
+            language_name = get_config().get_language_name(language)
+            query_lang_instruction = f"\nRespond in {language_name}." if language_name != "Unknown" else ""
+        else:
+            query_lang_instruction = ""
+        return f"""Answer the following question based on the meeting content below (summary, key topics, and transcript).
+Be concise and direct. If the answer requires inference from what was discussed, that's fine.
+Only say you don't know if the topic truly wasn't discussed at all.{query_lang_instruction}
+
+QUESTION: {question}
+
+{transcript}
+
+ANSWER:"""
+
     def query_transcript_streaming(self, transcript: str, question: str, language: str = "en"):
         """Generator that yields text chunks from the LLM for a transcript query."""
         if not transcript or transcript.strip() == "":
@@ -939,22 +956,7 @@ TITLE:"""
             yield "Please provide a question."
             return
 
-        if language and language not in ("en", "auto"):
-            from .config import get_config
-            language_name = get_config().get_language_name(language)
-            query_lang_instruction = f"\nRespond in {language_name}." if language_name != "Unknown" else ""
-        else:
-            query_lang_instruction = ""
-
-        prompt = f"""Answer the following question based on the meeting content below (summary, key topics, and transcript).
-Be concise and direct. If the answer requires inference from what was discussed, that's fine.
-Only say you don't know if the topic truly wasn't discussed at all.{query_lang_instruction}
-
-QUESTION: {question}
-
-{transcript}
-
-ANSWER:"""
+        prompt = self._build_query_prompt(transcript, question, language)
 
         try:
             if self.ai_provider == "cloud":
@@ -1014,26 +1016,7 @@ ANSWER:"""
             if not question or question.strip() == "":
                 return "Please provide a question."
 
-            # Build language instruction for query responses
-            if language and language not in ("en", "auto"):
-                from .config import get_config
-                language_name = get_config().get_language_name(language)
-                if language_name != "Unknown":
-                    query_lang_instruction = f"\nRespond in {language_name}."
-                else:
-                    query_lang_instruction = ""
-            else:
-                query_lang_instruction = ""
-
-            prompt = f"""Answer the following question based on the meeting content below (summary, key topics, and transcript).
-Be concise and direct. If the answer requires inference from what was discussed, that's fine.
-Only say you don't know if the topic truly wasn't discussed at all.{query_lang_instruction}
-
-QUESTION: {question}
-
-{transcript}
-
-ANSWER:"""
+            prompt = self._build_query_prompt(transcript, question, language)
 
             logger.info(f"Querying transcript with question: {question[:50]}...")
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -977,7 +977,11 @@ ANSWER:"""
                         if content:
                             yield content
             else:
-                self._ensure_ollama_ready()
+                if self.ai_provider == "remote":
+                    self.client = ollama.Client(host=self.remote_url)
+                else:
+                    self._ensure_ollama_ready()
+                    self.client = ollama.Client()
                 stream = self.client.chat(
                     model=self.model_name,
                     messages=[{"role": "user", "content": prompt}],

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -930,6 +930,67 @@ TITLE:"""
             logger.warning(f"Failed to generate meeting title: {e}")
             return None
 
+    def query_transcript_streaming(self, transcript: str, question: str, language: str = "en"):
+        """Generator that yields text chunks from the LLM for a transcript query."""
+        if not transcript or transcript.strip() == "":
+            yield "No transcript available to query."
+            return
+        if not question or question.strip() == "":
+            yield "Please provide a question."
+            return
+
+        if language and language not in ("en", "auto"):
+            from .config import get_config
+            language_name = get_config().get_language_name(language)
+            query_lang_instruction = f"\nRespond in {language_name}." if language_name != "Unknown" else ""
+        else:
+            query_lang_instruction = ""
+
+        prompt = f"""Answer the following question based on the meeting content below (summary, key topics, and transcript).
+Be concise and direct. If the answer requires inference from what was discussed, that's fine.
+Only say you don't know if the topic truly wasn't discussed at all.{query_lang_instruction}
+
+QUESTION: {question}
+
+{transcript}
+
+ANSWER:"""
+
+        try:
+            if self.ai_provider == "cloud":
+                if self.cloud_provider == "anthropic":
+                    with self.anthropic_client.messages.stream(
+                        model=self.model_name,
+                        max_tokens=2048,
+                        messages=[{"role": "user", "content": prompt}],
+                    ) as stream:
+                        for text in stream.text_stream:
+                            yield text
+                else:
+                    response = self.cloud_client.chat.completions.create(
+                        model=self.model_name,
+                        messages=[{"role": "user", "content": prompt}],
+                        stream=True,
+                    )
+                    for chunk in response:
+                        content = chunk.choices[0].delta.content
+                        if content:
+                            yield content
+            else:
+                self._ensure_ollama_ready()
+                stream = self.client.chat(
+                    model=self.model_name,
+                    messages=[{"role": "user", "content": prompt}],
+                    stream=True,
+                )
+                for chunk in stream:
+                    content = chunk['message']['content']
+                    if content:
+                        yield content
+        except Exception as e:
+            logger.error(f"Streaming query failed: {e}")
+            yield f"\n[Error: {e}]"
+
     def query_transcript(self, transcript: str, question: str, language: str = "en") -> Optional[str]:
         """
         Query a transcript with a question using Ollama.

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -975,6 +975,10 @@ ANSWER:"""
                         stream=True,
                     )
                     for chunk in response:
+                        # Some providers emit chunk variants with empty choices
+                        # (e.g. usage-only chunks); skip those instead of crashing.
+                        if not chunk.choices:
+                            continue
                         content = chunk.choices[0].delta.content
                         if content:
                             yield content


### PR DESCRIPTION
> **Stacked on #92** — depends on the chat interface redesign. Once #92 merges, this branch will be rebased onto `main` so the diff only shows changes below.

## Summary
- **Notes generation scanner**: Granola-style rounded rect overlay that glides smoothly down the page as notes stream in, with "Analyzing transcript" → "Generating notes" label and spinner
- **Regenerate button**: Icon spins in place instead of amber background + "Processing..." text swap; notes clear immediately on confirm
- **Inline title editing**: Click directly on meeting title to edit (Notion/Granola style), saves on blur — replaces edit button + modal
- **Fix: title save for `.md` meetings**: `update-meeting` IPC handler was calling `JSON.parse()` on YAML frontmatter files, causing silent save failures; now branches on file extension
- **Fix: `####` heading rendering** in streaming markdown renderer
- **Fix: bold-only lines** (e.g. "No topics discussed") now render as plain text instead of bold
- **Search bar**: Background colour matches sidebar/chat
- **Settings button**: Height aligned to match New Note button

## Test plan
- [x] Open a meeting, click regenerate — notes clear immediately, icon spins, scanner glides down as text streams in, scanner disappears on completion
- [x] Click meeting title, edit text, click away — title saves and updates in sidebar
- [x] Click meeting title, press Escape — reverts to original
- [x] Check `####` headings render correctly in streamed notes
- [x] Settings button and New Note button appear the same height
- [x] Search bar background matches sidebar colour

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a smooth notes-generation scanner on stop, inline title editing, streaming chat with a Stop button (Esc also cancels), and a live "Recording" sidebar entry. Renames the auto session prefix to "Note-" and improves chat reliability, title handling, scanner performance, and overall stability.

- **New Features**
  - Notes scanner on stop; glides as notes stream; regenerate clears instantly with spinner; header status removed.
  - Streaming chat with Stop/Esc; cancels in-flight queries and appends "Stopped".
  - Inline title editing (click to edit; saves on blur; Esc reverts).
  - Live "Recording" sidebar entry with pulsing dot; safe to navigate; replaced by "Processing…" then final note.
  - Auto session prefix updated to "Note-"; auto-title works for both "Meeting-" and "Note-".
  - Chat sessions persist to disk and load on startup.

- **Bug Fixes**
  - Recording: remove ghost "Recording" item when start fails.
  - Chat: prevent duplicate streaming bubble; guard provider usage-only chunks; prompt chips submit reliably; stays expanded after stop.
  - Queries: add `query-cancel` IPC; kill orphaned procs; clean up per-query "destroyed" listeners on normal close.
  - Title/YAML: fix `.md` saves; unescape YAML on read; reject/strip newlines; escape backslashes; revert inline title only if still editing that meeting.
  - Markdown/UI: fix `####` headings and bold-only lines; match transcript/chat panel styling; minimise icon; subtle dark-mode hover fills; sidebar to 250px with aligned toggle; align Settings/New Note heights; search bar background.
  - Scanner: batch position updates via `requestAnimationFrame`; clamp for short notes.
  - Config: use `sys.frozen` to detect bundled builds and resolve data dirs correctly.

<sup>Written for commit a37cc0cdff84a2ca3076453d33cbedd81914b4bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

