### PR TITLE
feat(home): paginate today's upcoming events

### DIFF
--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import { UpcomingCard } from '@/components/home/UpcomingCard';
 import { PreviousRow } from '@/components/home/PreviousRow';
@@ -10,7 +10,7 @@ import { useMeetings } from '@/hooks/useMeetings';
 import { useRecording } from '@/hooks/useRecording';
 import { useCalendarEvents } from '@/hooks/useCalendarEvents';
 import { useFolders } from '@/hooks/useFolders';
-import type { Meeting } from '@/lib/ipc';
+import type { CalendarEvent, Meeting } from '@/lib/ipc';
 import { shortcut } from '@/lib/utils';
 import { navigate } from '@/lib/router';
 
@@ -43,8 +43,55 @@ export function Home({ mode }: HomeProps) {
     return map;
   }, [folders.data]);
 
-  const upcoming =
-    calendar.data && !calendar.data.needsAuth ? calendar.data.events.slice(0, 3) : [];
+  // Today's relevant events: anything that overlaps with today AND
+  // hasn't ended yet. Includes timed events for today, all-day events
+  // for today, AND multi-day events (conference, OOO block) that
+  // started in the past but are still ongoing — those are useful
+  // context the user might want to glance at.
+  const upcomingToday = React.useMemo<CalendarEvent[]>(() => {
+    if (!calendar.data || calendar.data.needsAuth) return [];
+    const now = new Date();
+    const todayY = now.getFullYear();
+    const todayM = now.getMonth();
+    const todayD = now.getDate();
+    // 00:00 tomorrow — events that start at or after this aren't "today."
+    const startOfTomorrow = new Date(todayY, todayM, todayD + 1).getTime();
+    const nowMs = now.getTime();
+    return calendar.data.events
+      .filter((e) => {
+        const start = new Date(e.start).getTime();
+        const end = new Date(e.end).getTime();
+        if (Number.isNaN(start) || Number.isNaN(end)) return false;
+        // Event must end after now (not in the past).
+        if (end <= nowMs) return false;
+        // Event must start before end-of-today (so it overlaps today).
+        if (start >= startOfTomorrow) return false;
+        return true;
+      })
+      .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+  }, [calendar.data]);
+
+  const UPCOMING_PAGE_SIZE = 3;
+  const upcomingPageCount = Math.max(
+    1,
+    Math.ceil(upcomingToday.length / UPCOMING_PAGE_SIZE),
+  );
+  const [upcomingPage, setUpcomingPage] = React.useState(0);
+  // Clamp the page when the list shrinks underneath us — e.g. an event
+  // ends and rolls off, or the user reloads the calendar with fewer
+  // entries. Without this the user could be stuck on an empty page 3
+  // after the count drops to 5.
+  React.useEffect(() => {
+    if (upcomingPage >= upcomingPageCount) {
+      setUpcomingPage(Math.max(0, upcomingPageCount - 1));
+    }
+  }, [upcomingPage, upcomingPageCount]);
+  const upcomingVisible = upcomingToday.slice(
+    upcomingPage * UPCOMING_PAGE_SIZE,
+    (upcomingPage + 1) * UPCOMING_PAGE_SIZE,
+  );
+  const canPagePrev = upcomingPage > 0;
+  const canPageNext = upcomingPage < upcomingPageCount - 1;
 
   const previous = meetings.data ?? [];
 
@@ -147,31 +194,60 @@ export function Home({ mode }: HomeProps) {
                 className="max-w-[52ch] text-sm leading-[1.55]"
                 style={{ color: 'var(--fg-2)' }}
               >
-                {summaryLine(upcoming.length)}
+                {summaryLine(upcomingToday.length)}
               </p>
             </div>
           )}
 
-          {upcoming.length > 0 && mode === 'home' && (
+          {upcomingToday.length > 0 && mode === 'home' && (
             <section className="mb-10">
               <SectionHead
                 title="Upcoming"
-                count={upcoming.length}
+                count={upcomingToday.length}
                 action={
-                  <button
-                    type="button"
-                    className="inline-flex items-center rounded p-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50"
-                    title="Check for new calendar events"
-                    onClick={() => calendar.refetch()}
-                    disabled={calendar.isFetching}
-                    style={{ color: 'var(--fg-2)' }}
-                  >
-                    <RefreshCw className={`size-3 ${calendar.isFetching ? 'animate-spin' : ''}`} />
-                  </button>
+                  // Outer gap separates the page-nav cluster from the
+                  // refresh button so they read as two distinct groups.
+                  // Inner cluster keeps < and > tight against each other.
+                  <div className="flex items-center gap-1.5">
+                    {upcomingPageCount > 1 && (
+                      <div className="flex items-center gap-0.5">
+                        <button
+                          type="button"
+                          className="inline-flex items-center rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-30 disabled:hover:bg-transparent"
+                          title="Previous"
+                          onClick={() => setUpcomingPage((p) => Math.max(0, p - 1))}
+                          disabled={!canPagePrev}
+                          style={{ color: 'var(--fg-2)' }}
+                        >
+                          <ChevronLeft className="size-[14px]" />
+                        </button>
+                        <button
+                          type="button"
+                          className="inline-flex items-center rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-30 disabled:hover:bg-transparent"
+                          title="Next"
+                          onClick={() => setUpcomingPage((p) => Math.min(upcomingPageCount - 1, p + 1))}
+                          disabled={!canPageNext}
+                          style={{ color: 'var(--fg-2)' }}
+                        >
+                          <ChevronRight className="size-[14px]" />
+                        </button>
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      className="inline-flex items-center rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50"
+                      title="Check for new calendar events"
+                      onClick={() => calendar.refetch()}
+                      disabled={calendar.isFetching}
+                      style={{ color: 'var(--fg-2)' }}
+                    >
+                      <RefreshCw className={`size-[14px] ${calendar.isFetching ? 'animate-spin' : ''}`} />
+                    </button>
+                  </div>
                 }
               />
               <div className="flex flex-col gap-2">
-                {upcoming.map((event) => (
+                {upcomingVisible.map((event) => (
                   <UpcomingCard key={event.id} event={event} />
                 ))}
               </div>

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -63,7 +63,12 @@ export function Home({ mode }: HomeProps) {
   // context the user might want to glance at.
   const upcomingToday = React.useMemo<CalendarEvent[]>(() => {
     if (!calendar.data || calendar.data.needsAuth) return [];
-    const now = new Date();
+    // Use the tick as the time source so the memo is a pure function of
+    // its deps (same inputs → same output) — rather than reading
+    // Date.now() inside, which would leave upcomingTickMs as an
+    // ostensibly-unused dep used only to trigger re-runs. 60s
+    // staleness is well within tolerance for "has this event ended."
+    const now = new Date(upcomingTickMs);
     const todayY = now.getFullYear();
     const todayM = now.getMonth();
     const todayD = now.getDate();
@@ -82,8 +87,6 @@ export function Home({ mode }: HomeProps) {
         return true;
       })
       .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
-    // upcomingTickMs included so the filter re-runs each minute and
-    // ended events roll off without waiting for calendar.refetch.
   }, [calendar.data, upcomingTickMs]);
 
   const UPCOMING_PAGE_SIZE = 3;

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -43,6 +43,19 @@ export function Home({ mode }: HomeProps) {
     return map;
   }, [folders.data]);
 
+  // 60-second tick so the upcoming filter below re-evaluates and
+  // events whose end time has passed roll off the list without
+  // waiting for the next calendar refetch (which could be many
+  // minutes). Minute precision is plenty — events are minute-grained
+  // at best. Gated on `mode === 'home'` so the timer doesn't run on
+  // /meetings where this widget isn't rendered.
+  const [upcomingTickMs, setUpcomingTickMs] = React.useState<number>(() => Date.now());
+  React.useEffect(() => {
+    if (mode !== 'home') return;
+    const id = setInterval(() => setUpcomingTickMs(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, [mode]);
+
   // Today's relevant events: anything that overlaps with today AND
   // hasn't ended yet. Includes timed events for today, all-day events
   // for today, AND multi-day events (conference, OOO block) that
@@ -69,7 +82,9 @@ export function Home({ mode }: HomeProps) {
         return true;
       })
       .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
-  }, [calendar.data]);
+    // upcomingTickMs included so the filter re-runs each minute and
+    // ended events roll off without waiting for calendar.refetch.
+  }, [calendar.data, upcomingTickMs]);
 
   const UPCOMING_PAGE_SIZE = 3;
   const upcomingPageCount = Math.max(


### PR DESCRIPTION
The Upcoming widget on Home used to call `events.slice(0, 3)` on the calendar feed and silently drop the rest of the day's events. Anyone with more than three meetings in a day couldn't see the later ones from Home — they had to leave for their calendar app to find them.

This replaces the silent slice with **pagination within today**.

## What changes

- **Filter to today + still-ongoing.** Events that overlap today AND haven't ended yet. Includes all-day events for today and multi-day blocks (conference, OOO) that started earlier but are still ongoing — those are useful context the user might want to glance at.
- **Sort chronologically**, earliest first.
- **3 events per page**, with `<` / `>` buttons in the existing `SectionHead` action slot, alongside the refresh button. Slightly wider gap separating the page-nav cluster from refresh so they read as two distinct groups rather than three icons in a row.
- **`<` / `>` only render when there's more than one page** — small or empty days look identical to today's UI. No new chrome unless it's actually needed.
- **No "1 / N" indicator.** The section's existing count badge already shows the total for today; the `>` button greying out tells the user when they're done. A separate indicator would be redundant — discussed and dropped as scope creep before writing the code.
- **`upcomingPage` state clamps** when the list shrinks underneath the user (e.g. an event's end time passes and it rolls off mid-day). Without this they'd be stuck on an empty trailing page.
- **Section still hides entirely when there are zero remaining events today.** Absence is the message — no "no more meetings today" copy.

## What this is not

- Not cross-day navigation. Granola lets you browse forward/backward by day; we considered that pattern but the user explicitly scoped this to "within today only." Cross-day could be a small follow-up if anyone asks.
- Not a filter UI. No "hide all-day" dropdown. All-day events are mixed inline with timed ones — the date format on the card already differentiates them naturally.
- Not a scrollable variant. Pagination is a fixed-size widget; scrolling within Home would conflict with the page-level scroll.

## Files touched

Single file: `app/renderer/src/routes/Home.tsx`. ~95 LOC. No new IPC, no backend changes.

## Verified

Built `npm run pack` and tested on a packed `Steno.app`:

- ✅ With 4+ events today: `<` / `>` appear, page 1 shows events 1-3, page 2 shows event 4
- ✅ With ≤3 events today: no `<` / `>` chrome, identical to old UI
- ✅ `<` disabled on page 1, `>` disabled on the last page
- ✅ Past events disappear as their end time passes (count drops, pages reflow)
- ✅ Section hides entirely once today's remaining-events count hits zero
- ✅ Refresh button still works alongside the page-nav buttons

## Test plan

- [x] Pull the branch, `cd app && npm run pack`, launch `app/dist/mac-arm64/Steno.app`.
- [x] If you have ≥4 events today, see `<` `>` buttons appear next to the refresh icon in the "Upcoming" header.
- [x] Click `>` to advance through pages; verify `>` disables on the final page and `<` disables on page 1.
- [x] Confirm an all-day event today (or multi-day block spanning today) appears inline at its chronological position.
- [x] With <4 events, confirm no `<` `>` chrome appears and the widget looks identical to the previous behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated “Upcoming” on Home to show all of today’s remaining events, replacing the old top-3 slice. Past events now roll off automatically every minute without needing a refresh.

- **New Features**
  - Show events that overlap today and haven’t ended yet, including all-day and ongoing multi-day blocks; sorted earliest first.
  - 3 events per page with `<` and `>` in the `SectionHead` action area; buttons render only when there’s more than one page and disable at ends.
  - Keep the existing count badge; no separate “1/N” indicator.
  - Clamp page index when the list shrinks to avoid empty trailing pages.
  - Hide the section when there are zero remaining events today.
  - Renderer-only change in `app/renderer/src/routes/Home.tsx`; no IPC or backend updates.

- **Bug Fixes**
  - Re-evaluate the “today and not ended” filter every 60 seconds so ended events drop off without waiting for a refetch; interval runs only in `mode === 'home'`.
  - Refactor: the memo now uses `upcomingTickMs` as its time source to keep dependencies pure; no functional change.

<sup>Written for commit 6a73580e50bd24f689572a1a6b84aff4fb3e0f2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

