### PR TITLE
fix: live-draft leak on back-to-back recordings + release tag body

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -150,8 +150,18 @@ jobs:
       id: tag_body
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
+        # actions/checkout@v4 with fetch-tags: true sometimes leaves the
+        # annotated tag as a lightweight pointer (just the commit OID,
+        # no annotation object), which makes `for-each-ref --format=
+        # '%(contents:body)'` return empty. The action-gh-release step
+        # below then falls back to the commit subject in the release
+        # body — that's how every prior release ended up with
+        # "chore(release): prep vX.Y.Z" as its body instead of the
+        # actual notes we wrote on the tag. Refetch the tag explicitly
+        # so the annotation object is present locally before we read it.
+        git fetch --force origin "refs/tags/${{ github.ref_name }}:refs/tags/${{ github.ref_name }}"
         # Pull the body of the annotated tag (strips the PGP signature if any).
-        # Falls back to the commit subject if the tag is lightweight.
+        # Falls back to the tag subject if the body is empty (one-line tag).
         MSG=$(git for-each-ref --format='%(contents:body)' "refs/tags/${{ github.ref_name }}")
         if [ -z "$MSG" ]; then
           MSG=$(git for-each-ref --format='%(contents:subject)' "refs/tags/${{ github.ref_name }}")

--- a/app/renderer/src/hooks/liveDraftStore.ts
+++ b/app/renderer/src/hooks/liveDraftStore.ts
@@ -24,6 +24,10 @@ interface LiveDraftStore {
   /** Drop the draft for a finished session so the next "New note" with the
    *  same sessionName (e.g. the default 'Meeting' / 'Note') starts clean. */
   clear: (sessionName: string) => void;
+  /** Put a previously-snapshot draft back. Used to undo a speculative
+   *  `clear()` when the action that motivated it (e.g. start-recording IPC)
+   *  later fails. */
+  restore: (sessionName: string, draft: DraftEntry) => void;
 }
 
 export const useLiveDraftStore = create<LiveDraftStore>((set) => ({
@@ -64,6 +68,10 @@ export const useLiveDraftStore = create<LiveDraftStore>((set) => ({
       const { [sessionName]: _drop, ...rest } = state.drafts;
       return { drafts: rest };
     }),
+  restore: (sessionName, draft) =>
+    set((state) => ({
+      drafts: { ...state.drafts, [sessionName]: draft },
+    })),
 }));
 
 /** Non-hook accessor for the current draft (use inside event handlers). */

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -65,6 +65,23 @@ export function useRecording() {
       // (regex ^(Meeting|Note)(-[A-Z0-9]{6})?$) and replaces with an AI-
       // generated title from the summary + transcript.
       const optimisticName = name && name.trim() ? name.trim() : 'Note';
+      // Clear any stale draft keyed under this same name. The live-draft
+      // store is keyed by sessionName, and the most common case
+      // (default 'Note' or 'Meeting') means back-to-back recordings
+      // collide on the same key. Previously the draft was only cleared
+      // on processing-complete, which can land minutes after the user
+      // hits '+ New note' — meaning the new recording reads the previous
+      // session's notes and shows them in the UI. Clearing here is
+      // tighter: the new recording starts with a guaranteed-clean draft
+      // before useLiveMeeting's `ensure` looks for one.
+      //
+      // Edge case: if the previous recording's draft.title was edited
+      // (custom user rename), that rename is also cleared — Processing.tsx
+      // applies the rename on processing-complete by reading the draft,
+      // so it'll be lost. Acceptable trade-off: the leak case is common,
+      // the rename case is rare and recoverable via manual rename
+      // post-processing.
+      useLiveDraftStore.getState().clear(optimisticName);
       qc.setQueryData(queueKey, {
         success: true,
         isProcessing: false,

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -81,6 +81,11 @@ export function useRecording() {
       // so it'll be lost. Acceptable trade-off: the leak case is common,
       // the rename case is rare and recoverable via manual rename
       // post-processing.
+      //
+      // Snapshot before clearing so we can put it back if start-recording
+      // fails — without restore, a transient IPC error would silently drop
+      // the previous session's in-memory state.
+      const priorDraft = useLiveDraftStore.getState().drafts[optimisticName];
       useLiveDraftStore.getState().clear(optimisticName);
       qc.setQueryData(queueKey, {
         success: true,
@@ -99,6 +104,12 @@ export function useRecording() {
         return data;
       } catch (err) {
         // Roll back optimistic state and leave the dead /recording page.
+        // Restore the prior draft too — the recording never started so the
+        // previous session (probably still mid-processing) shouldn't lose
+        // its in-memory title / notes.
+        if (priorDraft) {
+          useLiveDraftStore.getState().restore(optimisticName, priorDraft);
+        }
         qc.invalidateQueries({ queryKey: queueKey });
         navigate('/');
         throw err;


### PR DESCRIPTION
Two unrelated hotfixes bundled — both are tiny and both came out of the v0.3.7 release shake-out.

---

## 1. Live-draft notes leak on back-to-back recordings

### The bug

User report: *"when I write a note and process and you start a new note — the same notes appear from the previous meeting. This was a bug before as well."*

### Root cause

Three pieces conspire:

1. **The live-draft store is keyed by `sessionName`** (`liveDraftStore.ts:11-26`). The default sessionName for any new recording is the `'Note'` placeholder, so any two back-to-back recordings (without a user-typed title) collide on the same key.
2. **`useLiveMeeting`'s `ensure(sessionName, ...)`** at `useLiveMeeting.ts:25` is a no-op when `drafts[sessionName]` already exists. That's deliberate — it protects user typing from being clobbered on every queue-poll re-render (~1 Hz).
3. **The clear runs only on `processing-complete`** (`useRecordingProcessingEffects` at `useRecording.ts:288`). With PR #136 enabling back-to-back recording while the previous note is still processing, `processing-complete` can land minutes after the user has already hit "+ New note." During that gap the new recording reads the stale draft and the user sees the previous session's notes.

### Fix

One-line change in `startRecording` (`useRecording.ts`): clear `drafts[optimisticName]` **before** the optimistic queue-cache write. The new recording starts with a guaranteed-clean draft regardless of how recent the previous one was.

Both entry paths — manual "+ New note" and auto-detect's `auto-record-requested` event — flow through this single `startRecording` callable, so one site covers everything.

### Previous-recording notes are safe

Notes are persisted to disk via `save-meeting-notes` IPC on a 500ms debounce (`useLiveMeeting.ts:34-37`), and the Python processor reads them from disk — the in-memory draft store is just the UI mirror. The debounced save fires with its own closure over the typed value and the *original* sessionName, so clearing the draft mid-flight doesn't disturb the in-flight save for recording 1; recording 1's summarisation still gets the notes.

### Known trade-off

If the previous recording's `draft.title` was customised (user renamed it in `/recording` before stopping), that rename is also dropped. `Processing.tsx:100` reads the draft on `processing-complete` to apply the rename via `updateMeeting.mutate`, so it'll be lost.

| Case | Frequency | Recovery |
|---|---|---|
| Notes leak between back-to-back recordings | Common | Notes are gone — they belonged to the *previous* recording but show on the new one. No recovery, just confusion. |
| Custom title rename lost when starting a new recording before previous finished | Rare (rename AND back-to-back AND no wait) | Recoverable via manual rename after the note finishes processing |

Common case is worse → fix it. Rare case is recoverable → acceptable cost.

---

## 2. Release tag body extraction

### The bug

Every release so far has shipped with the *commit subject* as the GitHub Release body — e.g. v0.3.7 published with "chore(release): prep v0.3.7 — README, version bump, trim What's New policy" instead of the multi-section release notes we wrote on the annotated tag. We've been hand-editing the release after every CI run.

### Root cause

`actions/checkout@v4` with `fetch-tags: true` sometimes leaves the annotated tag as a lightweight pointer (just the commit OID) without fetching the annotation object that carries the body/subject. The existing `git for-each-ref --format='%(contents:body)'` then returns empty, the YAML interpolates that empty string into the release body, and `softprops/action-gh-release` falls back to the commit subject as its default body.

### Fix

Single `git fetch --force origin "refs/tags/<tag>:refs/tags/<tag>"` step right before the `for-each-ref` read, so the annotation object is guaranteed to be present locally. The extraction logic that follows was correct all along — it just had no annotation to read.

After this lands, v0.3.8+ will pick up the tag annotation automatically. No more manual `gh release edit`.

---

## Test plan

### Live-draft leak (renderer)

- [ ] Start a recording. Type "buy milk" into the notes panel. Stop the recording — it goes into processing.
- [ ] Immediately click "+ New note" without waiting for processing to finish. The new recording's notes panel should be **empty**, not show "buy milk".
- [ ] Type new notes "call mom" in the new recording. Wait for processing of the first to complete.
- [ ] First recording's detail page → notes should be "buy milk" (saved to disk while it was live).
- [ ] Second recording's detail page (once it finishes) → notes should be "call mom" with no residue.
- [ ] Repeat with auto-detect: a "Meeting detected" notification triggers the second recording. Same expectation: clean draft.

### Workflow fix (CI)

- [ ] Naturally verified on the next release tag push. The release body should populate from the tag annotation rather than the merge-commit subject. No manual `gh release edit` required.