### PR TITLE
fix(transcriber): drop whisper hallucination loop segments

### DIFF
--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -469,19 +469,38 @@ class WhisperTranscriber:
                     # use its own internal language detection as a fallback.
                     resolved_language = None
 
-            # pywhispercpp returns a list of segments.
-            # suppress_non_speech_tokens stops whisper.cpp from emitting
-            # bracketed annotations like [Music], [Sounds of a question],
-            # [Applause]. On quiet/no-content audio whisper.cpp otherwise
-            # loops on these tokens and fills the transcript with dozens of
-            # identical bracketed lines.
-            transcribe_kwargs = {
-                "media": str(converted_path),
-                "suppress_non_speech_tokens": True,
-            }
+            # pywhispercpp returns a list of segments
+            transcribe_kwargs = {"media": str(converted_path)}
             if resolved_language and resolved_language != "auto":
                 transcribe_kwargs["language"] = resolved_language
             segments = self.model.transcribe(**transcribe_kwargs)
+
+            # Drop whisper.cpp loop hallucinations. On quiet/no-content audio
+            # the decoder gets stuck emitting the same segment text (often a
+            # bracketed annotation like "[Sounds of a question]" or a real
+            # phrase like "Thank you.") dozens of times in a row. A run of 5+
+            # consecutive identical segments is the signature of a loop;
+            # legitimate repetition (three speakers saying "yes", a chant)
+            # rarely exceeds 4 in a row.
+            if segments:
+                deduped: list = []
+                i = 0
+                while i < len(segments):
+                    text = segments[i].text.strip()
+                    run_end = i + 1
+                    while (
+                        run_end < len(segments)
+                        and segments[run_end].text.strip() == text
+                    ):
+                        run_end += 1
+                    if run_end - i >= 5 and text:
+                        logger.warning(
+                            f"Dropped {run_end - i} repeated whisper segments: {text[:60]!r}"
+                        )
+                    else:
+                        deduped.extend(segments[i:run_end])
+                    i = run_end
+                segments = deduped
 
             if not segments:
                 return {

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -469,8 +469,16 @@ class WhisperTranscriber:
                     # use its own internal language detection as a fallback.
                     resolved_language = None
 
-            # pywhispercpp returns a list of segments
-            transcribe_kwargs = {"media": str(converted_path)}
+            # pywhispercpp returns a list of segments.
+            # suppress_non_speech_tokens stops whisper.cpp from emitting
+            # bracketed annotations like [Music], [Sounds of a question],
+            # [Applause]. On quiet/no-content audio whisper.cpp otherwise
+            # loops on these tokens and fills the transcript with dozens of
+            # identical bracketed lines.
+            transcribe_kwargs = {
+                "media": str(converted_path),
+                "suppress_non_speech_tokens": True,
+            }
             if resolved_language and resolved_language != "auto":
                 transcribe_kwargs["language"] = resolved_language
             segments = self.model.transcribe(**transcribe_kwargs)


### PR DESCRIPTION
## Summary

Fixes a transcription quality bug where, on quiet or no-content audio, whisper.cpp gets stuck in a decoder loop and emits the same segment (e.g. \`[Sounds of a question]\` or \`Thank you.\`) dozens of times in a row. Reported by a user via Discord — example screenshot showed 16+ repeats of \`[Sounds of a question]\` in a single transcript.

The fix drops runs of **5+ consecutive identical segments** after whisper.cpp returns, in \`src/transcriber.py:_transcribe_whisper_cpp\`. Threshold is high enough that legitimate repetition (three speakers agreeing, a chant) is preserved — these rarely exceed 4 in a row.

### Why not the cleaner \`suppress_non_speech_tokens\` whisper.cpp flag

First commit on this branch tried that route — pywhispercpp's \`PARAMS_SCHEMA\` lists it as a supported param. Turns out it's a schema/binding mismatch: the underlying \`_pywhispercpp.whisper_full_params\` C struct doesn't actually expose that attribute. \`transcribe()\` raises \`AttributeError\` on every call, breaking transcription entirely. Verified by inspecting the C struct directly (\`dir(_pywhispercpp.WhisperFullParams())\` shows only \`suppress_blank\` and \`suppress_regex\`). Reverted in the second commit and replaced with post-processing.

The post-processing approach also catches non-bracketed loops (e.g. repeated \`Thank you.\` on silence), which the flag wouldn't have.

## Test plan

- [x] \`ruff check\` clean
- [x] \`python -m unittest discover tests\` — 46 tests pass
- [x] Manually verified in dev mode against a recording with system-audio + silence: dedup fires correctly when triggered (\`Dropped 6 repeated whisper segments: 'yeah'\` in the log), no false drops on normal speech.

## Known limitation

If whisper.cpp emits a loop as a **single segment** with the phrase repeated inside its \`.text\` (rather than as N separate segments), this fix won't catch it. We'd need an additional text-level pass on the joined output. Punted for now — the multi-segment form is the one we've seen in the wild.

The proper long-term fix is whisper.cpp's native VAD (\`vad_model\` param) to never feed silence to the decoder. Worth a follow-up to check pywhispercpp's exposure of that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repeated “hallucination” segments from whisper.cpp on silence by dropping runs of 5+ identical segments after transcription. Prevents transcripts flooded with lines like “[Sounds of a question]” while preserving normal repetition.

- **Bug Fixes**
  - Post-process in `src/transcriber.py:_transcribe_whisper_cpp` to remove 5+ identical consecutive segments.
  - Replaces the unsupported `pywhispercpp` `suppress_non_speech_tokens` path; works for bracketed and non-bracketed repeats.

<sup>Written for commit b251193b21db92f6af3fa725b0ad0d33095a18e6. Summary will update on new commits. <a href="https://cubic.dev/pr/ruzin/stenoai/pull/121?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

