### PR TITLE
fix(auto-detect): filter non-meeting mic events via bundle-id allowlist

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -2983,6 +2983,46 @@ const APP_NAME_OVERRIDES = [
   { match: /^org\.mozilla\./, name: 'Firefox' },
 ];
 
+// Allowlist of bundle-id patterns we treat as "meeting apps". Anything not
+// matching is ignored — without this filter, dictation tools (Wispr Flow,
+// Superwhisper, MacWhisper, Apple Dictation, VoiceInk) and music apps that
+// open the mic would all trigger "Meeting detected".
+// Browsers are included as a class because most web meetings (Meet, Teams
+// web, Whereby, Around, etc.) route mic capture through the browser bundle
+// id or a helper sub-process (see APP_NAME_OVERRIDES). Tradeoff: in-browser
+// dictation extensions also match, but browser meetings are far more common.
+const MEETING_APP_ALLOWLIST = [
+  // Native videoconf / meeting apps (prefix match catches helper sub-processes)
+  /^us\.zoom\.xos/,                    // Zoom
+  /^com\.microsoft\.teams/,            // Microsoft Teams (classic + new "teams2")
+  /^com\.cisco\.webexmeetingsapp/,     // Cisco Webex
+  /^com\.webex\.meetingmanager/,       // Cisco Webex (alt id)
+  /^com\.apple\.FaceTime/,             // FaceTime
+  /^com\.hnc\.Discord/,                // Discord
+  /^com\.tinyspeck\.slackmacgap/,      // Slack (huddles)
+  /^com\.logmein\.GoToMeeting/,        // GoToMeeting
+  /^com\.bluejeansnet\.BlueJeans/,     // BlueJeans
+  /^co\.pop\.desktop/,                 // Pop
+  /^com\.google\.meetings/,            // Google Meet (standalone PWA)
+  /^com\.apple\.VoiceMemos/,           // Apple Voice Memos
+  // Browsers — most web meetings route mic capture through here
+  /^com\.apple\.WebKit/,               // Safari (helper)
+  /^com\.apple\.Safari/,               // Safari (main)
+  /^com\.google\.Chrome/,              // Chrome (+ helpers)
+  /^org\.chromium\./,                  // Chromium
+  /^com\.microsoft\.edgemac/,          // Edge
+  /^company\.thebrowser\.Browser/,     // Arc
+  /^com\.brave\.Browser/,              // Brave
+  /^org\.mozilla\./,                   // Firefox
+];
+
+function isMeetingApp(evt) {
+  // macOS 12/13 fallback emits no app_id (device-level signal). We can't
+  // filter there, so preserve legacy behaviour and notify regardless.
+  if (!evt.app_id) return true;
+  return MEETING_APP_ALLOWLIST.some((re) => re.test(evt.app_id));
+}
+
 // Wait this long after the meeting app releases the mic before triggering
 // auto-pause + "Meeting ended" prompt. Verified empirically that Zoom/Meet/
 // Teams use software-mute (keep the OS-level stream open while muted), so
@@ -3110,6 +3150,11 @@ function handleMicEvent(line) {
       }
       sendDebugLog(`[auto-detect] auto-resumed: ${autoStartedSession.appName}`);
     }
+    return;
+  }
+
+  if (!isMeetingApp(evt)) {
+    sendDebugLog(`[auto-detect] ignoring non-meeting app: ${evt.app_name || evt.app_id}`);
     return;
   }
 


### PR DESCRIPTION
## Summary
- Adds `MEETING_APP_ALLOWLIST` — a list of bundle-id prefix patterns we treat as legitimate meeting/recording apps
- `handleMicEvent` now short-circuits with a debug log when an incoming mic-start event doesn't match the allowlist
- Without this filter, dictation tools (Wispr Flow, Superwhisper, MacWhisper, Apple Dictation, VoiceInk) and music apps that open the mic all triggered "Meeting detected"

## Allowlist contents
- **Native:** Zoom, Microsoft Teams, Cisco Webex, FaceTime, Discord, Slack (huddles), GoToMeeting, BlueJeans, Pop, Google Meet PWA, Apple Voice Memos
- **Browsers (web meetings):** Safari, Chrome, Chromium, Edge, Arc, Brave, Firefox

Prefix-anchored so helper sub-processes (e.g. `com.google.Chrome.helper`) also match.

## Known gap
`isMeetingApp` returns true when `evt.app_id` is missing, preserving the macOS 12/13 device-level fallback. On those OS versions everything still notifies. Can tighten in a follow-up.

## Test plan
- [x] Built signed DMG locally (`stenoAI-macos-0.3.4-arm64.dmg`)
- [x] Install from `/Applications`, open Voice Memos → "Meeting detected" fires
- [x] Open a dictation tool (Wispr Flow / Apple Dictation) → no notification, debug log shows `[auto-detect] ignoring non-meeting app: ...`
- [x] Open Zoom → "Meeting detected" fires as before
- [x] Open a Meet/Teams/Whereby call in Chrome → "Meeting detected" fires (browser bundle id matches)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop false “Meeting detected” alerts by filtering mic-start events with a bundle-id allowlist. Only known meeting apps and browsers trigger detection; dictation tools and music apps are ignored.

- **Bug Fixes**
  - Added `MEETING_APP_ALLOWLIST` with prefix regexes (matches helpers) for Zoom, Teams, Webex, FaceTime, Discord, Slack (huddles), GoToMeeting, BlueJeans, Pop, Google Meet PWA, Voice Memos, and major browsers (Safari, Chrome/Chromium, Edge, Arc, Brave, Firefox).
  - `handleMicEvent` now ignores non-allowlisted apps and logs `[auto-detect] ignoring non-meeting app: ...`.
  - macOS 12/13 fallback preserved when `evt.app_id` is missing (device-level signal).

<sup>Written for commit 93b4d2de8a3768823a67aa307f0fc715589104ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/126?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

