### PR TITLE
fix(ci): merge per-arch latest-mac.yml so Apple Silicon auto-updates ship arm64

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -154,7 +154,23 @@ jobs:
         mkdir -p release
         find artifacts -name "*.dmg" -exec cp {} release/ \;
         find artifacts -name "*.zip" -exec cp {} release/ \;
-        find artifacts -name "*.yml" -o -name "*.yaml" | xargs -I {} cp {} release/ 2>/dev/null || true
+        # Merge per-arch latest-mac.yml files into a single yml whose `files:`
+        # array lists both the x64 and arm64 zips. Without this, electron-updater
+        # on Apple Silicon downloads the x64 zip and runs the whole app under
+        # Rosetta — slow launch and slow runtime. The two build jobs run on
+        # different runners (macos-15-intel + macos-14) and each writes its own
+        # `latest-mac.yml`; a plain `cp` would let one overwrite the other.
+        # x64 is kept as the base so top-level `path`/`sha512` stay unchanged.
+        yq eval-all '
+          (select(fileIndex == 0)) as $x64 |
+          (select(fileIndex == 1)) as $arm64 |
+          $x64
+          | .files = ($x64.files + $arm64.files | unique_by(.url))
+          | .releaseDate = ([$x64.releaseDate, $arm64.releaseDate] | sort | reverse | .[0])
+        ' artifacts/build-x64/latest-mac.yml artifacts/build-arm64/latest-mac.yml \
+          > release/latest-mac.yml
+        echo "Merged latest-mac.yml:"
+        cat release/latest-mac.yml
         ls -la release/
         # Create website-friendly aliases for DMGs
         version="${{ github.event.inputs.version || steps.package_version.outputs.version }}"


### PR DESCRIPTION
## Summary

Apple Silicon users who auto-updated were silently being given the **x64** build, which then ran the entire Electron shell and PyInstaller backend under Rosetta on every launch and every subprocess spawn. Manual DMG installs were unaffected because the DMG filenames include `${arch}` and users picked the arm64 DMG themselves on the releases page.

## Root cause

The release job's two macOS build jobs run on separate runners (`macos-15-intel` + `macos-14`) and each writes its own `latest-mac.yml`. The release job's `find ... -exec cp` then copied both into `release/`, and the second cp silently overwrote the first. The x64 yml won — so the published `latest-mac.yml` only ever referenced `Steno-<ver>-mac.zip` (x64). electron-updater on arm64 hosts has no other choice and downloads it.

Confirmed on the live machine:
- `Apple M3 Max`, `arm64` native host
- `/Applications/Steno.app/Contents/MacOS/Steno` → `Mach-O 64-bit executable x86_64`
- `/Applications/Steno.app/Contents/Resources/stenoai/stenoai` → `Mach-O 64-bit executable x86_64`
- Published `latest-mac.yml` for v0.2.13, v0.3.0, v0.3.1 all list only the x64 zip

## Fix

Replace the cp with a `yq eval-all` merge that concatenates the two `files:` arrays (deduped by url) and keeps x64 as the top-level `path`/`sha512` so x64 user behaviour is unchanged. `yq` v4 is preinstalled on `ubuntu-latest`, so no setup step is needed.

After this lands, a fresh tag push produces a `latest-mac.yml` listing all 4 artifacts (x64 zip + dmg, arm64 zip + dmg), and electron-updater on Apple Silicon picks the arm64 zip by URL pattern.

## Retroactive fix for v0.3.1

The v0.3.1 release's `latest-mac.yml` was also patched manually (downloaded the arm64 artifacts, computed SHA512 in base64, built the merged yml with the same yq expression, uploaded with `gh release upload --clobber`). Arm64 users currently on auto-update should now get the arm64 zip when their app next checks for an update — but because they already report v0.3.1 installed, electron-updater will only re-deliver when v0.3.2+ ships. To get unstuck immediately they need to manually replace `/Applications/Steno.app` with the arm64 DMG from the release page.

## Test plan
- [ ] Tag a patch release (or run workflow_dispatch) and confirm the published `latest-mac.yml` lists both arch zips under `files:`.
- [ ] On an Apple Silicon Mac with the old x64 app installed, trigger auto-update and verify `/Applications/Steno.app/Contents/MacOS/Steno` is `Mach-O arm64` after the update applies.
- [ ] On Intel, trigger auto-update and verify behaviour is unchanged (still x64).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mac auto-update metadata so Apple Silicon users get the arm64 build instead of x64 under Rosetta. We now merge per-arch `latest-mac.yml` files into one that lists both architectures.

- **Bug Fixes**
  - Replaced the `cp` step with a `yq eval-all` merge of `artifacts/build-x64/latest-mac.yml` and `artifacts/build-arm64/latest-mac.yml`.
  - Combines `.files` and dedupes by `url`, keeps x64 `path`/`sha512`, and sets `releaseDate` to the newest.
  - `electron-updater` now selects the arm64 zip on Apple Silicon; Intel behavior is unchanged.
  - Uses preinstalled `yq` on `ubuntu-latest`; no extra setup required.

<sup>Written for commit c08be346462e654af70de52645ac1ebcdca4c788. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

