### PR TITLE
Website + README: enterprise positioning refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">AI-powered meeting intelligence that runs entirely on your device, your private data never leaves anywhere. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for healthcare, legal and finance professionals with confidential data needs.</p>
+<p align="center">Steno is the AI powered intelligence layer for all your confidential conversations, your private data never leaves anywhere. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
 
 <p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b> & <b>HashiCorp</b>.</sub></p>
 

--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/stenoai-logo.svg" />
     <link rel="icon" type="image/png" href="/dragonfly-logo-512.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Steno is a free, open-source AI meeting notes app that runs 100% locally on your Mac. Private transcription and summarization with no cloud, no accounts, no data leaving your device." />
+    <meta name="description" content="Steno is the AI powered intelligence layer for all your confidential conversations. No cloud, no usage limits and no bots joining your calls." />
     <title>stenoAI - confidential intelligence layer</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/website/src/components/Brand.jsx
+++ b/website/src/components/Brand.jsx
@@ -43,7 +43,7 @@ export function Wordmark({ size = 19 }) {
         lineHeight: 1,
       }}
     >
-      stenoAI.
+      steno.
     </span>
   );
 }

--- a/website/src/sections/FAQ.jsx
+++ b/website/src/sections/FAQ.jsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion as Motion } from "framer-motion";
 
 const faqs = [
   { q: "What's included for free?", a: "Unlimited local transcription and summarization. No account, no tier, no upsell. Steno is open source. You can build and run it yourself if you prefer." },
-  { q: "Which AI models can I use?", a: "Five open-weight models: Llama 3.2 3B, Gemma 3 4B, Qwen 3.5 9B, DeepSeek-R1 14B, and GPT-OSS 20B. All run locally on your Mac." },
+  { q: "Which AI models can I use?", a: "Five open-weight models: Llama 3.2 3B, Gemma 3 4B, Qwen 3.5 9B, DeepSeek-R1 14B, and GPT-OSS 20B. All run locally, on device." },
   { q: "Is my data really private?", a: "Yes. Steno makes no network requests after install. The source is open, so you can verify it yourself, or have your security team do so." },
   { q: "How accurate is the transcription?", a: "Steno uses Whisper. Results depend on audio clarity. Quiet rooms and good microphones produce the best outcomes. Whisper performs well across 99 languages." },
   { q: "What Mac do I need?", a: "macOS only, on Apple Silicon or Intel. Apple Silicon is recommended for speed. The app runs comfortably on an M1 MacBook Air." },

--- a/website/src/sections/Features.jsx
+++ b/website/src/sections/Features.jsx
@@ -1,10 +1,10 @@
-import { Cpu, NotebookPen, MessageSquare, ShieldOff, Layers, HardDrive } from "lucide-react";
+import { Workflow, NotebookPen, MessageSquare, ShieldOff, Layers, HardDrive } from "lucide-react";
 import { motion as Motion } from "framer-motion";
 
 const feats = [
-  { icon: <Cpu size={18} aria-hidden="true" />, title: "Local transcription", body: "Whisper.cpp runs on Apple Silicon and Intel. Fast on a laptop, private by architecture." },
+  { icon: <Workflow size={18} aria-hidden="true" />, title: "AI agent ready", body: "Summaries and notes save as plain Markdown. Pipe them into the AI agent, vault, or workflow your team already runs." },
   { icon: <NotebookPen size={18} aria-hidden="true" />, title: "AI notepad", body: "Jot notes during a recording. They're merged with the transcript to shape the AI summary." },
-  { icon: <MessageSquare size={18} aria-hidden="true" />, title: "Ask your meetings", body: "Chat with a model that has full context of the transcript. Answers come with citations to the source." },
+  { icon: <MessageSquare size={18} aria-hidden="true" />, title: "Ask your meetings", body: "Chat with your meetings or across your entire meeting history. Surface decisions, themes, and follow-ups." },
   { icon: <ShieldOff size={18} aria-hidden="true" />, title: "No data leaves", body: "Zero network requests after install. Verified by inspectable, open-source code you can audit yourself." },
   { icon: <Layers size={18} aria-hidden="true" />, title: "99 languages", body: "Whisper auto-detects the language spoken. Works equally well across multilingual meetings." },
   { icon: <HardDrive size={18} aria-hidden="true" />, title: "Runs offline", body: "No internet required after the initial model download. Works on planes, in hospitals, anywhere." },

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -40,7 +40,7 @@ export function Hero() {
               maxWidth: "14ch",
             }}
           >
-            AI that runs privately on your Mac.
+            AI for your confidential conversations.
           </Motion.h1>
 
           <Motion.p

--- a/website/src/sections/HowItWorks.jsx
+++ b/website/src/sections/HowItWorks.jsx
@@ -12,7 +12,7 @@ const steps = [
     n: "02",
     icon: <FileText size={18} aria-hidden="true" />,
     title: "Transcribe",
-    body: "Whisper.cpp converts audio to text entirely on your Mac. Ninety-nine languages, auto-detected. Apple Silicon runs it fast.",
+    body: "Whisper.cpp converts audio to text entirely on device. Ninety-nine languages, auto-detected. Apple Silicon runs it fast.",
   },
   {
     n: "03",

--- a/website/src/sections/Industries.jsx
+++ b/website/src/sections/Industries.jsx
@@ -4,7 +4,7 @@ const inds = [
   { title: "Government", body: "Sensitive briefings, policy discussions, and internal reviews stay within your perimeter. No cloud dependencies, no third-party processors, no records leaving the device." },
   { title: "Defense", body: "Operational planning and classified discussions run entirely on-device. Works offline, on air-gapped networks, with nothing transiting an external server." },
   { title: "Legal", body: "Client calls and case discussions remain privileged. Enforced by architecture, not policy or a privacy checkbox." },
-  { title: "Finance", body: "Earnings prep, board meetings, deal discussions. None of it touches a third-party server." },
+  { title: "CXOs", body: "Board prep, M&A discussions, exec offsites. The conversations that decide the company's direction never leave the device they're held on." },
 ];
 
 export function Industries() {
@@ -36,21 +36,6 @@ export function Industries() {
             If your meetings contain confidential data, you can't send audio to a third party.
             Steno is built for people who understand this.
           </p>
-          <blockquote
-            className="mt-10 text-fg-2"
-            style={{
-              fontFamily: "var(--font-serif)",
-              fontSize: "clamp(18px, 3vw, 22px)",
-              fontStyle: "italic",
-              fontWeight: 400,
-              lineHeight: 1.4,
-              borderLeft: "2px solid var(--border-strong)",
-              paddingLeft: 20,
-              margin: "40px 0 0",
-            }}
-          >
-            "Your data never leaves your Mac."
-          </blockquote>
         </Motion.div>
 
         <div className="flex flex-col">

--- a/website/src/sections/Models.jsx
+++ b/website/src/sections/Models.jsx
@@ -38,7 +38,7 @@ export function Models() {
           </h2>
           <p className="text-fg-2 text-lg leading-[1.55]" style={{ maxWidth: "44ch" }}>
             Five open-weight models included. Switch instantly without restarting.
-            All run on your Mac.
+            All run on device.
           </p>
         </Motion.div>
 


### PR DESCRIPTION
## Summary
- Reframe Hero, meta description, and README intro around *confidential conversations* (replacing Mac-centric copy).
- Industries: replace **Finance** pillar with **CXOs**; remove the *"Your data never leaves your Mac."* blockquote.
- Features: replace **Local transcription** card with **AI agent ready** (summaries save as Markdown → pipe into agent/vault/workflow); update **Ask your meetings** to reflect cross-meeting chat.
- Swap marketing-copy "on your Mac" → "on device" across FAQ, Models, HowItWorks (download/hardware references kept literal).
- Wordmark in nav/footer: `stenoAI.` → `steno.`
- README "Perfect for" retargeted to government, defence, legal, and C-suite.

## Test plan
- [ ] `cd website && npm run dev` — verify Hero H1, Features grid, Industries section, FAQ, Models, HowItWorks render with the new copy
- [ ] Confirm wordmark reads `steno.` in nav and footer
- [ ] Inspect `<title>` and `<meta name=\"description\">` in dev tools
- [ ] Render README on GitHub and verify the new intro + "Perfect for" line read cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes enterprise positioning across the website and README to focus on confidential conversations and on‑device privacy. Also updates the brand wordmark to `steno.`.

- **Refactors**
  - Rewrote hero, meta description, and README (intro + “Perfect for”) for the new positioning.
  - Industries: Finance → CXOs; removed the “Your data never leaves your Mac.” quote.
  - Features copy: “Agent ready” replaces “Local transcription”; “Ask your meetings” now covers cross‑meeting chat.
  - Replaced “on your Mac” with “on device” across FAQ, Models, and How It Works.

<sup>Written for commit 87632c55cb1903ef087004bda52b1960a7a7101f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

