### PR TITLE
fix(summarizer): keep markdown section headers in English for non-English summaries

### DIFF
--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -663,12 +663,20 @@ Return ONLY the response in this exact JSON format:
     
     def _create_markdown_prompt(self, transcript: str, language: str = "en", notes: str = None) -> str:
         """Create a prompt that asks the LLM to output markdown directly."""
-        # Language instruction
+        # Language instruction. The four ## section headers must stay in English
+        # because simple_recorder._parse_streamed_markdown matches on them
+        # literally; the body content is what gets translated.
         if language and language not in ("en", "auto"):
             from .config import get_config
             language_name = get_config().get_language_name(language)
             if language_name != "Unknown":
-                language_instruction = f"\n\nCRITICAL: Write the entire output in {language_name}."
+                language_instruction = (
+                    f"\n\nCRITICAL: Write all content (summary text, topic titles, "
+                    f"topic analysis, key points, action items) in {language_name}. "
+                    f"However, keep the markdown section headers exactly as shown in "
+                    f"English: '## Summary', '## Key Topics', '## Key Points', "
+                    f"'## Action Items'. Do not translate these four headers."
+                )
             else:
                 language_instruction = ""
         else:


### PR DESCRIPTION
## Summary
- Non-English (and auto-detect) meetings briefly showed a summary during streaming, then flipped to "No summary available for this meeting." once processing completed.
- Root cause: `_create_markdown_prompt` told the LLM to *"write the entire output in {language}"*, so it faithfully translated the `## Summary` / `## Key Topics` / `## Key Points` / `## Action Items` section headers too. `simple_recorder._parse_streamed_markdown` matches those headers literally, so for any non-English summary it returned `summary=""`, which was then persisted and shown as the empty-state.
- Fix: tighten the language instruction so body content is translated but the four `##` headers stay in English exactly as the template shows. The renderer never displays those headers — it uses its own labels — so this is invisible to users.

Why not make the parser language-agnostic instead? Considered structural parsing (first `##` block = summary, etc.), but it's brittle if the model adds extra sections or reorders. Pinning the headers is a one-line prompt change that keeps the parser deterministic.

## Test plan
- [x] Rebuilt PyInstaller backend (`pyinstaller stenoai.spec --noconfirm`) so the bundled CLI picks up the prompt change.
- [x] Launched the Electron app and regenerated notes on the existing French meeting from the bug report — summary now persists after `processingComplete` instead of flipping to the empty-state.
- [x] Old non-English meetings on disk are still empty until the user clicks regenerate-notes; no migration needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-English meeting summaries being cleared after processing by keeping markdown section headers in English and translating only the body.

- **Bug Fixes**
  - Updated `summarizer._create_markdown_prompt` to keep `## Summary`, `## Key Topics`, `## Key Points`, `## Action Items` in English; translate content only.
  - Ensures `simple_recorder._parse_streamed_markdown` matches headers and avoids the "No summary available..." state for non-English and auto-detect meetings.

- **Migration**
  - No migration. Existing non-English notes may need “Regenerate notes” to repopulate.

<sup>Written for commit 9962552cd407fcb196cea5b9f4778167452e1dd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

