### PR TITLE
fix(org): validate JWT in org-status and surface a sign-in CTA in the sidebar

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -5848,6 +5848,32 @@ function getOrgSessionPath() {
   return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.org-session');
 }
 
+// Decode the JWT's payload segment and check whether it's already past its
+// `exp` claim. The adapter signs with HS256 so we *cannot* verify the
+// signature client-side, but the `exp` timestamp is the part the adapter
+// itself enforces — if it's in the past, the next authenticated request
+// will get a 401 anyway. Checking here lets org-status and the sidebar
+// reflect reality without first having to make a request and watch it fail.
+//
+// We treat malformed/unparseable tokens as expired (defensive) so a corrupt
+// session file kicks the user back to sign-in instead of leaving them in a
+// "signed in but every request fails" limbo.
+function isJwtExpired(token) {
+  try {
+    const parts = String(token || '').split('.');
+    if (parts.length !== 3) return true;
+    const payload = JSON.parse(
+      Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'),
+    );
+    if (typeof payload.exp !== 'number') return true;
+    // 30-second skew buffer so a request fired right at the boundary doesn't
+    // race the adapter to "valid → expired" mid-flight.
+    return payload.exp <= Math.floor(Date.now() / 1000) + 30;
+  } catch (_) {
+    return true;
+  }
+}
+
 function saveOrgSession(session) {
   try {
     const dir = path.dirname(getOrgSessionPath());
@@ -5981,6 +6007,15 @@ async function adapterFetch(pathname, opts = {}) {
 ipcMain.handle('org-status', async () => {
   const session = loadOrgSession();
   if (!session) return { signedIn: false };
+  // Previously this returned signedIn:true as long as the session file
+  // existed, even if the JWT had long since expired. The renderer would
+  // happily show a "signed in" sticker until the user actually triggered
+  // an authenticated request and got booted by a 401. Validate the JWT's
+  // exp claim here so the UI reflects truth at startup.
+  if (isJwtExpired(session.token)) {
+    clearOrgSession();
+    return { signedIn: false, expired: true };
+  }
   return {
     signedIn: true,
     adapterUrl: session.adapterUrl,

--- a/app/main.js
+++ b/app/main.js
@@ -6040,7 +6040,15 @@ async function adapterFetch(pathname, opts = {}) {
 
 ipcMain.handle('org-status', async () => {
   const session = loadOrgSession();
-  const everSignedIn = hasOrgEverBeenSignedIn();
+  // Backfill the marker on first org-status hit when a session already
+  // exists from before the marker code shipped — without this, anyone
+  // who signed in on a previous build would lose the sidebar CTA on
+  // their next sign-out / expiry because their session predates the
+  // marker file. `everSignedIn` therefore treats "has live session OR
+  // marker file" as equivalent past-sign-in proof.
+  const knownBefore = hasOrgEverBeenSignedIn();
+  if (session && !knownBefore) markOrgKnown();
+  const everSignedIn = knownBefore || Boolean(session);
   if (!session) return { signedIn: false, everSignedIn };
   // Previously this returned signedIn:true as long as the session file
   // existed, even if the JWT had long since expired. The renderer would

--- a/app/main.js
+++ b/app/main.js
@@ -5858,20 +5858,25 @@ function getOrgSessionPath() {
 // We treat malformed/unparseable tokens as expired (defensive) so a corrupt
 // session file kicks the user back to sign-in instead of leaving them in a
 // "signed in but every request fails" limbo.
-function isJwtExpired(token) {
+function decodeJwtExp(token) {
   try {
     const parts = String(token || '').split('.');
-    if (parts.length !== 3) return true;
+    if (parts.length !== 3) return null;
     const payload = JSON.parse(
       Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'),
     );
-    if (typeof payload.exp !== 'number') return true;
-    // 30-second skew buffer so a request fired right at the boundary doesn't
-    // race the adapter to "valid → expired" mid-flight.
-    return payload.exp <= Math.floor(Date.now() / 1000) + 30;
+    return typeof payload.exp === 'number' ? payload.exp : null;
   } catch (_) {
-    return true;
+    return null;
   }
+}
+
+function isJwtExpired(token) {
+  const exp = decodeJwtExp(token);
+  if (exp === null) return true;
+  // 30-second skew buffer so a request fired right at the boundary doesn't
+  // race the adapter to "valid → expired" mid-flight.
+  return exp <= Math.floor(Date.now() / 1000) + 30;
 }
 
 function saveOrgSession(session) {
@@ -5905,6 +5910,35 @@ function clearOrgSession() {
     if (fs.existsSync(p)) fs.unlinkSync(p);
     return true;
   } catch (e) {
+    return false;
+  }
+}
+
+// Persistent marker — survives sign-out, gets written on the FIRST successful
+// org sign-in (password OR Google SSO). Used by the sidebar to decide whether
+// to surface the "Sign in to org" CTA: personal users who never sign in see
+// nothing; enterprise users get a one-click recovery path after their first
+// connection. Empty file content; existence is the only signal.
+function getOrgKnownMarkerPath() {
+  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.org-known');
+}
+
+function markOrgKnown() {
+  try {
+    const p = getOrgKnownMarkerPath();
+    if (!fs.existsSync(path.dirname(p))) fs.mkdirSync(path.dirname(p), { recursive: true });
+    if (!fs.existsSync(p)) fs.writeFileSync(p, '');
+    return true;
+  } catch (e) {
+    console.error('Failed to write org-known marker:', e.message);
+    return false;
+  }
+}
+
+function hasOrgEverBeenSignedIn() {
+  try {
+    return fs.existsSync(getOrgKnownMarkerPath());
+  } catch (_) {
     return false;
   }
 }
@@ -6006,7 +6040,8 @@ async function adapterFetch(pathname, opts = {}) {
 
 ipcMain.handle('org-status', async () => {
   const session = loadOrgSession();
-  if (!session) return { signedIn: false };
+  const everSignedIn = hasOrgEverBeenSignedIn();
+  if (!session) return { signedIn: false, everSignedIn };
   // Previously this returned signedIn:true as long as the session file
   // existed, even if the JWT had long since expired. The renderer would
   // happily show a "signed in" sticker until the user actually triggered
@@ -6014,10 +6049,15 @@ ipcMain.handle('org-status', async () => {
   // exp claim here so the UI reflects truth at startup.
   if (isJwtExpired(session.token)) {
     clearOrgSession();
-    return { signedIn: false, expired: true };
+    return { signedIn: false, everSignedIn };
   }
   return {
     signedIn: true,
+    everSignedIn,
+    // Surfaced so the renderer can schedule a precise setTimeout to
+    // invalidate this query the instant the JWT expires — no polling,
+    // no stale UI in the "app left open all day" case.
+    exp: decodeJwtExp(session.token) ?? undefined,
     adapterUrl: session.adapterUrl,
     email: session.email,
     name: session.name,
@@ -6052,6 +6092,7 @@ ipcMain.handle('org-login', async (_event, payload) => {
       orgId: body.org_id,
     };
     if (!saveOrgSession(session)) return { success: false, error: 'failed to persist session' };
+    markOrgKnown();
     return {
       success: true,
       signedIn: true,
@@ -6233,6 +6274,7 @@ ipcMain.handle('org-sso-google-start', async (_event, payload) => {
       orgId: cbBody.org_id,
     };
     if (!saveOrgSession(session)) return { success: false, error: 'failed to persist session' };
+    markOrgKnown();
     return {
       success: true,
       signedIn: true,

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -133,7 +133,9 @@ export function App() {
 
 function RouteView({ route }: { route: string }) {
   if (route === '/dev' || route.startsWith('/dev/')) return <Sandbox />;
-  if (route === '/settings') return <Settings />;
+  // Match deep-links like /settings?tab=organisation too — the Settings
+  // component reads the tab param off the route on mount.
+  if (route === '/settings' || route.startsWith('/settings?')) return <Settings />;
   if (route === '/setup') return <Setup />;
   if (route === '/recording') return <Recording />;
   if (route === '/chat') return <Chat />;

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -529,10 +529,12 @@ export function Sidebar({
             onClick={() => toggleSettings(currentRoute)}
             aria-label="Settings"
             title="Settings"
-            aria-pressed={currentRoute === '/settings'}
+            // startsWith so the cog still reads "active" on deep-link routes
+            // like /settings?tab=organisation, not just bare /settings.
+            aria-pressed={currentRoute.startsWith('/settings')}
             className={cn(
               'inline-flex h-[26px] w-7 items-center justify-center rounded-md transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]',
-              currentRoute === '/settings'
+              currentRoute.startsWith('/settings')
                 ? 'bg-[color:var(--surface-active)] text-[color:var(--fg-1)]'
                 : 'text-[color:var(--fg-2)]',
             )}

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -4,13 +4,14 @@ import {
   Globe,
   Home as HomeIcon,
   Inbox,
+  LogIn,
   LogOut,
   MessageSquare,
   Plus,
   Search,
   Settings as SettingsIcon,
 } from 'lucide-react';
-import { navigate, toggleSettings } from '@/lib/router';
+import { navigate, rememberNonSettingsRoute, toggleSettings } from '@/lib/router';
 import { cn, shortcut } from '@/lib/utils';
 import { LucideIcon, IconPicker } from '@/components/IconPicker';
 import { useUpdateFolderIcon } from '@/hooks/useFolders';
@@ -494,21 +495,37 @@ export function Sidebar({
 
         {/* Profile chip + Settings cog. When the user is signed in to an org
             adapter, the chip sits on the left and the cog moves to the right
-            (justify-between). When signed out the chip is gone and the cog
-            falls back to the left where it originally lived. */}
-        <div
-          className={cn(
-            'flex items-center gap-2 px-3 py-2',
-            orgSignedIn && 'justify-between',
-          )}
-        >
-          {orgSignedIn && (
+            (justify-between). When signed out we still surface a sign-in CTA
+            on the left so the path back into org features is one click rather
+            than a multi-step trek through Settings > Organisation. */}
+        <div className="flex items-center justify-between gap-2 px-3 py-2">
+          {orgSignedIn ? (
             <ProfileChip
               email={orgSession.data?.email ?? ''}
               name={orgSession.data?.name ?? ''}
               orgId={orgSession.data?.orgId ?? ''}
               onSignOut={() => orgLogout.mutate()}
             />
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                rememberNonSettingsRoute(currentRoute);
+                navigate('/settings?tab=organisation');
+              }}
+              className="inline-flex h-[26px] min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] transition-colors hover:bg-[color:var(--surface-hover)]"
+              style={{ color: 'var(--fg-1)' }}
+              title={
+                orgSession.data?.expired
+                  ? 'Your organisation session expired — sign in again'
+                  : 'Sign in to share notes with your organisation'
+              }
+            >
+              <LogIn className="size-[13px]" style={{ color: 'var(--fg-2)' }} />
+              <span className="truncate">
+                {orgSession.data?.expired ? 'Re-sign in to org' : 'Sign in to org'}
+              </span>
+            </button>
           )}
           <button
             type="button"

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -495,9 +495,10 @@ export function Sidebar({
 
         {/* Profile chip + Settings cog. When the user is signed in to an org
             adapter, the chip sits on the left and the cog moves to the right
-            (justify-between). When signed out we still surface a sign-in CTA
-            on the left so the path back into org features is one click rather
-            than a multi-step trek through Settings > Organisation. */}
+            (justify-between). When signed out we surface a one-click sign-in
+            CTA, but ONLY for users who've previously connected to an org —
+            personal users who have never signed in don't see clutter for a
+            feature they don't use. */}
         <div className="flex items-center justify-between gap-2 px-3 py-2">
           {orgSignedIn ? (
             <ProfileChip
@@ -506,7 +507,7 @@ export function Sidebar({
               orgId={orgSession.data?.orgId ?? ''}
               onSignOut={() => orgLogout.mutate()}
             />
-          ) : (
+          ) : orgSession.data?.everSignedIn ? (
             <button
               type="button"
               onClick={() => {
@@ -515,17 +516,13 @@ export function Sidebar({
               }}
               className="inline-flex h-[26px] min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] transition-colors hover:bg-[color:var(--surface-hover)]"
               style={{ color: 'var(--fg-1)' }}
-              title={
-                orgSession.data?.expired
-                  ? 'Your organisation session expired — sign in again'
-                  : 'Sign in to share notes with your organisation'
-              }
+              title="Sign in to share notes with your organisation"
             >
               <LogIn className="size-[13px]" style={{ color: 'var(--fg-2)' }} />
-              <span className="truncate">
-                {orgSession.data?.expired ? 'Re-sign in to org' : 'Sign in to org'}
-              </span>
+              <span className="truncate">Sign in to org</span>
             </button>
+          ) : (
+            <span />
           )}
           <button
             type="button"

--- a/app/renderer/src/hooks/useOrg.ts
+++ b/app/renderer/src/hooks/useOrg.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ipc } from '@/lib/ipc';
 import { unwrap } from '@/lib/result';
@@ -16,11 +17,39 @@ export const orgKeys = {
 };
 
 export function useOrgSession() {
-  return useQuery({
+  const qc = useQueryClient();
+  const query = useQuery({
     queryKey: orgKeys.status(),
     queryFn: () => ipc().org.status(),
     staleTime: 60_000,
   });
+
+  // Precise expiry detection: when the response carries a JWT exp claim,
+  // schedule a one-shot timer to invalidate this query at exactly that
+  // moment. The next refetch lands in main's org-status, which sees the
+  // expired token, clears the session, and returns signedIn:false — the
+  // sidebar swaps to the "Sign in" CTA without any polling or staleness.
+  //
+  // Edge cases:
+  // - exp in the past (clock skew, race): delay clamps to 0, fires
+  //   immediately
+  // - exp very far out (30-day TTL): setTimeout's max delay is ~2^31 ms
+  //   (~24.8 days). For longer values we cap at MAX_TIMEOUT and let the
+  //   effect re-run after invalidation — costs one extra IPC every ~23
+  //   days, negligible.
+  // - exp unset (signed out, malformed): effect skips, no timer
+  const exp = query.data?.signedIn ? query.data.exp : undefined;
+  React.useEffect(() => {
+    if (typeof exp !== 'number') return;
+    const MAX_TIMEOUT = 2_000_000_000; // safe upper bound for setTimeout
+    const delay = Math.max(0, Math.min(exp * 1000 - Date.now(), MAX_TIMEOUT));
+    const id = setTimeout(() => {
+      qc.invalidateQueries({ queryKey: orgKeys.status() });
+    }, delay);
+    return () => clearTimeout(id);
+  }, [exp, qc]);
+
+  return query;
 }
 
 export function useOrgLogin() {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -114,10 +114,16 @@ export interface OrgStatusResponse {
   email?: string;
   name?: string;
   orgId?: string;
-  /** Set by main when org-status detected an expired JWT and cleared the
-   *  session. Lets the UI show "Your session expired — sign in again"
-   *  copy distinct from "Sign in to your organisation" first-time copy. */
-  expired?: boolean;
+  /** True if the user has *ever* successfully signed in to an org (on this
+   *  install). Persists across sign-outs. Used by the sidebar to decide
+   *  whether to surface the "Sign in to org" CTA — personal users who've
+   *  never connected to an org don't see clutter; enterprise users get a
+   *  one-click recovery path after their first connection. */
+  everSignedIn?: boolean;
+  /** JWT exp claim (Unix seconds). When signedIn, the renderer schedules a
+   *  setTimeout to invalidate this query the instant the token expires —
+   *  no polling, no stale UI. Absent on signed-out / malformed responses. */
+  exp?: number;
 }
 
 export type OrgLoginResponse = Result<{

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -114,6 +114,10 @@ export interface OrgStatusResponse {
   email?: string;
   name?: string;
   orgId?: string;
+  /** Set by main when org-status detected an expired JWT and cleared the
+   *  session. Lets the UI show "Your session expired — sign in again"
+   *  copy distinct from "Sign in to your organisation" first-time copy. */
+  expired?: boolean;
 }
 
 export type OrgLoginResponse = Result<{

--- a/app/renderer/src/lib/router.ts
+++ b/app/renderer/src/lib/router.ts
@@ -39,7 +39,10 @@ export function useNavigate() {
 let lastNonSettingsRoute: string = '/';
 
 export function rememberNonSettingsRoute(route: string) {
-  if (route !== '/settings') lastNonSettingsRoute = route;
+  // `startsWith` rather than `===` so deep-links like /settings?tab=organisation
+  // are still recognised as the settings route and don't get stored as
+  // "last non-settings route" by mistake.
+  if (!route.startsWith('/settings')) lastNonSettingsRoute = route;
 }
 
 export function getLastNonSettingsRoute(): string {
@@ -52,10 +55,23 @@ export function getLastNonSettingsRoute(): string {
  * /settings.
  */
 export function toggleSettings(currentRoute: string) {
-  if (currentRoute === '/settings') {
+  if (currentRoute.startsWith('/settings')) {
     navigate(lastNonSettingsRoute || '/');
   } else {
     rememberNonSettingsRoute(currentRoute);
     navigate('/settings');
+  }
+}
+
+/** Pull a query-string param out of the current hash route. Used by Settings
+ *  to deep-link to a specific tab via `/settings?tab=organisation`. Returns
+ *  null when the param is absent or the route is malformed. */
+export function getRouteParam(route: string, name: string): string | null {
+  const qIdx = route.indexOf('?');
+  if (qIdx < 0) return null;
+  try {
+    return new URLSearchParams(route.slice(qIdx + 1)).get(name);
+  } catch (_) {
+    return null;
   }
 }

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -28,7 +28,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { MeetingsShell } from '@/components/MeetingsShell';
-import { useNavigate, getLastNonSettingsRoute } from '@/lib/router';
+import { useNavigate, getLastNonSettingsRoute, useRoute, getRouteParam } from '@/lib/router';
 import {
   clearDebugLogs,
   getDebugLogs,
@@ -448,7 +448,16 @@ function ModelCard({
 
 export function Settings() {
   const navigate = useNavigate();
-  const [tab, setTab] = React.useState<TabId>('general');
+  // Deep-link support: /settings?tab=<id> opens the matching tab on mount.
+  // Used by the sidebar's "Sign in to organisation" CTA to land users
+  // directly on the org sign-in form rather than the General tab.
+  const route = useRoute();
+  const initialTab = React.useMemo<TabId>(() => {
+    const requested = getRouteParam(route, 'tab');
+    if (requested && TABS.some((t) => t.id === requested)) return requested as TabId;
+    return 'general';
+  }, []); // Intentional — only consume the URL param on first mount.
+  const [tab, setTab] = React.useState<TabId>(initialTab);
   const version = useAppVersion();
 
   return (


### PR DESCRIPTION
## Summary
Addresses the customer feedback:

> I have to log in daily to the org, which is currently hidden in the settings. I know this will cause friction for non-technical users and break our automatic sync. They simply won't log in.

Pairs with **stenoai-enterprise v0.2.2** (JWT default TTL 8h → 30 days). Together: longer sessions on the server side + an unmissable re-sign-in path when they do eventually expire on the client side.

## The bugs this fixes

**1. `org-status` was a pure local-file check.** As long as the encrypted session file existed on disk, the renderer reported `signedIn: true` — even if the JWT had long since expired. The user only discovered the expiry when an authenticated request hit a 401 and threw them out.

**2. The only path back to sign-in was via Settings > Organisation** — two clicks deep, behind a tab, easy to miss.

**3. With staleTime + React Query's default triggers, the renderer wouldn't detect expiry while the app sat in the tray.** A user who closes the window (red X → hide-to-tray, not quit) and brings it back hours later would see stale "signed in" UI.

## Changes

| File | Change |
|---|---|
| `app/main.js` | `decodeJwtExp(token)` + `isJwtExpired(token)` helpers. `org-status` IPC clears the session and returns `signedIn: false` when the token has expired, and surfaces `exp` (Unix seconds) when valid. New persistent marker file (`~/Library/Application Support/stenoai/.org-known`) touched on first successful sign-in (password or Google SSO); used to derive `everSignedIn`. Backfills the marker on first `org-status` for sessions that pre-date the marker code so existing users aren't misclassified. |
| `app/renderer/src/lib/ipc.ts` | `OrgStatusResponse.everSignedIn?: boolean` + `OrgStatusResponse.exp?: number` |
| `app/renderer/src/hooks/useOrg.ts` | `useOrgSession` schedules a precise `setTimeout` at the JWT's `exp` to invalidate this query — no polling, sidebar reflects expiry the instant it happens. Handles the 24-day setTimeout cap by re-scheduling on invalidation. |
| `app/renderer/src/components/Sidebar.tsx` | When `signedIn: false && everSignedIn: true`, the bottom-left shows a one-click "Sign in to org" button → Settings > Organisation. Hidden entirely for personal users who have never connected to an org (no marker, no live session). Settings cog active-state uses `startsWith('/settings')` so deep-link routes still highlight the cog. |
| `app/renderer/src/lib/router.ts` | New `getRouteParam(route, name)` helper for parsing `?tab=<id>` off the hash. `rememberNonSettingsRoute` and `toggleSettings` updated from strict `===` to `startsWith('/settings')` so deep-links count as the settings route. |
| `app/renderer/src/routes/Settings.tsx` | Reads `?tab=<id>` from the URL on mount and opens that tab. |
| `app/renderer/src/App.tsx` | `RouteView` matches `/settings?tab=<id>` deep-links in addition to bare `/settings`. |

## Discrimination logic for the CTA

The CTA is gated on observed behaviour, not a config flag at install time (same DMG for personal + enterprise):

| Has live session? | Marker file exists? | Sidebar shows |
|---|---|---|
| Yes | Yes | Profile chip (signed in) |
| Yes | No | Profile chip (signed in) + marker written for next time |
| No | Yes | "Sign in to org" CTA |
| No | No | Nothing — personal user, no clutter |

Single "Sign in to org" string regardless of expiry vs. manual-sign-out state — both lead to the same flow, the marginal value of distinguishing copy wasn't worth the extra state.

## Test plan
- [x] Sign out → "Sign in to org" button visible → click → lands on Settings > Organisation tab
- [x] Sign in fresh → marker written → sign out → CTA persists
- [x] Typecheck (`npm run typecheck:renderer`) clean
- [x] Sign in with adapter TTL=120s → wait → `setTimeout` fires at exact `exp` → sidebar swaps to CTA without any user interaction
- [x] Settings cog visually active on `/settings?tab=organisation`
- [x] After enterprise v0.2.2 deploys: confirm session persists across many days for real
- [x] Reinstall edge case: marker is in `~/Library/Application Support/stenoai/`, survives "drag to trash" uninstall; clean wipe resets to "personal user" state