### PR TITLE
feat(ai): route summarisation through the org adapter when signed in

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -6233,10 +6233,16 @@ ipcMain.handle('org-login', async (_event, payload) => {
 
 ipcMain.handle('org-logout', async () => {
   clearOrgSession();
-  // Roll back the AI provider to 'local' if the user was on 'adapter';
-  // without this, the next summary attempt errors because the env vars
-  // are no longer populated and the Python summariser raises.
-  restorePreAdapterProvider().catch(() => {});
+  // Await the restore — the user just clicked sign-out and expects the
+  // app to settle into the signed-out state before returning. If we
+  // fire-and-forget here there's a race window where Python config
+  // still says 'adapter' but the env vars are already gone, and any
+  // AI op triggered in that window fails with "adapter not configured".
+  // org-status's stale-session path stays fire-and-forget because that
+  // handler is called frequently and any blocking would slow the UI.
+  try {
+    await restorePreAdapterProvider();
+  } catch (_) {}
   return { success: true };
 });
 

--- a/app/main.js
+++ b/app/main.js
@@ -1163,8 +1163,7 @@ ipcMain.handle('get-status', handleGetStatus);
 
 ipcMain.handle('process-recording', async (event, audioFile, sessionName) => {
   try {
-    const cloudKey = loadCloudApiKey();
-    const env = cloudKey ? { STENOAI_CLOUD_API_KEY: cloudKey } : {};
+    const env = getAiEnv();
     const result = await runPythonScript('simple_recorder.py', ['process', audioFile, '--name', sessionName], false, env);
     trackEvent('transcription_completed', { success: true });
     trackEvent('summarization_completed', { success: true });
@@ -1225,8 +1224,8 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
     sendDebugLog(`🔄 Reprocessing meeting: ${summaryFile}`);
     sendDebugLog(`$ stenoai ${args.join(' ')}`);
 
-    const cloudKey = loadCloudApiKey();
-    const reprocessEnv = cloudKey ? { ...require('process').env, STENOAI_CLOUD_API_KEY: cloudKey } : undefined;
+    const aiEnv = getAiEnv();
+    const reprocessEnv = Object.keys(aiEnv).length > 0 ? { ...require('process').env, ...aiEnv } : undefined;
 
     await new Promise((resolve, reject) => {
       const proc = spawn(getBackendPath(), args, {
@@ -1308,8 +1307,8 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
 
 ipcMain.handle('regen-meeting-title', async (event, summaryFile, sessionName) => {
   try {
-    const cloudKey = loadCloudApiKey();
-    const regenEnv = cloudKey ? { ...require('process').env, STENOAI_CLOUD_API_KEY: cloudKey } : undefined;
+    const aiEnv = getAiEnv();
+    const regenEnv = Object.keys(aiEnv).length > 0 ? { ...require('process').env, ...aiEnv } : undefined;
 
     await new Promise((resolve, reject) => {
       const proc = spawn(getBackendPath(), ['regen-title', summaryFile], {
@@ -1352,9 +1351,9 @@ ipcMain.handle('query-transcript', async (event, summaryFile, question) => {
   try {
     sendDebugLog(`🤖 Querying transcript: ${question.substring(0, 50)}...`);
 
-    // Run the query command (pass cloud key for cloud provider)
-    const cloudKey = loadCloudApiKey();
-    const env = cloudKey ? { STENOAI_CLOUD_API_KEY: cloudKey } : {};
+    // Run the query command — getAiEnv supplies the right env for whichever
+    // provider is active (cloud key for cloud, adapter url+token for org).
+    const env = getAiEnv();
     const result = await runPythonScript('simple_recorder.py', ['query', summaryFile, '-q', question], false, env);
 
     // Parse the JSON response
@@ -1416,8 +1415,7 @@ ipcMain.on('query-cancel', (_event, queryId) => {
 ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) => {
   console.log(`[QUERY] IPC received: question="${question.substring(0, 50)}" file="${summaryFile}"`);
   sendDebugLog(`🤖 Streaming query: ${question.substring(0, 50)}...`);
-  const cloudKey = loadCloudApiKey();
-  const env = cloudKey ? { ...process.env, STENOAI_CLOUD_API_KEY: cloudKey } : process.env;
+  const env = { ...process.env, ...getAiEnv() };
 
   let proc;
   try {
@@ -1507,8 +1505,7 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
 // yet and a full-corpus prompt blows local context windows.
 ipcMain.on('chat-global-stream', (event, queryId, question, folderId) => {
   sendDebugLog(`💬 Global chat query: ${String(question || '').slice(0, 80)}... (folder: ${folderId || 'all'})`);
-  const cloudKey = loadCloudApiKey();
-  const env = cloudKey ? { ...process.env, STENOAI_CLOUD_API_KEY: cloudKey } : process.env;
+  const env = { ...process.env, ...getAiEnv() };
 
   const args = ['chat-global-streaming', '-q', question];
   if (folderId && typeof folderId === 'string' && folderId !== 'all') {
@@ -2048,8 +2045,8 @@ async function processNextInQueue() {
   console.log(`🔄 Processing queued job: ${currentProcessingJob.sessionName}`);
   
   try {
-    const queueCloudKey = loadCloudApiKey();
-    const queueEnv = queueCloudKey ? { ...require('process').env, STENOAI_CLOUD_API_KEY: queueCloudKey } : undefined;
+    const queueAiEnv = getAiEnv();
+    const queueEnv = Object.keys(queueAiEnv).length > 0 ? { ...require('process').env, ...queueAiEnv } : undefined;
     const processArgs = ['process-streaming', currentProcessingJob.audioFile, '--name', currentProcessingJob.sessionName];
     if (currentProcessingJob.notesFile && fs.existsSync(currentProcessingJob.notesFile)) {
       processArgs.push('--notes', currentProcessingJob.notesFile);
@@ -2260,10 +2257,9 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
     sendDebugLog('$ stenoai record 7200');
 
     // Start background recording with 2-hour limit
-    // Pass cloud API key via env var for cloud summarization
-    const recordEnv = {};
-    const cloudKey = loadCloudApiKey();
-    if (cloudKey) recordEnv.STENOAI_CLOUD_API_KEY = cloudKey;
+    // Pass AI env (cloud key and/or org-adapter url+token) so the
+    // recorder subprocess can summarise via whichever provider is active.
+    const recordEnv = getAiEnv();
 
     currentRecordingProcess = spawn(getBackendPath(), ['record', '7200', actualSessionName], {
       cwd: getBackendCwd(),
@@ -4375,6 +4371,116 @@ function hasCloudApiKey() {
   return fs.existsSync(getCloudKeyPath());
 }
 
+// Build the env additions a Python AI-driven subprocess needs. Merges
+// the encrypted-on-disk cloud key (decrypted only here, never written
+// to the env if absent) AND the org adapter URL+JWT when a session
+// exists. Either or both may be empty — the Python summariser picks
+// the right path based on the configured ai_provider, and we just
+// surface whatever's available.
+function getAiEnv() {
+  const env = {};
+  const cloudKey = loadCloudApiKey();
+  if (cloudKey) env.STENOAI_CLOUD_API_KEY = cloudKey;
+  const session = loadOrgSession();
+  if (session && session.adapterUrl && session.token && !isJwtExpired(session.token)) {
+    env.STENOAI_ADAPTER_URL = session.adapterUrl;
+    env.STENOAI_ADAPTER_TOKEN = session.token;
+  }
+  return env;
+}
+
+// Read the Python-side ai_provider config so we can react to it on sign-in
+// / sign-out events. Returns 'local' on any error so an unreadable config
+// can't accidentally keep us in 'adapter' mode after logout.
+async function readAiProvider() {
+  try {
+    const raw = await runPythonScript('simple_recorder.py', ['get-ai-provider'], true);
+    const data = JSON.parse(raw.trim());
+    return typeof data.ai_provider === 'string' ? data.ai_provider : 'local';
+  } catch (e) {
+    sendDebugLog(`readAiProvider failed, treating as 'local': ${e.message}`);
+    return 'local';
+  }
+}
+
+// Tiny on-disk marker so the auto-switch can remember which provider
+// the user was on before we flipped them to 'adapter'. Restored on
+// sign-out so a user previously on 'cloud' goes back to 'cloud' rather
+// than getting silently downgraded to 'local'. Cleared whenever the
+// user manually picks a non-adapter provider — at that point there's
+// no longer a stale value to restore to.
+function getPreAdapterProviderPath() {
+  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.pre-adapter-provider');
+}
+
+function loadPreAdapterProvider() {
+  try {
+    const p = getPreAdapterProviderPath();
+    if (!fs.existsSync(p)) return null;
+    const value = fs.readFileSync(p, 'utf8').trim();
+    return value || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function savePreAdapterProvider(provider) {
+  try {
+    const p = getPreAdapterProviderPath();
+    if (!fs.existsSync(path.dirname(p))) fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, String(provider || ''));
+  } catch (e) {
+    sendDebugLog(`savePreAdapterProvider failed: ${e.message}`);
+  }
+}
+
+function clearPreAdapterProvider() {
+  try {
+    const p = getPreAdapterProviderPath();
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  } catch (_) {}
+}
+
+// Auto-switch helpers wired into the org sign-in / sign-out flow so a
+// user doesn't have to paste an Anthropic key in Settings > AI just to
+// summarise — the adapter brokers AI for them once they're signed in.
+// Switches from ANY non-adapter provider (local / remote / cloud) on
+// sign-in; remembers the previous choice so sign-out restores it. The
+// customer's ask was zero-config for org users, which means even users
+// already on 'cloud' (because they had no other option at the time)
+// shouldn't have to manually toggle to take advantage of the adapter.
+async function autoSwitchToAdapterOnSignIn() {
+  const current = await readAiProvider();
+  if (current === 'adapter') return;
+  sendDebugLog(`Org sign-in: switching ai_provider from ${current} to adapter (will restore ${current} on sign-out)`);
+  savePreAdapterProvider(current);
+  try {
+    await runPythonScript('simple_recorder.py', ['set-ai-provider', 'adapter']);
+  } catch (e) {
+    sendDebugLog(`auto-switch to adapter failed: ${e.message}`);
+    clearPreAdapterProvider(); // don't leave a stale marker if the switch never landed
+  }
+}
+
+// On sign-out (or stale-session clear), restore the pre-adapter provider
+// if we still have it. Falls back to 'local' if the marker is missing
+// (e.g. user manually switched to adapter without coming via auto-switch).
+async function restorePreAdapterProvider() {
+  const current = await readAiProvider();
+  if (current !== 'adapter') {
+    clearPreAdapterProvider(); // tidy: if not on adapter, the marker is stale
+    return;
+  }
+  const restored = loadPreAdapterProvider() || 'local';
+  sendDebugLog(`Org sign-out: restoring ai_provider from adapter to ${restored}`);
+  try {
+    await runPythonScript('simple_recorder.py', ['set-ai-provider', restored]);
+  } catch (e) {
+    sendDebugLog(`restore to ${restored} failed: ${e.message}`);
+  }
+  clearPreAdapterProvider();
+}
+
 ipcMain.handle('get-ai-provider', async () => {
   try {
     const result = await runPythonScript('simple_recorder.py', ['get-ai-provider'], true);
@@ -4391,6 +4497,11 @@ ipcMain.handle('get-ai-provider', async () => {
 ipcMain.handle('set-ai-provider', async (event, provider) => {
   try {
     sendDebugLog(`Setting AI provider to: ${provider}`);
+    // A manual switch away from 'adapter' invalidates the pre-adapter
+    // marker — without this, a user who auto-switched on sign-in and
+    // then manually moved to a different provider would still be
+    // restored to the stale "before adapter" value on sign-out.
+    if (provider !== 'adapter') clearPreAdapterProvider();
     const result = await runPythonScript('simple_recorder.py', ['set-ai-provider', provider]);
     const jsonMatch = result.match(/\{.*\}/s);
     if (jsonMatch) return JSON.parse(jsonMatch[0]);
@@ -6057,6 +6168,10 @@ ipcMain.handle('org-status', async () => {
   // exp claim here so the UI reflects truth at startup.
   if (isJwtExpired(session.token)) {
     clearOrgSession();
+    // If the user was on 'adapter', drop them back to 'local' so the next
+    // summary attempt doesn't error out with "adapter not configured".
+    // Same reasoning as the explicit-logout path; both end the session.
+    restorePreAdapterProvider().catch(() => {});
     return { signedIn: false, everSignedIn };
   }
   return {
@@ -6101,6 +6216,8 @@ ipcMain.handle('org-login', async (_event, payload) => {
     };
     if (!saveOrgSession(session)) return { success: false, error: 'failed to persist session' };
     markOrgKnown();
+    // Fire-and-forget — sign-in shouldn't wait on a config write.
+    autoSwitchToAdapterOnSignIn().catch(() => {});
     return {
       success: true,
       signedIn: true,
@@ -6116,6 +6233,10 @@ ipcMain.handle('org-login', async (_event, payload) => {
 
 ipcMain.handle('org-logout', async () => {
   clearOrgSession();
+  // Roll back the AI provider to 'local' if the user was on 'adapter';
+  // without this, the next summary attempt errors because the env vars
+  // are no longer populated and the Python summariser raises.
+  restorePreAdapterProvider().catch(() => {});
   return { success: true };
 });
 
@@ -6283,6 +6404,8 @@ ipcMain.handle('org-sso-google-start', async (_event, payload) => {
     };
     if (!saveOrgSession(session)) return { success: false, error: 'failed to persist session' };
     markOrgKnown();
+    // Fire-and-forget — sign-in shouldn't wait on a config write.
+    autoSwitchToAdapterOnSignIn().catch(() => {});
     return {
       success: true,
       signedIn: true,

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -235,7 +235,7 @@ export type MicPermissionStatus =
   | 'not-determined'
   | 'unknown';
 
-export type AiProvider = 'local' | 'remote' | 'cloud';
+export type AiProvider = 'local' | 'remote' | 'cloud' | 'adapter';
 export type CloudProvider = 'openai' | 'anthropic' | 'custom';
 
 // ---------- response envelopes ----------

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -51,10 +51,13 @@ export function Chat() {
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const isCloud = provider.data?.ai_provider === 'cloud';
+  const isAdapter = provider.data?.ai_provider === 'adapter';
   const cloudKeySet = provider.data?.cloud_api_key_set ?? false;
   // Org chat goes through the adapter's central key, so it doesn't need
-  // the local cloud provider configured.
-  const localReady = isCloud && cloudKeySet;
+  // the local cloud provider configured. Adapter mode also works — the
+  // adapter brokers a cloud model server-side, fitting the same
+  // "remote-hosted model" requirement that cross-note chat needs.
+  const localReady = (isCloud && cloudKeySet) || isAdapter;
   const orgScopeActive = scopeFolderId === ORG_SHARED_SCOPE;
   const ready = localReady || orgScopeActive;
 
@@ -400,8 +403,8 @@ function CloudRequiredBanner() {
     >
       <Sparkles className="mt-0.5 size-[14px] flex-shrink-0" style={{ color: 'var(--fg-2)' }} />
       <div className="flex-1">
-        Cross-note chat needs a cloud AI provider — local models can't fit a
-        full-corpus prompt yet. Switch to OpenAI or Anthropic in{' '}
+        Cross-note chat needs a remote-hosted model — local models can't fit
+        a full-corpus prompt yet. Switch to Cloud API or your Organisation in{' '}
         <button
           type="button"
           className="underline transition-colors hover:text-[color:var(--fg-1)]"

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -57,7 +57,12 @@ export function Chat() {
   // the local cloud provider configured. Adapter mode also works — the
   // adapter brokers a cloud model server-side, fitting the same
   // "remote-hosted model" requirement that cross-note chat needs.
-  const localReady = (isCloud && cloudKeySet) || isAdapter;
+  // Critically: adapter mode is only "ready" when the org session is
+  // actually signed in. Without this, a user on ai_provider=adapter but
+  // signed out (e.g. session expired mid-app, restore not yet run) sees
+  // the chat input enabled and gets an opaque failure on submit.
+  const orgSignedIn = orgSession.data?.signedIn === true;
+  const localReady = (isCloud && cloudKeySet) || (isAdapter && orgSignedIn);
   const orgScopeActive = scopeFolderId === ORG_SHARED_SCOPE;
   const ready = localReady || orgScopeActive;
 

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -824,7 +824,9 @@ function TranscriptionTab() {
 function AiTab() {
   const provider = useAiProvider();
   const setProvider = useSetAiProvider();
+  const orgSession = useOrgSession();
   const current = provider.data?.ai_provider ?? 'local';
+  const orgSignedIn = orgSession.data?.signedIn ?? false;
 
   return (
     <section data-settings-tab="ai">
@@ -859,20 +861,59 @@ function AiTab() {
             >
               Cloud API
             </SelectItem>
+            <SelectItem
+              value="adapter"
+              disabled={!orgSignedIn}
+              description={
+                orgSignedIn
+                  ? "Uses your organisation's AI key. No setup needed."
+                  : 'Sign in to your organisation to enable this option.'
+              }
+            >
+              Organisation
+            </SelectItem>
           </SelectContent>
         </Select>
       </SettingRow>
 
       {current === 'remote' && <RemoteProviderConfig />}
       {current === 'cloud' && <CloudProviderConfig />}
+      {current === 'adapter' && <AdapterProviderInfo signedIn={orgSignedIn} />}
 
-      {current !== 'cloud' && (
+      {current !== 'cloud' && current !== 'adapter' && (
         <>
           <SectionHeading>Model</SectionHeading>
           <ModelList />
         </>
       )}
     </section>
+  );
+}
+
+/** Adapter mode has no per-user configuration — the customer's IT
+ *  controls the model + API key on the adapter side. This block just
+ *  reassures the user it's working (or warns them if their session has
+ *  lapsed, in which case summarisation would fall back to an error). */
+function AdapterProviderInfo({ signedIn }: { signedIn: boolean }) {
+  return (
+    <div
+      className="space-y-2 py-4 text-[12px]"
+      style={{ borderBottom: '1px solid var(--border-subtle)', color: 'var(--fg-2)' }}
+    >
+      {signedIn ? (
+        <p>
+          Summaries, titles, and chat are routed through your organisation's
+          adapter. The model and API key are configured by your organisation
+          — no setup needed here.
+        </p>
+      ) : (
+        <p style={{ color: 'var(--accent-danger, var(--fg-1))' }}>
+          You are not signed in to an organisation. Sign in under{' '}
+          <strong>Settings &gt; Organisation</strong>, or switch this provider
+          back to Local / Private Server / Cloud API.
+        </p>
+      )}
+    </div>
   );
 }
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1895,17 +1895,22 @@ def chat_global_streaming(question, folder):
     context to the cloud LLM, stream the answer. Optionally scope to a single
     folder; default queries every note.
 
-    Cloud-only. Local models can't fit a full corpus of summaries reliably,
-    and we don't have retrieval (RAG) yet — caller (main.js) is responsible
-    for gating this on ai_provider === 'cloud'."""
+    Requires a remote-hosted model — either a direct cloud API key OR a
+    signed-in organisation adapter that brokers one. Local models can't fit
+    a full corpus of summaries reliably and we don't have retrieval (RAG)
+    yet — caller (main.js) is responsible for gating accordingly."""
     import sys
     import base64
     from pathlib import Path
     from src.config import get_config, get_data_dirs
 
     config = get_config()
-    if config.get_ai_provider() != "cloud":
-        print("CHAT_STREAM_ERROR:Cross-note chat requires a cloud AI provider. Switch in Settings → AI.", flush=True)
+    if config.get_ai_provider() not in ("cloud", "adapter"):
+        print(
+            "CHAT_STREAM_ERROR:Cross-note chat needs a cloud or organisation AI provider. "
+            "Switch in Settings → AI.",
+            flush=True,
+        )
         return
 
     dirs = get_data_dirs()

--- a/src/config.py
+++ b/src/config.py
@@ -474,11 +474,15 @@ class Config:
 
     # --- AI provider settings ---
 
-    VALID_AI_PROVIDERS = ("local", "remote", "cloud")
+    VALID_AI_PROVIDERS = ("local", "remote", "cloud", "adapter")
     VALID_CLOUD_PROVIDERS = ("openai", "anthropic", "custom")
 
     def get_ai_provider(self) -> str:
-        """Get the configured AI provider ('local', 'remote', or 'cloud')."""
+        """Get the configured AI provider ('local', 'remote', 'cloud', or
+        'adapter'). 'adapter' routes AI requests through a signed-in org's
+        adapter so the desktop never sees the provider key — see
+        get_adapter_url / get_adapter_token below for how the desktop's
+        Electron main passes the session into the Python subprocess."""
         value = self._config.get("ai_provider", "local")
         return value if value in self.VALID_AI_PROVIDERS else "local"
 
@@ -512,6 +516,19 @@ class Config:
         """Get the cloud API key from env var (set by Electron via safeStorage)."""
         import os
         return os.environ.get("STENOAI_CLOUD_API_KEY", "")
+
+    def get_adapter_url(self) -> str:
+        """Get the org adapter base URL (set by Electron when a session is
+        active). The summariser uses this when ai_provider == 'adapter' to
+        route AI requests through the customer's adapter instead of touching
+        a provider key directly."""
+        import os
+        return os.environ.get("STENOAI_ADAPTER_URL", "").rstrip("/")
+
+    def get_adapter_token(self) -> str:
+        """Get the org adapter JWT (set by Electron from the persisted session)."""
+        import os
+        return os.environ.get("STENOAI_ADAPTER_TOKEN", "")
 
     # Per-provider sensible defaults. Used when the user switches provider for
     # the first time and we have no remembered model for that provider yet.

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -403,7 +403,7 @@ class OllamaSummarizer:
                     raise
         raise RuntimeError("Adapter chat failed after all retries")
 
-    def _adapter_stream(self, prompt: str, timeout_seconds: int = 7200):
+    def _adapter_stream(self, prompt: str, timeout_seconds: int = 600):
         """Streaming AI request via the adapter's /ai/chat/stream endpoint.
 
         The adapter emits NDJSON — one JSON object per line:
@@ -863,7 +863,10 @@ TRANSCRIPT:
         logger.info(f"Starting streaming summary with {self.ai_provider} model: {self.model_name}")
 
         if self.ai_provider == "adapter":
-            yield from self._adapter_stream(prompt)
+            # Summarisation can legitimately take a long time for a long
+            # meeting; match the dynamic-timeout ceiling summarize_transcript
+            # already uses (2h).
+            yield from self._adapter_stream(prompt, timeout_seconds=7200)
             return
 
         if self.ai_provider == "cloud":
@@ -1105,7 +1108,10 @@ ANSWER:"""
 
         try:
             if self.ai_provider == "adapter":
-                yield from self._adapter_stream(prompt)
+                # Interactive query — user is waiting at the AskBar. Fail
+                # fast on a stalled connection rather than letting it hang
+                # for the summarisation-grade ceiling.
+                yield from self._adapter_stream(prompt, timeout_seconds=300)
                 return
             if self.ai_provider == "cloud":
                 if self.cloud_provider == "anthropic":

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -349,7 +349,7 @@ class OllamaSummarizer:
                     raise
         raise RuntimeError("OpenAI chat failed after all retries")
 
-    def _adapter_chat(self, prompt: str, timeout_seconds: int = 300) -> str:
+    def _adapter_chat(self, prompt: str, timeout_seconds: int = 7200) -> str:
         """One-shot AI request via the org adapter's /ai/chat endpoint.
 
         The adapter wraps Anthropic so the request/response shape mirrors
@@ -403,7 +403,7 @@ class OllamaSummarizer:
                     raise
         raise RuntimeError("Adapter chat failed after all retries")
 
-    def _adapter_stream(self, prompt: str, timeout_seconds: int = 300):
+    def _adapter_stream(self, prompt: str, timeout_seconds: int = 7200):
         """Streaming AI request via the adapter's /ai/chat/stream endpoint.
 
         The adapter emits NDJSON — one JSON object per line:

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -36,7 +36,26 @@ class OllamaSummarizer:
         self.ollama_process = None
         self.remote_url = config.get_remote_ollama_url()
 
-        if self.ai_provider == "cloud":
+        if self.ai_provider == "adapter":
+            # Adapter mode: route every AI request through the customer's
+            # org adapter, which holds the Anthropic key server-side. The
+            # desktop never sees the provider key. URL + JWT come from
+            # env vars set by Electron when a session is active.
+            self.adapter_url = config.get_adapter_url()
+            self.adapter_token = config.get_adapter_token()
+            # Model name is informational — the adapter is configured with
+            # its own DEFAULT_MODEL and we omit `model` from the request
+            # body so the customer's org-wide choice wins. Keep a label
+            # for logs.
+            self.model_name = model_name or "adapter (org)"
+            if not self.adapter_url or not self.adapter_token:
+                raise ValueError(
+                    "Organisation adapter is not configured. Sign in to your "
+                    "organisation in Settings > Organisation, then re-try."
+                )
+            logger.info(f"Adapter provider initialized: url={self.adapter_url}")
+
+        elif self.ai_provider == "cloud":
             # Cloud mode: use OpenAI-compatible or Anthropic API
             cloud_api_key = config.get_cloud_api_key()
             self.cloud_provider = config.get_cloud_provider()
@@ -330,6 +349,116 @@ class OllamaSummarizer:
                     raise
         raise RuntimeError("OpenAI chat failed after all retries")
 
+    def _adapter_chat(self, prompt: str, timeout_seconds: int = 300) -> str:
+        """One-shot AI request via the org adapter's /ai/chat endpoint.
+
+        The adapter wraps Anthropic so the request/response shape mirrors
+        the Anthropic Messages API: send {messages, system?, model?,
+        max_tokens?}, receive {reply, model, input_tokens, output_tokens}.
+        Same 3-retry pattern as _anthropic_chat — auth failures (401)
+        won't recover so we surface them immediately.
+        """
+        import urllib.request
+        import urllib.error
+        import json as _json
+
+        url = f"{self.adapter_url}/ai/chat"
+        # max_tokens is capped at 4096 on the adapter side. Long summaries
+        # may need that bumped on stenoai-enterprise; until then we max it.
+        payload = _json.dumps({
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 8192,
+        }).encode("utf-8")
+        headers = {
+            "content-type": "application/json",
+            "authorization": f"Bearer {self.adapter_token}",
+        }
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                if attempt > 0:
+                    logger.info(f"Adapter API retry attempt {attempt + 1}/{max_retries}")
+                    time.sleep(5)
+                req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+                with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:
+                    body = _json.loads(resp.read().decode("utf-8"))
+                return (body.get("reply") or "").strip()
+            except urllib.error.HTTPError as e:
+                # 401/403 won't fix themselves — abort retry loop early so
+                # the user sees the auth error rather than waiting through
+                # three pointless backoffs.
+                if e.code in (401, 403):
+                    raise RuntimeError(
+                        f"Org adapter rejected the request ({e.code}). "
+                        "Your session may have expired — re-sign in to your "
+                        "organisation in Settings."
+                    )
+                logger.error(f"Adapter API attempt {attempt + 1} failed: HTTP {e.code}")
+                if attempt == max_retries - 1:
+                    raise
+            except Exception as e:
+                logger.error(f"Adapter API attempt {attempt + 1} failed: {e}")
+                if attempt == max_retries - 1:
+                    raise
+        raise RuntimeError("Adapter chat failed after all retries")
+
+    def _adapter_stream(self, prompt: str, timeout_seconds: int = 300):
+        """Streaming AI request via the adapter's /ai/chat/stream endpoint.
+
+        The adapter emits NDJSON — one JSON object per line:
+            {"type": "chunk", "text": "..."}
+            ...
+            {"type": "done",  "model": "...", "input_tokens": N, "output_tokens": M}
+            or {"type": "error", "error": "..."} on failure.
+        Yields the text portion of each chunk record. Errors are logged
+        and the generator returns silently — matches the streaming-error
+        behaviour of the cloud and ollama paths.
+        """
+        import urllib.request
+        import urllib.error
+        import json as _json
+
+        url = f"{self.adapter_url}/ai/chat/stream"
+        payload = _json.dumps({
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 8192,
+        }).encode("utf-8")
+        headers = {
+            "content-type": "application/json",
+            "authorization": f"Bearer {self.adapter_token}",
+        }
+
+        try:
+            req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:
+                for raw_line in resp:
+                    line = raw_line.decode("utf-8", errors="replace").strip()
+                    if not line:
+                        continue
+                    try:
+                        record = _json.loads(line)
+                    except _json.JSONDecodeError:
+                        logger.warning(f"Adapter stream: malformed NDJSON line dropped: {line[:120]}")
+                        continue
+                    kind = record.get("type")
+                    if kind == "chunk":
+                        text = record.get("text") or ""
+                        if text:
+                            yield text
+                    elif kind == "error":
+                        logger.error(f"Adapter stream error: {record.get('error')}")
+                        return
+                    elif kind == "done":
+                        return
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                logger.error("Adapter stream rejected: session expired or unauthorized")
+            else:
+                logger.error(f"Adapter streaming failed: HTTP {e.code}")
+        except Exception as e:
+            logger.error(f"Adapter streaming failed: {e}")
+
     def _anthropic_chat(self, prompt: str, timeout_seconds: int = 300) -> str:
         """Send a chat request via the Anthropic Messages API."""
         max_retries = 3
@@ -341,7 +470,7 @@ class OllamaSummarizer:
 
                 response = self.anthropic_client.messages.create(
                     model=self.model_name,
-                    max_tokens=4096,
+                    max_tokens=8192,
                     messages=[{"role": "user", "content": prompt}],
                     timeout=timeout_seconds,
                 )
@@ -508,7 +637,9 @@ Return ONLY the response in this exact JSON format:
             timeout_seconds = min(base_timeout + extra_timeout, 7200)  # Cap at 2 hours
             logger.info(f"Using timeout: {timeout_seconds} seconds ({timeout_seconds // 60} minutes)")
 
-            if self.ai_provider == "cloud":
+            if self.ai_provider == "adapter":
+                response_text = self._adapter_chat(prompt, timeout_seconds)
+            elif self.ai_provider == "cloud":
                 response_text = self._cloud_chat(prompt, timeout_seconds)
             else:
                 # Retry logic for Ollama API calls (local or remote)
@@ -731,12 +862,16 @@ TRANSCRIPT:
         prompt = self._create_markdown_prompt(transcript, language, notes)
         logger.info(f"Starting streaming summary with {self.ai_provider} model: {self.model_name}")
 
+        if self.ai_provider == "adapter":
+            yield from self._adapter_stream(prompt)
+            return
+
         if self.ai_provider == "cloud":
             if self.cloud_provider == "anthropic":
                 try:
                     with self.anthropic_client.messages.stream(
                         model=self.model_name,
-                        max_tokens=4096,
+                        max_tokens=8192,
                         messages=[{"role": "user", "content": prompt}],
                     ) as stream:
                         for text in stream.text_stream:
@@ -901,7 +1036,9 @@ TITLE:"""
 
             logger.info("Generating meeting title from summary")
 
-            if self.ai_provider == "cloud":
+            if self.ai_provider == "adapter":
+                response_text = self._adapter_chat(prompt, 30)
+            elif self.ai_provider == "cloud":
                 response_text = self._cloud_chat(prompt, 30)
             else:
                 # HTTP-level timeout must account for model cold-start (~10s Metal init)
@@ -967,6 +1104,9 @@ ANSWER:"""
         prompt = self._build_query_prompt(transcript, question, language)
 
         try:
+            if self.ai_provider == "adapter":
+                yield from self._adapter_stream(prompt)
+                return
             if self.ai_provider == "cloud":
                 if self.cloud_provider == "anthropic":
                     with self.anthropic_client.messages.stream(
@@ -1032,7 +1172,9 @@ ANSWER:"""
 
             logger.info(f"Querying transcript with question: {question[:50]}...")
 
-            if self.ai_provider == "cloud":
+            if self.ai_provider == "adapter":
+                response_text = self._adapter_chat(prompt, 120)
+            elif self.ai_provider == "cloud":
                 response_text = self._cloud_chat(prompt, 120)
             else:
                 # Retry logic for Ollama API calls (local or remote)


### PR DESCRIPTION
## Summary
Addresses the customer feedback:

> Right now the user has to go to Settings/AI, select AI provider Cloud API, and add the Anthropic key. Giving users that key is a bit painful.

When a user signs in to their org, the desktop now routes every AI request (summary, title generation, transcript queries, cross-note chat) through the adapter's existing `/ai/chat` + `/ai/chat/stream` endpoints. The adapter holds the Anthropic key server-side; the desktop never needs to see it.

## Pairs with
**[stenoai-enterprise PR #6](https://github.com/ruzin/stenoai-enterprise/pull/6)** — bumps the adapter's `max_tokens` validator cap from 4096 to 8192 so the summariser's full output budget is honoured. **Merge that first**; this PR sends `max_tokens: 8192` and would 422 against the un-updated adapter.

## What's new

### Backend (Python)
- `src/config.py` — `'adapter'` added to `VALID_AI_PROVIDERS`; `get_adapter_url()` / `get_adapter_token()` helpers reading `STENOAI_ADAPTER_URL` / `STENOAI_ADAPTER_TOKEN` env vars (set by Electron when a session is active).
- `src/summarizer.py` — `_adapter_chat(prompt, timeout)` (one-shot JSON POST → `/ai/chat`) and `_adapter_stream(prompt, timeout)` (NDJSON POST → `/ai/chat/stream`, parses `{type:"chunk"/"done"/"error"}`). Adapter branches wired into every AI method: `summarize_transcript`, `summarize_transcript_streaming`, `generate_title`, `query_transcript`, `query_transcript_streaming`.
- `simple_recorder.py` `chat-global-streaming` gate now allows `'cloud' or 'adapter'`.

### Electron main
- `app/main.js` — `getAiEnv()` builds the env additions a Python subprocess needs: `STENOAI_CLOUD_API_KEY` if a cloud key is configured, plus `STENOAI_ADAPTER_URL` + `STENOAI_ADAPTER_TOKEN` when a session is active and the JWT is still valid. Threaded through every existing `STENOAI_CLOUD_API_KEY` pass site (10 of them).

### Auto-switch on sign-in / restore on sign-out
- On successful org sign-in (password or Google SSO), the desktop remembers the user's previous `ai_provider` in a marker file (`~/Library/Application Support/stenoai/.pre-adapter-provider`), then flips to `'adapter'`.
- On sign-out (or JWT expiry detected in `org-status`), the marker is read and the previous provider is restored. A user on `'cloud'` before sign-in goes back to `'cloud'` — not silently downgraded to `'local'`.
- A manual switch away from `'adapter'` via Settings clears the marker, so a later sign-out doesn't restore a stale prior value.
- Auto-switch only fires from sign-in events. A user manually picking (say) `'cloud'` while signed in has their choice respected — no auto-toggle on subsequent refetches.

### Renderer UI
- `app/renderer/src/lib/ipc.ts` — `AiProvider` type extended with `'adapter'`.
- `app/renderer/src/routes/Settings.tsx` — new "Organisation" radio option in the AI provider Select. Disabled and labelled with "Sign in to your organisation to enable this option" when not signed in. Model selector hidden in adapter mode (`AdapterProviderInfo` block explains the model is configured by the org).
- `app/renderer/src/routes/Chat.tsx` — cross-note chat readiness gate now accepts `'cloud'` OR `'adapter'`. Banner copy updated: "Cloud API or your Organisation in Settings → AI".

## Limits / future work
- `max_tokens` is now 8192 (Anthropic Sonnet 4.x natural ceiling without extended thinking). Anything longer needs an adapter-side bump.
- The desktop sends no `model` field in adapter requests — the customer's adapter `DEFAULT_MODEL` wins, which is the point (org picks the model org-wide).
- The auto-switch is conservative: only fires on the sign-in event itself. If we ever want to nudge users mid-session (e.g. "your org now has an adapter, switch to it?"), that'd be a separate banner / toast.

## Test plan
- [x] Python smoke tests pass (`python -m unittest discover tests` — 46/46)
- [x] Renderer typecheck passes (`npm run typecheck:renderer`)
- [x] Sign in to org with `ai_provider=cloud` → marker saved, provider flips to `adapter`, Settings → AI reflects "Organisation"
- [x] Record + process a meeting → adapter receives `POST /ai/chat/stream` (summary) + `POST /ai/chat` (title); no Cloud API key needed locally
- [x] Cross-note chat works under adapter (no "needs cloud provider" banner)
- [x] Sign out → provider restored from marker to `cloud`
- [x] Manual switch from adapter → cloud while signed in, then sign out → no surprise revert
- [x] After enterprise PR #6 deploys: confirm long summaries no longer truncate at the 4096 cap

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all summaries, titles, transcript queries, and cross‑note chat through the organisation adapter when the user is signed in. This removes local key setup and keeps keys server-side; pairs with `stenoai-enterprise` PR #6 to allow `max_tokens: 8192`.

- **New Features**
  - Added `ai_provider: 'adapter'` with auto-switch on org sign-in and restore on sign-out/JWT expiry; manual switches are respected.
  - Python: adapter paths (`/ai/chat`, `/ai/chat/stream`) with retries/streaming; wired into summarize, title, and query; `max_tokens: 8192`; no `model` sent so the org’s default applies.
  - Electron: `getAiEnv()` passes `STENOAI_CLOUD_API_KEY` and/or `STENOAI_ADAPTER_URL` + `STENOAI_ADAPTER_TOKEN` to all subprocesses.
  - UI: Settings adds an “Organisation” provider and an adapter info block; model picker hidden in adapter mode; chat banner updated; cross‑note chat allowed in adapter mode.

- **Bug Fixes**
  - Per-call-site adapter streaming timeouts: 7200s for summarisation; 300s for transcript queries; default lowered to 600s.
  - org-logout now awaits provider restore to prevent transient “adapter not configured” errors.
  - Cross‑note chat only enables in adapter mode when the org session is actually signed in.

<sup>Written for commit d4b74d5f94db533db295490a7c469dbadd75930a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

