### PR TITLE
fix(ai): invalidate ai-provider cache on org sign-in / sign-out

### DIFF
--- a/app/renderer/src/hooks/useOrg.ts
+++ b/app/renderer/src/hooks/useOrg.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ipc } from '@/lib/ipc';
 import { unwrap } from '@/lib/result';
+import { aiKeys } from './useAi';
 import type {
   OrgCreateMeetingPayload,
   OrgChatPayload,
@@ -52,6 +53,17 @@ export function useOrgSession() {
   return query;
 }
 
+// Sign-in / sign-out auto-switches the Python-side ai_provider (between
+// 'adapter' and the user's previous choice), so the renderer's
+// useAiProvider query needs to refetch — otherwise Settings > AI keeps
+// showing stale "adapter" copy after a sign-out, or "local" after a
+// sign-in. Invalidating both query namespaces on every org auth
+// transition keeps the renderer aligned with main's state.
+function invalidateOrgAndAi(qc: ReturnType<typeof useQueryClient>) {
+  qc.invalidateQueries({ queryKey: orgKeys.all });
+  qc.invalidateQueries({ queryKey: aiKeys.all });
+}
+
 export function useOrgLogin() {
   const qc = useQueryClient();
   return useMutation({
@@ -60,7 +72,7 @@ export function useOrgLogin() {
       email: string;
       password: string;
     }) => unwrap(await ipc().org.login(args.adapterUrl, args.email, args.password)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: orgKeys.all }),
+    onSuccess: () => invalidateOrgAndAi(qc),
   });
 }
 
@@ -73,7 +85,7 @@ export function useOrgSsoGoogle() {
   return useMutation({
     mutationFn: async (adapterUrl: string) =>
       unwrap(await ipc().org.ssoGoogleStart(adapterUrl)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: orgKeys.all }),
+    onSuccess: () => invalidateOrgAndAi(qc),
   });
 }
 
@@ -81,7 +93,7 @@ export function useOrgLogout() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => ipc().org.logout(),
-    onSuccess: () => qc.invalidateQueries({ queryKey: orgKeys.all }),
+    onSuccess: () => invalidateOrgAndAi(qc),
   });
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #131. The auto-switch between `ai_provider=adapter` and the user's previous choice was working at the backend level — Python config got updated correctly — but the renderer's `useAiProvider` query lives under `aiKeys` and wasn't being invalidated by the org auth mutations. Result: Settings > AI kept showing stale "Organisation" copy after sign-out even though the backend was already on `local`.

## Repro
1. Sign in to org from a starting state of `ai_provider=local`. Auto-switch fires → backend on `adapter`, Settings reflects it.
2. Sign out. Backend auto-restores to `local`. **Settings still shows "Organisation"** until you Cmd+R or wait for staleTime to expire.

## Fix
Add `aiKeys.all` to the invalidation set for `useOrgLogin`, `useOrgSsoGoogle`, and `useOrgLogout`. Extracted to a small `invalidateOrgAndAi` helper so the three mutations don't drift.

## No backend change
Backend logic from #131 was correct — only the renderer cache invalidation was missing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale AI provider in Settings by invalidating the renderer cache on org sign-in and sign-out. The UI now matches backend switches between `adapter` and `local` without needing a refresh.

- **Bug Fixes**
  - Invalidate `aiKeys.all` alongside `orgKeys.all` in `useOrgLogin`, `useOrgSsoGoogle`, and `useOrgLogout`.
  - Added `invalidateOrgAndAi(qc)` to keep cache invalidation consistent across org auth transitions.

<sup>Written for commit d5b7018c3ef3f384a8380066789931e4eba832a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

