### PR TITLE
feat(org): share transcript as a separate S3 artifact + surface in panel

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -6263,7 +6263,7 @@ ipcMain.handle('org-delete-meeting', async (_event, id) => {
 // attempt state. Centralised in main so the renderer doesn't have to do
 // raw PUT (and so we can keep the bytes off the renderer when the bucket
 // has stricter CORS).
-async function uploadMeetingToOrg({ title, body, visibility = 'org' }) {
+async function uploadMeetingToOrg({ title, body, transcript = '', visibility = 'org' }) {
   const safeTitle = String(title)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
@@ -6289,9 +6289,44 @@ async function uploadMeetingToOrg({ title, body, visibility = 'org' }) {
     throw new Error(`s3 upload failed (${putRes.status}): ${detail.slice(0, 200)}`);
   }
 
+  // Step 2b (optional): second presign+PUT for the transcript when one was
+  // supplied. Kept as a separate S3 object (rather than appended to the
+  // markdown body) so the desktop can lazily render it in the floating
+  // transcript panel instead of inline below the summary — matches the
+  // local-note UX. Failure here is non-fatal: the body upload already
+  // succeeded, so we POST /meetings without a transcript_s3_key rather
+  // than orphan an S3 object after rolling everything back.
+  let transcriptKey = null;
+  const transcriptText = String(transcript || '').trim();
+  if (transcriptText) {
+    try {
+      const tPresign = await adapterFetch('/uploads/presign', {
+        method: 'POST',
+        body: JSON.stringify({
+          filename: `${safeTitle}.transcript.txt`,
+          content_type: 'text/plain',
+        }),
+      });
+      const tPut = await fetch(tPresign.upload_url, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body: transcriptText,
+      });
+      if (tPut.ok) {
+        transcriptKey = tPresign.s3_key;
+      } else {
+        const detail = await tPut.text().catch(() => '');
+        console.warn(`transcript upload failed (${tPut.status}): ${detail.slice(0, 200)}`);
+      }
+    } catch (err) {
+      console.warn('transcript upload skipped:', err.message);
+    }
+  }
+
   // Step 3: register metadata in the adapter. The body field is empty —
-  // the adapter holds only the s3_key and serves a presigned GET when
-  // someone in the org opens the note.
+  // the adapter holds only the s3_key (+ optional transcript_s3_key) and
+  // serves a presigned GET / inlined body when someone in the org opens
+  // the note.
   const meeting = await adapterFetch('/meetings', {
     method: 'POST',
     body: JSON.stringify({
@@ -6299,19 +6334,20 @@ async function uploadMeetingToOrg({ title, body, visibility = 'org' }) {
       body: '',
       visibility,
       s3_key: presign.s3_key,
+      ...(transcriptKey ? { transcript_s3_key: transcriptKey } : {}),
     }),
   });
 
-  return { meeting, s3_key: presign.s3_key };
+  return { meeting, s3_key: presign.s3_key, transcript_s3_key: transcriptKey };
 }
 
 ipcMain.handle('org-share-meeting', async (_event, payload) => {
   try {
-    const { title, body, visibility = 'org', summaryFile } = payload || {};
+    const { title, body, transcript, visibility = 'org', summaryFile } = payload || {};
     if (!title) return { success: false, error: 'title is required' };
     if (typeof body !== 'string') return { success: false, error: 'body is required' };
 
-    const { meeting, s3_key } = await uploadMeetingToOrg({ title, body, visibility });
+    const { meeting, s3_key } = await uploadMeetingToOrg({ title, body, transcript, visibility });
     // Mark this note as having been attempted so a later auto-backup
     // trigger (e.g. a reprocess that re-fires processing-complete)
     // doesn't push a second copy into the org.
@@ -6356,7 +6392,7 @@ ipcMain.handle('org-set-auto-backup', async (_event, enabled) => {
 // manual Share).
 ipcMain.handle('org-try-auto-backup', async (_event, payload) => {
   try {
-    const { summaryFile, title, body, visibility = 'org' } = payload || {};
+    const { summaryFile, title, body, transcript, visibility = 'org' } = payload || {};
     if (!summaryFile) return { attempted: false, reason: 'missing-summary-file' };
     if (!title) return { attempted: false, reason: 'missing-title' };
     if (typeof body !== 'string') return { attempted: false, reason: 'missing-body' };
@@ -6389,7 +6425,7 @@ ipcMain.handle('org-try-auto-backup', async (_event, payload) => {
     // record the attempt — leaves the door open for a retry next time
     // something pokes this path.
     try {
-      const { meeting, s3_key } = await uploadMeetingToOrg({ title, body, visibility });
+      const { meeting, s3_key } = await uploadMeetingToOrg({ title, body, transcript, visibility });
       recordOrgBackupAttempt(summaryFile, meeting?.id);
       return { attempted: true, meeting, s3_key };
     } catch (e) {

--- a/app/main.js
+++ b/app/main.js
@@ -6319,7 +6319,10 @@ async function uploadMeetingToOrg({ title, body, transcript = '', visibility = '
         console.warn(`transcript upload failed (${tPut.status}): ${detail.slice(0, 200)}`);
       }
     } catch (err) {
-      console.warn('transcript upload skipped:', err.message);
+      console.warn(
+        'transcript upload skipped:',
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 

--- a/app/renderer/src/components/AskBar.tsx
+++ b/app/renderer/src/components/AskBar.tsx
@@ -17,7 +17,10 @@ import {
   type ChatSession,
 } from '@/hooks/useChatSessions';
 import { useGlobalStreaming } from '@/hooks/useStreamingQuery';
-import { TranscriptPanelContent } from '@/components/TranscriptPanel';
+import {
+  OrgTranscriptPanelContent,
+  TranscriptPanelContent,
+} from '@/components/TranscriptPanel';
 import { useMeeting } from '@/hooks/useMeetings';
 
 // ---------------------------------------------------------------------------
@@ -25,20 +28,29 @@ import { useMeeting } from '@/hooks/useMeetings';
 // ---------------------------------------------------------------------------
 
 export function TranscriptBar() {
-  const { activeSummaryFile, transcriptOpen, setTranscriptOpen } = useAskBar();
+  const { activeSummaryFile, activeOrgMeeting, transcriptOpen, setTranscriptOpen } = useAskBar();
   const meeting = useMeeting(activeSummaryFile ?? undefined);
   const [copied, setCopied] = React.useState(false);
+  const orgTranscript = activeOrgMeeting?.transcript ?? '';
+  const hasOrgTranscript = orgTranscript.trim().length > 0;
 
   const copyTranscript = async () => {
-    if (!meeting.data) return;
-    const text = (meeting.data.transcript ?? '').trim();
+    let text = '';
+    if (activeOrgMeeting) {
+      text = orgTranscript.trim();
+    } else if (meeting.data) {
+      text = (meeting.data.transcript ?? '').trim();
+    }
     if (!text) return;
     await navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
 
-  if (!transcriptOpen || !activeSummaryFile) return null;
+  if (!transcriptOpen) return null;
+  // Two valid contexts: a local meeting (activeSummaryFile) or a shared
+  // org note that was uploaded with a transcript.
+  if (!activeSummaryFile && !hasOrgTranscript) return null;
 
   return (
     <div
@@ -76,7 +88,11 @@ export function TranscriptBar() {
         </button>
       </div>
       <div style={{ height: 260, display: 'flex', flexDirection: 'column', borderTop: '1px solid var(--border-subtle)' }}>
-        <TranscriptPanelContent summaryFile={activeSummaryFile} />
+        {activeOrgMeeting ? (
+          <OrgTranscriptPanelContent transcript={orgTranscript} />
+        ) : (
+          <TranscriptPanelContent summaryFile={activeSummaryFile!} />
+        )}
       </div>
     </div>
   );
@@ -327,10 +343,12 @@ export function AskBar() {
         className="mv-chat"
         onSubmit={(e) => { e.preventDefault(); void submit(); }}
       >
-        {/* Transcript toggle — local-meeting only. Shared (org) notes have
-            no transcript to display, so hide the toggle in that mode rather
-            than expose a button that opens an empty panel. */}
-        {!activeOrgMeeting && (
+        {/* Transcript toggle — shown for any meeting that actually has a
+            transcript. For local meetings that's always true; for shared
+            (org) notes it depends on whether the original share included
+            a transcript artifact. Older shared notes have no transcript
+            and the toggle stays hidden. */}
+        {(activeSummaryFile || (activeOrgMeeting?.transcript ?? '').trim()) && (
         <button
           type="button"
           className={cn('mv-chat-tool', transcriptOpen && 'active')}

--- a/app/renderer/src/components/TranscriptPanel.tsx
+++ b/app/renderer/src/components/TranscriptPanel.tsx
@@ -4,14 +4,14 @@ import { Search as SearchIcon } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { useMeeting } from '@/hooks/useMeetings';
-import type { Meeting } from '@/lib/ipc';
 
 interface Segment {
   speaker: 'You' | 'Others' | null;
   text: string;
 }
 
-/** Bare transcript content — no outer card or header. Used inside the dock's mv-transcript panel. */
+/** Local-meeting wrapper — fetches the meeting JSON, then renders. Kept as
+ *  the original API so existing callers don't change. */
 export function TranscriptPanelContent({
   summaryFile,
 }: {
@@ -26,12 +26,28 @@ export function TranscriptPanelContent({
   if (!meeting.data) {
     return <div className="px-4 py-3 text-sm text-muted-foreground">No transcript available.</div>;
   }
-  return <TranscriptBody meeting={meeting.data} />;
+  const m = meeting.data;
+  const isDiarised = !!(m.is_diarised && m.diarised_text);
+  const text = isDiarised ? (m.diarised_text ?? '') : (m.transcript ?? '');
+  return <TranscriptBody text={text} isDiarised={isDiarised} />;
+}
+
+/** Org-meeting wrapper — transcript already in memory (came from the
+ *  adapter's GET /meetings/{id} response). Diarisation is auto-detected
+ *  from the presence of [You]/[Others] markers because the adapter
+ *  doesn't currently round-trip an explicit flag (avoids another
+ *  enterprise schema change). */
+export function OrgTranscriptPanelContent({ transcript }: { transcript: string }) {
+  if (!transcript.trim()) {
+    return <div className="px-4 py-3 text-sm text-muted-foreground">No transcript available.</div>;
+  }
+  const isDiarised = /\[(?:You|Others)\]/.test(transcript);
+  return <TranscriptBody text={transcript} isDiarised={isDiarised} />;
 }
 
 
-function TranscriptBody({ meeting }: { meeting: Meeting }) {
-  const segments = React.useMemo(() => parseTranscript(meeting), [meeting]);
+function TranscriptBody({ text, isDiarised }: { text: string; isDiarised: boolean }) {
+  const segments = React.useMemo(() => parseTranscript(text, isDiarised), [text, isDiarised]);
   const [query, setQuery] = React.useState('');
 
   const filtered = React.useMemo(() => {
@@ -157,9 +173,9 @@ function renderHighlighted(text: string, highlight: string): React.ReactNode {
   return parts;
 }
 
-function parseTranscript(meeting: Meeting): Segment[] {
-  if (meeting.is_diarised && meeting.diarised_text) {
-    const blocks = meeting.diarised_text.split(/(?=\[You\]|\[Others\])/);
+function parseTranscript(text: string, isDiarised: boolean): Segment[] {
+  if (isDiarised) {
+    const blocks = text.split(/(?=\[You\]|\[Others\])/);
     return blocks
       .map((b) => b.trim())
       .filter(Boolean)
@@ -170,12 +186,12 @@ function parseTranscript(meeting: Meeting): Segment[] {
         return { speaker: null, text: b };
       });
   }
-  const text = (meeting.transcript ?? '').trim();
-  if (!text) return [];
-  const sentences = text
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  const sentences = trimmed
     .split(/(?<=[.!?])\s+(?=[A-Z"'(\[])/)
     .map((s) => s.trim())
     .filter(Boolean);
-  return (sentences.length > 1 ? sentences : [text]).map((s) => ({ speaker: null, text: s }));
+  return (sentences.length > 1 ? sentences : [trimmed]).map((s) => ({ speaker: null, text: s }));
 }
 

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -210,12 +210,16 @@ export function useRecordingProcessingEffects() {
         // sidebar Shared Notes view updates without a refresh.
         const title = newMeeting.session_info.name || 'Untitled note';
         const body = composeShareBody(newMeeting);
+        const transcript = (newMeeting.is_diarised && newMeeting.diarised_text)
+          ? newMeeting.diarised_text
+          : (newMeeting.transcript ?? '');
         if (body) {
           ipc()
             .org.tryAutoBackup({
               summaryFile: newSummaryFile,
               title,
               body,
+              transcript,
               visibility: 'org',
             })
             .then((res) => {

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -6,7 +6,7 @@ import { meetingsKeys } from './meetingKeys';
 import { orgKeys } from './useOrg';
 import { useLiveDraftStore } from './liveDraftStore';
 import { navigate } from '@/lib/router';
-import { composeShareBody } from '@/routes/MeetingDetail';
+import { composeShareBody, pickTranscriptForShare } from '@/routes/MeetingDetail';
 import type { Meeting, QueueStatus } from '@/lib/ipc';
 
 export type RecordingStatus = 'idle' | 'recording' | 'paused' | 'processing';
@@ -210,9 +210,7 @@ export function useRecordingProcessingEffects() {
         // sidebar Shared Notes view updates without a refresh.
         const title = newMeeting.session_info.name || 'Untitled note';
         const body = composeShareBody(newMeeting);
-        const transcript = (newMeeting.is_diarised && newMeeting.diarised_text)
-          ? newMeeting.diarised_text
-          : (newMeeting.transcript ?? '');
+        const transcript = pickTranscriptForShare(newMeeting);
         if (body) {
           ipc()
             .org.tryAutoBackup({

--- a/app/renderer/src/lib/askBarContext.tsx
+++ b/app/renderer/src/lib/askBarContext.tsx
@@ -5,6 +5,10 @@ export interface ActiveOrgMeeting {
   title: string;
   body: string;
   ownerEmail: string;
+  /** When the shared note was uploaded with a transcript, the adapter
+   *  inlines it on GET /meetings/{id}. The AskBar's transcript toggle
+   *  surfaces only when this is non-empty. */
+  transcript?: string;
 }
 
 interface AskBarContextValue {
@@ -50,7 +54,8 @@ export function AskBarProvider({ children }: { children: React.ReactNode }) {
         prev.id === meeting.id &&
         prev.title === meeting.title &&
         prev.body === meeting.body &&
-        prev.ownerEmail === meeting.ownerEmail
+        prev.ownerEmail === meeting.ownerEmail &&
+        prev.transcript === meeting.transcript
       ) {
         return prev;
       }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -132,10 +132,17 @@ export interface OrgMeetingSummary {
   visibility: 'private' | 'org';
   created_at: number;
   has_artifact: boolean;
+  /** True when the shared note also has a transcript artifact in S3. Lets
+   *  the list view show a "has transcript" affordance without GETting each
+   *  meeting individually. */
+  has_transcript: boolean;
 }
 
 export interface OrgMeeting extends OrgMeetingSummary {
   body: string;
+  /** Inlined transcript content. Only present when the meeting was shared
+   *  with a transcript (post-v0.3.0 adapter). Missing for older notes. */
+  transcript_body?: string;
   download_url?: string;
 }
 
@@ -152,6 +159,11 @@ export interface OrgCreateMeetingPayload {
 export interface OrgShareMeetingPayload {
   title: string;
   body: string;
+  /** Optional transcript content uploaded as a separate S3 object. Diarised
+   *  text (with [You]/[Others] tags) is preferred when available; the
+   *  desktop side decides which to send. Empty string skips the second
+   *  upload entirely. */
+  transcript?: string;
   visibility?: 'private' | 'org';
   /** When present, main records this summary as "backup attempted" so the
    *  auto-backup trigger won't push a duplicate copy on a later reprocess. */
@@ -164,6 +176,8 @@ export interface OrgTryAutoBackupPayload {
   summaryFile: string;
   title: string;
   body: string;
+  /** Optional transcript — same semantics as OrgShareMeetingPayload.transcript. */
+  transcript?: string;
   visibility?: 'private' | 'org';
 }
 

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -123,12 +123,17 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
     setShareState('sharing');
     setShareError(null);
     const title = meeting.session_info.name || 'Untitled note';
-    // Compose the full structured note as markdown — same content the
-    // local detail page renders, minus the raw transcript (kept off the
-    // shared corpus to limit blast radius if the bucket is ever leaked).
+    // Body = structured summary markdown (same as local detail page).
+    // Transcript ships as a separate S3 artifact so the org viewer can
+    // toggle it via the side panel rather than rendering it inline below
+    // the summary. Diarised text (with [You]/[Others] tags) is preferred
+    // when available so the org viewer gets the speaker-attributed view.
     const body = composeShareBody(meeting);
+    const transcript = (meeting.is_diarised && meeting.diarised_text)
+      ? meeting.diarised_text
+      : (meeting.transcript ?? '');
     try {
-      await shareToOrg.mutateAsync({ title, body, visibility: 'org', summaryFile });
+      await shareToOrg.mutateAsync({ title, body, transcript, visibility: 'org', summaryFile });
       setShareState('shared');
       setTimeout(() => setShareState('idle'), 2500);
     } catch (e) {

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -129,9 +129,7 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
     // the summary. Diarised text (with [You]/[Others] tags) is preferred
     // when available so the org viewer gets the speaker-attributed view.
     const body = composeShareBody(meeting);
-    const transcript = (meeting.is_diarised && meeting.diarised_text)
-      ? meeting.diarised_text
-      : (meeting.transcript ?? '');
+    const transcript = pickTranscriptForShare(meeting);
     try {
       await shareToOrg.mutateAsync({ title, body, transcript, visibility: 'org', summaryFile });
       setShareState('shared');
@@ -1146,7 +1144,19 @@ function getErrorMessage(error: unknown): string {
   return 'Something went wrong.';
 }
 
-/** Builds the markdown body shipped to the org adapter when the user shares
+/** Pick which transcript flavour to ship to org. Diarised text (with
+ *  [You]/[Others] tags) preferred when available so org viewers get the
+ *  speaker-attributed view; falls back to the plain transcript. Returns
+ *  an empty string for meetings with no transcript at all, which the
+ *  upload path treats as "skip the second presign+PUT". Kept here next
+ *  to composeShareBody so manual-share (MeetingDetail) and auto-backup
+ *  (useRecording) can't drift out of sync. */
+export function pickTranscriptForShare(meeting: Meeting): string {
+  if (meeting.is_diarised && meeting.diarised_text) return meeting.diarised_text;
+  return meeting.transcript ?? '';
+}
+
+/** Compose the markdown body that will be uploaded to S3 when sharing
  *  a local note. Mirrors what the local note view renders (minus the raw
  *  transcript) so colleagues see the same structured summary. */
 export function composeShareBody(meeting: Meeting): string {

--- a/app/renderer/src/routes/OrgShared.tsx
+++ b/app/renderer/src/routes/OrgShared.tsx
@@ -149,6 +149,7 @@ export function OrgSharedDetail({ id }: { id: string }) {
             title: meeting.data.title,
             body: meeting.data.body ?? '',
             ownerEmail: meeting.data.owner_email,
+            transcript: meeting.data.transcript_body ?? '',
           }
         : null,
     [
@@ -156,6 +157,7 @@ export function OrgSharedDetail({ id }: { id: string }) {
       meeting.data?.title,
       meeting.data?.body,
       meeting.data?.owner_email,
+      meeting.data?.transcript_body,
     ],
   );
   useActiveOrgMeeting(activeOrgMeeting);


### PR DESCRIPTION
## Summary
Pairs with [stenoai-enterprise #2](https://github.com/ruzin/stenoai-enterprise/pull/2). When sharing a note to org, the desktop now uploads the transcript as a second S3 object alongside the summary body, then registers `transcript_s3_key` on the meeting record. When viewing a shared note in the **Shared notes** view, the AskBar's existing floating Transcript panel surfaces — same UX as local notes (search bar + virtualised list + diarised chat bubbles when applicable). Resolves the customer report "I can't find the actual transcript of a call, only the summary."

## Why a separate artifact (not appended to the body markdown)?
The transcript stays out of the rendered shared-note body so the summary renders clean, and the desktop can fetch transcript-on-demand into the floating panel — matches the local-note UX (your screenshot).

## Changes (8 files, ~135 LOC)

### Main process
- **`app/main.js`** — `uploadMeetingToOrg` now accepts an optional `transcript`. When non-empty: second `/uploads/presign` + PUT (content-type `text/plain`), then `POST /meetings` includes `transcript_s3_key`. Transcript-upload failure is non-fatal — the body upload already succeeded so we register the meeting without `transcript_s3_key` rather than orphan an S3 object. Both `org-share-meeting` and `org-try-auto-backup` handlers forward the new field.

### Renderer
- **`app/renderer/src/components/TranscriptPanel.tsx`** — `TranscriptBody` refactored to take `{ text, isDiarised }` as props (was: a whole `Meeting` object). Two thin wrappers:
  - `TranscriptPanelContent` (local — unchanged API, fetches via `useMeeting`)
  - `OrgTranscriptPanelContent` (new — takes transcript string, auto-detects diarisation from `[You]`/`[Others]` markers)
- **`app/renderer/src/components/AskBar.tsx`** — transcript toggle button now surfaces when `activeOrgMeeting.transcript` is non-empty (was: local meetings only). `TranscriptBar` routes to the right wrapper based on context. Copy-transcript button works in both contexts.
- **`app/renderer/src/lib/askBarContext.tsx`** — `ActiveOrgMeeting` carries optional `transcript` field.
- **`app/renderer/src/routes/OrgShared.tsx`** — passes `transcript_body` from the GET response into `useActiveOrgMeeting`.
- **`app/renderer/src/lib/ipc.ts`** — `OrgMeetingSummary.has_transcript`, `OrgMeeting.transcript_body`, plus `transcript` field on `OrgShareMeetingPayload` and `OrgTryAutoBackupPayload`.
- **`app/renderer/src/routes/MeetingDetail.tsx`** — `onShareToOrg` sends `transcript` (prefers `diarised_text` when available so org viewers get speaker attribution).
- **`app/renderer/src/hooks/useRecording.ts`** — auto-backup path sends the same.

## What's unchanged
- `composeShareBody` — summary body markdown still excludes the transcript; the panel is the path
- Local-note transcript UX — fully unchanged
- Local meeting JSON / transcript files — fully unchanged

## Backwards compatibility
Shared notes uploaded before this change have no `transcript_s3_key`, so the GET response omits `transcript_body` → AskBar's transcript toggle stays hidden for those, no breakage. Tests in stenoai-enterprise PR #2 cover both the with-transcript and without-transcript paths.

## Dependency
Requires the enterprise PR #2 + tag `v0.3.0`. Tested end-to-end against a local adapter running PR #2.

## Live test (just done)
Shared three local recordings to org:

| Note | Body | Transcript artifact |
|---|---|---|
| `high` | 427 B | 10 B (\"Thank you.\") |
| `singapore-travel-plans` | 667 B | 69 B |
| `ai-hype-cycle-limitations-and-saas` | 1985 B | **2730 B** (transcript larger than summary — full conversation content) |

Adapter logs show the expected pattern: 2× `POST /uploads/presign` (body + transcript) → 1× `POST /meetings 201` per share. All three meeting records persisted with both `s3_key` and `transcript_s3_key`. Transcript panel renders with content + search bar in the shared-note view.

## Test plan for reviewers
- [x] Share a note that has a transcript → verify both S3 objects exist
- [x] Open the shared note in Shared notes → transcript toggle appears in AskBar
- [x] Click toggle → floating panel opens with content + search works
- [x] Diarised meeting → speaker chat-bubbles render with `[You]`/`[Others]` mapping
- [x] Share a note without a transcript (legacy local note, fresh recording with no audio) → meeting still uploads, transcript toggle stays hidden
- [x] Unshare → both S3 objects hard-deleted (depends on enterprise PR #1 already merged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share-to-org now uploads transcripts as a separate S3 artifact and shows them in the Shared notes view. Org viewers can read, search, and copy transcripts, matching the local note experience. Pairs with enterprise adapter PR #2 (`transcript_s3_key`, tag `v0.3.0`).

- New Features
  - Uploads transcript as a second S3 object and registers `transcript_s3_key`; upload failure is non-fatal.
  - Shows a transcript toggle for org notes with transcripts; floating panel supports search and copy.
  - Uses diarised text when available (auto-detected via “[You]/[Others]”).
  - TranscriptPanel now takes `{ text, isDiarised }`; adds `OrgTranscriptPanelContent`; local UX unchanged.
  - Manual share and auto-backup share the same transcript-pick via `pickTranscriptForShare`.
  - Older shared notes have no transcript; toggle stays hidden.

- Bug Fixes
  - Guards transcript-upload catch against non-Error throws in `uploadMeetingToOrg`.

<sup>Written for commit 099ce46a10267a808012d7a5f4b60766d57d9b54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

