### PR TITLE
feat: cross-note Chat tab

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1459,6 +1459,93 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
   });
 });
 
+// Cross-note chat (Chat tab). Same wire protocol as query-transcript-stream
+// (CHAT_CHUNK / CHAT_STREAM_COMPLETE / CHAT_STREAM_ERROR -> query-chunk /
+// query-done) so the renderer can reuse useStreamingQuery. Cloud-only —
+// the Python CLI rejects local providers because we don't have retrieval
+// yet and a full-corpus prompt blows local context windows.
+ipcMain.on('chat-global-stream', (event, queryId, question) => {
+  sendDebugLog(`💬 Global chat query: ${String(question || '').slice(0, 80)}...`);
+  const cloudKey = loadCloudApiKey();
+  const env = cloudKey ? { ...process.env, STENOAI_CLOUD_API_KEY: cloudKey } : process.env;
+
+  let proc;
+  try {
+    proc = require('child_process').spawn(
+      getBackendPath(),
+      ['chat-global-streaming', '-q', question],
+      { env, cwd: getBackendCwd() },
+    );
+  } catch (err) {
+    event.sender.send('query-done', { queryId, success: false, error: err.message });
+    return;
+  }
+
+  activeQueryProcs.set(queryId, proc);
+  const onSenderDestroyed = () => {
+    if (activeQueryProcs.has(queryId)) {
+      proc.kill();
+      activeQueryProcs.delete(queryId);
+    }
+  };
+  event.sender.once('destroyed', onSenderDestroyed);
+
+  let buf = '';
+  let chunkCount = 0;
+  proc.stdout.on('data', (data) => {
+    buf += data.toString();
+    const lines = buf.split('\n');
+    buf = lines.pop();
+    for (const line of lines) {
+      if (line.startsWith('CHAT_CHUNK:')) {
+        try {
+          const chunk = Buffer.from(line.slice(11), 'base64').toString('utf-8');
+          chunkCount++;
+          if (!event.sender.isDestroyed()) {
+            event.sender.send('query-chunk', { queryId, chunk });
+          } else {
+            proc.kill();
+            activeQueryProcs.delete(queryId);
+          }
+        } catch (e) { /* ignore decode errors */ }
+      } else if (line === 'CHAT_STREAM_COMPLETE') {
+        if (!event.sender.isDestroyed()) {
+          event.sender.send('query-done', { queryId, success: true });
+        }
+      } else if (line.startsWith('CHAT_STREAM_ERROR:')) {
+        const errMsg = line.slice(18);
+        if (!event.sender.isDestroyed()) {
+          event.sender.send('query-done', { queryId, success: false, error: errMsg });
+        }
+      }
+    }
+  });
+
+  proc.stderr.on('data', (data) => {
+    const msg = data.toString().trim();
+    if (msg) sendDebugLog(`[chat-global stderr] ${msg.slice(0, 200)}`);
+  });
+
+  proc.on('close', (code) => {
+    activeQueryProcs.delete(queryId);
+    if (!event.sender.isDestroyed()) {
+      event.sender.removeListener('destroyed', onSenderDestroyed);
+    }
+    if (buf.trim() === 'CHAT_STREAM_COMPLETE') {
+      if (!event.sender.isDestroyed()) event.sender.send('query-done', { queryId, success: true });
+    } else if (code !== 0 && code !== null && !event.sender.isDestroyed()) {
+      event.sender.send('query-done', { queryId, success: false, error: `Process exited with code ${code}` });
+    }
+  });
+
+  proc.on('error', (err) => {
+    activeQueryProcs.delete(queryId);
+    if (!event.sender.isDestroyed()) {
+      event.sender.send('query-done', { queryId, success: false, error: err.message });
+    }
+  });
+});
+
 // Chat sessions persistence.
 //
 // The legacy renderer reads/writes `chat_sessions.json` as a flat array.
@@ -3527,6 +3614,27 @@ ipcMain.handle('set-language', async (event, languageCode) => {
     return { success: true, language: languageCode };
   } catch (error) {
     sendDebugLog(`Error setting language: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('get-user-name', async () => {
+  try {
+    const result = await runPythonScript('simple_recorder.py', ['get-user-name'], true);
+    const jsonData = JSON.parse(result.trim());
+    return { success: true, ...jsonData };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('set-user-name', async (event, name) => {
+  try {
+    const result = await runPythonScript('simple_recorder.py', ['set-user-name', String(name ?? '')]);
+    const jsonMatch = result.match(/\{.*\}/s);
+    if (jsonMatch) return JSON.parse(jsonMatch[0]);
+    return { success: true, user_name: String(name ?? '').trim() };
+  } catch (error) {
     return { success: false, error: error.message };
   }
 });

--- a/app/main.js
+++ b/app/main.js
@@ -1464,16 +1464,21 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
 // query-done) so the renderer can reuse useStreamingQuery. Cloud-only —
 // the Python CLI rejects local providers because we don't have retrieval
 // yet and a full-corpus prompt blows local context windows.
-ipcMain.on('chat-global-stream', (event, queryId, question) => {
-  sendDebugLog(`💬 Global chat query: ${String(question || '').slice(0, 80)}...`);
+ipcMain.on('chat-global-stream', (event, queryId, question, folderId) => {
+  sendDebugLog(`💬 Global chat query: ${String(question || '').slice(0, 80)}... (folder: ${folderId || 'all'})`);
   const cloudKey = loadCloudApiKey();
   const env = cloudKey ? { ...process.env, STENOAI_CLOUD_API_KEY: cloudKey } : process.env;
+
+  const args = ['chat-global-streaming', '-q', question];
+  if (folderId && typeof folderId === 'string' && folderId !== 'all') {
+    args.push('-f', folderId);
+  }
 
   let proc;
   try {
     proc = require('child_process').spawn(
       getBackendPath(),
-      ['chat-global-streaming', '-q', question],
+      args,
       { env, cwd: getBackendCwd() },
     );
   } catch (err) {

--- a/app/preload.js
+++ b/app/preload.js
@@ -117,6 +117,7 @@ const stenoai = {
   query: {
     ask: (file, q) => invoke('query-transcript', file, q),
     askStream: (id, file, q) => send('query-transcript-stream', id, file, q),
+    chatGlobalStream: (id, q) => send('chat-global-stream', id, q),
     cancel: (id) => send('query-cancel', id),
   },
 
@@ -156,6 +157,8 @@ const stenoai = {
     setSystemAudio: (v) => invoke('set-system-audio', v),
     getLanguage: () => invoke('get-language'),
     setLanguage: (code) => invoke('set-language', code),
+    getUserName: () => invoke('get-user-name'),
+    setUserName: (name) => invoke('set-user-name', name),
     getStoragePath: () => invoke('get-storage-path'),
     setStoragePath: (p) => invoke('set-storage-path', p),
     pickStorageFolder: () => invoke('select-storage-folder'),

--- a/app/preload.js
+++ b/app/preload.js
@@ -117,7 +117,7 @@ const stenoai = {
   query: {
     ask: (file, q) => invoke('query-transcript', file, q),
     askStream: (id, file, q) => send('query-transcript-stream', id, file, q),
-    chatGlobalStream: (id, q) => send('chat-global-stream', id, q),
+    chatGlobalStream: (id, q, folderId) => send('chat-global-stream', id, q, folderId ?? null),
     cancel: (id) => send('query-cancel', id),
   },
 

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { Sandbox } from '@/routes/Sandbox';
 import { Settings } from '@/routes/Settings';
 import { Setup } from '@/routes/Setup';
+import { Chat } from '@/routes/Chat';
+import { ChatConversation } from '@/routes/ChatConversation';
+import { StreamingProvider } from '@/hooks/useStreamingQuery';
 import { Home } from '@/routes/Home';
 import { MeetingDetail } from '@/routes/MeetingDetail';
 import { FolderDetail } from '@/routes/FolderDetail';
@@ -95,26 +98,33 @@ export function App() {
 
   const isRecordingRoute = route === '/recording';
   const isProcessingRoute = route === '/meetings/processing';
+  // The /chat page has its own large composer, so the floating AskBar dock
+  // would just stack a second redundant input below the same page. The
+  // sub-route /chat/<id> (conversation view) also owns its own composer.
+  const isChatRoute = route === '/chat' || route.startsWith('/chat/');
+  const showAskBar = !isRecordingRoute && !isProcessingRoute && !isChatRoute;
 
   return (
-    <AskBarProvider>
-      <RouteView route={route} />
-      <QuitDialog />
+    <StreamingProvider>
+      <AskBarProvider>
+        <RouteView route={route} />
+        <QuitDialog />
 
-      {/* Bottom dock — shared anchor across recording → processing → meeting. */}
-      <BottomDockSlot>
-        {isRecordingRoute && <LiveDock />}
-        {isProcessingRoute && <ProcessingDock />}
-        {!isRecordingRoute && !isProcessingRoute && <AskBar />}
-      </BottomDockSlot>
-
-      {/* Transcript — floats above the chat bar (only on real meeting routes). */}
-      {!isRecordingRoute && !isProcessingRoute && (
-        <BottomDockSlot bottomOffset={72}>
-          <TranscriptBar />
+        {/* Bottom dock — shared anchor across recording → processing → meeting. */}
+        <BottomDockSlot>
+          {isRecordingRoute && <LiveDock />}
+          {isProcessingRoute && <ProcessingDock />}
+          {showAskBar && <AskBar />}
         </BottomDockSlot>
-      )}
-    </AskBarProvider>
+
+        {/* Transcript — floats above the chat bar (only on real meeting routes). */}
+        {showAskBar && (
+          <BottomDockSlot bottomOffset={72}>
+            <TranscriptBar />
+          </BottomDockSlot>
+        )}
+      </AskBarProvider>
+    </StreamingProvider>
   );
 }
 
@@ -123,6 +133,11 @@ function RouteView({ route }: { route: string }) {
   if (route === '/settings') return <Settings />;
   if (route === '/setup') return <Setup />;
   if (route === '/recording') return <Recording />;
+  if (route === '/chat') return <Chat />;
+  if (route.startsWith('/chat/')) {
+    const sessionId = safeDecode(route.slice('/chat/'.length));
+    return <ChatConversation sessionId={sessionId} />;
+  }
   if (route === '/meetings/processing') return <Processing />;
   if (route.startsWith('/meetings/')) {
     const summaryFile = safeDecode(route.slice('/meetings/'.length));

--- a/app/renderer/src/components/AskBar.tsx
+++ b/app/renderer/src/components/AskBar.tsx
@@ -9,13 +9,14 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { renderMarkdown } from '@/lib/markdown';
 import { useAskBar } from '@/lib/askBarContext';
 import {
   useChatSessions,
   type ChatMessage,
   type ChatSession,
 } from '@/hooks/useChatSessions';
-import { useStreamingQuery } from '@/hooks/useStreamingQuery';
+import { useGlobalStreaming } from '@/hooks/useStreamingQuery';
 import { TranscriptPanelContent } from '@/components/TranscriptPanel';
 import { useMeeting } from '@/hooks/useMeetings';
 
@@ -84,7 +85,7 @@ export function TranscriptBar() {
 export function AskBar() {
   const { activeSummaryFile, activeMeetingName, transcriptOpen, setTranscriptOpen } = useAskBar();
   const chat = useChatSessions(activeSummaryFile, activeMeetingName);
-  const streaming = useStreamingQuery();
+  const streaming = useGlobalStreaming();
 
   const [expanded, setExpanded] = React.useState(false);
   const [sessionMenuOpen, setSessionMenuOpen] = React.useState(false);
@@ -573,75 +574,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Minimal markdown renderer (lists + bold)
-// ---------------------------------------------------------------------------
-
-function renderMarkdown(text: string): React.ReactNode {
-  const lines = text.split('\n');
-  const nodes: React.ReactNode[] = [];
-  let listItems: string[] = [];
-  let listType: 'ul' | 'ol' | null = null;
-  let key = 0;
-
-  const flushList = () => {
-    if (!listItems.length) return;
-    const Tag = listType ?? 'ul';
-    nodes.push(
-      <Tag
-        key={key++}
-        className={cn('my-1 space-y-0.5 pl-5', Tag === 'ul' ? 'list-disc' : 'list-decimal')}
-      >
-        {listItems.map((item, i) => (
-          <li key={i}>{renderInline(item)}</li>
-        ))}
-      </Tag>,
-    );
-    listItems = [];
-    listType = null;
-  };
-
-  for (const line of lines) {
-    const ulMatch = line.match(/^[-*]\s+(.+)/);
-    const olMatch = line.match(/^\d+\.\s+(.+)/);
-
-    if (ulMatch) {
-      if (listType === 'ol') flushList();
-      listType = 'ul';
-      listItems.push(ulMatch[1]);
-    } else if (olMatch) {
-      if (listType === 'ul') flushList();
-      listType = 'ol';
-      listItems.push(olMatch[1]);
-    } else {
-      flushList();
-      if (line.trim()) {
-        nodes.push(<p key={key++}>{renderInline(line)}</p>);
-      } else if (nodes.length > 0) {
-        nodes.push(<br key={key++} />);
-      }
-    }
-  }
-  flushList();
-
-  return <>{nodes}</>;
-}
-
-function renderInline(text: string): React.ReactNode {
-  const parts = text.split(/(\*\*[^*]+\*\*)/g);
-  if (parts.length === 1) return text;
-  return (
-    <>
-      {parts.map((part, i) =>
-        part.startsWith('**') && part.endsWith('**') ? (
-          <strong key={i}>{part.slice(2, -2)}</strong>
-        ) : (
-          part || null
-        ),
-      )}
-    </>
-  );
-}
+// Markdown rendering moved to lib/markdown.tsx so the Chat tab can share it.
 
 const SUGGESTION_CHIPS: { label: string; prompt: string }[] = [
   { label: 'Summarize key decisions', prompt: 'Summarize the key decisions made' },

--- a/app/renderer/src/components/ChatHistoryRow.tsx
+++ b/app/renderer/src/components/ChatHistoryRow.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import { MessageSquare, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { relativeTime } from '@/lib/chat';
+import { navigate } from '@/lib/router';
+
+export interface ChatHistoryRowSession {
+  id: string;
+  name: string;
+  updatedAt: number;
+}
+
+interface ChatHistoryRowProps {
+  session: ChatHistoryRowSession;
+  /** Pass the route's current sessionId to highlight the active row. */
+  activeId?: string | null;
+  /** Show a relative-time chip on the right. Used on the /chat entry page;
+   *  the dropdown variant hides it because group headers carry the time. */
+  showTime?: boolean;
+  onRename: (name: string) => void;
+  onDelete: () => void | Promise<void>;
+}
+
+/**
+ * Single row used by both the Chat entry page's Recents list and the
+ * conversation page's History dropdown. Shared so the rename/delete
+ * affordance behaves identically in both places.
+ *
+ * Hover surfaces a "..." button that opens a secondary menu with Rename
+ * (pencil) and Delete (trash, --danger). Rename swaps the title for an
+ * inline input — Enter saves, Escape cancels, blur auto-commits.
+ */
+export function ChatHistoryRow({
+  session,
+  activeId,
+  showTime = false,
+  onRename,
+  onDelete,
+}: ChatHistoryRowProps) {
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [renaming, setRenaming] = React.useState(false);
+  const [draft, setDraft] = React.useState(session.name);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (!renaming) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [renaming]);
+
+  const startRename = () => {
+    setDraft(session.name);
+    setRenaming(true);
+    setMenuOpen(false);
+  };
+
+  const commitRename = () => {
+    const next = draft.trim();
+    if (next && next !== session.name) onRename(next);
+    setRenaming(false);
+  };
+
+  const isActive = activeId === session.id;
+  const navigateToChat = () =>
+    navigate(`/chat/${encodeURIComponent(session.id)}`);
+
+  return (
+    <div
+      className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+      style={{
+        color: isActive ? 'var(--fg-1)' : 'var(--fg-1)',
+        background: isActive ? 'var(--surface-active)' : undefined,
+      }}
+    >
+      <MessageSquare
+        className="size-[13px] flex-shrink-0"
+        style={{ color: 'var(--fg-muted)' }}
+      />
+      {renaming ? (
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commitRename();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              setRenaming(false);
+            }
+          }}
+          onBlur={commitRename}
+          className="flex-1 min-w-0 rounded border-0 bg-transparent px-1 py-0 text-[13px] outline-none focus:shadow-[inset_0_0_0_1px_hsl(var(--border))]"
+          style={{ color: 'var(--fg-1)' }}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={navigateToChat}
+          className="flex-1 truncate text-left"
+        >
+          {session.name || 'Untitled chat'}
+        </button>
+      )}
+      {showTime && !renaming && (
+        <span
+          className="shrink-0 text-[11.5px] tabular-nums opacity-100 transition-opacity group-hover:opacity-0"
+          style={{ color: 'var(--fg-muted)' }}
+          aria-hidden
+        >
+          {relativeTime(session.updatedAt)}
+        </span>
+      )}
+      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Chat actions"
+            title="Actions"
+            className={cn(
+              'inline-flex size-6 shrink-0 items-center justify-center rounded transition-opacity hover:bg-[color:var(--surface-active)]',
+              menuOpen ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus:opacity-100',
+              // When showing time, the menu replaces the time on hover so
+              // the row width stays stable.
+              showTime && '-ml-1',
+            )}
+            style={{ color: 'var(--fg-2)' }}
+          >
+            <MoreHorizontal className="size-[14px]" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          side="right"
+          className="w-[140px] p-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              startRename();
+            }}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+            style={{ color: 'var(--fg-1)' }}
+          >
+            <Pencil className="size-[13px]" style={{ color: 'var(--fg-2)' }} />
+            Rename
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setMenuOpen(false);
+              void onDelete();
+            }}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+            style={{ color: 'var(--danger)' }}
+          >
+            <Trash2 className="size-[13px]" />
+            Delete
+          </button>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/app/renderer/src/components/ChatHistoryRow.tsx
+++ b/app/renderer/src/components/ChatHistoryRow.tsx
@@ -22,6 +22,9 @@ interface ChatHistoryRowProps {
   /** Show a relative-time chip on the right. Used on the /chat entry page;
    *  the dropdown variant hides it because group headers carry the time. */
   showTime?: boolean;
+  /** Fires after a successful navigate so the parent (e.g. a History
+   *  popover) can close itself. No-op for non-dismissible parents. */
+  onSelect?: () => void;
   onRename: (name: string) => void;
   onDelete: () => void | Promise<void>;
 }
@@ -39,6 +42,7 @@ export function ChatHistoryRow({
   session,
   activeId,
   showTime = false,
+  onSelect,
   onRename,
   onDelete,
 }: ChatHistoryRowProps) {
@@ -66,8 +70,10 @@ export function ChatHistoryRow({
   };
 
   const isActive = activeId === session.id;
-  const navigateToChat = () =>
+  const navigateToChat = () => {
     navigate(`/chat/${encodeURIComponent(session.id)}`);
+    onSelect?.();
+  };
 
   return (
     <div

--- a/app/renderer/src/components/ChatHistoryRow.tsx
+++ b/app/renderer/src/components/ChatHistoryRow.tsx
@@ -50,6 +50,9 @@ export function ChatHistoryRow({
   const [renaming, setRenaming] = React.useState(false);
   const [draft, setDraft] = React.useState(session.name);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  // Tracks whether the user pressed Escape so the imminent blur cancels
+  // instead of committing the (possibly edited) draft.
+  const cancelRef = React.useRef(false);
 
   React.useEffect(() => {
     if (!renaming) return;
@@ -98,10 +101,17 @@ export function ChatHistoryRow({
               commitRename();
             } else if (e.key === 'Escape') {
               e.preventDefault();
+              cancelRef.current = true;
               setRenaming(false);
             }
           }}
-          onBlur={commitRename}
+          onBlur={() => {
+            if (cancelRef.current) {
+              cancelRef.current = false;
+              return;
+            }
+            commitRename();
+          }}
           className="flex-1 min-w-0 rounded border-0 bg-transparent px-1 py-0 text-[13px] outline-none focus:shadow-[inset_0_0_0_1px_hsl(var(--border))]"
           style={{ color: 'var(--fg-1)' }}
         />

--- a/app/renderer/src/components/FolderScopePicker.tsx
+++ b/app/renderer/src/components/FolderScopePicker.tsx
@@ -29,6 +29,15 @@ export function FolderScopePicker({ value, onChange }: FolderScopePickerProps) {
     return folders.data?.find((f) => f.id === value) ?? null;
   }, [folders.data, value]);
 
+  // If the scoped folder was deleted out from under us, drop the scope so we
+  // don't keep filtering against a dead id (and so the chip stops lying about
+  // what's selected).
+  React.useEffect(() => {
+    if (value && folders.data && !folder) {
+      onChange(null);
+    }
+  }, [value, folders.data, folder, onChange]);
+
   const label = folder ? folder.name : 'All notes';
 
   return (

--- a/app/renderer/src/components/FolderScopePicker.tsx
+++ b/app/renderer/src/components/FolderScopePicker.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { ChevronDown, Folder as FolderIcon, Inbox } from 'lucide-react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { useFolders } from '@/hooks/useFolders';
+import type { Folder } from '@/lib/ipc';
+
+interface FolderScopePickerProps {
+  /** Selected folder ID. null = all notes. */
+  value: string | null;
+  onChange: (folderId: string | null) => void;
+}
+
+/**
+ * Compact "scope" chip used inside chat composers. Lets the user limit a
+ * cross-note query to a single folder instead of asking across everything.
+ * Backend filter happens server-side; this just persists the choice and
+ * passes it to startGlobalStream.
+ */
+export function FolderScopePicker({ value, onChange }: FolderScopePickerProps) {
+  const folders = useFolders();
+  const [open, setOpen] = React.useState(false);
+
+  const folder = React.useMemo<Folder | null>(() => {
+    if (!value) return null;
+    return folders.data?.find((f) => f.id === value) ?? null;
+  }, [folders.data, value]);
+
+  const label = folder ? folder.name : 'All notes';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Scope: ${label}`}
+          title={`Scope: ${label}`}
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[12px] transition-colors hover:bg-[color:var(--surface-hover)]"
+          style={{ color: 'var(--fg-2)' }}
+        >
+          {folder ? (
+            <FolderIcon className="size-[12px]" />
+          ) : (
+            <Inbox className="size-[12px]" />
+          )}
+          <span className="max-w-[140px] truncate">{label}</span>
+          <ChevronDown className="size-[11px] opacity-60" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[220px] p-1">
+        <div className="px-2 pb-1 pt-0.5 text-[11px] font-medium" style={{ color: 'var(--fg-muted)' }}>
+          Ask across…
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            onChange(null);
+            setOpen(false);
+          }}
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+          style={{
+            color: 'var(--fg-1)',
+            background: value === null ? 'var(--surface-active)' : undefined,
+          }}
+        >
+          <Inbox className="size-[13px]" style={{ color: 'var(--fg-2)' }} />
+          All notes
+        </button>
+        {(folders.data ?? []).length > 0 && (
+          <div
+            className="mx-2 my-1 h-px"
+            style={{ background: 'var(--border-subtle)' }}
+            aria-hidden
+          />
+        )}
+        {(folders.data ?? []).map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            onClick={() => {
+              onChange(f.id);
+              setOpen(false);
+            }}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+            style={{
+              color: 'var(--fg-1)',
+              background: value === f.id ? 'var(--surface-active)' : undefined,
+            }}
+          >
+            <FolderIcon className="size-[13px]" style={{ color: 'var(--fg-2)' }} />
+            <span className="truncate">{f.name}</span>
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Moon, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, PencilLine, Sun } from 'lucide-react';
+import { MessageSquare, Moon, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, PencilLine, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { AudioWave } from '@/components/AudioWave';
@@ -14,6 +14,7 @@ import {
 } from '@/hooks/useSettings';
 import type { RecordingStatus } from '@/hooks/useRecording';
 import { useTheme } from '@/hooks/useTheme';
+import { useRoute, navigate } from '@/lib/router';
 import { cn } from '@/lib/utils';
 
 interface MainToolbarProps {
@@ -36,6 +37,13 @@ export function MainToolbar({
   const isPaused = recordingStatus === 'paused';
   const isProcessing = recordingStatus === 'processing';
   const { resolved: resolvedTheme, setTheme } = useTheme();
+  // Route-aware primary action. On chat routes the "+ New" affordance maps
+  // to a new chat (navigates back to /chat entry). Everywhere else it's
+  // the recording button. Recording always wins if a session is active —
+  // we don't want a navigation to silently swallow a stop-recording click.
+  const route = useRoute();
+  const isChatRoute = route === '/chat' || route.startsWith('/chat/');
+  const showChatPrimary = isChatRoute && !isRecording && !isProcessing;
 
   // Matches sb-top padding-left (82px clears macOS traffic lights)
   const toggleLeft = 82;
@@ -93,7 +101,7 @@ export function MainToolbar({
         </button>
         <button
           type="button"
-          onClick={onToggleRecording}
+          onClick={showChatPrimary ? () => navigate('/chat') : onToggleRecording}
           disabled={isProcessing}
           className={cn('record-btn', isRecording && 'is-recording')}
           aria-label={
@@ -101,14 +109,18 @@ export function MainToolbar({
               ? 'Processing previous recording'
               : isRecording
                 ? 'Open recording in progress'
-                : 'New note'
+                : showChatPrimary
+                  ? 'New chat'
+                  : 'New note'
           }
           title={
             isProcessing
               ? 'Processing previous recording'
               : isRecording
                 ? 'Open recording in progress'
-                : 'New note'
+                : showChatPrimary
+                  ? 'New chat'
+                  : 'New note'
           }
         >
           {isProcessing ? (
@@ -137,6 +149,11 @@ export function MainToolbar({
                 {formatElapsed(elapsedSeconds)}
               </span>
               <span>{isPaused ? 'Paused' : 'Recording'}</span>
+            </>
+          ) : showChatPrimary ? (
+            <>
+              <MessageSquare className="size-[13px]" />
+              New chat
             </>
           ) : (
             <>

--- a/app/renderer/src/components/MeetingsShell.tsx
+++ b/app/renderer/src/components/MeetingsShell.tsx
@@ -452,7 +452,7 @@ function RenamePopover({
 
 interface BuildArgs {
   meetings: Meeting[];
-  folders: Array<{ id: string; name: string; icon?: string; order: number }>;
+  folders: Array<{ id: string; name: string; icon?: string; color?: string; order: number }>;
   search: string;
   activeSummaryFile: string | null;
 }
@@ -472,6 +472,7 @@ function buildSidebar({ meetings, folders, search, activeSummaryFile }: BuildArg
         id: f.id,
         name: f.name,
         icon: f.icon,
+        color: f.color,
         meetings: folderMeetings
           .filter(match)
           .map((m) => meetingToSidebar(m, activeSummaryFile)),

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDown,
   Home as HomeIcon,
   Inbox,
+  MessageSquare,
   Plus,
   Search,
   Settings as SettingsIcon,
@@ -160,6 +161,7 @@ export function Sidebar({
 
   const isHomeActive = currentRoute === '/' || currentRoute === '';
   const isAllMeetingsActive = currentRoute === '/meetings';
+  const isChatActive = currentRoute === '/chat';
   // Malformed % escapes throw URIError. Guard so a bad route can't crash
   // the entire sidebar render.
   const activeFolderId = React.useMemo<string | null>(() => {
@@ -373,6 +375,15 @@ export function Sidebar({
               )}
             </button>
           </div>
+
+          <button
+            type="button"
+            className={cn('sb-row', isChatActive && 'active')}
+            onClick={() => navigate('/chat')}
+          >
+            <MessageSquare className="size-[14px]" />
+            <span className="flex-1 truncate">Chat</span>
+          </button>
 
           {/* Folders group */}
           <div className="mt-3.5">

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -164,7 +164,9 @@ export function Sidebar({
 
   const isHomeActive = currentRoute === '/' || currentRoute === '';
   const isAllMeetingsActive = currentRoute === '/meetings';
-  const isChatActive = currentRoute === '/chat';
+  // Match /chat as well as any /chat/<id> conversation route — the same Chat
+  // tab item should stay highlighted when drilling into a session.
+  const isChatActive = currentRoute === '/chat' || currentRoute.startsWith('/chat/');
   // Malformed % escapes throw URIError. Guard so a bad route can't crash
   // the entire sidebar render.
   const activeFolderId = React.useMemo<string | null>(() => {

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -25,6 +25,9 @@ export interface SidebarFolder {
   id: string;
   name: string;
   icon?: string;
+  /** User-chosen folder color. Used to tint the sidebar icon so it
+   *  matches the chip in the FolderScopePicker / FolderDetail header. */
+  color?: string;
   meetings: SidebarMeeting[];
 }
 

--- a/app/renderer/src/components/home/UpcomingCard.tsx
+++ b/app/renderer/src/components/home/UpcomingCard.tsx
@@ -3,6 +3,7 @@ import { Video } from 'lucide-react';
 import type { CalendarEvent } from '@/lib/ipc';
 import { ipc } from '@/lib/ipc';
 import { cn } from '@/lib/utils';
+import { useRecording } from '@/hooks/useRecording';
 
 interface UpcomingCardProps {
   event: CalendarEvent;
@@ -12,11 +13,31 @@ export function UpcomingCard({ event }: UpcomingCardProps) {
   const relative = relativeLabel(event.start);
   const { dayLabel, clock, end } = formatStartEnd(event.start, event.end);
   const meetingUrl = event.meeting_url?.trim();
+  const recording = useRecording();
 
+  // Click the card → start a new recording titled after this event. The
+  // event title becomes the note's session name (instead of the auto
+  // 'Note' placeholder), so the AI rename step skips it and the user
+  // gets the meeting they expected. Doesn't open the join URL — the
+  // Join / Start now buttons on the right own that action.
+  const onStart = () => {
+    if (recording.status !== 'idle') return;
+    void recording.startRecording(event.title);
+  };
+
+  // Open the meeting URL externally. Used by the inner Join button only.
   const onJoin = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!meetingUrl) return;
     void ipc().shell.openExternal(meetingUrl);
+  };
+
+  // Start recording AND open the URL — used by the urgent "Start now"
+  // button when the meeting is imminent.
+  const onStartAndJoin = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onStart();
+    if (meetingUrl) void ipc().shell.openExternal(meetingUrl);
   };
 
   return (
@@ -24,11 +45,11 @@ export function UpcomingCard({ event }: UpcomingCardProps) {
       className={cn('upcoming-card', relative.urgent && 'upcoming-card-live')}
       role="button"
       tabIndex={0}
-      onClick={meetingUrl ? onJoin : undefined}
+      onClick={onStart}
       onKeyDown={(e) => {
-        if ((e.key === 'Enter' || e.key === ' ') && meetingUrl) {
+        if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          onJoin(e as unknown as React.MouseEvent);
+          onStart();
         }
       }}
     >
@@ -82,7 +103,7 @@ export function UpcomingCard({ event }: UpcomingCardProps) {
           relative.urgent ? (
             <button
               type="button"
-              onClick={onJoin}
+              onClick={onStartAndJoin}
               className="inline-flex h-7 items-center gap-[7px] rounded-full px-3 text-xs font-medium"
               style={{
                 background: 'var(--fg-1)',

--- a/app/renderer/src/components/home/UpcomingCard.tsx
+++ b/app/renderer/src/components/home/UpcomingCard.tsx
@@ -47,6 +47,10 @@ export function UpcomingCard({ event }: UpcomingCardProps) {
       tabIndex={0}
       onClick={onStart}
       onKeyDown={(e) => {
+        // Only handle Enter/Space when the card itself has focus — inner
+        // buttons (Join, Start now) own their own keyboard activation, and
+        // we don't want to double-fire them.
+        if (e.target !== e.currentTarget) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onStart();

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -596,6 +596,12 @@
     flex: 1;
   }
 
+  /* Chat bubble — trim leading/trailing margins from rendered markdown so
+     the inner padding stays balanced regardless of which block element
+     starts/ends the response (paragraph, heading, list…). */
+  .chat-bubble > :first-child { margin-top: 0; }
+  .chat-bubble > :last-child { margin-bottom: 0; }
+
   /* Chat composer */
   .mv-chat {
     display: flex;

--- a/app/renderer/src/hooks/useChatSessions.ts
+++ b/app/renderer/src/hooks/useChatSessions.ts
@@ -41,6 +41,28 @@ function migrateLegacyBlob(legacy: LegacyBlob): ChatSessionsBlob {
   return { sessions };
 }
 
+/**
+ * Returns the full chat blob (every session across every meeting). Used by
+ * the Chat tab's Recents list and any future global chat-history view.
+ * Shares the same query key as useChatSessions so a save in one place is
+ * reflected everywhere.
+ */
+export function useAllChatSessions() {
+  return useQuery<ChatSessionsBlob>({
+    queryKey: CHAT_KEY,
+    queryFn: async () => {
+      const res = await ipc().chat.load();
+      if (!res.success) throw new Error(res.error);
+      const data = res.data;
+      if (!data) return emptyBlob();
+      if (Array.isArray(data.sessions)) return data;
+      if (Array.isArray(data)) return migrateLegacyBlob(data as unknown as LegacyBlob);
+      return emptyBlob();
+    },
+    staleTime: Infinity,
+  });
+}
+
 export function useChatSessions(summaryFile: string | null, meetingName?: string | null) {
   const queryClient = useQueryClient();
   const [activeId, setActiveId] = React.useState<string | null>(null);

--- a/app/renderer/src/hooks/useSettings.ts
+++ b/app/renderer/src/hooks/useSettings.ts
@@ -124,10 +124,44 @@ export function useClearSystemState() {
   });
 }
 
+// Mirror the persisted user name into sessionStorage so the next mount in
+// the same session has the value synchronously and the chat greeting
+// doesn't flash 'Ask anything' before flipping to 'Hi <name>, ...'.
+const USER_NAME_CACHE_KEY = 'steno-user-name';
+
+function readCachedUserName(): string {
+  try {
+    return sessionStorage.getItem(USER_NAME_CACHE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function writeCachedUserName(name: string) {
+  try {
+    sessionStorage.setItem(USER_NAME_CACHE_KEY, name);
+  } catch {
+    // Storage may be unavailable in private mode — graceful degradation.
+  }
+}
+
 export function useUserName() {
   return useQuery({
     queryKey: settingsKeys.userName(),
-    queryFn: async () => unwrap(await ipc().settings.getUserName()).user_name,
+    queryFn: async () => {
+      const name = unwrap(await ipc().settings.getUserName()).user_name;
+      writeCachedUserName(name);
+      return name;
+    },
+    // The name only changes via useSetUserName (which invalidates this
+    // key), so once we have it there's no reason to refetch on remount.
+    staleTime: Infinity,
+    // placeholderData (NOT initialData) so the query still fetches the
+    // canonical value from disk on first mount. initialData was marking
+    // the query as already-fresh — combined with staleTime: Infinity that
+    // suppressed the queryFn entirely, so the greeting was stuck on the
+    // empty sessionStorage default forever.
+    placeholderData: readCachedUserName(),
   });
 }
 
@@ -136,6 +170,9 @@ export function useSetUserName() {
   return useMutation({
     mutationFn: async (name: string) =>
       unwrap(await ipc().settings.setUserName(name)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.userName() }),
+    onSuccess: (_data, name) => {
+      writeCachedUserName(name.trim());
+      qc.invalidateQueries({ queryKey: settingsKeys.userName() });
+    },
   });
 }

--- a/app/renderer/src/hooks/useSettings.ts
+++ b/app/renderer/src/hooks/useSettings.ts
@@ -11,6 +11,7 @@ export const settingsKeys = {
   language: () => [...settingsKeys.all, 'language'] as const,
   storagePath: () => [...settingsKeys.all, 'storagePath'] as const,
   appVersion: () => [...settingsKeys.all, 'appVersion'] as const,
+  userName: () => [...settingsKeys.all, 'userName'] as const,
 };
 
 export function useNotificationsSetting() {
@@ -120,5 +121,21 @@ export function useAppVersion() {
 export function useClearSystemState() {
   return useMutation({
     mutationFn: async () => unwrap(await ipc().system.clearState()),
+  });
+}
+
+export function useUserName() {
+  return useQuery({
+    queryKey: settingsKeys.userName(),
+    queryFn: async () => unwrap(await ipc().settings.getUserName()).user_name,
+  });
+}
+
+export function useSetUserName() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (name: string) =>
+      unwrap(await ipc().settings.setUserName(name)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.userName() }),
   });
 }

--- a/app/renderer/src/hooks/useStreamingQuery.ts
+++ b/app/renderer/src/hooks/useStreamingQuery.ts
@@ -57,8 +57,12 @@ export function useStreamingQuery() {
   }, []);
 
   // Cross-note variant of startStream — same wire shape, no summaryFile.
-  // Used by the Chat tab to ask questions across every meeting summary.
-  const startGlobalStream = React.useCallback((question: string): string => {
+  // Used by the Chat tab to ask questions across every meeting summary,
+  // optionally scoped to a single folder.
+  const startGlobalStream = React.useCallback((
+    question: string,
+    folderId?: string | null,
+  ): string => {
     const id = newId();
     setStreams((prev) => ({
       ...prev,
@@ -92,7 +96,7 @@ export function useStreamingQuery() {
       },
     });
     unsubsRef.current.set(id, off);
-    ipc().query.chatGlobalStream(id, question);
+    ipc().query.chatGlobalStream(id, question, folderId ?? null);
     return id;
   }, []);
 

--- a/app/renderer/src/hooks/useStreamingQuery.ts
+++ b/app/renderer/src/hooks/useStreamingQuery.ts
@@ -56,6 +56,46 @@ export function useStreamingQuery() {
     return id;
   }, []);
 
+  // Cross-note variant of startStream — same wire shape, no summaryFile.
+  // Used by the Chat tab to ask questions across every meeting summary.
+  const startGlobalStream = React.useCallback((question: string): string => {
+    const id = newId();
+    setStreams((prev) => ({
+      ...prev,
+      [id]: { text: '', status: 'streaming', error: null },
+    }));
+    activeRef.current.add(id);
+
+    const off = ipc().subscribeQueryStream(id, {
+      onChunk: (chunk) => {
+        setStreams((prev) => {
+          const current = prev[id];
+          if (!current) return prev;
+          return { ...prev, [id]: { ...current, text: current.text + chunk } };
+        });
+      },
+      onDone: () => {
+        setStreams((prev) => {
+          const current = prev[id];
+          if (!current) return prev;
+          return { ...prev, [id]: { ...current, status: 'done' } };
+        });
+        activeRef.current.delete(id);
+      },
+      onError: (err) => {
+        setStreams((prev) => {
+          const current = prev[id];
+          if (!current) return prev;
+          return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
+        });
+        activeRef.current.delete(id);
+      },
+    });
+    unsubsRef.current.set(id, off);
+    ipc().query.chatGlobalStream(id, question);
+    return id;
+  }, []);
+
   const cancelStream = React.useCallback((id: string) => {
     const off = unsubsRef.current.get(id);
     off?.();
@@ -92,5 +132,26 @@ export function useStreamingQuery() {
     };
   }, []);
 
-  return { streams, startStream, cancelStream, clearStream };
+  return { streams, startStream, startGlobalStream, cancelStream, clearStream };
+}
+
+export type StreamingQueryApi = ReturnType<typeof useStreamingQuery>;
+
+// Context-shared streaming state. Mounted at App level so streams survive
+// route changes (e.g. submitting on /chat then navigating to /chat/<id>
+// without losing the in-flight response). Consumers should prefer
+// useGlobalStreaming() over calling useStreamingQuery() directly.
+const StreamingContext = React.createContext<StreamingQueryApi | null>(null);
+
+export function StreamingProvider({ children }: { children: React.ReactNode }) {
+  const value = useStreamingQuery();
+  return React.createElement(StreamingContext.Provider, { value }, children);
+}
+
+export function useGlobalStreaming(): StreamingQueryApi {
+  const ctx = React.useContext(StreamingContext);
+  if (!ctx) {
+    throw new Error('useGlobalStreaming must be used inside <StreamingProvider>');
+  }
+  return ctx;
 }

--- a/app/renderer/src/hooks/useStreamingQuery.ts
+++ b/app/renderer/src/hooks/useStreamingQuery.ts
@@ -18,6 +18,19 @@ export function useStreamingQuery() {
   const unsubsRef = React.useRef<Map<string, () => void>>(new Map());
   const activeRef = React.useRef<Set<string>>(new Set());
 
+  // Tear down the IPC subscription for a stream and forget its handle.
+  // Called from onDone/onError so the listener doesn't linger past the
+  // stream's lifetime (otherwise unsubsRef accumulates dead entries until
+  // the component unmounts).
+  const detachStream = (id: string) => {
+    const off = unsubsRef.current.get(id);
+    if (off) {
+      off();
+      unsubsRef.current.delete(id);
+    }
+    activeRef.current.delete(id);
+  };
+
   const startStream = React.useCallback((file: string, question: string): string => {
     const id = newId();
     setStreams((prev) => ({
@@ -40,7 +53,7 @@ export function useStreamingQuery() {
           if (!current) return prev;
           return { ...prev, [id]: { ...current, status: 'done' } };
         });
-        activeRef.current.delete(id);
+        detachStream(id);
       },
       onError: (err) => {
         setStreams((prev) => {
@@ -48,7 +61,7 @@ export function useStreamingQuery() {
           if (!current) return prev;
           return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
         });
-        activeRef.current.delete(id);
+        detachStream(id);
       },
     });
     unsubsRef.current.set(id, off);
@@ -84,7 +97,7 @@ export function useStreamingQuery() {
           if (!current) return prev;
           return { ...prev, [id]: { ...current, status: 'done' } };
         });
-        activeRef.current.delete(id);
+        detachStream(id);
       },
       onError: (err) => {
         setStreams((prev) => {
@@ -92,7 +105,7 @@ export function useStreamingQuery() {
           if (!current) return prev;
           return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
         });
-        activeRef.current.delete(id);
+        detachStream(id);
       },
     });
     unsubsRef.current.set(id, off);

--- a/app/renderer/src/lib/chat.ts
+++ b/app/renderer/src/lib/chat.ts
@@ -22,12 +22,17 @@ export function bucketKey(ts: number, now: number = Date.now()): string {
   today.setHours(0, 0, 0, 0);
   const startOfDay = today.getTime();
   if (ts >= startOfDay) return 'today';
-  // Yesterday: ts >= startOfDay - 1 day
-  if (ts >= startOfDay - 86_400_000) return 'yesterday';
-  // Within the last 7 days
-  if (ts >= startOfDay - 7 * 86_400_000) return 'this-week';
-  // Within the last 14 days
-  if (ts >= startOfDay - 14 * 86_400_000) return 'last-2-weeks';
+  // Day-difference comparisons. Subtracting fixed 24h offsets breaks across
+  // DST boundaries (a Sunday morning shift means "yesterday" really started
+  // 23h ago, not 24h), so step back by calendar day instead.
+  const dayBefore = (n: number): number => {
+    const t = new Date(today);
+    t.setDate(t.getDate() - n);
+    return t.getTime();
+  };
+  if (ts >= dayBefore(1)) return 'yesterday';
+  if (ts >= dayBefore(7)) return 'this-week';
+  if (ts >= dayBefore(14)) return 'last-2-weeks';
   // Same calendar month
   if (
     d.getFullYear() === today.getFullYear() &&

--- a/app/renderer/src/lib/chat.ts
+++ b/app/renderer/src/lib/chat.ts
@@ -1,0 +1,30 @@
+// Shared helpers for the Chat tab + conversation view.
+
+// Sentinel summaryFile that marks a chat session as belonging to the global
+// Chat tab rather than any specific meeting. Stored on the session record so
+// the Recents list can filter to chat-tab sessions and skip in-meeting
+// AskBar history.
+export const GLOBAL_SCOPE = '__global__';
+
+export function deriveSessionName(question: string): string {
+  const trimmed = question.trim().replace(/\s+/g, ' ');
+  if (trimmed.length <= 40) return trimmed;
+  return trimmed.slice(0, 40) + '…';
+}
+
+export function relativeTime(ts: number): string {
+  const now = Date.now();
+  const diff = Math.max(0, now - ts);
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.floor(months / 12)}y`;
+}

--- a/app/renderer/src/lib/chat.ts
+++ b/app/renderer/src/lib/chat.ts
@@ -12,6 +12,50 @@ export function deriveSessionName(question: string): string {
   return trimmed.slice(0, 40) + '…';
 }
 
+// Bucket label for grouped chat-history lists (matches the Granola
+// History dropdown's "Today / Last 2 weeks / April" pattern). Returns a
+// stable key (not localized) so consumers can sort/group; format the key
+// with toBucketLabel() before display.
+export function bucketKey(ts: number, now: number = Date.now()): string {
+  const d = new Date(ts);
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const startOfDay = today.getTime();
+  if (ts >= startOfDay) return 'today';
+  // Yesterday: ts >= startOfDay - 1 day
+  if (ts >= startOfDay - 86_400_000) return 'yesterday';
+  // Within the last 7 days
+  if (ts >= startOfDay - 7 * 86_400_000) return 'this-week';
+  // Within the last 14 days
+  if (ts >= startOfDay - 14 * 86_400_000) return 'last-2-weeks';
+  // Same calendar month
+  if (
+    d.getFullYear() === today.getFullYear() &&
+    d.getMonth() === today.getMonth()
+  ) {
+    return 'this-month';
+  }
+  // Same calendar year — return month name as the key
+  if (d.getFullYear() === today.getFullYear()) {
+    return `month-${d.getMonth()}`;
+  }
+  return `year-${d.getFullYear()}`;
+}
+
+export function toBucketLabel(key: string): string {
+  if (key === 'today') return 'Today';
+  if (key === 'yesterday') return 'Yesterday';
+  if (key === 'this-week') return 'This week';
+  if (key === 'last-2-weeks') return 'Last 2 weeks';
+  if (key === 'this-month') return 'This month';
+  if (key.startsWith('month-')) {
+    const m = parseInt(key.slice(6), 10);
+    return new Date(2000, m, 1).toLocaleString(undefined, { month: 'long' });
+  }
+  if (key.startsWith('year-')) return key.slice(5);
+  return key;
+}
+
 export function relativeTime(ts: number): string {
   const now = Date.now();
   const diff = Math.max(0, now - ts);

--- a/app/renderer/src/lib/chatPresets.tsx
+++ b/app/renderer/src/lib/chatPresets.tsx
@@ -1,0 +1,52 @@
+// Templated preset prompts surfaced two ways:
+//   1. Chip row at the bottom of the /chat entry page (always visible).
+//   2. Popover triggered by typing '/' as the first character in either
+//      composer (entry page or /chat/<id> conversation page).
+// Edit the list here; both call sites pick it up automatically.
+export interface ChatPreset {
+  label: string;
+  prompt: string;
+  description: string;
+}
+
+export const PRESETS: ChatPreset[] = [
+  {
+    label: 'List recent todos',
+    prompt: 'List my action items from the last week.',
+    description: 'Pulls outstanding to-dos from recent meeting notes',
+  },
+  {
+    label: 'Coach me',
+    prompt: 'Coach me on my recent meetings — patterns, blind spots, things to work on.',
+    description: 'Looks for patterns and suggests areas to improve',
+  },
+  {
+    label: 'Write weekly recap',
+    prompt: 'Write a recap of this week based on my notes.',
+    description: 'Summary of the week across every meeting',
+  },
+  {
+    label: 'Blind spots',
+    prompt: 'What blind spots have come up across my recent meetings?',
+    description: 'Surfaces themes you may have missed',
+  },
+];
+
+/** Slash glyph used as the leading icon on every preset chip + popover
+ *  row. Reinforces the "/" keyboard shortcut. Plain grey using the
+ *  existing ink tokens so it sits quietly in the warm paper palette
+ *  without claiming a colored accent. */
+export function PresetGlyph() {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex size-[18px] flex-shrink-0 items-center justify-center rounded-md font-mono text-[13px] font-semibold leading-none"
+      style={{
+        color: 'var(--fg-2)',
+        background: 'var(--surface-active)',
+      }}
+    >
+      /
+    </span>
+  );
+}

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -180,6 +180,7 @@ export type GetTelemetryResponse = Result<{
 export type GetDockIconResponse = Result<{ hide_dock_icon: boolean }>;
 export type GetSystemAudioResponse = Result<{ system_audio_enabled: boolean }>;
 export type GetLanguageResponse = Result<{ language: string }>;
+export type GetUserNameResponse = Result<{ user_name: string }>;
 export type StoragePathResponse = Result<{
   storage_path: string | null;
   custom_path: string | null;
@@ -333,6 +334,7 @@ export interface StenoaiBridge {
   query: {
     ask: RequestFn<[file: string, q: string], QueryResponse>;
     askStream: SendFn<[id: string, file: string, q: string]>;
+    chatGlobalStream: SendFn<[id: string, q: string]>;
     cancel: SendFn<[id: string]>;
   };
 
@@ -378,6 +380,8 @@ export interface StenoaiBridge {
     setSystemAudio: RequestFn<[v: boolean], Result<Record<string, never>>>;
     getLanguage: RequestFn<[], GetLanguageResponse>;
     setLanguage: RequestFn<[code: string], Result<Record<string, never>>>;
+    getUserName: RequestFn<[], GetUserNameResponse>;
+    setUserName: RequestFn<[name: string], Result<Record<string, never>>>;
     getStoragePath: RequestFn<[], StoragePathResponse>;
     setStoragePath: RequestFn<[p: string], Result<Record<string, never>>>;
     pickStorageFolder: RequestFn<[], PickStorageFolderResponse>;

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -334,7 +334,7 @@ export interface StenoaiBridge {
   query: {
     ask: RequestFn<[file: string, q: string], QueryResponse>;
     askStream: SendFn<[id: string, file: string, q: string]>;
-    chatGlobalStream: SendFn<[id: string, q: string]>;
+    chatGlobalStream: SendFn<[id: string, q: string, folderId?: string | null]>;
     cancel: SendFn<[id: string]>;
   };
 

--- a/app/renderer/src/lib/markdown.tsx
+++ b/app/renderer/src/lib/markdown.tsx
@@ -1,0 +1,182 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+// Lightweight markdown → React renderer for chat bubbles. Handles the
+// formatting LLMs actually produce in answers: headings, paragraphs,
+// bullet/numbered lists, bold/italic, inline code, fenced code blocks.
+// Intentionally NOT a full CommonMark parser — we trade completeness for
+// zero deps, predictable output, and safe-by-default React text rendering
+// (no innerHTML).
+
+export function renderMarkdown(text: string): React.ReactNode {
+  if (!text) return null;
+
+  const lines = text.split('\n');
+  const nodes: React.ReactNode[] = [];
+  let listItems: string[] = [];
+  let listType: 'ul' | 'ol' | null = null;
+  let codeLines: string[] = [];
+  let codeLang: string | null = null;
+  let inCode = false;
+  let key = 0;
+
+  const flushList = () => {
+    if (!listItems.length) return;
+    const Tag = listType ?? 'ul';
+    nodes.push(
+      <Tag
+        key={key++}
+        className={cn(
+          'my-1.5 space-y-0.5 pl-5',
+          Tag === 'ul' ? 'list-disc' : 'list-decimal',
+        )}
+      >
+        {listItems.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </Tag>,
+    );
+    listItems = [];
+    listType = null;
+  };
+
+  const flushCode = () => {
+    if (!inCode) return;
+    nodes.push(
+      <pre
+        key={key++}
+        className="my-2 overflow-x-auto rounded-md px-3 py-2 text-[12.5px]"
+        style={{
+          background: 'var(--surface-active)',
+          fontFamily: 'var(--font-mono)',
+          color: 'var(--fg-1)',
+        }}
+        data-lang={codeLang || undefined}
+      >
+        <code>{codeLines.join('\n')}</code>
+      </pre>,
+    );
+    codeLines = [];
+    codeLang = null;
+    inCode = false;
+  };
+
+  for (const line of lines) {
+    // Fenced code block: ```lang ... ```
+    const fence = line.match(/^```(\w*)\s*$/);
+    if (fence) {
+      if (inCode) {
+        flushCode();
+      } else {
+        flushList();
+        inCode = true;
+        codeLang = fence[1] || null;
+      }
+      continue;
+    }
+    if (inCode) {
+      codeLines.push(line);
+      continue;
+    }
+
+    // Heading (# / ## / ###). h1 is reserved for page titles, so the LLM's
+    // top-level heading maps to h3 inside a bubble — keeps the visual
+    // hierarchy of the surrounding UI intact.
+    const h = line.match(/^(#{1,6})\s+(.+)$/);
+    if (h) {
+      flushList();
+      const level = h[1].length;
+      const content = h[2];
+      const sizeClass =
+        level <= 1
+          ? 'mt-3 mb-1.5 text-[16px] font-semibold'
+          : level === 2
+            ? 'mt-3 mb-1.5 text-[15px] font-semibold'
+            : 'mt-2.5 mb-1 text-[14px] font-semibold';
+      nodes.push(
+        <div key={key++} className={sizeClass} style={{ color: 'var(--fg-1)' }}>
+          {renderInline(content)}
+        </div>,
+      );
+      continue;
+    }
+
+    // Bulleted item: -, *, • all accepted (LLMs sometimes use bullet glyph).
+    const ulMatch = line.match(/^\s*[-*•]\s+(.+)/);
+    const olMatch = line.match(/^\s*\d+\.\s+(.+)/);
+
+    if (ulMatch) {
+      if (listType === 'ol') flushList();
+      listType = 'ul';
+      listItems.push(ulMatch[1]);
+      continue;
+    }
+    if (olMatch) {
+      if (listType === 'ul') flushList();
+      listType = 'ol';
+      listItems.push(olMatch[1]);
+      continue;
+    }
+
+    flushList();
+    if (line.trim()) {
+      nodes.push(
+        <p key={key++} className="my-1.5">
+          {renderInline(line)}
+        </p>,
+      );
+    } else if (nodes.length > 0) {
+      // Blank line between blocks — collapse runs, but preserve one as a gap.
+      const last = nodes[nodes.length - 1];
+      if (typeof last === 'object' && last && 'type' in (last as object) && (last as { type?: unknown }).type !== 'br') {
+        nodes.push(<div key={key++} className="h-2" aria-hidden />);
+      }
+    }
+  }
+  flushList();
+  flushCode();
+
+  return <>{nodes}</>;
+}
+
+// Inline markdown: **bold**, *italic*/_italic_, `code`. Order matters —
+// resolve code spans first so backticks inside don't get parsed as
+// emphasis, then bold (greedy double-star), then italic.
+export function renderInline(text: string): React.ReactNode {
+  const out: React.ReactNode[] = [];
+  let key = 0;
+  // Match the next inline span: code, bold, or italic. The combined regex
+  // walks left-to-right so we don't double-process overlapping ranges.
+  const RE = /(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*\n]+\*)|(_[^_\n]+_)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = RE.exec(text)) !== null) {
+    if (m.index > last) out.push(text.slice(last, m.index));
+    const tok = m[0];
+    if (tok.startsWith('`')) {
+      out.push(
+        <code
+          key={key++}
+          className="rounded px-1 py-px text-[0.9em]"
+          style={{
+            background: 'var(--surface-active)',
+            fontFamily: 'var(--font-mono)',
+            color: 'var(--fg-1)',
+          }}
+        >
+          {tok.slice(1, -1)}
+        </code>,
+      );
+    } else if (tok.startsWith('**')) {
+      out.push(<strong key={key++}>{tok.slice(2, -2)}</strong>);
+    } else {
+      // *italic* or _italic_
+      out.push(<em key={key++}>{tok.slice(1, -1)}</em>);
+    }
+    last = m.index + tok.length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  if (out.length === 0) return text;
+  if (out.length === 1) return out[0];
+  return <>{out}</>;
+}

--- a/app/renderer/src/lib/markdown.tsx
+++ b/app/renderer/src/lib/markdown.tsx
@@ -11,13 +11,16 @@ import { cn } from '@/lib/utils';
 export function renderMarkdown(text: string): React.ReactNode {
   if (!text) return null;
 
-  const lines = text.split('\n');
+  // Strip trailing \r so CRLF input doesn't leave ghost characters at the end
+  // of every line — that breaks regex anchors and table cell parsing.
+  const lines = text.split('\n').map((l) => l.replace(/\r$/, ''));
   const nodes: React.ReactNode[] = [];
   let listItems: string[] = [];
   let listType: 'ul' | 'ol' | null = null;
   let codeLines: string[] = [];
   let codeLang: string | null = null;
   let inCode = false;
+  let lastWasGap = false;
   let key = 0;
 
   // Detect a markdown table starting at index i. Returns the table's row
@@ -38,11 +41,18 @@ export function renderMarkdown(text: string): React.ReactNode {
     const header = splitRow(headerRaw);
     const align = parseAlign(sepRaw);
     if (header.length === 0 || align.length === 0) return null;
+    // Header and separator must agree on column count, otherwise the alignment
+    // array would have undefined slots and the table would be malformed.
+    if (header.length !== align.length) return null;
 
     const rows: string[][] = [];
     let j = i + 2;
     while (j < lines.length && isTableRow(lines[j])) {
-      rows.push(splitRow(lines[j]));
+      const cells = splitRow(lines[j]);
+      // Pad/truncate to header width so React doesn't render undefined cells.
+      while (cells.length < header.length) cells.push('');
+      if (cells.length > header.length) cells.length = header.length;
+      rows.push(cells);
       j++;
     }
     // Require at least one data row — otherwise it's likely just two
@@ -69,6 +79,7 @@ export function renderMarkdown(text: string): React.ReactNode {
     );
     listItems = [];
     listType = null;
+    lastWasGap = false;
   };
 
   const flushCode = () => {
@@ -90,6 +101,7 @@ export function renderMarkdown(text: string): React.ReactNode {
     codeLines = [];
     codeLang = null;
     inCode = false;
+    lastWasGap = false;
   };
 
   for (let i = 0; i < lines.length; i++) {
@@ -163,6 +175,7 @@ export function renderMarkdown(text: string): React.ReactNode {
             </table>
           </div>,
         );
+        lastWasGap = false;
         i = tbl.end;
         continue;
       }
@@ -187,6 +200,7 @@ export function renderMarkdown(text: string): React.ReactNode {
           {renderInline(content)}
         </div>,
       );
+      lastWasGap = false;
       continue;
     }
 
@@ -214,12 +228,11 @@ export function renderMarkdown(text: string): React.ReactNode {
           {renderInline(line)}
         </p>,
       );
-    } else if (nodes.length > 0) {
+      lastWasGap = false;
+    } else if (nodes.length > 0 && !lastWasGap) {
       // Blank line between blocks — collapse runs, but preserve one as a gap.
-      const last = nodes[nodes.length - 1];
-      if (typeof last === 'object' && last && 'type' in (last as object) && (last as { type?: unknown }).type !== 'br') {
-        nodes.push(<div key={key++} className="h-2" aria-hidden />);
-      }
+      nodes.push(<div key={key++} className="h-2" aria-hidden />);
+      lastWasGap = true;
     }
   }
   flushList();
@@ -253,11 +266,30 @@ function isTableSeparator(line: string): boolean {
 }
 
 function splitRow(line: string): string[] {
-  // Strip the outer pipes then split. Trim each cell. Empty trailing cells
-  // (when the row ends with `|`) are dropped — we don't want to render a
-  // ghost column.
+  // Walk the row character-by-character so we can treat `\|` as a literal
+  // pipe inside cell content rather than a column boundary. Strip the
+  // outer pipes and any trailing empty cells (a row of `| a | b |` should
+  // not render a phantom third column).
   const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
-  return trimmed.split('|').map((c) => c.trim());
+  const cells: string[] = [];
+  let buf = '';
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '\\' && trimmed[i + 1] === '|') {
+      buf += '|';
+      i++;
+      continue;
+    }
+    if (ch === '|') {
+      cells.push(buf.trim());
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  cells.push(buf.trim());
+  while (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+  return cells;
 }
 
 function parseAlign(separator: string): ('left' | 'center' | 'right' | null)[] {

--- a/app/renderer/src/lib/markdown.tsx
+++ b/app/renderer/src/lib/markdown.tsx
@@ -20,6 +20,37 @@ export function renderMarkdown(text: string): React.ReactNode {
   let inCode = false;
   let key = 0;
 
+  // Detect a markdown table starting at index i. Returns the table's row
+  // index range and the parsed rows + alignment, or null if it isn't one.
+  // Expected shape:
+  //   | h1 | h2 |
+  //   |----|:---:|
+  //   | a  | b  |
+  // The separator row distinguishes a real table from a bunch of pipes
+  // in regular text.
+  const detectTable = (
+    i: number,
+  ): { end: number; header: string[]; rows: string[][]; align: ('left' | 'center' | 'right' | null)[] } | null => {
+    if (i + 1 >= lines.length) return null;
+    const headerRaw = lines[i];
+    const sepRaw = lines[i + 1];
+    if (!isTableRow(headerRaw) || !isTableSeparator(sepRaw)) return null;
+    const header = splitRow(headerRaw);
+    const align = parseAlign(sepRaw);
+    if (header.length === 0 || align.length === 0) return null;
+
+    const rows: string[][] = [];
+    let j = i + 2;
+    while (j < lines.length && isTableRow(lines[j])) {
+      rows.push(splitRow(lines[j]));
+      j++;
+    }
+    // Require at least one data row — otherwise it's likely just two
+    // adjacent pipe-containing lines that aren't actually a table.
+    if (rows.length === 0) return null;
+    return { end: j - 1, header, rows, align };
+  };
+
   const flushList = () => {
     if (!listItems.length) return;
     const Tag = listType ?? 'ul';
@@ -61,7 +92,8 @@ export function renderMarkdown(text: string): React.ReactNode {
     inCode = false;
   };
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     // Fenced code block: ```lang ... ```
     const fence = line.match(/^```(\w*)\s*$/);
     if (fence) {
@@ -77,6 +109,63 @@ export function renderMarkdown(text: string): React.ReactNode {
     if (inCode) {
       codeLines.push(line);
       continue;
+    }
+
+    // Markdown table. Detect on the header row, consume through the last
+    // data row, render as a real <table>. Tested before headings/lists
+    // so a leading-pipe table row never gets mistaken for something else.
+    if (line.trimStart().startsWith('|')) {
+      const tbl = detectTable(i);
+      if (tbl) {
+        flushList();
+        nodes.push(
+          <div key={key++} className="my-2 overflow-x-auto">
+            <table
+              className="w-full border-collapse text-[13px]"
+              style={{ fontFamily: 'var(--font-sans)' }}
+            >
+              <thead>
+                <tr>
+                  {tbl.header.map((cell, ci) => (
+                    <th
+                      key={ci}
+                      className="border-b px-2.5 py-1.5 text-left font-semibold"
+                      style={{
+                        borderColor: 'var(--border-subtle)',
+                        color: 'var(--fg-1)',
+                        textAlign: tbl.align[ci] ?? 'left',
+                      }}
+                    >
+                      {renderInline(cell)}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {tbl.rows.map((row, ri) => (
+                  <tr key={ri}>
+                    {row.map((cell, ci) => (
+                      <td
+                        key={ci}
+                        className="border-b px-2.5 py-1.5 align-top"
+                        style={{
+                          borderColor: 'var(--border-subtle)',
+                          color: 'var(--fg-1)',
+                          textAlign: tbl.align[ci] ?? 'left',
+                        }}
+                      >
+                        {renderInline(cell)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>,
+        );
+        i = tbl.end;
+        continue;
+      }
     }
 
     // Heading (# / ## / ###). h1 is reserved for page titles, so the LLM's
@@ -137,6 +226,50 @@ export function renderMarkdown(text: string): React.ReactNode {
   flushCode();
 
   return <>{nodes}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Table helpers
+// ---------------------------------------------------------------------------
+
+function isTableRow(line: string): boolean {
+  // A row starts with `|` (after optional whitespace) and contains at least
+  // one more `|`. Pure separator runs are excluded — those go through
+  // isTableSeparator.
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return false;
+  // Need at least 2 pipes to delimit a single cell.
+  return (trimmed.match(/\|/g) || []).length >= 2;
+}
+
+function isTableSeparator(line: string): boolean {
+  // Each cell is dashes with optional leading/trailing colons for alignment.
+  // Examples: |---|---|, | :--- | :---: | ---: |
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return false;
+  const cells = splitRow(trimmed);
+  if (cells.length === 0) return false;
+  return cells.every((c) => /^:?-{3,}:?$/.test(c.trim()));
+}
+
+function splitRow(line: string): string[] {
+  // Strip the outer pipes then split. Trim each cell. Empty trailing cells
+  // (when the row ends with `|`) are dropped — we don't want to render a
+  // ghost column.
+  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
+  return trimmed.split('|').map((c) => c.trim());
+}
+
+function parseAlign(separator: string): ('left' | 'center' | 'right' | null)[] {
+  return splitRow(separator).map((cell) => {
+    const t = cell.trim();
+    const startsColon = t.startsWith(':');
+    const endsColon = t.endsWith(':');
+    if (startsColon && endsColon) return 'center';
+    if (endsColon) return 'right';
+    if (startsColon) return 'left';
+    return null;
+  });
 }
 
 // Inline markdown: **bold**, *italic*/_italic_, `code`. Order matters —

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -1,0 +1,342 @@
+import * as React from 'react';
+import {
+  ArrowUp,
+  ChefHat,
+  ChevronRight,
+  MessageSquare,
+  Mic,
+  Paperclip,
+  Sparkles,
+  Trash2,
+} from 'lucide-react';
+import { MeetingsShell } from '@/components/MeetingsShell';
+import {
+  useAllChatSessions,
+  useChatSessions,
+} from '@/hooks/useChatSessions';
+import { useGlobalStreaming } from '@/hooks/useStreamingQuery';
+import { useAiProvider } from '@/hooks/useAi';
+import { useUserName } from '@/hooks/useSettings';
+import { navigate } from '@/lib/router';
+import { GLOBAL_SCOPE, deriveSessionName, relativeTime } from '@/lib/chat';
+
+// Templated prompts ("Meals" — Steno's playful name for what other apps call
+// recipes/suggestions). Keep this list small at the top level; "See all"
+// can reveal the full library in a follow-up.
+const MEALS: { label: string; prompt: string }[] = [
+  { label: 'List recent todos', prompt: 'List my action items from the last week.' },
+  { label: 'Coach me', prompt: 'Coach me on my recent meetings — patterns, blind spots, things to work on.' },
+  { label: 'Write weekly recap', prompt: 'Write a recap of this week based on my notes.' },
+  { label: 'Streamline my calendar', prompt: 'Look at my upcoming meetings and suggest which ones I could skip or combine.' },
+  { label: 'Blind spots', prompt: 'What blind spots have come up across my recent meetings?' },
+];
+
+export function Chat() {
+  const allSessions = useAllChatSessions();
+  // Reuse useChatSessions's persist/createSession with the global sentinel
+  // so saves go through the same atomic-write path.
+  const chat = useChatSessions(GLOBAL_SCOPE, null);
+  const streaming = useGlobalStreaming();
+  const provider = useAiProvider();
+  const userName = useUserName();
+
+  const [input, setInput] = React.useState('');
+  const submittingRef = React.useRef(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const isCloud = provider.data?.ai_provider === 'cloud';
+  const cloudKeySet = provider.data?.cloud_api_key_set ?? false;
+  const ready = isCloud && cloudKeySet;
+
+  // Recents = global-scope chats only (sessions started from THIS tab),
+  // never the in-meeting AskBar history.
+  const recents = React.useMemo(() => {
+    const list = allSessions.data?.sessions ?? [];
+    return list
+      .filter((s) => s.summaryFile === GLOBAL_SCOPE)
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, 8);
+  }, [allSessions.data?.sessions]);
+
+  const submit = async (raw: string) => {
+    const q = raw.trim();
+    if (!q || submittingRef.current || !ready) return;
+    submittingRef.current = true;
+    try {
+      const sessionId = await chat.createSession(deriveSessionName(q));
+      await chat.appendMessage(sessionId, {
+        role: 'user',
+        content: q,
+        ts: Date.now(),
+      });
+      setInput('');
+      const streamId = streaming.startGlobalStream(q);
+      // Stash the stream id + session id on a module-level pending map so
+      // the conversation page can pick them up after navigation. Avoids
+      // having to thread them through the URL.
+      pendingNewChat = { sessionId, streamId };
+      navigate(`/chat/${encodeURIComponent(sessionId)}`);
+    } finally {
+      submittingRef.current = false;
+    }
+  };
+
+  const onPickMeal = (prompt: string) => {
+    setInput(prompt);
+    inputRef.current?.focus();
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void submit(input);
+  };
+
+  return (
+    <MeetingsShell activeSummaryFile={null}>
+      <div className="mx-auto max-w-[640px] pt-14">
+        <h1
+          className="mb-6"
+          style={{
+            fontFamily: 'var(--font-serif)',
+            fontSize: 32,
+            lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+            color: 'var(--fg-1)',
+          }}
+        >
+          {userName.data ? `Hi ${userName.data}, ask anything` : 'Ask anything'}
+        </h1>
+
+        {!ready && provider.isFetched && <CloudRequiredBanner />}
+
+        <form
+          onSubmit={onSubmit}
+          className="mb-8 rounded-2xl border p-3 transition-shadow focus-within:shadow-[var(--shadow-md)]"
+          style={{
+            borderColor: 'var(--border-subtle)',
+            background: 'var(--surface-raised)',
+            opacity: ready ? 1 : 0.6,
+          }}
+        >
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                void submit(input);
+              }
+            }}
+            disabled={!ready}
+            placeholder={ready ? 'What topics came up?' : 'Connect a cloud provider in Settings to ask across notes'}
+            className="block w-full bg-transparent px-2 pb-3 pt-1 outline-none disabled:cursor-not-allowed"
+            style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
+          />
+          <div className="flex items-center justify-between gap-2 px-1">
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                disabled
+                className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50"
+                style={{ color: 'var(--fg-2)' }}
+                aria-label="Attach a note (coming soon)"
+                title="Attach a note (coming soon)"
+              >
+                <Paperclip className="size-[14px]" />
+              </button>
+              <span className="text-[12px]" style={{ color: 'var(--fg-muted)' }}>
+                {provider.data?.cloud_provider
+                  ? `${provider.data.cloud_provider} · ${provider.data.cloud_model}`
+                  : 'Auto'}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                disabled
+                className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50"
+                style={{ color: 'var(--fg-2)' }}
+                aria-label="Voice input (coming soon)"
+                title="Voice input (coming soon)"
+              >
+                <Mic className="size-[14px]" />
+              </button>
+              <button
+                type="submit"
+                disabled={!input.trim() || !ready}
+                className="inline-flex size-7 items-center justify-center rounded-full transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-40"
+                style={{ color: 'var(--fg-1)' }}
+                aria-label="Send"
+              >
+                <ArrowUp className="size-[14px]" />
+              </button>
+            </div>
+          </div>
+        </form>
+
+        <section className="mb-10">
+          <SectionHead title="Recents" action={<SeeAll />} />
+          {recents.length === 0 ? (
+            <div
+              className="rounded-md border px-4 py-6 text-center text-[13px]"
+              style={{
+                borderColor: 'var(--border-subtle)',
+                color: 'var(--fg-2)',
+                background: 'var(--surface-sunken)',
+              }}
+            >
+              Your past chats will show up here.
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              {recents.map((s) => (
+                <div
+                  key={s.id}
+                  className="group flex items-center gap-3 rounded-md px-1 py-2 transition-colors hover:bg-[color:var(--surface-hover)]"
+                >
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/chat/${encodeURIComponent(s.id)}`)}
+                    className="flex flex-1 items-center gap-3 text-left"
+                  >
+                    <MessageSquare className="size-[14px] flex-shrink-0" style={{ color: 'var(--fg-2)' }} />
+                    <span className="flex-1 truncate text-[13.5px]" style={{ color: 'var(--fg-1)' }}>
+                      {s.name || 'Untitled chat'}
+                    </span>
+                    <span className="text-[11.5px] tabular-nums" style={{ color: 'var(--fg-muted)' }}>
+                      {relativeTime(s.updatedAt)}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void chat.deleteSession(s.id);
+                    }}
+                    aria-label={`Delete chat ${s.name || 'Untitled'}`}
+                    title="Delete chat"
+                    className="inline-flex size-6 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[color:var(--surface-active)] group-hover:opacity-100 focus:opacity-100"
+                    style={{ color: 'var(--fg-2)' }}
+                  >
+                    <Trash2 className="size-[12px]" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="pb-12">
+          <SectionHead title="Meals" />
+          <div className="flex flex-wrap gap-2">
+            {MEALS.map((m) => (
+              <button
+                key={m.label}
+                type="button"
+                onClick={() => onPickMeal(m.prompt)}
+                className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+                style={{
+                  borderColor: 'var(--border-subtle)',
+                  color: 'var(--fg-1)',
+                  background: 'var(--surface-raised)',
+                }}
+              >
+                <ChefHat className="size-[13px]" style={{ color: 'var(--fg-2)' }} />
+                {m.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+              style={{ color: 'var(--fg-2)' }}
+              aria-label="See all preset prompts"
+              title="See all (coming soon)"
+            >
+              See all
+              <ChevronRight className="size-[12px]" />
+            </button>
+          </div>
+        </section>
+      </div>
+    </MeetingsShell>
+  );
+}
+
+// Module-level handoff between the entry page (kicks off the stream right
+// before navigating) and the conversation page (picks up the stream id +
+// session id on mount). Avoids stuffing them in the URL.
+export interface PendingNewChat {
+  sessionId: string;
+  streamId: string;
+}
+let pendingNewChat: PendingNewChat | null = null;
+
+export function consumePendingNewChat(sessionId: string): PendingNewChat | null {
+  if (!pendingNewChat) return null;
+  if (pendingNewChat.sessionId !== sessionId) return null;
+  const out = pendingNewChat;
+  pendingNewChat = null;
+  return out;
+}
+
+function CloudRequiredBanner() {
+  return (
+    <div
+      className="mb-4 flex items-start gap-3 rounded-md border px-3 py-2.5 text-[13px]"
+      style={{
+        borderColor: 'var(--border-subtle)',
+        background: 'var(--surface-sunken)',
+        color: 'var(--fg-2)',
+      }}
+    >
+      <Sparkles className="mt-0.5 size-[14px] flex-shrink-0" style={{ color: 'var(--fg-2)' }} />
+      <div className="flex-1">
+        Cross-note chat needs a cloud AI provider — local models can't fit a
+        full-corpus prompt yet. Switch to OpenAI or Anthropic in{' '}
+        <button
+          type="button"
+          className="underline transition-colors hover:text-[color:var(--fg-1)]"
+          onClick={() => navigate('/settings')}
+          style={{ color: 'var(--fg-1)' }}
+        >
+          Settings → AI
+        </button>
+        .
+      </div>
+    </div>
+  );
+}
+
+function SectionHead({
+  title,
+  action,
+}: {
+  title: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-baseline justify-between">
+      <h2 className="text-[13px] font-medium tracking-[-0.005em]" style={{ color: 'var(--fg-1)' }}>
+        {title}
+      </h2>
+      {action}
+    </div>
+  );
+}
+
+function SeeAll() {
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-0.5 text-[12px] transition-colors hover:text-[color:var(--fg-1)]"
+      style={{ color: 'var(--fg-2)' }}
+      aria-label="See all chats"
+      title="See all (coming soon)"
+    >
+      See all
+      <ChevronRight className="size-[12px]" />
+    </button>
+  );
+}

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import {
   ArrowUp,
-  ChefHat,
   ChevronRight,
   Mic,
   Paperclip,
   Sparkles,
 } from 'lucide-react';
 import { ChatHistoryRow } from '@/components/ChatHistoryRow';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/components/ui/popover';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import {
   useAllChatSessions,
@@ -18,17 +22,7 @@ import { useAiProvider } from '@/hooks/useAi';
 import { useUserName } from '@/hooks/useSettings';
 import { navigate } from '@/lib/router';
 import { GLOBAL_SCOPE, bucketKey, deriveSessionName, toBucketLabel } from '@/lib/chat';
-
-// Templated prompts ("Meals" — Steno's playful name for what other apps call
-// recipes/suggestions). Keep this list small at the top level; "See all"
-// can reveal the full library in a follow-up.
-const MEALS: { label: string; prompt: string }[] = [
-  { label: 'List recent todos', prompt: 'List my action items from the last week.' },
-  { label: 'Coach me', prompt: 'Coach me on my recent meetings — patterns, blind spots, things to work on.' },
-  { label: 'Write weekly recap', prompt: 'Write a recap of this week based on my notes.' },
-  { label: 'Streamline my calendar', prompt: 'Look at my upcoming meetings and suggest which ones I could skip or combine.' },
-  { label: 'Blind spots', prompt: 'What blind spots have come up across my recent meetings?' },
-];
+import { PRESETS, PresetGlyph } from '@/lib/chatPresets';
 
 export function Chat() {
   const allSessions = useAllChatSessions();
@@ -40,6 +34,7 @@ export function Chat() {
   const userName = useUserName();
 
   const [input, setInput] = React.useState('');
+  const [presetsOpen, setPresetsOpen] = React.useState(false);
   const submittingRef = React.useRef(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -103,8 +98,9 @@ export function Chat() {
     }
   };
 
-  const onPickMeal = (prompt: string) => {
+  const onPickPreset = (prompt: string) => {
     setInput(prompt);
+    setPresetsOpen(false);
     inputRef.current?.focus();
   };
 
@@ -131,31 +127,41 @@ export function Chat() {
 
         {!ready && provider.isFetched && <CloudRequiredBanner />}
 
-        <form
-          onSubmit={onSubmit}
-          className="mb-8 rounded-2xl border p-3 transition-shadow focus-within:shadow-[var(--shadow-md)]"
-          style={{
-            borderColor: 'var(--border-subtle)',
-            background: 'var(--surface-raised)',
-            opacity: ready ? 1 : 0.6,
-          }}
-        >
-          <input
-            ref={inputRef}
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                void submit(input);
-              }
-            }}
-            disabled={!ready}
-            placeholder={ready ? 'What topics came up?' : 'Connect a cloud provider in Settings to ask across notes'}
-            className="block w-full bg-transparent px-2 pb-3 pt-1 outline-none disabled:cursor-not-allowed"
-            style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
-          />
+        <Popover open={presetsOpen} onOpenChange={setPresetsOpen}>
+          <PopoverAnchor asChild>
+            <form
+              onSubmit={onSubmit}
+              className="mb-8 rounded-2xl border p-3 transition-shadow focus-within:shadow-[var(--shadow-md)]"
+              style={{
+                borderColor: 'var(--border-subtle)',
+                background: 'var(--surface-raised)',
+                opacity: ready ? 1 : 0.6,
+              }}
+            >
+              <input
+                ref={inputRef}
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  // Type "/" with an empty input → open the presets picker
+                  // (matches the Granola pattern). Don't insert the slash —
+                  // it's a shortcut character, not part of the prompt.
+                  if (e.key === '/' && input === '' && ready) {
+                    e.preventDefault();
+                    setPresetsOpen(true);
+                    return;
+                  }
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    void submit(input);
+                  }
+                }}
+                disabled={!ready}
+                placeholder={ready ? 'Summarise my meetings this week  /' : 'Connect a cloud provider in Settings to ask across notes'}
+                className="block w-full bg-transparent px-2 pb-3 pt-1 outline-none disabled:cursor-not-allowed"
+                style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
+              />
           <div className="flex items-center justify-between gap-2 px-1">
             <div className="flex items-center gap-1">
               <button
@@ -197,6 +203,38 @@ export function Chat() {
             </div>
           </div>
         </form>
+          </PopoverAnchor>
+          <PopoverContent
+            align="start"
+            sideOffset={8}
+            className="w-[var(--radix-popover-trigger-width)] max-w-none p-1"
+            // Don't yank focus from the input when the popover opens — the
+            // user is mid-typing and Enter/Esc need to keep working there.
+            onOpenAutoFocus={(e) => e.preventDefault()}
+          >
+            <div className="px-2 pb-1 pt-0.5 text-[11px] font-medium" style={{ color: 'var(--fg-muted)' }}>
+              Presets
+            </div>
+            <div className="flex flex-col">
+              {PRESETS.map((p) => (
+                <button
+                  key={p.label}
+                  type="button"
+                  onClick={() => onPickPreset(p.prompt)}
+                  className="flex flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[color:var(--surface-hover)]"
+                >
+                  <div className="flex items-center gap-2 text-[13px]" style={{ color: 'var(--fg-1)' }}>
+                    <PresetGlyph />
+                    {p.label}
+                  </div>
+                  <div className="pl-[26px] text-[12px]" style={{ color: 'var(--fg-2)' }}>
+                    {p.description}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
 
         <section className="mb-10">
           <SectionHead
@@ -266,13 +304,13 @@ export function Chat() {
         </section>
 
         <section className="pb-12">
-          <SectionHead title="Meals" />
+          <SectionHead title="Presets" />
           <div className="flex flex-wrap gap-2">
-            {MEALS.map((m) => (
+            {PRESETS.map((m) => (
               <button
                 key={m.label}
                 type="button"
-                onClick={() => onPickMeal(m.prompt)}
+                onClick={() => onPickPreset(m.prompt)}
                 className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
                 style={{
                   borderColor: 'var(--border-subtle)',
@@ -280,20 +318,10 @@ export function Chat() {
                   background: 'var(--surface-raised)',
                 }}
               >
-                <ChefHat className="size-[13px]" style={{ color: 'var(--fg-2)' }} />
+                <PresetGlyph />
                 {m.label}
               </button>
             ))}
-            <button
-              type="button"
-              className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
-              style={{ color: 'var(--fg-2)' }}
-              aria-label="See all preset prompts"
-              title="See all (coming soon)"
-            >
-              See all
-              <ChevronRight className="size-[12px]" />
-            </button>
           </div>
         </section>
       </div>

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -3,12 +3,11 @@ import {
   ArrowUp,
   ChefHat,
   ChevronRight,
-  MessageSquare,
   Mic,
   Paperclip,
   Sparkles,
-  Trash2,
 } from 'lucide-react';
+import { ChatHistoryRow } from '@/components/ChatHistoryRow';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import {
   useAllChatSessions,
@@ -18,7 +17,7 @@ import { useGlobalStreaming } from '@/hooks/useStreamingQuery';
 import { useAiProvider } from '@/hooks/useAi';
 import { useUserName } from '@/hooks/useSettings';
 import { navigate } from '@/lib/router';
-import { GLOBAL_SCOPE, deriveSessionName, relativeTime } from '@/lib/chat';
+import { GLOBAL_SCOPE, bucketKey, deriveSessionName, toBucketLabel } from '@/lib/chat';
 
 // Templated prompts ("Meals" — Steno's playful name for what other apps call
 // recipes/suggestions). Keep this list small at the top level; "See all"
@@ -50,13 +49,36 @@ export function Chat() {
 
   // Recents = global-scope chats only (sessions started from THIS tab),
   // never the in-meeting AskBar history.
-  const recents = React.useMemo(() => {
+  const allRecents = React.useMemo(() => {
     const list = allSessions.data?.sessions ?? [];
     return list
       .filter((s) => s.summaryFile === GLOBAL_SCOPE)
-      .sort((a, b) => b.updatedAt - a.updatedAt)
-      .slice(0, 8);
+      .sort((a, b) => b.updatedAt - a.updatedAt);
   }, [allSessions.data?.sessions]);
+
+  // Default view shows the 8 most-recent chats; "See all" expands to the
+  // full list grouped by time bucket (Today / Last 2 weeks / April / …).
+  // Hide the toggle entirely when the list already fits.
+  const COLLAPSED_LIMIT = 8;
+  const [recentsExpanded, setRecentsExpanded] = React.useState(false);
+  const canExpand = allRecents.length > COLLAPSED_LIMIT;
+  const recents = recentsExpanded ? allRecents : allRecents.slice(0, COLLAPSED_LIMIT);
+  const groupedRecents = React.useMemo(() => {
+    if (!recentsExpanded) return null;
+    const groups = new Map<string, typeof allRecents>();
+    const now = Date.now();
+    for (const s of allRecents) {
+      const k = bucketKey(s.updatedAt, now);
+      const arr = groups.get(k) ?? [];
+      arr.push(s);
+      groups.set(k, arr);
+    }
+    return Array.from(groups.entries()).map(([key, sessions]) => ({
+      key,
+      label: toBucketLabel(key),
+      sessions,
+    }));
+  }, [recentsExpanded, allRecents]);
 
   const submit = async (raw: string) => {
     const q = raw.trim();
@@ -177,8 +199,25 @@ export function Chat() {
         </form>
 
         <section className="mb-10">
-          <SectionHead title="Recents" action={<SeeAll />} />
-          {recents.length === 0 ? (
+          <SectionHead
+            title="Recents"
+            action={
+              canExpand ? (
+                <button
+                  type="button"
+                  onClick={() => setRecentsExpanded((v) => !v)}
+                  className="inline-flex items-center gap-0.5 text-[12px] transition-colors hover:text-[color:var(--fg-1)]"
+                  style={{ color: 'var(--fg-2)' }}
+                >
+                  {recentsExpanded ? 'Show less' : 'See all'}
+                  <ChevronRight
+                    className={`size-[12px] transition-transform ${recentsExpanded ? 'rotate-90' : ''}`}
+                  />
+                </button>
+              ) : undefined
+            }
+          />
+          {allRecents.length === 0 ? (
             <div
               className="rounded-md border px-4 py-6 text-center text-[13px]"
               style={{
@@ -189,40 +228,38 @@ export function Chat() {
             >
               Your past chats will show up here.
             </div>
+          ) : recentsExpanded && groupedRecents ? (
+            <div className="flex flex-col">
+              {groupedRecents.map((group) => (
+                <div key={group.key} className="mb-2 last:mb-0">
+                  <div
+                    className="px-1 pb-1 pt-2 text-[11px] font-medium"
+                    style={{ color: 'var(--fg-muted)' }}
+                  >
+                    {group.label}
+                  </div>
+                  {group.sessions.map((s) => (
+                    <ChatHistoryRow
+                      key={s.id}
+                      session={s}
+                      showTime
+                      onRename={(name) => void chat.renameSession(s.id, name)}
+                      onDelete={() => void chat.deleteSession(s.id)}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
           ) : (
             <div className="flex flex-col">
               {recents.map((s) => (
-                <div
+                <ChatHistoryRow
                   key={s.id}
-                  className="group flex items-center gap-3 rounded-md px-1 py-2 transition-colors hover:bg-[color:var(--surface-hover)]"
-                >
-                  <button
-                    type="button"
-                    onClick={() => navigate(`/chat/${encodeURIComponent(s.id)}`)}
-                    className="flex flex-1 items-center gap-3 text-left"
-                  >
-                    <MessageSquare className="size-[14px] flex-shrink-0" style={{ color: 'var(--fg-2)' }} />
-                    <span className="flex-1 truncate text-[13.5px]" style={{ color: 'var(--fg-1)' }}>
-                      {s.name || 'Untitled chat'}
-                    </span>
-                    <span className="text-[11.5px] tabular-nums" style={{ color: 'var(--fg-muted)' }}>
-                      {relativeTime(s.updatedAt)}
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void chat.deleteSession(s.id);
-                    }}
-                    aria-label={`Delete chat ${s.name || 'Untitled'}`}
-                    title="Delete chat"
-                    className="inline-flex size-6 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[color:var(--surface-active)] group-hover:opacity-100 focus:opacity-100"
-                    style={{ color: 'var(--fg-2)' }}
-                  >
-                    <Trash2 className="size-[12px]" />
-                  </button>
-                </div>
+                  session={s}
+                  showTime
+                  onRename={(name) => void chat.renameSession(s.id, name)}
+                  onDelete={() => void chat.deleteSession(s.id)}
+                />
               ))}
             </div>
           )}
@@ -326,17 +363,3 @@ function SectionHead({
   );
 }
 
-function SeeAll() {
-  return (
-    <button
-      type="button"
-      className="inline-flex items-center gap-0.5 text-[12px] transition-colors hover:text-[color:var(--fg-1)]"
-      style={{ color: 'var(--fg-2)' }}
-      aria-label="See all chats"
-      title="See all (coming soon)"
-    >
-      See all
-      <ChevronRight className="size-[12px]" />
-    </button>
-  );
-}

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import {
   ArrowUp,
   ChevronRight,
-  Mic,
-  Paperclip,
   Sparkles,
 } from 'lucide-react';
 import { ChatHistoryRow } from '@/components/ChatHistoryRow';
+import { FolderScopePicker } from '@/components/FolderScopePicker';
 import {
   Popover,
   PopoverAnchor,
@@ -35,6 +34,10 @@ export function Chat() {
 
   const [input, setInput] = React.useState('');
   const [presetsOpen, setPresetsOpen] = React.useState(false);
+  // Scope: null = ask across every note. Folder ID limits the corpus
+  // server-side. Default null so first-time users get the broadest
+  // possible answer.
+  const [scopeFolderId, setScopeFolderId] = React.useState<string | null>(null);
   const submittingRef = React.useRef(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -87,11 +90,11 @@ export function Chat() {
         ts: Date.now(),
       });
       setInput('');
-      const streamId = streaming.startGlobalStream(q);
-      // Stash the stream id + session id on a module-level pending map so
-      // the conversation page can pick them up after navigation. Avoids
-      // having to thread them through the URL.
-      pendingNewChat = { sessionId, streamId };
+      const streamId = streaming.startGlobalStream(q, scopeFolderId);
+      // Stash the stream id + session id + scope on a module-level pending
+      // map so the conversation page can pick them up after navigation.
+      // Avoids having to thread them through the URL.
+      pendingNewChat = { sessionId, streamId, folderId: scopeFolderId };
       navigate(`/chat/${encodeURIComponent(sessionId)}`);
     } finally {
       submittingRef.current = false;
@@ -164,16 +167,7 @@ export function Chat() {
               />
           <div className="flex items-center justify-between gap-2 px-1">
             <div className="flex items-center gap-1">
-              <button
-                type="button"
-                disabled
-                className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50"
-                style={{ color: 'var(--fg-2)' }}
-                aria-label="Attach a note (coming soon)"
-                title="Attach a note (coming soon)"
-              >
-                <Paperclip className="size-[14px]" />
-              </button>
+              <FolderScopePicker value={scopeFolderId} onChange={setScopeFolderId} />
               <span className="text-[12px]" style={{ color: 'var(--fg-muted)' }}>
                 {provider.data?.cloud_provider
                   ? `${provider.data.cloud_provider} · ${provider.data.cloud_model}`
@@ -181,16 +175,6 @@ export function Chat() {
               </span>
             </div>
             <div className="flex items-center gap-1">
-              <button
-                type="button"
-                disabled
-                className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50"
-                style={{ color: 'var(--fg-2)' }}
-                aria-label="Voice input (coming soon)"
-                title="Voice input (coming soon)"
-              >
-                <Mic className="size-[14px]" />
-              </button>
               <button
                 type="submit"
                 disabled={!input.trim() || !ready}
@@ -335,6 +319,7 @@ export function Chat() {
 export interface PendingNewChat {
   sessionId: string;
   streamId: string;
+  folderId: string | null;
 }
 let pendingNewChat: PendingNewChat | null = null;
 

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -78,24 +78,42 @@ export function Chat() {
     }));
   }, [recentsExpanded, allRecents]);
 
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
   const submit = async (raw: string) => {
     const q = raw.trim();
     if (!q || submittingRef.current || !ready) return;
     submittingRef.current = true;
+    setSubmitError(null);
+    let createdSessionId: string | null = null;
     try {
-      const sessionId = await chat.createSession(deriveSessionName(q));
-      await chat.appendMessage(sessionId, {
+      createdSessionId = await chat.createSession(deriveSessionName(q));
+      await chat.appendMessage(createdSessionId, {
         role: 'user',
         content: q,
         ts: Date.now(),
       });
       setInput('');
       const streamId = streaming.startGlobalStream(q, scopeFolderId);
-      // Stash the stream id + session id + scope on a module-level pending
-      // map so the conversation page can pick them up after navigation.
-      // Avoids having to thread them through the URL.
-      pendingNewChat = { sessionId, streamId, folderId: scopeFolderId };
-      navigate(`/chat/${encodeURIComponent(sessionId)}`);
+      // Record the handoff under THIS sessionId so a fast double-submit
+      // can't clobber an earlier in-flight stream before the conversation
+      // page mounts and claims it.
+      recordPendingNewChat({ sessionId: createdSessionId, streamId, folderId: scopeFolderId });
+      navigate(`/chat/${encodeURIComponent(createdSessionId)}`);
+    } catch (err) {
+      // appendMessage / startGlobalStream / createSession can all fail
+      // (disk full, IPC error, cloud-key revoked). Surface the error,
+      // restore the user's text so they don't have to retype, and roll
+      // back the empty session so it doesn't appear in History/Recents.
+      const message = err instanceof Error ? err.message : 'Failed to send';
+      setSubmitError(message);
+      setInput(q);
+      if (createdSessionId) {
+        try {
+          await chat.deleteSession(createdSessionId);
+        } catch {
+          // best-effort cleanup
+        }
+      }
     } finally {
       submittingRef.current = false;
     }
@@ -129,6 +147,19 @@ export function Chat() {
         </h1>
 
         {!ready && provider.isFetched && <CloudRequiredBanner />}
+        {submitError && (
+          <div
+            role="alert"
+            className="mb-4 rounded-md border px-3 py-2 text-[13px]"
+            style={{
+              borderColor: 'var(--border-subtle)',
+              background: 'var(--danger-bg)',
+              color: 'var(--danger)',
+            }}
+          >
+            {submitError}
+          </div>
+        )}
 
         <Popover open={presetsOpen} onOpenChange={setPresetsOpen}>
           <PopoverAnchor asChild>
@@ -316,18 +347,24 @@ export function Chat() {
 // Module-level handoff between the entry page (kicks off the stream right
 // before navigating) and the conversation page (picks up the stream id +
 // session id on mount). Avoids stuffing them in the URL.
+//
+// Keyed by sessionId so a fast double-submit can't clobber an earlier
+// in-flight handoff before the conversation page mounts to claim it.
 export interface PendingNewChat {
   sessionId: string;
   streamId: string;
   folderId: string | null;
 }
-let pendingNewChat: PendingNewChat | null = null;
+const pendingNewChats = new Map<string, PendingNewChat>();
+
+export function recordPendingNewChat(pending: PendingNewChat) {
+  pendingNewChats.set(pending.sessionId, pending);
+}
 
 export function consumePendingNewChat(sessionId: string): PendingNewChat | null {
-  if (!pendingNewChat) return null;
-  if (pendingNewChat.sessionId !== sessionId) return null;
-  const out = pendingNewChat;
-  pendingNewChat = null;
+  const out = pendingNewChats.get(sessionId);
+  if (!out) return null;
+  pendingNewChats.delete(sessionId);
   return out;
 }
 

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -3,10 +3,9 @@ import {
   ArrowLeft,
   ArrowUp,
   ChevronDown,
-  Mic,
-  Paperclip,
   Square,
 } from 'lucide-react';
+import { FolderScopePicker } from '@/components/FolderScopePicker';
 import { ChatHistoryRow } from '@/components/ChatHistoryRow';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import {
@@ -47,6 +46,10 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
   const [activeStreamId, setActiveStreamId] = React.useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = React.useState(false);
   const [presetsOpen, setPresetsOpen] = React.useState(false);
+  // Folder scope persists for the lifetime of the conversation page mount.
+  // The entry page's scope is handed off via consumePendingNewChat; later
+  // turns in the same conversation can be re-scoped from this composer.
+  const [scopeFolderId, setScopeFolderId] = React.useState<string | null>(null);
   const pendingPersistRef = React.useRef<string | null>(null);
   const submittingRef = React.useRef(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -65,11 +68,14 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
 
   // Pick up an in-flight stream the entry page kicked off right before
   // navigating, so we don't lose its tokens during the route change.
+  // The entry page's chosen scope rides along with the handoff so the
+  // composer here starts with the same folder context.
   React.useEffect(() => {
     const pending = consumePendingNewChat(sessionId);
     if (pending) {
       pendingPersistRef.current = pending.sessionId;
       setActiveStreamId(pending.streamId);
+      setScopeFolderId(pending.folderId);
     }
   }, [sessionId]);
 
@@ -148,7 +154,7 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
         ts: Date.now(),
       });
       setInput('');
-      const streamId = streaming.startGlobalStream(q);
+      const streamId = streaming.startGlobalStream(q, scopeFolderId);
       pendingPersistRef.current = session.id;
       setActiveStreamId(streamId);
     } finally {
@@ -347,9 +353,7 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
           />
           <div className="flex items-center justify-between gap-2 px-1">
             <div className="flex items-center gap-1">
-              <button type="button" disabled className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50" style={{ color: 'var(--fg-2)' }} aria-label="Attach (coming soon)">
-                <Paperclip className="size-[14px]" />
-              </button>
+              <FolderScopePicker value={scopeFolderId} onChange={setScopeFolderId} />
               <span className="text-[12px]" style={{ color: 'var(--fg-muted)' }}>
                 {provider.data?.cloud_provider
                   ? `${provider.data.cloud_provider} · ${provider.data.cloud_model}`
@@ -357,9 +361,6 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
               </span>
             </div>
             <div className="flex items-center gap-1">
-              <button type="button" disabled className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50" style={{ color: 'var(--fg-2)' }} aria-label="Voice (coming soon)">
-                <Mic className="size-[14px]" />
-              </button>
               {isStreaming ? (
                 <button
                   type="button"

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -143,10 +143,12 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
     if (el) el.scrollTop = el.scrollHeight;
   }, [session?.messages.length, activeStream?.text]);
 
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
   const submit = async (raw: string) => {
     const q = raw.trim();
     if (!q || isStreaming || submittingRef.current || !ready || !session) return;
     submittingRef.current = true;
+    setSubmitError(null);
     try {
       await chat.appendMessage(session.id, {
         role: 'user',
@@ -157,6 +159,12 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
       const streamId = streaming.startGlobalStream(q, scopeFolderId);
       pendingPersistRef.current = session.id;
       setActiveStreamId(streamId);
+    } catch (err) {
+      // Disk write / IPC / streaming setup can all fail. Restore the
+      // user's text so they don't lose it, surface the error.
+      const message = err instanceof Error ? err.message : 'Failed to send';
+      setSubmitError(message);
+      setInput(q);
     } finally {
       submittingRef.current = false;
     }
@@ -275,6 +283,7 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
                               key={s.id}
                               session={s}
                               activeId={sessionId}
+                              onSelect={() => setHistoryOpen(false)}
                               onRename={(name) => void chat.renameSession(s.id, name)}
                               onDelete={async () => {
                                 const wasActive = s.id === sessionId;
@@ -317,6 +326,19 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
         {/* Composer pinned at the visual bottom — out of the scroll
             container, in the flex column. No leftover padding underneath. */}
         <div className="mx-auto w-full max-w-[760px] px-10 pb-6 pt-2">
+          {submitError && (
+            <div
+              role="alert"
+              className="mb-3 rounded-md border px-3 py-2 text-[13px]"
+              style={{
+                borderColor: 'var(--border-subtle)',
+                background: 'var(--danger-bg)',
+                color: 'var(--danger)',
+              }}
+            >
+              {submitError}
+            </div>
+          )}
           <Popover open={presetsOpen} onOpenChange={setPresetsOpen}>
             <PopoverAnchor asChild>
           <form

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -1,0 +1,387 @@
+import * as React from 'react';
+import {
+  ArrowLeft,
+  ArrowUp,
+  ChevronDown,
+  Mic,
+  Paperclip,
+  Square,
+  Trash2,
+} from 'lucide-react';
+import { MeetingsShell } from '@/components/MeetingsShell';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  useAllChatSessions,
+  useChatSessions,
+  type ChatMessage,
+} from '@/hooks/useChatSessions';
+import { useGlobalStreaming } from '@/hooks/useStreamingQuery';
+import { useAiProvider } from '@/hooks/useAi';
+import { navigate } from '@/lib/router';
+import {
+  GLOBAL_SCOPE,
+  deriveSessionName,
+  relativeTime,
+} from '@/lib/chat';
+import { consumePendingNewChat } from '@/routes/Chat';
+import { renderMarkdown } from '@/lib/markdown';
+
+interface ChatConversationProps {
+  sessionId: string;
+}
+
+export function ChatConversation({ sessionId }: ChatConversationProps) {
+  const allSessions = useAllChatSessions();
+  const chat = useChatSessions(GLOBAL_SCOPE, null);
+  const streaming = useGlobalStreaming();
+  const provider = useAiProvider();
+
+  const [input, setInput] = React.useState('');
+  const [activeStreamId, setActiveStreamId] = React.useState<string | null>(null);
+  const pendingPersistRef = React.useRef<string | null>(null);
+  const submittingRef = React.useRef(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  const isCloud = provider.data?.ai_provider === 'cloud';
+  const cloudKeySet = provider.data?.cloud_api_key_set ?? false;
+  const ready = isCloud && cloudKeySet;
+
+  // Make THIS session the active one as soon as the route mounts so
+  // chat.activeSession / chat.appendMessage operate on the right record
+  // instead of whichever one useChatSessions's auto-restore landed on.
+  React.useEffect(() => {
+    chat.setActiveId(sessionId);
+  }, [sessionId, chat]);
+
+  // Pick up an in-flight stream the entry page kicked off right before
+  // navigating, so we don't lose its tokens during the route change.
+  React.useEffect(() => {
+    const pending = consumePendingNewChat(sessionId);
+    if (pending) {
+      pendingPersistRef.current = pending.sessionId;
+      setActiveStreamId(pending.streamId);
+    }
+  }, [sessionId]);
+
+  const session = React.useMemo(() => {
+    const list = allSessions.data?.sessions ?? [];
+    return list.find((s) => s.id === sessionId) ?? null;
+  }, [allSessions.data?.sessions, sessionId]);
+
+  const otherSessions = React.useMemo(() => {
+    const list = allSessions.data?.sessions ?? [];
+    return list
+      .filter((s) => s.summaryFile === GLOBAL_SCOPE)
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  }, [allSessions.data?.sessions]);
+
+  const activeStream = activeStreamId ? streaming.streams[activeStreamId] : null;
+  const isStreaming = activeStream?.status === 'streaming';
+
+  // Persist the assistant turn when its stream finishes.
+  React.useEffect(() => {
+    if (!activeStreamId) return;
+    const stream = streaming.streams[activeStreamId];
+    if (!stream || stream.status === 'streaming') return;
+    const persistId = pendingPersistRef.current;
+    if (!persistId) return;
+    const content =
+      stream.text.trim() ||
+      (stream.status === 'error'
+        ? `Error: ${stream.error ?? 'query failed'}`
+        : '(empty response)');
+    const message: ChatMessage = {
+      role: 'assistant',
+      content,
+      ts: Date.now(),
+    };
+    void chat.appendMessage(persistId, message);
+    pendingPersistRef.current = null;
+    streaming.clearStream(activeStreamId);
+    setActiveStreamId(null);
+  }, [activeStreamId, streaming, chat]);
+
+  // Keep the conversation scrolled to the bottom on new content.
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [session?.messages.length, activeStream?.text]);
+
+  const submit = async (raw: string) => {
+    const q = raw.trim();
+    if (!q || isStreaming || submittingRef.current || !ready || !session) return;
+    submittingRef.current = true;
+    try {
+      await chat.appendMessage(session.id, {
+        role: 'user',
+        content: q,
+        ts: Date.now(),
+      });
+      setInput('');
+      const streamId = streaming.startGlobalStream(q);
+      pendingPersistRef.current = session.id;
+      setActiveStreamId(streamId);
+    } finally {
+      submittingRef.current = false;
+    }
+  };
+
+  const stop = () => {
+    if (!activeStreamId) return;
+    streaming.cancelStream(activeStreamId);
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void submit(input);
+  };
+
+  const liveText = isStreaming ? activeStream?.text ?? '' : '';
+
+  // Session might not exist yet on cold reload (allSessions is still
+  // loading). Show a soft loading state rather than dumping the user
+  // back to /chat — the URL is the source of truth.
+  if (!session && allSessions.isFetched) {
+    return (
+      <MeetingsShell activeSummaryFile={null}>
+        <div className="mx-auto max-w-[640px] py-20 text-center">
+          <h1 className="mv-title mb-3">Chat not found.</h1>
+          <p className="text-[14px]" style={{ color: 'var(--fg-2)' }}>
+            This conversation may have been deleted.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate('/chat')}
+            className="mt-4 inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+            style={{ color: 'var(--fg-1)', background: 'var(--surface-raised)' }}
+          >
+            <ArrowLeft className="size-[13px]" />
+            Back to Chat
+          </button>
+        </div>
+      </MeetingsShell>
+    );
+  }
+
+  return (
+    // bleed: skip AppShell's centered scroll wrapper (which has pb-36 baked
+    // in) so we can own the layout — flex column with a scrolling message
+    // area + composer pinned to the bottom of the viewport with no padding
+    // gap underneath.
+    <MeetingsShell activeSummaryFile={null} bleed>
+      <div className="flex min-h-0 flex-1 flex-col" style={{ background: 'var(--page)' }}>
+        {/* Toolbar — back, History dropdown, New chat. */}
+        <div className="mx-auto flex w-full max-w-[760px] items-center justify-between gap-2 px-10 pb-3 pt-2">
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => navigate('/chat')}
+              className="inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-[color:var(--surface-hover)]"
+              style={{ color: 'var(--fg-2)' }}
+              aria-label="Back to Chat"
+              title="Back to Chat"
+            >
+              <ArrowLeft className="size-[15px]" />
+            </button>
+
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="ml-1 inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+                  style={{
+                    borderColor: 'var(--border-subtle)',
+                    color: 'var(--fg-1)',
+                    background: 'var(--surface-raised)',
+                  }}
+                  aria-label="Switch chat"
+                >
+                  History
+                  <ChevronDown className="size-[12px]" style={{ color: 'var(--fg-2)' }} />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-[280px] p-1">
+                {otherSessions.length === 0 ? (
+                  <div className="px-3 py-3 text-[13px]" style={{ color: 'var(--fg-2)' }}>
+                    No other chats yet.
+                  </div>
+                ) : (
+                  <div className="max-h-[320px] overflow-y-auto">
+                    {otherSessions.map((s) => (
+                      <div
+                        key={s.id}
+                        className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+                        style={{
+                          color: s.id === sessionId ? 'var(--fg-1)' : 'var(--fg-2)',
+                          background: s.id === sessionId ? 'var(--surface-active)' : undefined,
+                        }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => navigate(`/chat/${encodeURIComponent(s.id)}`)}
+                          className="flex flex-1 items-center justify-between gap-2 text-left"
+                        >
+                          <span className="flex-1 truncate">{s.name || 'Untitled chat'}</span>
+                          <span className="text-[11px] tabular-nums" style={{ color: 'var(--fg-muted)' }}>
+                            {relativeTime(s.updatedAt)}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            // If the user just nuked the chat they're
+                            // actively viewing, bounce back to /chat so we
+                            // don't leave them on a "Chat not found" page.
+                            const wasActive = s.id === sessionId;
+                            await chat.deleteSession(s.id);
+                            if (wasActive) navigate('/chat');
+                          }}
+                          aria-label={`Delete chat ${s.name || 'Untitled'}`}
+                          title="Delete chat"
+                          className="inline-flex size-6 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[color:var(--surface-active)] group-hover:opacity-100 focus:opacity-100"
+                          style={{ color: 'var(--fg-2)' }}
+                        >
+                          <Trash2 className="size-[12px]" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          {/* "New chat" lives in the global toolbar (route-aware "+ New" pill)
+              when on chat routes, so we don't repeat it here. */}
+        </div>
+
+        {/* Scrolling message area. flex-1 takes all remaining vertical space
+            so the composer below it renders at the actual viewport bottom
+            with no empty band underneath. */}
+        <div
+          ref={scrollRef}
+          className="scrollbar-clean min-h-0 flex-1 overflow-y-auto"
+          style={{ scrollbarGutter: 'stable' }}
+        >
+          <div className="mx-auto flex w-full max-w-[760px] flex-col gap-5 px-10 pb-6 pt-2">
+            {(session?.messages ?? []).map((m, i) => (
+              <Bubble key={i} role={m.role} content={m.content} />
+            ))}
+            {isStreaming && (
+              <Bubble role="assistant" content={liveText || 'Thinking…'} live />
+            )}
+          </div>
+        </div>
+
+        {/* Composer pinned at the visual bottom — out of the scroll
+            container, in the flex column. No leftover padding underneath. */}
+        <div className="mx-auto w-full max-w-[760px] px-10 pb-6 pt-2">
+          <form
+            onSubmit={onSubmit}
+            className="rounded-2xl border p-3 transition-shadow focus-within:shadow-[var(--shadow-md)]"
+            style={{
+              borderColor: 'var(--border-subtle)',
+              background: 'var(--surface-raised)',
+            }}
+          >
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey && !isStreaming) {
+                e.preventDefault();
+                void submit(input);
+              }
+            }}
+            disabled={!ready || isStreaming}
+            placeholder="Ask anything"
+            className="block w-full bg-transparent px-2 pb-3 pt-1 outline-none disabled:cursor-not-allowed"
+            style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
+          />
+          <div className="flex items-center justify-between gap-2 px-1">
+            <div className="flex items-center gap-1">
+              <button type="button" disabled className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50" style={{ color: 'var(--fg-2)' }} aria-label="Attach (coming soon)">
+                <Paperclip className="size-[14px]" />
+              </button>
+              <span className="text-[12px]" style={{ color: 'var(--fg-muted)' }}>
+                {provider.data?.cloud_provider
+                  ? `${provider.data.cloud_provider} · ${provider.data.cloud_model}`
+                  : 'Auto'}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <button type="button" disabled className="inline-flex size-7 items-center justify-center rounded-md disabled:opacity-50" style={{ color: 'var(--fg-2)' }} aria-label="Voice (coming soon)">
+                <Mic className="size-[14px]" />
+              </button>
+              {isStreaming ? (
+                <button
+                  type="button"
+                  onClick={stop}
+                  className="inline-flex size-7 items-center justify-center rounded-full transition-colors hover:bg-[color:var(--surface-hover)]"
+                  style={{ color: 'var(--fg-1)' }}
+                  aria-label="Stop"
+                >
+                  <Square className="size-[12px]" fill="currentColor" />
+                </button>
+              ) : (
+                <button
+                  type="submit"
+                  disabled={!input.trim() || !ready}
+                  className="inline-flex size-7 items-center justify-center rounded-full transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-40"
+                  style={{ color: 'var(--fg-1)' }}
+                  aria-label="Send"
+                >
+                  <ArrowUp className="size-[14px]" />
+                </button>
+              )}
+            </div>
+          </div>
+          </form>
+        </div>
+      </div>
+    </MeetingsShell>
+  );
+}
+
+function Bubble({
+  role,
+  content,
+  live,
+}: {
+  role: 'user' | 'assistant';
+  content: string;
+  live?: boolean;
+}) {
+  const isUser = role === 'user';
+  return (
+    <div className={isUser ? 'flex justify-end' : 'flex'}>
+      <div
+        className={`chat-bubble max-w-[85%] rounded-2xl px-4 py-3 text-[14px] leading-[1.55] ${live ? 'animate-pulse' : ''}`}
+        style={{
+          background: isUser ? 'var(--surface-active)' : 'var(--surface-sunken)',
+          color: 'var(--fg-1)',
+          fontFamily: 'var(--font-sans)',
+        }}
+      >
+        {/* User turns are typed plain text — render as-is to preserve any
+            literal asterisks/backticks. Assistant turns get full markdown. */}
+        {isUser ? (
+          <span style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
+        ) : (
+          renderMarkdown(content)
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Re-export so callers don't need to know about deriveSessionName here.
+export { deriveSessionName };

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -11,9 +11,11 @@ import { ChatHistoryRow } from '@/components/ChatHistoryRow';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { PRESETS, PresetGlyph } from '@/lib/chatPresets';
 import {
   useAllChatSessions,
   useChatSessions,
@@ -43,6 +45,8 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
 
   const [input, setInput] = React.useState('');
   const [activeStreamId, setActiveStreamId] = React.useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = React.useState(false);
+  const [presetsOpen, setPresetsOpen] = React.useState(false);
   const pendingPersistRef = React.useRef<string | null>(null);
   const submittingRef = React.useRef(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -210,7 +214,7 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
               <ArrowLeft className="size-[15px]" />
             </button>
 
-            <Popover>
+            <Popover open={historyOpen} onOpenChange={setHistoryOpen}>
               <PopoverTrigger asChild>
                 <button
                   type="button"
@@ -242,6 +246,7 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
                           key={s.id}
                           session={s}
                           activeId={sessionId}
+                          onSelect={() => setHistoryOpen(false)}
                           onRename={(name) => void chat.renameSession(s.id, name)}
                           onDelete={async () => {
                             const wasActive = s.id === sessionId;
@@ -306,6 +311,8 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
         {/* Composer pinned at the visual bottom — out of the scroll
             container, in the flex column. No leftover padding underneath. */}
         <div className="mx-auto w-full max-w-[760px] px-10 pb-6 pt-2">
+          <Popover open={presetsOpen} onOpenChange={setPresetsOpen}>
+            <PopoverAnchor asChild>
           <form
             onSubmit={onSubmit}
             className="rounded-2xl border p-3 transition-shadow focus-within:shadow-[var(--shadow-md)]"
@@ -320,13 +327,21 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {
+              // Same '/' shortcut as the entry page — opens the preset
+              // picker when the input is empty so a literal slash typed
+              // mid-sentence doesn't surprise the user.
+              if (e.key === '/' && input === '' && ready && !isStreaming) {
+                e.preventDefault();
+                setPresetsOpen(true);
+                return;
+              }
               if (e.key === 'Enter' && !e.shiftKey && !isStreaming) {
                 e.preventDefault();
                 void submit(input);
               }
             }}
             disabled={!ready || isStreaming}
-            placeholder="Ask anything"
+            placeholder="Ask anything  /"
             className="block w-full bg-transparent px-2 pb-3 pt-1 outline-none disabled:cursor-not-allowed"
             style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
           />
@@ -369,6 +384,47 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
             </div>
           </div>
           </form>
+            </PopoverAnchor>
+            <PopoverContent
+              align="start"
+              side="top"
+              sideOffset={8}
+              className="w-[var(--radix-popover-trigger-width)] max-w-none p-1"
+              onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+              <div
+                className="px-2 pb-1 pt-0.5 text-[11px] font-medium"
+                style={{ color: 'var(--fg-muted)' }}
+              >
+                Presets
+              </div>
+              <div className="flex flex-col">
+                {PRESETS.map((p) => (
+                  <button
+                    key={p.label}
+                    type="button"
+                    onClick={() => {
+                      setInput(p.prompt);
+                      setPresetsOpen(false);
+                      inputRef.current?.focus();
+                    }}
+                    className="flex flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[color:var(--surface-hover)]"
+                  >
+                    <div
+                      className="flex items-center gap-2 text-[13px]"
+                      style={{ color: 'var(--fg-1)' }}
+                    >
+                      <PresetGlyph />
+                      {p.label}
+                    </div>
+                    <div className="pl-[26px] text-[12px]" style={{ color: 'var(--fg-2)' }}>
+                      {p.description}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
     </MeetingsShell>

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -149,22 +149,26 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
     if (!q || isStreaming || submittingRef.current || !ready || !session) return;
     submittingRef.current = true;
     setSubmitError(null);
+    let appended = false;
     try {
       await chat.appendMessage(session.id, {
         role: 'user',
         content: q,
         ts: Date.now(),
       });
+      appended = true;
       setInput('');
       const streamId = streaming.startGlobalStream(q, scopeFolderId);
       pendingPersistRef.current = session.id;
       setActiveStreamId(streamId);
     } catch (err) {
-      // Disk write / IPC / streaming setup can all fail. Restore the
-      // user's text so they don't lose it, surface the error.
+      // Disk write / IPC / streaming setup can all fail. Surface the error.
+      // Only restore the input if nothing made it to disk — once the user
+      // message is persisted it's already visible in the thread, and
+      // re-populating the box would duplicate it on the next submit.
       const message = err instanceof Error ? err.message : 'Failed to send';
       setSubmitError(message);
-      setInput(q);
+      if (!appended) setInput(q);
     } finally {
       submittingRef.current = false;
     }

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -6,8 +6,8 @@ import {
   Mic,
   Paperclip,
   Square,
-  Trash2,
 } from 'lucide-react';
+import { ChatHistoryRow } from '@/components/ChatHistoryRow';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import {
   Popover,
@@ -24,8 +24,9 @@ import { useAiProvider } from '@/hooks/useAi';
 import { navigate } from '@/lib/router';
 import {
   GLOBAL_SCOPE,
+  bucketKey,
   deriveSessionName,
-  relativeTime,
+  toBucketLabel,
 } from '@/lib/chat';
 import { consumePendingNewChat } from '@/routes/Chat';
 import { renderMarkdown } from '@/lib/markdown';
@@ -79,6 +80,26 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
       .filter((s) => s.summaryFile === GLOBAL_SCOPE)
       .sort((a, b) => b.updatedAt - a.updatedAt);
   }, [allSessions.data?.sessions]);
+
+  // Group sessions into time buckets for the History dropdown ("Today",
+  // "Last 2 weeks", "April", etc.) — same pattern Granola uses. Order is
+  // determined by the highest updatedAt in each group, so a stale "April"
+  // group sinks below a fresh "Today" automatically.
+  const groupedSessions = React.useMemo(() => {
+    const groups = new Map<string, typeof otherSessions>();
+    const now = Date.now();
+    for (const s of otherSessions) {
+      const k = bucketKey(s.updatedAt, now);
+      const arr = groups.get(k) ?? [];
+      arr.push(s);
+      groups.set(k, arr);
+    }
+    return Array.from(groups.entries()).map(([key, sessions]) => ({
+      key,
+      label: toBucketLabel(key),
+      sessions,
+    }));
+  }, [otherSessions]);
 
   const activeStream = activeStreamId ? streaming.streams[activeStreamId] : null;
   const isStreaming = activeStream?.status === 'streaming';
@@ -205,52 +226,55 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
                   <ChevronDown className="size-[12px]" style={{ color: 'var(--fg-2)' }} />
                 </button>
               </PopoverTrigger>
-              <PopoverContent align="start" className="w-[280px] p-1">
+              <PopoverContent align="start" className="w-[320px] p-1">
                 {otherSessions.length === 0 ? (
                   <div className="px-3 py-3 text-[13px]" style={{ color: 'var(--fg-2)' }}>
                     No other chats yet.
                   </div>
                 ) : (
-                  <div className="max-h-[320px] overflow-y-auto">
-                    {otherSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
-                        style={{
-                          color: s.id === sessionId ? 'var(--fg-1)' : 'var(--fg-2)',
-                          background: s.id === sessionId ? 'var(--surface-active)' : undefined,
-                        }}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => navigate(`/chat/${encodeURIComponent(s.id)}`)}
-                          className="flex flex-1 items-center justify-between gap-2 text-left"
-                        >
-                          <span className="flex-1 truncate">{s.name || 'Untitled chat'}</span>
-                          <span className="text-[11px] tabular-nums" style={{ color: 'var(--fg-muted)' }}>
-                            {relativeTime(s.updatedAt)}
-                          </span>
-                        </button>
-                        <button
-                          type="button"
-                          onClick={async (e) => {
-                            e.stopPropagation();
-                            // If the user just nuked the chat they're
-                            // actively viewing, bounce back to /chat so we
-                            // don't leave them on a "Chat not found" page.
+                  <div className="max-h-[420px] overflow-y-auto py-1">
+                    {/* Few chats → flat list, no group headers (less visual
+                        noise). Many chats → grouped by time bucket so old
+                        ones are findable. */}
+                    {otherSessions.length <= 5 ? (
+                      otherSessions.map((s) => (
+                        <ChatHistoryRow
+                          key={s.id}
+                          session={s}
+                          activeId={sessionId}
+                          onRename={(name) => void chat.renameSession(s.id, name)}
+                          onDelete={async () => {
                             const wasActive = s.id === sessionId;
                             await chat.deleteSession(s.id);
                             if (wasActive) navigate('/chat');
                           }}
-                          aria-label={`Delete chat ${s.name || 'Untitled'}`}
-                          title="Delete chat"
-                          className="inline-flex size-6 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[color:var(--surface-active)] group-hover:opacity-100 focus:opacity-100"
-                          style={{ color: 'var(--fg-2)' }}
-                        >
-                          <Trash2 className="size-[12px]" />
-                        </button>
-                      </div>
-                    ))}
+                        />
+                      ))
+                    ) : (
+                      groupedSessions.map((group) => (
+                        <div key={group.key} className="mb-1.5 last:mb-0">
+                          <div
+                            className="px-2 pb-0.5 pt-1 text-[11px] font-medium"
+                            style={{ color: 'var(--fg-muted)' }}
+                          >
+                            {group.label}
+                          </div>
+                          {group.sessions.map((s) => (
+                            <ChatHistoryRow
+                              key={s.id}
+                              session={s}
+                              activeId={sessionId}
+                              onRename={(name) => void chat.renameSession(s.id, name)}
+                              onDelete={async () => {
+                                const wasActive = s.id === sessionId;
+                                await chat.deleteSession(s.id);
+                                if (wasActive) navigate('/chat');
+                              }}
+                            />
+                          ))}
+                        </div>
+                      ))
+                    )}
                   </div>
                 )}
               </PopoverContent>
@@ -350,6 +374,7 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
     </MeetingsShell>
   );
 }
+
 
 function Bubble({
   role,

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -49,9 +49,11 @@ import {
   useSetStoragePath,
   useSetSystemAudio,
   useSetTelemetry,
+  useSetUserName,
   useStoragePath,
   useSystemAudioSetting,
   useTelemetrySetting,
+  useUserName,
 } from '@/hooks/useSettings';
 import {
   useAiProvider,
@@ -470,6 +472,22 @@ function GeneralTab() {
   const setDockIcon = useSetDockIcon();
   const google = useGoogleCalendarAuth();
   const outlook = useOutlookCalendarAuth();
+  const userName = useUserName();
+  const setUserName = useSetUserName();
+  const [nameDraft, setNameDraft] = React.useState('');
+  const nameSeededRef = React.useRef(false);
+  React.useEffect(() => {
+    if (nameSeededRef.current) return;
+    if (userName.data !== undefined) {
+      setNameDraft(userName.data);
+      nameSeededRef.current = true;
+    }
+  }, [userName.data]);
+  const persistName = () => {
+    const trimmed = nameDraft.trim();
+    if (trimmed === (userName.data ?? '')) return;
+    setUserName.mutate(trimmed);
+  };
 
   const calendarConnected =
     google.status.data?.connected || outlook.status.data?.connected;
@@ -514,6 +532,28 @@ function GeneralTab() {
 
   return (
     <section data-settings-tab="general">
+      <SettingRow
+        label="Your name"
+        description="First name only — used for in-app greetings. Stored locally."
+      >
+        <Input
+          value={nameDraft}
+          onChange={(e) => setNameDraft(e.target.value)}
+          onBlur={persistName}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              persistName();
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          placeholder="Ruzin"
+          autoComplete="given-name"
+          className="h-[30px] w-[180px] rounded-[6px] text-[13px]"
+          data-testid="user-name-input"
+        />
+      </SettingRow>
+
       <SettingRow
         label="Appearance"
         description="Choose light, dark, or match your system"

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -476,13 +476,17 @@ function GeneralTab() {
   const setUserName = useSetUserName();
   const [nameDraft, setNameDraft] = React.useState('');
   const nameSeededRef = React.useRef(false);
+  // Wait for the real query (not the sessionStorage placeholder) before
+  // seeding — otherwise we lock onto a stale empty string and ignore the
+  // canonical value when it arrives from disk.
   React.useEffect(() => {
     if (nameSeededRef.current) return;
+    if (userName.isPending || userName.isPlaceholderData) return;
     if (userName.data !== undefined) {
       setNameDraft(userName.data);
       nameSeededRef.current = true;
     }
-  }, [userName.data]);
+  }, [userName.data, userName.isPending, userName.isPlaceholderData]);
   const persistName = () => {
     const trimmed = nameDraft.trim();
     if (trimmed === (userName.data ?? '')) return;
@@ -543,7 +547,8 @@ function GeneralTab() {
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault();
-              persistName();
+              // Just blur — onBlur runs persistName, so calling it directly
+              // here would queue a duplicate setUserName mutation.
               (e.target as HTMLInputElement).blur();
             }
           }}

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -13,7 +13,12 @@ import {
 import { Display, Lead, Muted } from '@/components/ui/typography';
 import { useNavigate } from '@/lib/router';
 import { useCheckMicPermission, useRequestMicPermission, useSetupStep } from '@/hooks/useSetup';
-import { useSetTelemetry, useTelemetrySetting } from '@/hooks/useSettings';
+import {
+  useSetTelemetry,
+  useSetUserName,
+  useTelemetrySetting,
+  useUserName,
+} from '@/hooks/useSettings';
 import {
   useSetAiProvider,
   useSetCloudApiKey,
@@ -118,6 +123,27 @@ export function Setup() {
   const telemetry = useTelemetrySetting();
   const setTelemetry = useSetTelemetry();
   const telemetryEnabled = telemetry.data?.telemetry_enabled ?? true;
+
+  // First name powers the in-app greeting ("Hi <name>, ask anything"). Stored
+  // locally only — never sent anywhere. Persisted on blur to avoid a write
+  // per keystroke.
+  const userName = useUserName();
+  const setUserName = useSetUserName();
+  const [name, setName] = React.useState('');
+  // Sync once when the initial fetch resolves so we don't clobber user input.
+  const seededRef = React.useRef(false);
+  React.useEffect(() => {
+    if (seededRef.current) return;
+    if (userName.data !== undefined) {
+      setName(userName.data);
+      seededRef.current = true;
+    }
+  }, [userName.data]);
+  const persistName = () => {
+    const trimmed = name.trim();
+    if (trimmed === (userName.data ?? '')) return;
+    setUserName.mutate(trimmed);
+  };
 
   // Summarization-engine choice. 'local' downloads the bundled model
   // (privacy + free, slower); 'cloud' wires up an API key (no download,
@@ -253,6 +279,36 @@ export function Setup() {
         <div className="mb-8 text-center">
           <Display className="mb-3">Welcome to Steno</Display>
           <Lead>We'll help you set up everything needed for meeting intelligence.</Lead>
+        </div>
+
+        <div
+          className="mb-6 flex items-center gap-4 rounded-md border border-border p-4"
+          data-setup-name
+        >
+          <div className="min-w-0 flex-1">
+            <label htmlFor="setup-name-input" className="text-sm font-medium text-foreground">
+              What should we call you?
+            </label>
+            <Muted className="mt-0.5">
+              First name only — used for in-app greetings. Stored locally.
+            </Muted>
+          </div>
+          <Input
+            id="setup-name-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={persistName}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                persistName();
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+            placeholder="Ruzin"
+            autoComplete="given-name"
+            className="w-[160px]"
+          />
         </div>
 
         <div className="space-y-3" data-setup-steps>

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -131,14 +131,18 @@ export function Setup() {
   const setUserName = useSetUserName();
   const [name, setName] = React.useState('');
   // Sync once when the initial fetch resolves so we don't clobber user input.
+  // Wait for the real query to settle — placeholderData (sessionStorage cache)
+  // could be stale or empty, and we don't want to seed from it and then ignore
+  // the canonical value when it arrives from disk.
   const seededRef = React.useRef(false);
   React.useEffect(() => {
     if (seededRef.current) return;
+    if (userName.isPending || userName.isPlaceholderData) return;
     if (userName.data !== undefined) {
       setName(userName.data);
       seededRef.current = true;
     }
-  }, [userName.data]);
+  }, [userName.data, userName.isPending, userName.isPlaceholderData]);
   const persistName = () => {
     const trimmed = name.trim();
     if (trimmed === (userName.data ?? '')) return;

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1832,6 +1832,95 @@ def query_streaming(transcript_file, question):
         print(f"CHAT_STREAM_ERROR:{e}", flush=True)
 
 
+@cli.command(name='chat-global-streaming')
+@click.option('--question', '-q', required=True, help='Question to ask across all notes')
+def chat_global_streaming(question):
+    """Cross-note chat: gather every meeting's title + summary + key points,
+    feed as context to the cloud LLM, stream the answer.
+
+    Cloud-only. Local models can't fit a full corpus of summaries reliably,
+    and we don't have retrieval (RAG) yet — caller (main.js) is responsible
+    for gating this on ai_provider === 'cloud'."""
+    import sys
+    import base64
+    from pathlib import Path
+    from src.config import get_config, get_data_dirs
+
+    config = get_config()
+    if config.get_ai_provider() != "cloud":
+        print("CHAT_STREAM_ERROR:Cross-note chat requires a cloud AI provider. Switch in Settings → AI.", flush=True)
+        return
+
+    dirs = get_data_dirs()
+    output_dir = dirs["output"]
+
+    # Collect every summary file, preferring .md (the new format) but reading
+    # legacy .json too so users with old recordings aren't excluded.
+    summaries: list[tuple[Path, dict]] = []
+    seen = set()
+    for f in sorted(output_dir.glob("*_summary.md")):
+        try:
+            data = _parse_meeting_markdown(f)
+            summaries.append((f, data))
+            seen.add(f.stem.replace('_summary', ''))
+        except Exception:
+            continue
+    for f in sorted(output_dir.glob("*_summary.json")):
+        if f.stem.replace('_summary', '') in seen:
+            continue
+        try:
+            with open(f, 'r', encoding='utf-8') as fh:
+                summaries.append((f, json.load(fh)))
+        except Exception:
+            continue
+
+    if not summaries:
+        print("CHAT_STREAM_ERROR:No notes found yet. Record a meeting first.", flush=True)
+        return
+
+    # Most-recent first so the model weights newer context higher when token
+    # budget is tight. Each block is kept compact (title + summary + key
+    # points + action items) — full transcripts would blow even a 200k window.
+    def sort_key(item):
+        _, data = item
+        return data.get("session_info", {}).get("processed_at") or ""
+
+    summaries.sort(key=sort_key, reverse=True)
+
+    blocks = []
+    for _, data in summaries:
+        info = data.get("session_info", {}) or {}
+        name = info.get("name") or "Untitled"
+        date = (info.get("processed_at") or "")[:10]
+        summary = (data.get("summary") or "").strip()
+        key_points = data.get("key_points") or []
+        action_items = data.get("action_items") or []
+        block = [f"## {name}" + (f" — {date}" if date else "")]
+        if summary:
+            block.append(summary)
+        if key_points:
+            block.append("Key points:\n" + "\n".join(f"- {p}" for p in key_points))
+        if action_items:
+            block.append("Action items:\n" + "\n".join(f"- {a}" for a in action_items))
+        blocks.append("\n".join(block))
+
+    corpus = "\n\n---\n\n".join(blocks)
+
+    language = config.get_language()
+    if language == "auto":
+        language = "en"
+
+    try:
+        summarizer = OllamaSummarizer()
+        for chunk in summarizer.query_transcript_streaming(corpus, question, language=language):
+            encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
+            sys.stdout.write(f"CHAT_CHUNK:{encoded}\n")
+            sys.stdout.flush()
+        print("CHAT_STREAM_COMPLETE", flush=True)
+    except Exception as e:
+        print(f"CHAT_STREAM_ERROR:{e}", flush=True)
+
+
 @cli.command()
 def list_failed():
     """List summary files that failed processing (have fallback summaries)"""
@@ -2360,6 +2449,25 @@ def set_language(language_code):
         }))
     else:
         print(json.dumps({"success": False, "error": "Failed to save language setting"}))
+
+
+@cli.command(name='get-user-name')
+def get_user_name_cmd():
+    """Get the user's first name (for in-app greetings)."""
+    from src.config import get_config
+    print(json.dumps({"user_name": get_config().get_user_name()}))
+
+
+@cli.command(name='set-user-name')
+@click.argument('name', default='')
+def set_user_name_cmd(name):
+    """Set the user's first name. Empty string clears it."""
+    from src.config import get_config
+    success = get_config().set_user_name(name)
+    if success:
+        print(json.dumps({"success": True, "user_name": name.strip()}))
+    else:
+        print(json.dumps({"success": False, "error": "Failed to save user name"}))
 
 
 @cli.command()

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1833,10 +1833,12 @@ def query_streaming(transcript_file, question):
 
 
 @cli.command(name='chat-global-streaming')
-@click.option('--question', '-q', required=True, help='Question to ask across all notes')
-def chat_global_streaming(question):
-    """Cross-note chat: gather every meeting's title + summary + key points,
-    feed as context to the cloud LLM, stream the answer.
+@click.option('--question', '-q', required=True, help='Question to ask across notes')
+@click.option('--folder', '-f', default=None, help='Folder ID to scope the corpus to (default: all notes)')
+def chat_global_streaming(question, folder):
+    """Cross-note chat: gather meeting title + summary + key points, feed as
+    context to the cloud LLM, stream the answer. Optionally scope to a single
+    folder; default queries every note.
 
     Cloud-only. Local models can't fit a full corpus of summaries reliably,
     and we don't have retrieval (RAG) yet — caller (main.js) is responsible
@@ -1874,8 +1876,20 @@ def chat_global_streaming(question):
         except Exception:
             continue
 
+    # Folder scoping. Each meeting record carries a 'folders' array of IDs;
+    # filter to only those that include the requested ID. Empty folder ID
+    # or 'all' explicitly means no filter.
+    if folder and folder != 'all':
+        summaries = [
+            (path, data) for (path, data) in summaries
+            if isinstance(data.get('folders'), list) and folder in data['folders']
+        ]
+
     if not summaries:
-        print("CHAT_STREAM_ERROR:No notes found yet. Record a meeting first.", flush=True)
+        if folder and folder != 'all':
+            print("CHAT_STREAM_ERROR:No notes in this folder yet. Pick another or remove the filter.", flush=True)
+        else:
+            print("CHAT_STREAM_ERROR:No notes found yet. Record a meeting first.", flush=True)
         return
 
     # Most-recent first so the model weights newer context higher when token

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1925,7 +1925,16 @@ def chat_global_streaming(question, folder):
             block.append("Action items:\n" + "\n".join(f"- {a}" for a in action_items))
         block_text = "\n".join(block)
         # +5 accounts for the "\n\n---\n\n" separator added later.
-        if used_chars + len(block_text) + 5 > CORPUS_CHAR_BUDGET and blocks:
+        if used_chars + len(block_text) + 5 > CORPUS_CHAR_BUDGET:
+            # If the very first block is already larger than the budget,
+            # truncate it so we still send something representative rather
+            # than blasting the model with an oversized prompt.
+            if not blocks:
+                budget_left = max(0, CORPUS_CHAR_BUDGET - used_chars - 80)
+                if budget_left > 0:
+                    truncated_block = block_text[:budget_left].rstrip() + "\n…(truncated)"
+                    blocks.append(truncated_block)
+                    used_chars += len(truncated_block) + 5
             truncated = len(summaries) - len(blocks)
             break
         blocks.append(block_text)

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1901,7 +1901,14 @@ def chat_global_streaming(question, folder):
 
     summaries.sort(key=sort_key, reverse=True)
 
+    # Cap the assembled corpus so a user with hundreds of meetings can't blow
+    # past the cloud model's context window. ~400k chars ≈ 100k tokens, well
+    # under both Anthropic (200k) and recent OpenAI (128k+) limits while
+    # leaving headroom for the prompt scaffold and the model's reply.
+    CORPUS_CHAR_BUDGET = 400_000
     blocks = []
+    used_chars = 0
+    truncated = 0
     for _, data in summaries:
         info = data.get("session_info", {}) or {}
         name = info.get("name") or "Untitled"
@@ -1916,9 +1923,21 @@ def chat_global_streaming(question, folder):
             block.append("Key points:\n" + "\n".join(f"- {p}" for p in key_points))
         if action_items:
             block.append("Action items:\n" + "\n".join(f"- {a}" for a in action_items))
-        blocks.append("\n".join(block))
+        block_text = "\n".join(block)
+        # +5 accounts for the "\n\n---\n\n" separator added later.
+        if used_chars + len(block_text) + 5 > CORPUS_CHAR_BUDGET and blocks:
+            truncated = len(summaries) - len(blocks)
+            break
+        blocks.append(block_text)
+        used_chars += len(block_text) + 5
 
     corpus = "\n\n---\n\n".join(blocks)
+    if truncated:
+        corpus += (
+            f"\n\n---\n\n_Note: {truncated} older note(s) omitted to stay within"
+            " the model's context window. Ask about a specific older meeting"
+            " to pull it in directly._"
+        )
 
     language = config.get_language()
     if language == "auto":

--- a/src/config.py
+++ b/src/config.py
@@ -514,6 +514,24 @@ class Config:
         self._config["cloud_model"] = model.strip()
         return self._save()
 
+    def get_user_name(self) -> str:
+        """Get the user's first name (for greetings). Empty string when unset."""
+        value = self._config.get("user_name")
+        if not isinstance(value, str):
+            return ""
+        return value.strip()
+
+    def set_user_name(self, name: str) -> bool:
+        """Persist the user's first name. Trims whitespace; an empty name
+        clears the field."""
+        cleaned = (name or "").strip()
+        # Cap to a sane length so a paste of someone's whole bio doesn't end
+        # up in the greeting.
+        if len(cleaned) > 60:
+            cleaned = cleaned[:60]
+        self._config["user_name"] = cleaned
+        return self._save()
+
     def get_anonymous_id(self) -> str:
         """Get the anonymous telemetry ID, generating one if missing."""
         anon_id = self._config.get("anonymous_id")


### PR DESCRIPTION
## Summary

Adds a global Chat tab that lets users ask questions across every meeting note. Two-screen flow (entry → conversation), markdown rendering for replies, rename/delete history, slash-command preset picker, optional folder scoping, and an in-app first-name greeting captured during setup.

Cloud-only for v1 — local models can't fit a full corpus of summaries reliably and we don't have retrieval (RAG) yet, so the Python CLI rejects non-cloud providers with a clear empty state. The renderer gates the composer behind \`ai_provider === 'cloud'\` and surfaces a Settings deep-link when not configured.

## What's in each commit

1. **\`ac2a845\` — Cross-note Chat tab with two-screen flow.**
   - New \`Chat\` sidebar entry between All notes and Folders.
   - \`/chat\` entry: greeting (\`Hi <name>, ask anything\`), composer, Recents, Meals/preset chips. Submit creates a session, kicks off a stream, hands off to the conversation page.
   - \`/chat/<sessionId>\` conversation: back arrow + History dropdown + (initially) New chat button on the right; scrolling messages; sticky-bottom composer (uses \`MeetingsShell bleed\` to escape the shared \`pb-36\` and pin to the actual viewport bottom).
   - Backend: \`chat-global-streaming\` CLI gathers every \`_summary.md\`/\`.json\`, builds a corpus of \`title + summary + key points + action items\` (skips raw transcripts to stay within cloud token budgets), streams the answer via the existing \`query_transcript_streaming\` path. Returns \`CHAT_STREAM_ERROR\` if non-cloud.
   - \`StreamingProvider\` hoists \`useStreamingQuery\` to App level so streams persist across the entry → conversation route change.
   - First name captured during Setup (\"What should we call you?\") and editable in Settings → General → Your name. Stored locally; never sent. Drives the greeting.
   - Markdown rendering (\`lib/markdown.tsx\`, zero deps): headings, bullet/numbered lists, **bold**, *italic*, \`inline code\`, fenced code blocks. User turns stay literal text — only assistant turns render markdown.

2. **\`af957ad\` — Markdown tables, expandable history, rename + better dropdown.**
   - Markdown tables (pipe + \`---\`/\`:---:\` separator) render as real \`<table>\` with horizontal scroll + per-column alignment.
   - History dropdown grouped by time bucket (\"Today\" / \"Last 2 weeks\" / month / year), flat list when ≤5 sessions, controlled popover that closes on row select.
   - Per-row \`...\` menu with Rename (inline input) and Delete. Deleting the active chat bounces back to \`/chat\`.
   - \`/chat\` Recents got the same triple-dot menu and a \"See all ↔ Show less\" toggle that expands to grouped view when there are >8 chats.

3. **\`26797fe\` — Rename Meals → Presets, slash shortcut on both composers.**
   - \`/\` typed as the first character in either composer (entry or conversation) opens a preset picker. Entry-page popover opens below; conversation-page opens above (it's pinned to viewport bottom).
   - Preset glyph styled with existing ink tokens — sits quietly in the warm paper palette, adapts to dark mode.
   - Toolbar primary button morphs by route: \"+ New chat\" on chat routes, \"+ New note\" everywhere else. Recording / processing states still take precedence.

4. **\`bc8effc\` — Folder scope picker + drop disabled icons.**
   - Removed disabled paperclip + microphone icons (placeholders signaling \"coming soon\" but doing nothing).
   - New \`FolderScopePicker\`: composer footer chip showing \"All notes\" by default; click → popover with all folders. Server-side filter (\`-f <folderId>\`) restricts the corpus to that folder's notes. Per-session state, threaded through the entry → conversation handoff.

## Notable design choices

- **Cross-note context is summaries, not transcripts.** A user with 100 meetings × 30 min has 1–2M tokens of raw transcript — far too much for any context window. Summaries + key points + action items per meeting fit comfortably in cloud model windows and give the LLM enough to answer reflective questions accurately. RAG (embed + retrieve) is the natural follow-up to scale beyond ~200 meetings or to support local models.
- **Streams survive route changes.** Submitting on \`/chat\` immediately navigates to \`/chat/<id>\`. The stream itself is owned by App-level \`StreamingProvider\` and persisted via a module-level handoff (\`pendingNewChat\`), so no tokens are dropped during the navigation.
- **Cloud-only gate is enforced in two layers.** The Python CLI rejects non-cloud providers with a clear error; the renderer disables the composer and shows a banner with a Settings deep-link. Both because the IPC layer shouldn't trust the renderer to gate, and because the renderer wants to give the user actionable UX before they hit submit.

## Other small UX wins
- Click an Upcoming calendar card on Home to start a recording titled with the event.
- Markdown tables, lists, code blocks render in both AskBar (in-meeting chat) and the new Chat tab via shared \`lib/markdown.tsx\`.
- Selection highlight retuned (translucent indigo) so search-bar selections are visible against the faint surface tint.

## Not in this PR (intentional)

- **Retrieval (RAG)** for local models. Tracked as the obvious follow-up.
- **Attachment / voice input** in the chat composer — placeholders removed; will return as real features.
- **Removing the legacy renderer + flag toggle**. PR #95 shipped flag-gated and we agreed to do the deletion as its own \`chore/remove-legacy-renderer\` PR after a release cycle, to keep the diff reviewable.

## Test plan
- [ ] Open Chat tab with a cloud provider configured → composer is active, Recents/Presets render.
- [ ] Open Chat tab with no cloud provider → banner shown, composer disabled, Settings deep-link works.
- [ ] Type \`/\` in either composer when input is empty → presets popover opens.
- [ ] Click a preset → fills input + closes popover.
- [ ] Submit a question → navigates to \`/chat/<id>\`, response streams in markdown, persists to \`chat_sessions_v2.json\`.
- [ ] Cold-reload an active conversation → message history restored from disk.
- [ ] History dropdown: groups appear when >5 sessions, flat list otherwise. Click row navigates + closes popover. Rename swaps title to inline input. Delete the active chat → bounces to \`/chat\`.
- [ ] Recents on entry: \"See all\" expands to grouped view; trash + rename behave the same as History.
- [ ] Folder scope: pick a folder → response only references notes from that folder. Pick \"All notes\" → unrestricted.
- [ ] First name input in Setup wizard + Settings → General persists; greeting reads \`Hi <name>, ask anything\`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-note Chat tab to ask questions across all meeting summaries with a two-screen flow, streaming replies, and rich markdown. Cloud-only in v1; shows a clear empty state with a Settings deep-link when not configured.

- **New Features**
  - Chat tab with entry and conversation views; Recents/History support rename/delete and a “See all” grouped view.
  - App-level `StreamingProvider` keeps replies streaming across navigation; AskBar is hidden on chat routes.
  - Shared markdown renderer `lib/markdown.tsx` (headings, lists, code, tables).
  - Presets with “/” shortcut in both composers.
  - Folder scope picker to limit queries; server-side filter with `-f <folderId>`.
  - Backend `chat-global-streaming` across summaries (cloud-only) with a ~400k char corpus cap and most-recent-first truncation.
  - First-name greeting captured in Setup and editable in Settings → General; cached to avoid greeting flicker.
  - Route-aware toolbar shows “New chat”; Sidebar Chat stays active on `/chat/<id>` routes.

- **Bug Fixes**
  - Streaming listeners detach on done/error; `pendingNewChat` is keyed per session and rolls back on submit failure.
  - Markdown fixes: CR stripping, table alignment validation, escaped pipes, trailing empty cells, and preserved blank-line gaps.
  - Folder scope drops when the folder is deleted; clear error when a scoped folder has no notes; conversation can re-scope mid-session.
  - History popovers close on select; Escape cancels rename without committing; Settings name input no longer double-submits.
  - Bucket grouping uses calendar-day steps (DST-safe).
  - UpcomingCard key handler ignores events from inner buttons.
  - Composer restores input on failure only if no user message was saved, preventing duplicate turns.
  - Corpus cap applies even when the first block exceeds the budget; the block is truncated instead of bypassing the cap.

<sup>Written for commit cc4a450c4bca1e39e900c7994a7b2218040681c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

