### PR TITLE
feat(auto-detect): name recordings after the calendar event title

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -3114,7 +3114,7 @@ function stopMicMonitor() {
   clearAutoStartedSession();
 }
 
-function handleMicEvent(line) {
+async function handleMicEvent(line) {
   let evt;
   try {
     evt = JSON.parse(line);
@@ -3170,7 +3170,11 @@ function handleMicEvent(line) {
 
   const appName = humanizeAppName(evt);
   sendDebugLog(`[auto-detect] meeting detected: ${appName} (${evt.app_id || 'no-bundle-id'})`);
-  showMeetingDetectedNotification(appName, evt);
+  const calEvent = await getCalendarEventForNow();
+  if (calEvent) {
+    sendDebugLog(`[auto-detect] matched calendar event: ${calEvent.title}`);
+  }
+  showMeetingDetectedNotification(appName, evt, calEvent);
 }
 
 function handleMicStop(evt) {
@@ -3199,17 +3203,17 @@ function handleMicStop(evt) {
   }, MEETING_END_DEBOUNCE_MS);
 }
 
-function showMeetingDetectedNotification(appName, originatingEvt) {
+function showMeetingDetectedNotification(appName, originatingEvt, calEvent) {
   // Notification rendering quirk: setting `closeButtonText` alongside a single
   // `actions` entry causes macOS to collapse everything into an "Options"
   // dropdown instead of showing the action inline. Leaving closeButtonText
   // unset gives us Granola's layout — single inline button to the right.
   const notif = new Notification({
     title: 'Meeting detected',
-    body: appName,
+    body: calEvent?.title || appName,
     actions: [{ type: 'button', text: 'Take Notes' }],
   });
-  const trigger = () => requestAutoRecord(appName, originatingEvt);
+  const trigger = () => requestAutoRecord(appName, originatingEvt, calEvent);
   notif.on('action', (_evt, _index) => trigger()); // shown when banner style = Alerts
   notif.on('click', trigger);                       // body tap (always available)
   notif.show();
@@ -3237,12 +3241,15 @@ function showMeetingEndedNotification(appName) {
   return notif;
 }
 
-function requestAutoRecord(appName, originatingEvt) {
-  // Match the existing "session" naming style: "<App> — YYYY-MM-DD HH:MM".
+function requestAutoRecord(appName, originatingEvt, calEvent) {
+  // Prefer the calendar event title when we matched one — it's user-authored
+  // and recognisable weeks later. Falls back to "<App> — YYYY-MM-DD HH:MM",
+  // which simple_recorder.py treats as an "auto-named" placeholder and lets
+  // the post-summary LLM-title step rewrite (see _AUTO_NAMED_PATTERN).
   const now = new Date();
   const pad = (n) => String(n).padStart(2, '0');
   const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
-  const sessionName = `${appName} — ${stamp}`;
+  const sessionName = calEvent?.title || `${appName} — ${stamp}`;
   sendDebugLog(`[auto-detect] user requested record: ${sessionName}`);
 
   // Track the originating app so we can pair its mic-stop with this recording
@@ -5708,6 +5715,66 @@ ipcMain.handle('get-calendar-events', async () => {
     return { success: false, error: error.message };
   }
 });
+
+// Pick the calendar event most likely to be the one the user is joining now.
+// Tolerance: ±5 min on the event start, so an early join (a few min before
+// the scheduled time) or joining a meeting already in progress both match.
+// Preference: in-progress events beat upcoming ones; among ties, the most
+// recently started (or soonest-upcoming) wins.
+function pickCurrentCalendarEvent(events, now = new Date()) {
+  const TOLERANCE_MS = 5 * 60 * 1000;
+  const nowMs = now.getTime();
+  const candidates = [];
+  for (const e of events) {
+    if (!e || !e.start || !e.end) continue;
+    const startMs = new Date(e.start).getTime();
+    const endMs = new Date(e.end).getTime();
+    if (!isFinite(startMs) || !isFinite(endMs)) continue;
+    if (nowMs >= startMs - TOLERANCE_MS && nowMs < endMs) {
+      candidates.push({ event: e, startMs });
+    }
+  }
+  if (candidates.length === 0) return null;
+  const inProgress = candidates.filter((c) => c.startMs <= nowMs);
+  if (inProgress.length > 0) {
+    inProgress.sort((a, b) => b.startMs - a.startMs);
+    return inProgress[0].event;
+  }
+  candidates.sort((a, b) => a.startMs - b.startMs);
+  return candidates[0].event;
+}
+
+// Fetches from whichever provider is connected, applies a hard timeout so a
+// slow API never blocks the "Meeting detected" notification. Returns the
+// matched event or null.
+async function getCalendarEventForNow(timeoutMs = 1500) {
+  const fetchOnce = async () => {
+    try {
+      const googleToken = await getValidAccessToken();
+      if (googleToken) {
+        const raw = await fetchCalendarEvents(googleToken);
+        return raw.map(normalizeCalendarEvent);
+      }
+      const outlookToken = await getValidOutlookAccessToken();
+      if (outlookToken) {
+        const raw = await fetchOutlookCalendarEvents(outlookToken);
+        return raw.map(normalizeCalendarEvent);
+      }
+      return null;
+    } catch (err) {
+      sendDebugLog(`[auto-detect] calendar lookup failed: ${err.message}`);
+      return null;
+    }
+  };
+  const timeout = new Promise((resolve) => setTimeout(() => resolve('timeout'), timeoutMs));
+  const events = await Promise.race([fetchOnce(), timeout]);
+  if (events === 'timeout') {
+    sendDebugLog(`[auto-detect] calendar lookup timed out after ${timeoutMs}ms`);
+    return null;
+  }
+  if (!events) return null;
+  return pickCurrentCalendarEvent(events);
+}
 
 // ── Outlook Calendar: IPC Handlers ──────────────────────────────────────
 

--- a/app/main.js
+++ b/app/main.js
@@ -5247,7 +5247,7 @@ function refreshAccessToken(refreshToken) {
 
 // ── Google Calendar: Fetch Events ───────────────────────────────────────
 
-function fetchCalendarEvents(accessToken, maxResults = 7) {
+function fetchCalendarEvents(accessToken, maxResults = 7, signal) {
   return new Promise((resolve, reject) => {
     const now = new Date();
     const weekAhead = new Date(now);
@@ -5269,6 +5269,7 @@ function fetchCalendarEvents(accessToken, maxResults = 7) {
         'Authorization': `Bearer ${accessToken}`
       }
     };
+    if (signal) options.signal = signal;
 
     const req = https.request(options, (res) => {
       let data = '';
@@ -5520,7 +5521,7 @@ function refreshOutlookAccessToken(refreshToken) {
 
 // ── Outlook Calendar: Fetch Events ──────────────────────────────────────
 
-function fetchOutlookCalendarEvents(accessToken, maxResults = 7) {
+function fetchOutlookCalendarEvents(accessToken, maxResults = 7, signal) {
   return new Promise((resolve, reject) => {
     const now = new Date();
     const weekAhead = new Date(now);
@@ -5543,6 +5544,7 @@ function fetchOutlookCalendarEvents(accessToken, maxResults = 7) {
         'Prefer': 'outlook.timezone="UTC"'
       }
     };
+    if (signal) options.signal = signal;
 
     const req = https.request(options, (res) => {
       let data = '';
@@ -5723,63 +5725,80 @@ ipcMain.handle('get-calendar-events', async () => {
 // The 10-min floor only matters for meetings shorter than 10 min: a 5-min
 // standup that overruns by a couple of minutes still matches when the user
 // joins late. Long meetings are unaffected (their end is past start+10).
-// Preference: in-progress events beat upcoming ones; among ties, the most
-// recently started (or soonest-upcoming) wins.
+// Priority:
+//   1. Genuinely in-progress (now within real [start, end))
+//   2. Upcoming (start is still in the future) — soonest first
+//   3. Recently ended but still within the late-floor — most recently ended
+// (2) beats (3) so a short event that overran the floor cannot block the next
+// real upcoming meeting.
+// All-day events are skipped — their start is a date-only string ("YYYY-MM-DD")
+// with no 'T' separator, spans midnight to midnight, and would mistag every
+// meeting that day (e.g. "On vacation" appearing in every recording's title).
 function pickCurrentCalendarEvent(events, now = new Date()) {
   const EARLY_GRACE_MS = 5 * 60 * 1000;
   const LATE_FLOOR_MS = 10 * 60 * 1000;
   const nowMs = now.getTime();
   const candidates = [];
   for (const e of events) {
-    if (!e || !e.start || !e.end) continue;
+    if (!e || typeof e.start !== 'string' || typeof e.end !== 'string') continue;
+    if (!e.start.includes('T') || !e.end.includes('T')) continue;
     const startMs = new Date(e.start).getTime();
     const endMs = new Date(e.end).getTime();
     if (!isFinite(startMs) || !isFinite(endMs)) continue;
     const closesAt = Math.max(endMs, startMs + LATE_FLOOR_MS);
     if (nowMs >= startMs - EARLY_GRACE_MS && nowMs < closesAt) {
-      candidates.push({ event: e, startMs });
+      candidates.push({ event: e, startMs, endMs });
     }
   }
   if (candidates.length === 0) return null;
-  const inProgress = candidates.filter((c) => c.startMs <= nowMs);
+
+  const inProgress = candidates.filter((c) => c.startMs <= nowMs && nowMs < c.endMs);
   if (inProgress.length > 0) {
     inProgress.sort((a, b) => b.startMs - a.startMs);
     return inProgress[0].event;
   }
-  candidates.sort((a, b) => a.startMs - b.startMs);
+  const upcoming = candidates.filter((c) => c.startMs > nowMs);
+  if (upcoming.length > 0) {
+    upcoming.sort((a, b) => a.startMs - b.startMs);
+    return upcoming[0].event;
+  }
+  candidates.sort((a, b) => b.endMs - a.endMs);
   return candidates[0].event;
 }
 
 // Fetches from whichever provider is connected, applies a hard timeout so a
-// slow API never blocks the "Meeting detected" notification. Returns the
-// matched event or null.
+// slow API never blocks the "Meeting detected" notification. The timeout
+// aborts the in-flight request (via AbortController) so we don't leak the
+// HTTPS request after fallback. Returns the matched event or null.
 async function getCalendarEventForNow(timeoutMs = 1500) {
-  const fetchOnce = async () => {
-    try {
-      const googleToken = await getValidAccessToken();
-      if (googleToken) {
-        const raw = await fetchCalendarEvents(googleToken);
-        return raw.map(normalizeCalendarEvent);
-      }
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    let events = null;
+    const googleToken = await getValidAccessToken();
+    if (googleToken) {
+      const raw = await fetchCalendarEvents(googleToken, 7, signal);
+      events = raw.map(normalizeCalendarEvent);
+    } else {
       const outlookToken = await getValidOutlookAccessToken();
       if (outlookToken) {
-        const raw = await fetchOutlookCalendarEvents(outlookToken);
-        return raw.map(normalizeCalendarEvent);
+        const raw = await fetchOutlookCalendarEvents(outlookToken, 7, signal);
+        events = raw.map(normalizeCalendarEvent);
       }
-      return null;
-    } catch (err) {
-      sendDebugLog(`[auto-detect] calendar lookup failed: ${err.message}`);
-      return null;
     }
-  };
-  const timeout = new Promise((resolve) => setTimeout(() => resolve('timeout'), timeoutMs));
-  const events = await Promise.race([fetchOnce(), timeout]);
-  if (events === 'timeout') {
-    sendDebugLog(`[auto-detect] calendar lookup timed out after ${timeoutMs}ms`);
+    if (!events) return null;
+    return pickCurrentCalendarEvent(events);
+  } catch (err) {
+    if (signal.aborted) {
+      sendDebugLog(`[auto-detect] calendar lookup timed out after ${timeoutMs}ms`);
+    } else {
+      sendDebugLog(`[auto-detect] calendar lookup failed: ${err.message}`);
+    }
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
-  if (!events) return null;
-  return pickCurrentCalendarEvent(events);
 }
 
 // ── Outlook Calendar: IPC Handlers ──────────────────────────────────────

--- a/app/main.js
+++ b/app/main.js
@@ -5717,12 +5717,17 @@ ipcMain.handle('get-calendar-events', async () => {
 });
 
 // Pick the calendar event most likely to be the one the user is joining now.
-// Tolerance: ±5 min on the event start, so an early join (a few min before
-// the scheduled time) or joining a meeting already in progress both match.
+// Match window:
+//   - opens 5 min before the scheduled start (early-join grace)
+//   - closes at the scheduled end, OR 10 min after start, whichever is later
+// The 10-min floor only matters for meetings shorter than 10 min: a 5-min
+// standup that overruns by a couple of minutes still matches when the user
+// joins late. Long meetings are unaffected (their end is past start+10).
 // Preference: in-progress events beat upcoming ones; among ties, the most
 // recently started (or soonest-upcoming) wins.
 function pickCurrentCalendarEvent(events, now = new Date()) {
-  const TOLERANCE_MS = 5 * 60 * 1000;
+  const EARLY_GRACE_MS = 5 * 60 * 1000;
+  const LATE_FLOOR_MS = 10 * 60 * 1000;
   const nowMs = now.getTime();
   const candidates = [];
   for (const e of events) {
@@ -5730,7 +5735,8 @@ function pickCurrentCalendarEvent(events, now = new Date()) {
     const startMs = new Date(e.start).getTime();
     const endMs = new Date(e.end).getTime();
     if (!isFinite(startMs) || !isFinite(endMs)) continue;
-    if (nowMs >= startMs - TOLERANCE_MS && nowMs < endMs) {
+    const closesAt = Math.max(endMs, startMs + LATE_FLOOR_MS);
+    if (nowMs >= startMs - EARLY_GRACE_MS && nowMs < closesAt) {
       candidates.push({ event: e, startMs });
     }
   }


### PR DESCRIPTION
## Summary
When "Meeting detected" fires, look up the connected calendar (Google or Outlook) for an event happening now and use its title as the session name. Scheduled meetings become recognisable weeks later instead of being saved as `Zoom — 2026-05-29 14:30` then LLM-renamed to whatever the model thinks the conversation was about.

## How it works
- New helpers `pickCurrentCalendarEvent()` and `getCalendarEventForNow()` in `app/main.js`
- `handleMicEvent` now `async` — awaits the calendar lookup before showing the notification
- `getCalendarEventForNow` reuses the existing `fetchCalendarEvents` / `fetchOutlookCalendarEvents` and the existing token-refresh path; provider precedence matches the rest of the app (Google first, then Outlook)
- ±5 min start tolerance on the matching window (covers early joiners and joining a meeting already in progress)
- Multiple matches tiebreak: in-progress > upcoming; among ties, most-recently-started > soonest-upcoming
- 1.5s hard timeout via `Promise.race` so a slow API never delays the notification
- No calendar connected, no match, fetch error, or timeout → falls back to the existing `<App> — YYYY-MM-DD HH:MM` placeholder, which `_AUTO_NAMED_PATTERN` (`simple_recorder.py:53`) still treats as auto-named so the post-summary LLM title step continues to rewrite

## Result
- **No calendar connected** → identical to today
- **Calendar matches** → notification body shows the meeting title, recording is saved under that title, LLM-title step skips (calendar title doesn't match the placeholder regex)
- **Calendar miss** → placeholder name + LLM-rename as today

## Test plan
- [x] Built signed DMG locally (`stenoAI-macos-0.3.4-arm64.dmg`)
- [x] Install from `/Applications`, connect Google Calendar in settings
- [x] Schedule a test event for now ± 2 min and open Zoom/Meet → notification shows the event title
- [x] Verify the recording in the list is named after the calendar event
- [x] Disconnect calendar → notification falls back to app name; recording uses `<App> — <stamp>` and gets LLM-renamed post-summary
- [x] Connect Outlook instead of Google → same behaviour
- [x] Simulate slow API (offline mode) → notification still fires within ~1.5s with app-name fallback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recordings and the “Meeting detected” notification now use the current calendar event title when a meeting is auto-detected. If no match is found, we fall back to the existing placeholder so the LLM rename still applies.

- New Features
  - Added `pickCurrentCalendarEvent()` and `getCalendarEventForNow()` reusing existing Google/Outlook fetch and token refresh; Google is tried first.
  - Made `handleMicEvent` async and wait up to 1.5s for a calendar match; the notification shows the matched title.
  - Session names prefer the calendar title; otherwise use "<App> — YYYY-MM-DD HH:MM" to keep post-summary renaming.
  - Matching window opens 5 min before start and closes at max(end, start+10min) to cover short overruns.

- Bug Fixes
  - Skip all-day events (date-only start/end) to avoid mistagging.
  - Abort in-flight calendar requests on timeout using `AbortController`; plumbed `signal` to `fetchCalendarEvents` and `fetchOutlookCalendarEvents`.
  - Tiebreak order fixed: real in‑progress > upcoming > recently‑ended (within the late floor).

<sup>Written for commit c353e682c3f32ab9d16e04c59aae8e878602eea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

