### PR TITLE
fix: allow new recording during processing + use "Note" as fallback title

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1120,11 +1120,11 @@ async function handleGetNotifications() {
 // IPC Handlers - Separate start/stop with better error handling
 ipcMain.handle('start-recording', async (event, sessionName) => {
   try {
-    sendDebugLog(`Starting recording session: ${sessionName || 'Meeting'}`);
+    sendDebugLog(`Starting recording session: ${sessionName || 'Note'}`);
     sendDebugLog('$ python simple_recorder.py start');
 
     // Start recording (removed clear-state to prevent race conditions)
-    const result = await runPythonScript('simple_recorder.py', ['start', sessionName || 'Meeting']);
+    const result = await runPythonScript('simple_recorder.py', ['start', sessionName || 'Note']);
 
     if (result.includes('SUCCESS')) {
       sendDebugLog('Recording started successfully');
@@ -2223,7 +2223,7 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
       return { success: false, error: 'Recording already in progress' };
     }
 
-    const actualSessionName = sessionName || 'Meeting';
+    const actualSessionName = sessionName || 'Note';
 
     // Renderer-driven dual-stream path: when system audio is enabled the
     // renderer (useSystemAudioCapture) captures mic + system loopback and
@@ -3239,13 +3239,13 @@ function showMeetingEndedNotification(appName) {
 
 function requestAutoRecord(appName, originatingEvt, calEvent) {
   // Prefer the calendar event title when we matched one — it's user-authored
-  // and recognisable weeks later. Falls back to "<App> — YYYY-MM-DD HH:MM",
-  // which simple_recorder.py treats as an "auto-named" placeholder and lets
-  // the post-summary LLM-title step rewrite (see _AUTO_NAMED_PATTERN).
-  const now = new Date();
-  const pad = (n) => String(n).padStart(2, '0');
-  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
-  const sessionName = calEvent?.title || `${appName} — ${stamp}`;
+  // and recognisable weeks later. Otherwise fall back to the neutral
+  // 'Note' placeholder that simple_recorder.py recognises in
+  // _AUTO_NAMED_PATTERN and lets the post-summary LLM-title step rewrite.
+  // The previous "<App> — YYYY-MM-DD HH:MM" format leaked the internal
+  // app-detection string (e.g. "an app — 2026-06-01 17:00") to the user
+  // whenever title regeneration produced nothing.
+  const sessionName = calEvent?.title || 'Note';
   sendDebugLog(`[auto-detect] user requested record: ${sessionName}`);
 
   // Track the originating app so we can pair its mic-stop with this recording
@@ -4627,7 +4627,7 @@ ipcMain.handle('get-recordings-dir', async () => {
 ipcMain.handle('write-system-audio-blob', async (_event, payload, sessionName) => {
   try {
     const dir = resolveRecordingsDir();
-    const safeName = String(sessionName || 'Meeting').replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
+    const safeName = String(sessionName || 'Note').replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
     const filename = `sysaudio-${Date.now()}-${safeName}.webm`;
     const filePath = path.join(dir, filename);
     const buf = Buffer.isBuffer(payload) ? payload : Buffer.from(payload);
@@ -4654,7 +4654,7 @@ ipcMain.handle('process-system-audio-recording', async (event, audioFilePath, se
       return { success: false, error: 'Audio file not found' };
     }
 
-    const actualSessionName = sessionName || 'Meeting';
+    const actualSessionName = sessionName || 'Note';
 
     // Check for user notes file
     const safeName = actualSessionName.replace(/[^a-zA-Z0-9_-]/g, '_');

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -35,15 +35,16 @@ export function MainToolbar({
   const isRecording =
     recordingStatus === 'recording' || recordingStatus === 'paused';
   const isPaused = recordingStatus === 'paused';
-  const isProcessing = recordingStatus === 'processing';
   const { resolved: resolvedTheme, setTheme } = useTheme();
   // Route-aware primary action. On chat routes the "+ New" affordance maps
   // to a new chat (navigates back to /chat entry). Everywhere else it's
   // the recording button. Recording always wins if a session is active —
   // we don't want a navigation to silently swallow a stop-recording click.
+  // Processing of a previous note runs in the background queue and
+  // doesn't gate this button.
   const route = useRoute();
   const isChatRoute = route === '/chat' || route.startsWith('/chat/');
-  const showChatPrimary = isChatRoute && !isRecording && !isProcessing;
+  const showChatPrimary = isChatRoute && !isRecording;
 
   // Matches sb-top padding-left (82px clears macOS traffic lights)
   const toggleLeft = 82;
@@ -102,35 +103,23 @@ export function MainToolbar({
         <button
           type="button"
           onClick={showChatPrimary ? () => navigate('/chat') : onToggleRecording}
-          disabled={isProcessing}
           className={cn('record-btn', isRecording && 'is-recording')}
           aria-label={
-            isProcessing
-              ? 'Processing previous recording'
-              : isRecording
-                ? 'Open recording in progress'
-                : showChatPrimary
-                  ? 'New chat'
-                  : 'New note'
+            isRecording
+              ? 'Open recording in progress'
+              : showChatPrimary
+                ? 'New chat'
+                : 'New note'
           }
           title={
-            isProcessing
-              ? 'Processing previous recording'
-              : isRecording
-                ? 'Open recording in progress'
-                : showChatPrimary
-                  ? 'New chat'
-                  : 'New note'
+            isRecording
+              ? 'Open recording in progress'
+              : showChatPrimary
+                ? 'New chat'
+                : 'New note'
           }
         >
-          {isProcessing ? (
-            <>
-              <span style={{ color: '#FFFFFF', display: 'inline-flex' }}>
-                <AudioWave active={false} paused bars={5} height={12} barWidth={2} gap={2} />
-              </span>
-              <span>Processing</span>
-            </>
-          ) : isRecording ? (
+          {isRecording ? (
             <>
               <span style={{ color: '#FFFFFF', display: 'inline-flex' }}>
                 <AudioWave

--- a/app/renderer/src/components/MeetingsShell.tsx
+++ b/app/renderer/src/components/MeetingsShell.tsx
@@ -105,14 +105,16 @@ export function MeetingsShell({
   const totalMeetings = meetings.data?.length ?? 0;
 
   const isRecording = recording.status === 'recording' || recording.status === 'paused';
-  // Toolbar button behaviour: idle → start (which auto-navigates to /recording);
-  // recording or paused → navigate back to /recording instead of stopping. Stop
-  // is intentionally only available from the LiveDock on the /recording route.
+  // Toolbar button behaviour: idle or processing → start a new recording
+  // (auto-navigates to /recording, previous note keeps processing in the
+  // background queue); recording or paused → navigate back to /recording
+  // instead of stopping. Stop is intentionally only available from the
+  // LiveDock on the /recording route.
   const onToggleRecording = () => {
-    if (recording.status === 'idle') {
-      void recording.startRecording();
-    } else if (isRecording) {
+    if (isRecording) {
       navigate('/recording');
+    } else {
+      void recording.startRecording();
     }
   };
 

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -26,12 +26,14 @@ export function Home({ mode }: HomeProps) {
 
   const emptyState = !meetings.data?.length;
   const isRecording = recording.status === 'recording' || recording.status === 'paused';
-  // Empty-state CTA: idle → start (auto-navigates); recording/paused → back to /recording.
+  // Empty-state CTA: idle or processing → start a new recording (auto-navigates;
+  // previous note keeps processing in the background queue); recording/paused
+  // → back to /recording.
   const onToggleRecording = () => {
-    if (recording.status === 'idle') {
-      void recording.startRecording();
-    } else if (isRecording) {
+    if (isRecording) {
       navigate('/recording');
+    } else {
+      void recording.startRecording();
     }
   };
 


### PR DESCRIPTION
Two related rough edges from Joe's report, both small and mechanical.

## 1. New recording blocked during processing

> "During processing, you cannot start a new meeting. This is bad for back-to-back meetings, especially when using Turbo."

Three layers had to be unblocked, not just the visible disable:

- `MainToolbar.tsx`: dropped `disabled={isProcessing}` on the New-note button and the special "Processing" label branch that swallowed clicks. Button now reads "+ New note" while a previous note is processing; click navigates straight into a new recording.
- `MeetingsShell.tsx` + `Home.tsx`: the `onToggleRecording` handler silently no-op'd when `recording.status === 'processing'` (it only branched on `'idle'` and the recording/paused case). Now it starts a new recording whenever no recording is active, regardless of whether the queue is busy. **This was the actual blocker — even after removing the visible `disabled` attribute, clicks did nothing because the handler ignored the processing state.**
- `MainToolbar showChatPrimary`: also relaxed the `!isProcessing` gate so chat routes can still flip to "+ New chat" while a note is processing.

Auto-share, adapter calls, and S3 backups are unchanged — they all happen after `processing-complete` fires, which is per-note and serial in the queue. **This PR does not introduce concurrent processing of two notes** — only concurrent record + process (where the recording is renderer-side and doesn't touch the Python queue until stopped).

## 2. "Note" replaces "Meeting" / "an app — &lt;timestamp&gt;" fallback

> "Proper meeting titles should be implemented before rolling out."

Joe's note titled `"an app — 2026-06-01 17:00"` was the auto-detect placeholder leaking to the user. That format was always meant to be internal — `simple_recorder.py`'s `_AUTO_NAMED_PATTERN` matches both `<App> — <YYYY-MM-DD HH:MM>` and the bare placeholders (`"Meeting"`, `"Note"`) so the LLM-title step can rewrite either. The fix:

- `main.js:3248` (`requestAutoRecord`): when no calendar event matched, fall back to the bare `'Note'` placeholder instead of `${appName} — ${stamp}`. Calendar matches still use the calendar's title verbatim.
- `main.js` (all five `sessionName || 'Meeting'` defaults across `start-recording`, `start-recording-ui`, `write-system-audio-blob`, and `process-system-audio-recording`): switched to `'Note'` for consistency. The renderer's optimistic state at `useRecording.ts:49` already defaulted to `'Note'` and the comment there explicitly called this out as the intended placeholder — the main-side defaults were stale.

`_AUTO_NAMED_PATTERN` matches both `'Meeting'` and `'Note'`, so LLM regeneration triggers identically — the only user-visible difference is what shows up when regeneration produces nothing (silent recording, LLM output too short, processing failed). Now they see **"Note"** instead of **"an app — 2026-06-01 17:00"**.

## Verified manually

1. ✅ Start a recording → stop it (processing kicks off) → click "+ New note" while previous still processing → straight into a new recording. Previous one continues processing in the background queue.
2. ✅ Toolbar button no longer says "Processing" while a note is processing in the queue — reads "+ New note" with the pencil icon.
3. ✅ Manual New-note default name is "Note" (used to be "Meeting").
4. ✅ Auto-detect fallback is "Note" when no calendar event matched.
5. ✅ Calendar-matched recordings still use the calendar event's title verbatim (e.g. "Joseph - Babar: Catch up" from Joe's log).

## Out of scope / follow-up

The deeper UX of pause-and-resume + an explicit "Generate notes" button (Granola-style) is filed separately as #135. That's a substantive architecture change — multi-blob audio storage, in-flight-notes registry, lifecycle policy — and benefits from proper design discussion. This PR is the small mechanical fix that addresses the immediate Joe report without rearchitecting recording lifecycle.

## Test plan

- [ ] Pull, `npm start` in `app/`. Start a recording → stop → while previous is being summarised, click "+ New note". Should navigate to /recording and start a fresh session. Previous note continues processing in the background.
- [ ] Confirm a recording that produces an empty/silent summary surfaces as "Note" in the sidebar (not "Meeting" or "an app — ...").
- [ ] Confirm a recording with a real summary still gets the LLM-generated title (verify via reprocess of an existing note).
- [ ] Calendar-matched auto-record on a recognised event still names the note from the calendar event title.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow starting a new recording while a previous note is processing, and switch the default fallback title to "Note" instead of "Meeting" or "<App> — <timestamp>". Processing remains serial; this only changes UI behavior and default naming.

- **Bug Fixes**
  - Enable "+ New note"/recording during processing by removing the `isProcessing` gate and updating `onToggleRecording` in `MainToolbar`, `MeetingsShell`, and `Home`.
  - Use "Note" as the default session name across main IPC paths (`start-recording`, `start-recording-ui`, `write-system-audio-blob`, `process-system-audio-recording`) and auto-detect when no calendar match is found; calendar titles are still used when available.

<sup>Written for commit b3fb8c502d8f813b5e3327719f7cb967e15d4915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

