### PR TITLE
feat: enhance Chinese language support with variant handling and conversion

### DIFF
--- a/app/renderer/src/routes/settings/languages.ts
+++ b/app/renderer/src/routes/settings/languages.ts
@@ -3,8 +3,11 @@ import { PARAKEET_LANGUAGE_CODES } from '@/lib/transcription-languages';
 export type LangOption = { value: string; label: string };
 
 // Curated language list shown in Settings → Transcribe. Whisper supports
-// all 12 (it covers 99 languages at the model level; the dropdown is just
-// the tested curation).
+// all 13 (it covers 99 languages at the model level; the dropdown is just
+// the tested curation). Chinese is split into Simplified (zh-Hans) and
+// Traditional (zh-Hant): whisper.cpp always emits Simplified, so Traditional
+// is a post-transcription OpenCC conversion (see src/chinese.py) — both map
+// to whisper's "zh" for the actual ASR call.
 export const LANGUAGES_WHISPER: LangOption[] = [
   { value: 'auto', label: 'Auto (detect)' },
   { value: 'en', label: 'English' },
@@ -14,7 +17,8 @@ export const LANGUAGES_WHISPER: LangOption[] = [
   { value: 'nl', label: 'Dutch' },
   { value: 'pt', label: 'Portuguese' },
   { value: 'ja', label: 'Japanese' },
-  { value: 'zh', label: 'Chinese' },
+  { value: 'zh-Hans', label: 'Chinese (Simplified)' },
+  { value: 'zh-Hant', label: 'Chinese (Traditional)' },
   { value: 'ko', label: 'Korean' },
   { value: 'hi', label: 'Hindi' },
   { value: 'ar', label: 'Arabic' },

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,8 @@ pydantic>=2.5.0
 python-dateutil>=2.8.0
 openai>=1.0.0
 anthropic>=0.18.0
+# OpenCC (pure-Python reimplementation) converts Chinese Simplified ↔ Traditional
+# for the zh-Hans / zh-Hant language options. Cross-platform, no native deps.
+# PINNED to an exact version — this ships inside the signed/notarised binary, and
+# its dictionary JSON is bundled via collect_data_files('opencc') in stenoai.spec.
+opencc-python-reimplemented==0.1.7

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -99,6 +99,29 @@ def resolve_output_language(
     return "en"
 
 
+def _apply_chinese_variant(text: Optional[str]) -> Optional[str]:
+    """Convert ``text`` to the user's selected Chinese script, if any.
+
+    whisper.cpp and Parakeet (and the summariser LLM) emit Simplified for
+    Chinese; a user who picked Traditional (``zh-Hant``) gets an s2t pass here.
+    A thin, never-throwing hook: non-Chinese languages, a missing OpenCC, or a
+    conversion error all fall through to the input unchanged so transcription
+    is never broken by variant conversion.
+    """
+    if not text:
+        return text
+    try:
+        from src.config import get_config
+        from src.chinese import apply_variant
+
+        variant = get_config().get_chinese_variant()
+        if variant:
+            return apply_variant(text, variant)
+    except Exception as e:
+        logger.warning(f"Chinese variant conversion skipped: {e}")
+    return text
+
+
 def resolve_persisted_output_language(
     session_info: dict,
     transcript_text: Optional[str],
@@ -464,9 +487,12 @@ Summary output language: {config.get_language_name(output_language)}
 
         # Get configured language
         configured_language = config.get_language()
+        # ASR only knows "zh" for Chinese; the Simplified/Traditional choice is
+        # applied as a post-transcription conversion, not an ASR mode.
+        asr_language = config.get_whisper_language()
 
         # Transcribe with diarisation support (stereo → [You]/[Others])
-        transcript_result = self.transcriber.transcribe_diarised(audio_path, language=configured_language)
+        transcript_result = self.transcriber.transcribe_diarised(audio_path, language=asr_language)
 
         # A transcription crash (e.g. an OOM on a long file) is not silence:
         # propagate the flag and skip writing a normal transcript file so the
@@ -502,6 +528,10 @@ Summary output language: {config.get_language_name(output_language)}
         if isinstance(transcript_result, dict):
             is_diarised = transcript_result.get("is_diarised", False)
             diarised_text = transcript_result.get("diarised_text")
+
+        # Convert the transcript to the selected Chinese script (no-op otherwise).
+        transcript_text = _apply_chinese_variant(transcript_text)
+        diarised_text = _apply_chinese_variant(diarised_text)
 
         output_language = self._resolve_output_language(
             configured_language, detected_language, transcript_text=diarised_text or transcript_text
@@ -736,7 +766,7 @@ Summary output language: {config.get_language_name(output_language)}
             err_msg = str(e).replace('\n', ' ').replace('\r', ' ')
             print(f"STREAM_ERROR:{err_msg}", flush=True)
             raise
-        streamed_md = ''.join(streamed_chunks)
+        streamed_md = _apply_chinese_variant(''.join(streamed_chunks)) or ''
 
         print("STREAM_COMPLETE", flush=True)
 
@@ -748,6 +778,7 @@ Summary output language: {config.get_language_name(output_language)}
             generated_title = self.summarizer.generate_title(
                 streamed_md, transcript_text, language=output_language
             )
+            generated_title = _apply_chinese_variant(generated_title)
             if generated_title:
                 session_name = generated_title
                 print(f"TITLE:{session_name}", flush=True)
@@ -1282,7 +1313,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
             print(f"STREAM_ERROR:{err_msg}", flush=True)
             sys.exit(1)
 
-        streamed_md = ''.join(streamed_chunks)
+        streamed_md = _apply_chinese_variant(''.join(streamed_chunks)) or ''
 
         print("STREAM_COMPLETE", flush=True)
 
@@ -1293,6 +1324,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
                 generated_title = recorder.summarizer.generate_title(
                     streamed_md, transcript_text, language=output_language
                 )
+                generated_title = _apply_chinese_variant(generated_title)
                 if generated_title:
                     session_name = generated_title
                     print(f"TITLE:{session_name}", flush=True)
@@ -2943,7 +2975,7 @@ def reprocess(summary_file, regenerate_title, retranscribe):
             print(f"STREAM_ERROR:{err_msg}", flush=True)
             sys.exit(1)
 
-        streamed_md = ''.join(streamed_chunks)
+        streamed_md = _apply_chinese_variant(''.join(streamed_chunks)) or ''
 
         # Regenerate the title when explicitly forced OR when the note still has
         # an auto/placeholder name. The latter is the common case now that the
@@ -2963,6 +2995,7 @@ def reprocess(summary_file, regenerate_title, retranscribe):
             generated_title = recorder.summarizer.generate_title(
                 streamed_md, transcript, language=output_language
             )
+            generated_title = _apply_chinese_variant(generated_title)
             if generated_title:
                 session_name = generated_title
                 existing_data["session_info"]["name"] = generated_title
@@ -3202,7 +3235,7 @@ def generate_report(summary_file, template_id):
         print(f"STREAM_ERROR:{err_msg}", flush=True)
         sys.exit(1)
 
-    streamed_md = ''.join(streamed_chunks)
+    streamed_md = _apply_chinese_variant(''.join(streamed_chunks)) or ''
 
     # Do NOT persist an empty report — surface a stream error instead.
     if not streamed_md.strip():
@@ -3264,6 +3297,7 @@ def regen_title(summary_file):
             recorder.summarizer = OllamaSummarizer()
 
         generated_title = recorder.summarizer.generate_title(summary, transcript, language=output_language)
+        generated_title = _apply_chinese_variant(generated_title)
         if not generated_title:
             print("ERROR: Title generation returned empty result")
             sys.exit(1)

--- a/src/chinese.py
+++ b/src/chinese.py
@@ -1,0 +1,95 @@
+"""Chinese script conversion (Simplified ↔ Traditional) via OpenCC.
+
+Thin, dependency-optional wrapper. OpenCC (``opencc-python-reimplemented``) is
+imported lazily so a bundle or dev checkout without it degrades gracefully:
+every entry point returns its input unchanged rather than raising, and the
+"unavailable" warning is logged once. whisper.cpp / Parakeet emit Simplified
+for Chinese ("zh"); this module is how a user who picked Traditional
+(``zh-Hant``) gets their transcript + summary converted after the fact.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_converter_s2t = None
+_converter_t2s = None
+_unavailable_logged = False
+
+
+def _get_converter(direction: str):
+    global _converter_s2t, _converter_t2s, _unavailable_logged
+    try:
+        from opencc import OpenCC
+    except ImportError:
+        if not _unavailable_logged:
+            logger.warning("opencc not installed — Chinese variant conversion disabled")
+            _unavailable_logged = True
+        return None
+    if direction == "s2t":
+        if _converter_s2t is None:
+            try:
+                _converter_s2t = OpenCC("s2t")
+            except Exception as e:
+                logger.warning(f"OpenCC s2t converter unavailable: {e}")
+                return None
+        return _converter_s2t
+    if direction == "t2s":
+        if _converter_t2s is None:
+            try:
+                _converter_t2s = OpenCC("t2s")
+            except Exception as e:
+                logger.warning(f"OpenCC t2s converter unavailable: {e}")
+                return None
+        return _converter_t2s
+    return None
+
+
+def to_traditional(text: Optional[str]) -> Optional[str]:
+    """Simplified → Traditional (s2t). Pass-through when OpenCC is unavailable."""
+    if not text:
+        return text
+    conv = _get_converter("s2t")
+    if conv is None:
+        return text
+    try:
+        return conv.convert(text)
+    except Exception as e:
+        logger.warning(f"OpenCC s2t conversion failed: {e}")
+        return text
+
+
+def to_simplified(text: Optional[str]) -> Optional[str]:
+    """Traditional → Simplified (t2s). Pass-through when OpenCC is unavailable."""
+    if not text:
+        return text
+    conv = _get_converter("t2s")
+    if conv is None:
+        return text
+    try:
+        return conv.convert(text)
+    except Exception as e:
+        logger.warning(f"OpenCC t2s conversion failed: {e}")
+        return text
+
+
+def apply_variant(text: Optional[str], variant: Optional[str]) -> Optional[str]:
+    """Convert ``text`` to the requested Chinese variant; pass through if N/A.
+
+    ``variant`` accepts the config-level names ``"traditional"`` / ``"simplified"``
+    (see ``Config.get_chinese_variant``) as well as the UI language codes
+    ``"zh-Hant"`` / ``"zh-Hans"``. Anything else (None, "en", …) returns the
+    input unchanged.
+    """
+    if variant in ("traditional", "zh-Hant"):
+        return to_traditional(text)
+    if variant in ("simplified", "zh-Hans"):
+        return to_simplified(text)
+    return text
+
+
+def convert(text: Optional[str], target_variant: Optional[str]) -> Optional[str]:
+    """Public alias for :func:`apply_variant` (converts ``text`` to ``target_variant``)."""
+    return apply_variant(text, target_variant)

--- a/src/config.py
+++ b/src/config.py
@@ -216,7 +216,8 @@ class Config:
         "nl": "Dutch",
         "pt": "Portuguese",
         "ja": "Japanese",
-        "zh": "Chinese",
+        "zh-Hans": "Chinese (Simplified)",
+        "zh-Hant": "Chinese (Traditional)",
         "ko": "Korean",
         "hi": "Hindi",
         "ar": "Arabic",
@@ -297,9 +298,25 @@ class Config:
         self._migrate_whisper_model()
         self._migrate_summary_model()
         self._migrate_transcription_engine()
+        self._migrate_language_zh()
         self._migrate_privacy_notice_seen()
         self._normalize_templates()
         self._seed_sample_template()
+
+    def _migrate_language_zh(self) -> None:
+        """Migrate the legacy single ``"zh"`` language to Simplified (``zh-Hans``).
+
+        Chinese used to be one selectable entry ("zh"); it's now split into
+        ``zh-Hans`` (Simplified) and ``zh-Hant`` (Traditional). whisper.cpp
+        emits Simplified for "zh", so an existing "zh" user was effectively on
+        Simplified — map them there and leave the Traditional opt-in to the
+        Settings dropdown.
+        """
+        if self._load_failed:
+            return  # never persist defaults over a corrupt-but-recoverable file
+        if self._config.get("language") == "zh":
+            self._config["language"] = "zh-Hans"
+            self._save()
 
     def _migrate_transcription_engine(self) -> None:
         """Decide the active ASR engine on first launch of a version that has
@@ -1152,6 +1169,33 @@ class Config:
         # transcript's language instead of silently defaulting to English (#281).
         return self._config.get("language", "auto")
 
+    def get_whisper_language(self) -> str:
+        """Map the UI language code to the code the ASR engine understands.
+
+        whisper.cpp (and Parakeet's language hint) only know ``"zh"`` for
+        Chinese — the Simplified/Traditional distinction is a post-transcription
+        conversion, not an ASR mode — so both ``zh-Hans`` and ``zh-Hant`` fold
+        to ``zh`` here. Every other code passes through unchanged.
+        """
+        code = self.get_language()
+        if code in ("zh-Hans", "zh-Hant"):
+            return "zh"
+        return code
+
+    def get_chinese_variant(self) -> Optional[str]:
+        """Return the target Chinese script for output conversion.
+
+        ``"traditional"`` for ``zh-Hant``, ``"simplified"`` for ``zh-Hans``,
+        and ``None`` for any non-Chinese language (no conversion needed).
+        Consumed by ``src.chinese.apply_variant``.
+        """
+        code = self.get_language()
+        if code == "zh-Hant":
+            return "traditional"
+        if code == "zh-Hans":
+            return "simplified"
+        return None
+
     def set_language(self, language_code: str) -> bool:
         """
         Set the language for transcription and summarization.
@@ -1162,6 +1206,11 @@ class Config:
         Returns:
             True if saved successfully, False otherwise
         """
+        # Legacy "zh" (pre Simplified/Traditional split) is still accepted and
+        # normalised to Simplified, matching the on-load migration.
+        if language_code == "zh":
+            language_code = "zh-Hans"
+
         if language_code not in self.SUPPORTED_LANGUAGES:
             logger.error(f"Unsupported language code: {language_code}")
             return False

--- a/stenoai.spec
+++ b/stenoai.spec
@@ -159,6 +159,17 @@ for pkg in _DATA_PKGS:
     except Exception:
         pass
 
+# OpenCC ships the Chinese Simplified↔Traditional conversion dictionaries
+# (JSON + text) as package data, loaded by path at runtime. Without bundling
+# them the s2t/t2s converters raise on init and zh-Hant output silently falls
+# back to Simplified. Pure-Python + cross-platform, so this applies to both the
+# macOS and Windows bundles (no platform gate). Guarded so a missing/renamed
+# package never breaks the build.
+try:
+    datas += collect_data_files('opencc')
+except Exception:
+    pass
+
 # Copy package metadata (.dist-info) for packages that read their own version
 # via importlib.metadata at import time. onnx_asr/__init__.py does
 # `__version__ = importlib.metadata.version("onnx-asr")` on import — without the

--- a/tests/test_chinese.py
+++ b/tests/test_chinese.py
@@ -1,0 +1,108 @@
+"""Tests for src.chinese (Simplified ↔ Traditional conversion via OpenCC).
+
+The real-conversion tests double as the staleness check on
+``opencc-python-reimplemented==0.1.7``: its PyPI classifiers stop at Python 3.5,
+so a green run here proves it still imports AND converts on the interpreter that
+ships in the signed binary. The missing-OpenCC test proves the module degrades
+gracefully (returns its input, never raises) when the dependency is absent.
+"""
+import builtins
+import unittest
+from unittest.mock import patch
+
+from src import chinese
+
+# Known-good pair. 简体中文 (Simplified) ↔ 簡體中文 (Traditional).
+SIMPLIFIED = "简体中文"
+TRADITIONAL = "簡體中文"
+
+
+def _opencc_installed() -> bool:
+    try:
+        import opencc  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@unittest.skipUnless(_opencc_installed(), "opencc not installed in this env")
+class ChineseRealConversionTests(unittest.TestCase):
+    """Exercise the real OpenCC converters (no mocks)."""
+
+    def setUp(self):
+        # Converters are module-level singletons; other tests may have poisoned
+        # them (missing-import test). Reset so we build fresh real ones.
+        chinese._converter_s2t = None
+        chinese._converter_t2s = None
+        chinese._unavailable_logged = False
+
+    def test_s2t_converts_simplified_to_traditional(self):
+        self.assertEqual(chinese.to_traditional(SIMPLIFIED), TRADITIONAL)
+
+    def test_t2s_converts_traditional_to_simplified(self):
+        self.assertEqual(chinese.to_simplified(TRADITIONAL), SIMPLIFIED)
+
+    def test_round_trip_is_identity(self):
+        self.assertEqual(chinese.to_simplified(chinese.to_traditional(SIMPLIFIED)), SIMPLIFIED)
+
+    def test_apply_variant_traditional(self):
+        self.assertEqual(chinese.apply_variant(SIMPLIFIED, "traditional"), TRADITIONAL)
+
+    def test_apply_variant_simplified(self):
+        self.assertEqual(chinese.apply_variant(TRADITIONAL, "simplified"), SIMPLIFIED)
+
+    def test_apply_variant_accepts_ui_language_codes(self):
+        self.assertEqual(chinese.apply_variant(SIMPLIFIED, "zh-Hant"), TRADITIONAL)
+        self.assertEqual(chinese.apply_variant(TRADITIONAL, "zh-Hans"), SIMPLIFIED)
+
+    def test_convert_alias(self):
+        self.assertEqual(chinese.convert(SIMPLIFIED, "traditional"), TRADITIONAL)
+
+
+class ChineseVariantPassthroughTests(unittest.TestCase):
+    """Behaviour that must hold regardless of whether OpenCC is installed."""
+
+    def test_apply_variant_passes_through_without_variant(self):
+        self.assertEqual(chinese.apply_variant("hello", None), "hello")
+
+    def test_apply_variant_passes_through_unknown_variant(self):
+        self.assertEqual(chinese.apply_variant("hello", "en"), "hello")
+
+    def test_empty_and_none_are_returned_unchanged(self):
+        self.assertEqual(chinese.apply_variant("", "traditional"), "")
+        self.assertIsNone(chinese.apply_variant(None, "traditional"))
+
+
+class ChineseMissingOpenCCTests(unittest.TestCase):
+    """When OpenCC can't be imported, every entry point degrades gracefully."""
+
+    def setUp(self):
+        # Drop any cached real converters so _get_converter re-attempts the
+        # (now-failing) import instead of returning a live singleton.
+        chinese._converter_s2t = None
+        chinese._converter_t2s = None
+        chinese._unavailable_logged = False
+
+    def tearDown(self):
+        chinese._converter_s2t = None
+        chinese._converter_t2s = None
+        chinese._unavailable_logged = False
+
+    def test_conversion_returns_input_when_opencc_missing(self):
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "opencc" or name.startswith("opencc."):
+                raise ImportError("simulated: opencc not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            # No throw, and the input is returned unchanged in every direction.
+            self.assertEqual(chinese.to_traditional(SIMPLIFIED), SIMPLIFIED)
+            self.assertEqual(chinese.to_simplified(TRADITIONAL), TRADITIONAL)
+            self.assertEqual(chinese.apply_variant(SIMPLIFIED, "traditional"), SIMPLIFIED)
+            self.assertIsNone(chinese.apply_variant(None, "traditional"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,62 @@ class ConfigLanguageTests(unittest.TestCase):
             self.assertEqual(config.get_language(), "auto")
             self.assertEqual(config.get_language_name("auto"), "Auto (detect)")
 
+    def test_legacy_zh_migrates_to_simplified_on_load(self):
+        # Chinese used to be a single "zh" entry; it's now split into
+        # zh-Hans / zh-Hant. An existing "zh" config must migrate to
+        # Simplified (what whisper.cpp emitted for "zh" anyway) on load and
+        # persist so the Settings dropdown shows a valid selection.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = Path(tmp_dir) / "config.json"
+            config_path.write_text(json.dumps({"language": "zh"}))
+
+            config = Config(config_path=config_path)
+            self.assertEqual(config.get_language(), "zh-Hans")
+            # Migration is persisted to disk, not just in memory.
+            on_disk = json.loads(config_path.read_text())
+            self.assertEqual(on_disk["language"], "zh-Hans")
+
+    def test_set_language_accepts_both_chinese_variants(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+
+            self.assertTrue(config.set_language("zh-Hant"))
+            self.assertEqual(config.get_language(), "zh-Hant")
+            self.assertEqual(config.get_language_name("zh-Hant"), "Chinese (Traditional)")
+
+            self.assertTrue(config.set_language("zh-Hans"))
+            self.assertEqual(config.get_language(), "zh-Hans")
+            self.assertEqual(config.get_language_name("zh-Hans"), "Chinese (Simplified)")
+
+    def test_set_language_legacy_zh_normalises_to_simplified(self):
+        # Back-compat: a caller (or old deep link) passing bare "zh" is still
+        # accepted and normalised to Simplified rather than rejected.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertTrue(config.set_language("zh"))
+            self.assertEqual(config.get_language(), "zh-Hans")
+
+    def test_chinese_variants_map_to_zh_for_asr(self):
+        # whisper.cpp only knows "zh"; both variants must fold to it for the
+        # ASR call while the variant drives post-transcription conversion.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+
+            config.set_language("zh-Hant")
+            self.assertEqual(config.get_whisper_language(), "zh")
+            self.assertEqual(config.get_chinese_variant(), "traditional")
+
+            config.set_language("zh-Hans")
+            self.assertEqual(config.get_whisper_language(), "zh")
+            self.assertEqual(config.get_chinese_variant(), "simplified")
+
+    def test_non_chinese_language_has_no_variant_and_passes_asr_code(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            config.set_language("de")
+            self.assertIsNone(config.get_chinese_variant())
+            self.assertEqual(config.get_whisper_language(), "de")
+
 
 class ConfigMicrophoneTests(unittest.TestCase):
     def test_default_microphone_is_system_default(self):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds full Chinese variant support (Simplified and Traditional) with OpenCC-based conversion across transcripts, summaries, titles, and reports. Also ships diarised, timestamped transcripts in the UI and improves Ollama startup reliability.

- **New Features**
  - Chinese variants: UI now offers `zh-Hans`/`zh-Hant`. Map both to Whisper `zh`. Convert transcripts (incl. diarised text), streamed summaries, final summaries, generated titles, and reports via OpenCC. Fails safe — if OpenCC is missing or errors, output falls back to original text. Migrate legacy `zh` to `zh-Hans`.
  - Diarised transcripts: include [mm:ss] timestamps and interleave mic/others by start time; omit speaker tag for single-source recordings. UI parses and displays timestamps and copies `diarised_text` when present. Expose per-segment data from whisper.cpp and fall back when segments are missing.
  - Transcript/summary polish: add recording duration to transcript headers. Normalize markdown spacing in streamed and final outputs; prompt enforces spaces after headings and bullets.
  - Reliability: reuse an already running Ollama on 11434 to avoid “address already in use” and speed up retries.

- **Dependencies**
  - Added `opencc-python-reimplemented` (pinned) for Simplified/Traditional conversion; bundled OpenCC data files in packaging.

<sup>Written for commit 5e9b72ab7c30ecb2c693be17a0e86a873e5eb2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

