### PR TITLE
ci: build mic-monitor helper in the macOS matrix before packaging

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -72,6 +72,24 @@ jobs:
           -name "*.dylib" -exec codesign --remove-signature {} \; 2>/dev/null || true
         echo "Stripped ad-hoc signatures from pywhispercpp dylibs"
 
+    - name: Build mic-monitor helper (Swift)
+      run: |
+        chmod +x scripts/build-mic-monitor.sh
+        # Matrix uses electron-builder's "x64"/"arm64" naming. swiftc wants
+        # "x86_64"/"arm64", so translate when invoking the build script.
+        if [ "${{ matrix.arch }}" = "x64" ]; then
+          ./scripts/build-mic-monitor.sh x86_64
+        else
+          ./scripts/build-mic-monitor.sh arm64
+        fi
+        file bin/mic-monitor
+        # Fail loudly if the binary doesn't match the matrix arch — silent
+        # mismatches would ship users a Rosetta'd helper.
+        case "${{ matrix.arch }}" in
+          arm64)  file bin/mic-monitor | grep -q "arm64" ;;
+          x64)    file bin/mic-monitor | grep -q "x86_64" ;;
+        esac
+
     - name: Build Python backend with PyInstaller
       run: |
         pyinstaller stenoai.spec --noconfirm


### PR DESCRIPTION
## Summary

#117 adds a Swift `mic-monitor` binary bundled via electron-builder's `extraResources` (path: `../bin/mic-monitor`). But the build pipeline assumes the binary already exists on disk — locally that's fine (developers run `make -C mic-monitor` or `scripts/build-mic-monitor.sh` once), but **CI doesn't build it**. So a tagged release after #117 merges would ship a DMG without the helper, the watcher would spawn-fail at runtime, and auto-detect would silently do nothing.

This PR adds a "Build mic-monitor helper (Swift)" step in the macOS matrix job, immediately before the PyInstaller step.

## Details

- Calls `scripts/build-mic-monitor.sh` with arch translation: the matrix uses electron-builder's `x64` / `arm64` names whereas swiftc wants `x86_64` / `arm64`. ~5 lines of bash translation in-step.
- Adds a `file` + `grep` guard that fails the job loudly if the produced binary's architecture doesn't match the matrix arch. Without this, a Rosetta'd helper could silently ship to arm64 users (same class of bug as the auto-update arm64 issue we hit earlier).
- No changes to packaging — `bin/mic-monitor` was already being picked up by `extraResources` (added in #117).

## Test plan

- [ ] Merge after #117. Push a no-op release tag (or workflow_dispatch) and confirm:
  - `bin/mic-monitor` is produced in both arm64 and x64 jobs
  - The arch-mismatch guard passes (no false failures)
  - The resulting DMG contains `Contents/Resources/mic-monitor` as a Mach-O matching the host arch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the Swift `mic-monitor` helper in the macOS CI matrix before packaging so releases include the helper and auto-detect works on Intel and Apple Silicon. Adds an arch check to prevent shipping a Rosetta-translated binary.

- **Bug Fixes**
  - Runs `scripts/build-mic-monitor.sh` per-arch (translates `x64`→`x86_64`, keeps `arm64`).
  - Verifies `bin/mic-monitor` architecture with `file` + `grep`; fails on mismatch.
  - No packaging changes; `electron-builder` `extraResources` already includes `bin/mic-monitor`.

<sup>Written for commit 8ba33f177373e2317bd018d28ac7bef3c3e5804e. Summary will update on new commits. <a href="https://cubic.dev/pr/ruzin/stenoai/pull/118?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

