### PR TITLE
fix(recording): stop transition no longer races to home; clear draft on processing-complete

### DIFF
--- a/app/renderer/src/hooks/liveDraftStore.ts
+++ b/app/renderer/src/hooks/liveDraftStore.ts
@@ -21,6 +21,9 @@ interface LiveDraftStore {
   ensure: (sessionName: string, defaults: { startedAtMs: number }) => void;
   setTitle: (sessionName: string, title: string) => void;
   setNotes: (sessionName: string, notes: string) => void;
+  /** Drop the draft for a finished session so the next "New note" with the
+   *  same sessionName (e.g. the default 'Meeting' / 'Note') starts clean. */
+  clear: (sessionName: string) => void;
 }
 
 export const useLiveDraftStore = create<LiveDraftStore>((set) => ({
@@ -54,6 +57,12 @@ export const useLiveDraftStore = create<LiveDraftStore>((set) => ({
       return {
         drafts: { ...state.drafts, [sessionName]: { ...existing, notes } },
       };
+    }),
+  clear: (sessionName) =>
+    set((state) => {
+      if (!state.drafts[sessionName]) return state;
+      const { [sessionName]: _drop, ...rest } = state.drafts;
+      return { drafts: rest };
     }),
 }));
 

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ipc } from '@/lib/ipc';
 import { unwrap } from '@/lib/result';
 import { meetingsKeys } from './meetingKeys';
+import { useLiveDraftStore } from './liveDraftStore';
 import { navigate } from '@/lib/router';
 import type { Meeting, QueueStatus } from '@/lib/ipc';
 
@@ -175,6 +176,12 @@ export function useRecordingProcessingEffects() {
       }
       qc.invalidateQueries({ queryKey: meetingsKeys.all });
       qc.invalidateQueries({ queryKey: queueKey });
+      // Clear the live-draft entry for this finished session so the next
+      // "New note" with the same default sessionName ('Meeting' / 'Note')
+      // doesn't inherit the previous title or notes.
+      if (data.sessionName) {
+        useLiveDraftStore.getState().clear(data.sessionName);
+      }
       if (data.success && data.meetingData?.session_info.summary_file) {
         navigate(`/meetings/${encodeURIComponent(data.meetingData.session_info.summary_file)}`);
       }

--- a/app/renderer/src/routes/Recording.tsx
+++ b/app/renderer/src/routes/Recording.tsx
@@ -20,10 +20,24 @@ export function Recording() {
   // it stopped), bounce back home so we don't leave the user on a dead page.
   // Status 'processing' is handled by the global listener which redirects to
   // /meetings/processing.
+  //
+  // 500ms grace period: during a normal stop, the optimistic cache write
+  // briefly transitions status (idle ↔ processing) and live.active flips off
+  // BEFORE navigate('/meetings/processing') completes its render. Without the
+  // delay this effect raced the optimistic flow and bounced the user back
+  // home — visible most reliably when the user had been typing notes (queue
+  // poll cadence + cache updates landed in a different order). The delay
+  // lets the transition settle before we make any bouncing decision.
   React.useEffect(() => {
-    if (!recording.isLoading && !live.active && recording.status !== 'processing') {
-      navigate('/');
-    }
+    if (recording.isLoading) return;
+    if (live.active) return;
+    if (recording.status === 'processing') return;
+    const t = setTimeout(() => {
+      if (!recording.isLoading && !live.active && recording.status !== 'processing') {
+        navigate('/');
+      }
+    }, 500);
+    return () => clearTimeout(t);
   }, [recording.isLoading, live.active, recording.status, navigate]);
 
   const startedAt = live.startedAt ?? new Date();


### PR DESCRIPTION
## Summary

Two related bugs in the existing recording flow, hit reliably when the
user types into the live-notes textarea on short recordings.

### Bug 1: Stop bounces the user to home, skipping the Processing page

`Recording.tsx`'s cold-reload guard fires too eagerly:

```ts
if (!recording.isLoading && !live.active && recording.status !== 'processing') {
  navigate('/');
}
```

During a normal stop, the optimistic queue cache write + `navigate('/meetings/processing')` land in a different order than this useEffect's dependencies resolve — there's a brief window where `live.active` flips to `false` but `status` hasn't yet transitioned from `'idle'` to `'processing'`. The guard bounces the user home before they see the analyser bar / streamed summary.

**Fix:** wrap the bounce in a 500 ms `setTimeout` with a re-check of the same conditions. The guard still catches genuine cold-reload onto a dead `/recording` page (after 500 ms idle), but it no longer races the optimistic stop transition.

### Bug 2: Typed notes / title persist across recordings

`liveDraftStore` is keyed by `sessionName` but never cleared. The default `sessionName` (`Meeting` / `Note`) is reused on every *New note*, so the previous recording's typed title and notes inherit into the next one.

**Fix:** add `clear(sessionName)` action to the store; call it from `useRecordingProcessingEffects` when `processing-complete` fires for that session.

## Test plan
- [x] Record briefly (5–15 s), don't type notes → Stop. Confirm Processing page renders with analyser bar, then lands on the final meeting.
- [x] Record briefly, type notes for a few seconds → Stop. Same flow — no bounce to home.
- [x] After the meeting opens, click *New note* — title and notes textarea both blank.
- [x] Cold-reload while on `/recording` with no active recording (hard refresh dev mode) → still bounces home after ~500 ms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stop flow so users see the Processing page instead of being bounced home, and clears typed drafts after processing so new recordings start clean.

- **Bug Fixes**
  - `Recording.tsx`: Add a 500 ms grace period and re-check before navigating home to avoid racing the optimistic stop transition.
  - `useLiveDraftStore` + `useRecordingProcessingEffects`: Add `clear(sessionName)` and clear the draft on `processing-complete` so title and notes don’t carry over.

<sup>Written for commit cb2b8b09cc1511e144c838a17fd4d78b11c36172. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

