### PR TITLE
fix: adapter SSL trust store + remove flaky Calendar section

### DIFF
--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -20,7 +20,6 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { MeetingsShell } from '@/components/MeetingsShell';
-import { Chip } from '@/components/ui/chip';
 import {
   Select,
   SelectContent,
@@ -50,9 +49,8 @@ import {
   useRemoveMeetingFromFolder,
   useCreateFolder,
 } from '@/hooks/useFolders';
-import { useCalendarEvents } from '@/hooks/useCalendarEvents';
 import { useActiveMeeting } from '@/lib/askBarContext';
-import { ipc, type CalendarEvent, type Meeting } from '@/lib/ipc';
+import { ipc, type Meeting } from '@/lib/ipc';
 import { unwrap } from '@/lib/result';
 import { cn } from '@/lib/utils';
 import { navigate } from '@/lib/router';
@@ -553,7 +551,6 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
             </section>
           )}
 
-          <CalendarSection meeting={meeting} />
         </div>
       )}
 
@@ -840,66 +837,6 @@ function StreamingView({ text, phase }: { text: string; phase: StreamPhase }) {
 }
 
 // ---------------------------------------------------------------------------
-// Calendar section (related events for a meeting)
-// ---------------------------------------------------------------------------
-
-function CalendarSection({ meeting }: { meeting: Meeting }) {
-  const calendar = useCalendarEvents();
-  const state = calendar.data;
-
-  if (calendar.isLoading || !state || state.needsAuth) return null;
-
-  const related = findRelatedEvents(state.events, meeting);
-  if (related.length === 0) return null;
-
-  return (
-    <section className="flex flex-col gap-3">
-      <SectionTitle>Calendar</SectionTitle>
-      <ul className="space-y-3">
-        {related.map((event) => (
-          <li
-            key={event.id}
-            className="rounded-md border p-4"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              background: 'var(--surface-raised)',
-            }}
-          >
-            <div className="flex items-start gap-3">
-              <CalendarIcon
-                className="mt-0.5 size-4 flex-shrink-0"
-                style={{ color: 'var(--fg-2)' }}
-              />
-              <div className="flex-1 space-y-1">
-                <div className="font-medium" style={{ color: 'var(--fg-1)' }}>{event.title}</div>
-                <div className="text-xs" style={{ color: 'var(--fg-2)' }}>
-                  {formatEventTime(event)}
-                </div>
-                {event.location && (
-                  <div className="text-xs" style={{ color: 'var(--fg-2)' }}>{event.location}</div>
-                )}
-                {event.attendees && event.attendees.length > 0 && (
-                  <div className="mt-2 flex flex-wrap gap-1">
-                    {event.attendees.slice(0, 6).map((a, i) => (
-                      <Chip key={i} variant="muted">
-                        {a.name ?? a.email}
-                      </Chip>
-                    ))}
-                    {event.attendees.length > 6 && (
-                      <Chip variant="muted">+{event.attendees.length - 6}</Chip>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Folder picker (meeting → folder assignment via the chip dropdown)
 // ---------------------------------------------------------------------------
 
@@ -1066,39 +1003,6 @@ function formatDuration(seconds?: number): string | undefined {
   if (h > 0) return `${h}h ${m}m`;
   if (m > 0) return `${m}m`;
   return `${s}s`;
-}
-
-function formatEventTime(event: CalendarEvent): string {
-  try {
-    const start = new Date(event.start);
-    const end = new Date(event.end);
-    const sameDay =
-      start.getFullYear() === end.getFullYear() &&
-      start.getMonth() === end.getMonth() &&
-      start.getDate() === end.getDate();
-    const dateFmt: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
-    const timeFmt: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' };
-    if (sameDay) {
-      return `${start.toLocaleDateString(undefined, dateFmt)} · ${start.toLocaleTimeString(undefined, timeFmt)} – ${end.toLocaleTimeString(undefined, timeFmt)}`;
-    }
-    return `${start.toLocaleString(undefined, { ...dateFmt, ...timeFmt })} – ${end.toLocaleString(undefined, { ...dateFmt, ...timeFmt })}`;
-  } catch {
-    return event.start;
-  }
-}
-
-function findRelatedEvents(events: CalendarEvent[], meeting: Meeting): CalendarEvent[] {
-  const processedAt = meeting.session_info.processed_at;
-  if (!processedAt) return [];
-  const processed = new Date(processedAt).getTime();
-  if (Number.isNaN(processed)) return [];
-  const windowMs = 4 * 60 * 60 * 1000;
-  return events.filter((e) => {
-    const start = new Date(e.start).getTime();
-    const end = new Date(e.end).getTime();
-    if (Number.isNaN(start) || Number.isNaN(end)) return false;
-    return Math.abs(start - processed) <= windowMs || (processed >= start && processed <= end);
-  });
 }
 
 function asStringArray(value: unknown): string[] {

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -26,6 +26,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+# Wire stdlib SSL up to certifi's CA bundle before anything tries to make
+# an HTTPS call. PyInstaller's compiled-in cert paths don't exist on a
+# customer's Mac, so without this the adapter request in summarizer.py
+# fails with CERTIFICATE_VERIFY_FAILED.
+from src import tls_bootstrap  # noqa: F401
+
 # Import modules with graceful fallback for missing dependencies
 try:
     from src.audio_recorder import AudioRecorder
@@ -2953,6 +2959,35 @@ def pull_model(model_name):
         print(json.dumps({"success": True, "model": model_name}))
     except Exception as e:
         print(json.dumps({"success": False, "error": str(e)}))
+
+
+@cli.command(name='check-adapter')
+@click.argument('url')
+def check_adapter_cmd(url: str):
+    """Probe an adapter's /health over HTTPS using the bundle's stdlib SSL stack.
+
+    Diagnostic for the customer-side trust-store issue where the
+    PyInstaller bundle's compiled-in CA paths don't exist on the host.
+    Prints OK on a successful TLS handshake or the underlying SSL/HTTP
+    error so support can paste it into a ticket.
+    """
+    import urllib.request
+    import urllib.error
+
+    url = url.rstrip('/') + '/health'
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            body = resp.read().decode('utf-8', errors='replace')
+        print(f"OK {resp.status} {url}")
+        print(body)
+    except urllib.error.URLError as e:
+        print(f"FAIL {url}")
+        print(f"  reason: {e.reason}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"FAIL {url}")
+        print(f"  error: {e}")
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/src/tls_bootstrap.py
+++ b/src/tls_bootstrap.py
@@ -1,0 +1,32 @@
+"""Point Python's stdlib SSL at certifi's CA bundle.
+
+PyInstaller compiles `_ssl` with the build host's `OPENSSLDIR` baked in
+(usually a Homebrew path on a dev Mac). On a customer's clean Mac that
+path doesn't exist, so every HTTPS call from `urllib` / `http.client` —
+including the adapter requests in `summarizer.py` — fails with
+`[SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate`.
+
+Pointing `SSL_CERT_FILE` at certifi's bundle (which PyInstaller already
+ships as a data file under `_internal/certifi/cacert.pem`) makes stdlib
+SSL self-contained, so the desktop app works on any Mac without the
+user touching anything.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def configure() -> None:
+    try:
+        import certifi
+    except ImportError:
+        return
+    ca_file = certifi.where()
+    if not os.path.isfile(ca_file):
+        return
+    os.environ["SSL_CERT_FILE"] = ca_file
+    os.environ["REQUESTS_CA_BUNDLE"] = ca_file
+
+
+configure()

--- a/tests/test_tls_bootstrap.py
+++ b/tests/test_tls_bootstrap.py
@@ -1,0 +1,106 @@
+"""Regression test for the adapter SSL failure.
+
+The customer-side bug was that `urllib.request.urlopen` against
+`https://<org-adapter>/ai/chat` failed with
+`unable to get local issuer certificate`, because the PyInstaller bundle
+ships a `_ssl` module whose compiled-in `OPENSSLDIR` paths don't exist
+on the customer's Mac. `src.tls_bootstrap` is supposed to point stdlib
+SSL at certifi's bundle so the default `ssl.create_default_context()` —
+which is what `urlopen()` uses when called without an explicit context —
+trusts a real set of CAs.
+
+The asserts exercise that contract directly: simulate the customer's
+broken state by pointing the env at `/nonexistent`, run the bootstrap,
+build a default SSL context the same way `urlopen` does, and verify it
+ended up with certifi's authorities loaded.
+"""
+
+import importlib
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import certifi
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TlsBootstrapTests(unittest.TestCase):
+    def setUp(self):
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE")
+        }
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _reimport(self):
+        sys.modules.pop("src.tls_bootstrap", None)
+        return importlib.import_module("src.tls_bootstrap")
+
+    def test_configure_points_ssl_cert_file_at_certifi_bundle(self):
+        os.environ.pop("SSL_CERT_FILE", None)
+        os.environ.pop("REQUESTS_CA_BUNDLE", None)
+
+        self._reimport()
+
+        self.assertEqual(os.environ["SSL_CERT_FILE"], certifi.where())
+        self.assertEqual(os.environ["REQUESTS_CA_BUNDLE"], certifi.where())
+        self.assertTrue(os.path.isfile(os.environ["SSL_CERT_FILE"]))
+
+    def test_configure_overrides_a_broken_inherited_value(self):
+        # The customer's bundle effectively starts with a broken cert path
+        # (the compiled-in OPENSSLDIR). The bootstrap must replace it, not
+        # politely leave it alone — otherwise the fix does nothing for the
+        # exact users we're trying to help.
+        os.environ["SSL_CERT_FILE"] = "/nonexistent/cert.pem"
+        os.environ["REQUESTS_CA_BUNDLE"] = "/nonexistent/cert.pem"
+
+        self._reimport()
+
+        self.assertEqual(os.environ["SSL_CERT_FILE"], certifi.where())
+        self.assertEqual(os.environ["REQUESTS_CA_BUNDLE"], certifi.where())
+
+    def test_default_ssl_context_trusts_certifi_after_bootstrap(self):
+        # Run in a subprocess with SSL_CERT_FILE / DIR explicitly pointed
+        # at /nonexistent so any working trust store comes from the
+        # bootstrap rather than the dev machine's Homebrew CA bundle.
+        # Without the bootstrap this fails to load certs and the
+        # post-bootstrap context loads 100+ — that delta is the proof
+        # the customer's CERTIFICATE_VERIFY_FAILED can no longer happen.
+        env = {
+            **os.environ,
+            "SSL_CERT_FILE": "/nonexistent/cert.pem",
+            "SSL_CERT_DIR": "/nonexistent",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+        env.pop("REQUESTS_CA_BUNDLE", None)
+        script = (
+            "import ssl;"
+            "before = len(ssl.create_default_context().get_ca_certs());"
+            "import src.tls_bootstrap;"
+            "after = len(ssl.create_default_context().get_ca_certs());"
+            "print(before, after)"
+        )
+        out = subprocess.check_output(
+            [sys.executable, "-c", script],
+            env=env,
+            cwd=str(REPO_ROOT),
+            text=True,
+        ).strip()
+        before_str, after_str = out.split()
+        before, after = int(before_str), int(after_str)
+        self.assertEqual(before, 0, "expected the broken-env context to load zero CAs")
+        self.assertGreater(after, 100, "expected certifi's CAs to be loaded after bootstrap")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two unrelated bug fixes for the desktop app. Both surfaced from the same customer report (Joe — empty summaries, no auto-share, wrong calendar events on note pages). Easier to ship together since they touch the same area of the product.

Closes #125.

## Fix 1 — adapter HTTPS trust store (`9d4d33c`)

### Root cause
PyInstaller compiles `_ssl` with the build host's `OPENSSLDIR` baked in (usually a Homebrew path). On a customer's clean Mac that path doesn't exist, so every `urllib.request.urlopen` call from `src/summarizer.py` fails with `CERTIFICATE_VERIFY_FAILED unable to get local issuer certificate`. The bundle is effectively missing a trust store.

### Fix
`src/tls_bootstrap.py` points stdlib SSL at certifi's bundle (already shipped by PyInstaller as a data file via the `anthropic`/`openai`/`httpx` transitive deps — no new dependency, no spec change). Imported at the top of `simple_recorder.py` so it runs before any other module touches SSL. Unconditional — customers do not need to set any env var.

Also adds a `check-adapter <url>` CLI subcommand as a permanent diagnostic for future support tickets.

### Customer-visible impact
Symptoms from the client logs, all the same root cause:
- Empty meeting summaries (`Adapter streaming failed`)
- Missing meeting titles (falls back to filename — `Adapter API attempt 3 failed`)
- No S3 auto-share at all — gated in `app/main.js:6610-6654` (`org-try-auto-backup`) on title + non-empty body, and in `app/renderer/src/hooks/useRecording.ts:214` on `composeShareBody(meeting)` being non-empty. No summary → no body → renderer skips the IPC entirely.

### Why we didn't catch this in dev
The dev's Mac has the exact Homebrew CA paths the bundle's `_ssl` was compiled against, so the bundled Python silently falls back to a working trust store. On a clean customer Mac those paths are dead.

### Tests
**Unit (`tests/test_tls_bootstrap.py`, 3 cases — all pass):**
1. Bootstrap from a clean env sets `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` to `certifi.where()` and the file actually exists.
2. Bootstrap overrides a pre-existing broken value (proves it fixes the customer's exact compiled-in-`OPENSSLDIR` scenario rather than politely no-op-ing).
3. **The load-bearing one** — subprocess with `SSL_CERT_FILE=/nonexistent` (simulating the customer's broken state) shows `ssl.create_default_context()` loads **0** CAs before bootstrap and **100+** CAs after.

Full existing suite still green: 49 tests pass.

**End-to-end with the PyInstaller bundle:**
Built `dist/stenoai/` twice (with and without the fix) and ran `check-adapter https://github.com` under a simulated customer state (`SSL_CERT_FILE=/tmp/empty-ca.pem SSL_CERT_DIR=/tmp`):

| Scenario | Unfixed bundle | Fixed bundle |
|---|---|---|
| Dev Mac (real CA paths present) | `OK 200` | `OK 200` |
| Simulated customer state (empty CA bundle) | Crashes — `NO_CERTIFICATE_OR_CRL_FOUND` at httpx import | `OK 200` |

Same bundle binary, same broken environment — only difference is the bootstrap. Also verified `dist/stenoai/stenoai check-adapter http://localhost:8000` against the local enterprise adapter container returns the expected health payload.

## Fix 2 — remove unreliable Calendar section on meeting detail (`6e1b3dd`, closes #125)

### Root cause
`findRelatedEvents` in `MeetingDetail.tsx` matched calendar events to a meeting purely by time proximity, with a ±4h window centred on `processed_at` and an additional "is `processed_at` inside the event window" predicate. That second predicate had no upper bound on event duration — any year-long placeholder (recurring office hours, all-day blocks, multi-day off-sites) whose window happened to include `processed_at` got attached. Zero-duration Outlook focus blocks and auto-RSVP slots also slipped through.

### Fix
Ripped out the Calendar section entirely. The actual identifying match (calendar event → meeting title) already happens at recording-start time in `app/main.js` (`[auto-detect] matched calendar event ...`). The detail-page section was decorative — no attach/detach action, no link, just a list that was wrong more often than right.

Removes `CalendarSection`, `findRelatedEvents`, `formatEventTime`, and the now-unused `useCalendarEvents` / `CalendarEvent` / `Chip` imports inside `MeetingDetail.tsx`. The `useCalendarEvents` hook itself stays — `Home.tsx` and `Settings.tsx` still use it. Net: −97 lines / +1 line, no schema or backend changes.

### Verification
- `npm run typecheck:renderer` clean
- Diff is purely deletion of dead-end UI; streaming branch (`StreamingView`, `streamPhase`, the streaming reposition indicator at line 776) is in a different render branch and untouched

## Test plan
- [x] Pull the branch, `pyinstaller stenoai.spec --noconfirm`, run a recording against an org adapter — summary, title, and S3 auto-share should all populate.
- [x] `dist/stenoai/stenoai check-adapter https://<your-adapter>` against a clean macOS user — should return `OK 200` on `/health`.
- [x] Open Joe's note (or any note from a day with a long-running recurring calendar event) — Calendar block should be absent.
- [ ] Manual Share still works on legacy notes whose `org-backup-attempted` flag is set from the broken period (those need a fresh Share since `recordOrgBackupAttempt` was never written on the failed runs).