### PR TITLE
chore(app): rebrand dev-mode app as Steno Dev with dragonfly icon

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -28,6 +28,12 @@ if (IS_E2E_MOCK_IPC) {
   require('./e2e-mock-ipc').install({ ipcMain, BrowserWindow });
 }
 
+// Distinguish dev runs from the packaged "Steno" app in the dock, About menu,
+// and Cmd+Tab. Production keeps the productName from package.json untouched.
+if (!app.isPackaged) {
+  app.setName('Steno Dev');
+}
+
 // Initialize electron-audio-loopback before app is ready.
 // forceCoreAudioTap drives Chromium to use macOS 14.4+ CoreAudio Process Taps
 // (NSAudioCaptureUsageDescription) rather than ScreenCaptureKit. SCK was
@@ -840,6 +846,16 @@ if (!gotSingleInstanceLock) {
         sendDebugLog(`[sysaudio] macOS ${osVer} — CoreAudio Tap supported=${tapOk}, screen permission=${screenPerm}`);
       } catch (e) {
         sendDebugLog(`[sysaudio] startup probe failed: ${e.message}`);
+      }
+    }
+
+    // Dev runs otherwise show the default Electron dock icon. Packaged builds
+    // already get this icon via electron-builder's `mac.icon` setting.
+    if (!app.isPackaged && process.platform === 'darwin' && app.dock) {
+      try {
+        app.dock.setIcon(path.join(__dirname, 'build', 'icon-dragonfly.icns'));
+      } catch (e) {
+        console.error('Failed to set dev dock icon:', e.message);
       }
     }
 

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/ruzin/stenoai.git"
   },
   "scripts": {
+    "postinstall": "node scripts/patch-electron-dev.js",
     "start": "npm run build:renderer && electron .",
     "start:nobuild": "electron .",
     "dev:renderer": "vite",

--- a/app/scripts/patch-electron-dev.js
+++ b/app/scripts/patch-electron-dev.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Rebrands the Electron.app bundle that npm pulls into node_modules so dev
+// runs show "Steno Dev" with the dragonfly icon in the dock, Cmd+Tab, and
+// menu bar instead of the default "Electron" + atom logo. Runs as a
+// postinstall hook so a fresh `npm install` always re-applies the patch.
+
+const fs = require('fs');
+const path = require('path');
+
+const APP_NAME = 'Steno Dev';
+const ICON_SOURCE = path.join(__dirname, '..', 'build', 'icon-dragonfly.icns');
+const ICON_FILENAME = 'icon-dragonfly.icns';
+
+const electronAppDir = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  'electron',
+  'dist',
+  'Electron.app',
+);
+
+if (!fs.existsSync(electronAppDir)) {
+  console.log('[patch-electron-dev] Electron.app not found, skipping.');
+  process.exit(0);
+}
+
+const infoPlistPath = path.join(electronAppDir, 'Contents', 'Info.plist');
+const resourcesDir = path.join(electronAppDir, 'Contents', 'Resources');
+const iconDest = path.join(resourcesDir, ICON_FILENAME);
+
+let plist = fs.readFileSync(infoPlistPath, 'utf8');
+
+function replaceStringValue(source, key, value) {
+  const re = new RegExp(
+    `(<key>${key}</key>\\s*<string>)[^<]*(</string>)`,
+    'g',
+  );
+  return source.replace(re, `$1${value}$2`);
+}
+
+plist = replaceStringValue(plist, 'CFBundleName', APP_NAME);
+plist = replaceStringValue(plist, 'CFBundleDisplayName', APP_NAME);
+plist = replaceStringValue(plist, 'CFBundleIconFile', ICON_FILENAME);
+
+fs.writeFileSync(infoPlistPath, plist);
+
+if (fs.existsSync(ICON_SOURCE)) {
+  fs.copyFileSync(ICON_SOURCE, iconDest);
+} else {
+  console.warn(
+    `[patch-electron-dev] Icon source not found at ${ICON_SOURCE}; dock will fall back to the default icon.`,
+  );
+}
+
+// Touch the .app so macOS Launch Services picks up the new metadata on next
+// launch instead of reading a cached entry.
+const now = new Date();
+fs.utimesSync(electronAppDir, now, now);
+
+console.log(`[patch-electron-dev] Rebranded Electron.app -> "${APP_NAME}".`);

--- a/app/scripts/patch-electron-dev.js
+++ b/app/scripts/patch-electron-dev.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const APP_NAME = 'Steno Dev';
 const ICON_SOURCE = path.join(__dirname, '..', 'build', 'icon-dragonfly.icns');
@@ -29,28 +30,63 @@ const infoPlistPath = path.join(electronAppDir, 'Contents', 'Info.plist');
 const resourcesDir = path.join(electronAppDir, 'Contents', 'Resources');
 const iconDest = path.join(resourcesDir, ICON_FILENAME);
 
-let plist = fs.readFileSync(infoPlistPath, 'utf8');
+const plistBefore = fs.readFileSync(infoPlistPath, 'utf8');
+let plist = plistBefore;
 
+// Replace the value of an existing <key>/<string> pair. If the key isn't
+// present (or its <string> shape doesn't match), throw — silently doing
+// nothing means the dev brand quietly regresses to "Electron" on the next
+// Electron version bump that changes plist layout, and the postinstall
+// would still print success. Better to fail loudly.
 function replaceStringValue(source, key, value) {
   const re = new RegExp(
     `(<key>${key}</key>\\s*<string>)[^<]*(</string>)`,
     'g',
   );
-  return source.replace(re, `$1${value}$2`);
+  let replaced = false;
+  const next = source.replace(re, (_match, open, close) => {
+    replaced = true;
+    return `${open}${value}${close}`;
+  });
+  if (!replaced) {
+    throw new Error(
+      `[patch-electron-dev] Could not find <key>${key}</key><string>…</string> in ${infoPlistPath}. ` +
+        `Electron's Info.plist layout may have changed; update this script.`,
+    );
+  }
+  return next;
 }
 
 plist = replaceStringValue(plist, 'CFBundleName', APP_NAME);
 plist = replaceStringValue(plist, 'CFBundleDisplayName', APP_NAME);
 plist = replaceStringValue(plist, 'CFBundleIconFile', ICON_FILENAME);
 
-fs.writeFileSync(infoPlistPath, plist);
+const plistChanged = plist !== plistBefore;
+if (plistChanged) {
+  fs.writeFileSync(infoPlistPath, plist);
+}
 
+let iconChanged = false;
 if (fs.existsSync(ICON_SOURCE)) {
-  fs.copyFileSync(ICON_SOURCE, iconDest);
+  // Skip the copy + bundle touch when the icon already matches — keeps
+  // routine `npm install` runs silent and idempotent.
+  const sourceBuf = fs.readFileSync(ICON_SOURCE);
+  const destBuf = fs.existsSync(iconDest) ? fs.readFileSync(iconDest) : null;
+  if (!destBuf || !sourceBuf.equals(destBuf)) {
+    fs.copyFileSync(ICON_SOURCE, iconDest);
+    iconChanged = true;
+  }
 } else {
   console.warn(
     `[patch-electron-dev] Icon source not found at ${ICON_SOURCE}; dock will fall back to the default icon.`,
   );
+}
+
+const bundleChanged = plistChanged || iconChanged;
+if (!bundleChanged) {
+  // Idempotent run — nothing to do, stay quiet so postinstall logs aren't
+  // noisy on every `npm install`.
+  process.exit(0);
 }
 
 // Touch the .app so macOS Launch Services picks up the new metadata on next
@@ -58,4 +94,30 @@ if (fs.existsSync(ICON_SOURCE)) {
 const now = new Date();
 fs.utimesSync(electronAppDir, now, now);
 
+// macOS caches CFBundleName aggressively in Launch Services and Spotlight;
+// without an explicit flush, the dock + Cmd+Tab + Spotlight keep showing the
+// old "Electron" name until reboot. Force re-registration and reindex so a
+// fresh `npm install` is enough to see "Steno Dev" everywhere. macOS-only;
+// the binaries don't exist on Linux/Windows and aren't needed there anyway.
+if (process.platform === 'darwin') {
+  const LSREGISTER =
+    '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister';
+  // `-f` re-reads the bundle's plist; safe to run repeatedly. stdio:'ignore'
+  // keeps the install log clean; failures are non-fatal (worst case the user
+  // sees the old name until they relaunch the app a second time).
+  spawnSync(LSREGISTER, ['-f', electronAppDir], { stdio: 'ignore' });
+  spawnSync('mdimport', [electronAppDir], { stdio: 'ignore' });
+}
+
 console.log(`[patch-electron-dev] Rebranded Electron.app -> "${APP_NAME}".`);
+if (process.platform === 'darwin') {
+  // Most macOS surfaces (menu bar, Launch Services, Spotlight on first
+  // index) pick up the new name from the lsregister + mdimport above.
+  // The Dock + Cmd+Tab tile cache, though, only fully drops at session
+  // start — so contributors who ran the old "Electron"-named dev app
+  // before this patch will keep seeing the old tile until they log out
+  // and back in (or reboot). Fresh installs are unaffected.
+  console.log(
+    '[patch-electron-dev] If you ran the dev app before this rebrand, log out and back in to refresh the macOS Dock cache.',
+  );
+}


### PR DESCRIPTION
## Summary
- In dev mode the Electron shell shows up as "Electron" with the default atom icon in the dock, Cmd+Tab, and About menu — packaged builds already get the correct "Steno" + dragonfly via electron-builder.
- This rebrands dev runs as **Steno Dev** with the dragonfly icon so dev/prod are visually distinct (Steno Dev sits next to Steno in the dock instead of impersonating Electron).

## Changes
- `app/main.js` — `app.setName('Steno Dev')` and `app.dock.setIcon(build/icon-dragonfly.icns)`, both guarded by `!app.isPackaged` so production is untouched.
- `app/scripts/patch-electron-dev.js` — postinstall script that patches `node_modules/electron/dist/Electron.app/Contents/Info.plist` (`CFBundleName`, `CFBundleDisplayName`, `CFBundleIconFile`) and copies the dragonfly `.icns` into the bundle. Required because the dock-hover label and Launch Services entry come from the bundle's Info.plist, not from `app.setName()`. Idempotent.
- `app/package.json` — wire the script as a `postinstall` hook so every `npm install` re-applies the patch (npm wipes node_modules' modifications otherwise).

## Side effect to note
`app.setName('Steno Dev')` moves Electron's userData folder for dev from `~/Library/Application Support/stenoai/` to `~/Library/Application Support/Steno Dev/`. Only affects Electron's own state (window bounds, cookies, renderer localStorage). Recordings/transcripts/output stay at `~/Library/Application Support/stenoai/` because Python resolves that path independently via `src.config.get_data_dirs()`.

## Test plan
- [ ] `cd app && npm install` — postinstall reports `Rebranded Electron.app -> "Steno Dev"`.
- [ ] `cd app && npm start` — dock shows the dragonfly icon and hover label reads "Steno Dev"; menu bar shows "Steno Dev" next to the Apple logo; About menu shows "Steno Dev".
- [ ] Packaged build (`npm run build`) still ships as "Steno" with the same icon — no regression on production branding.
- [ ] If the dock keeps the old label after the first run, `killall Dock` once forces Launch Services to pick up the patched bundle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebranded dev runs as “Steno Dev” with the dragonfly icon so dev and production are visually distinct in the Dock, Cmd+Tab, and About menu. Production branding stays “Steno”.

- **New Features**
  - In dev (`!app.isPackaged`), set app name to “Steno Dev” and set the macOS Dock icon to the dragonfly.
  - Added `app/scripts/patch-electron-dev.js` wired as `postinstall` to patch `Electron.app` Info.plist and copy the `.icns`; idempotent, fails loudly if plist keys change, touches the bundle, and runs `lsregister` + `mdimport` on macOS to refresh Launch Services/Spotlight.

- **Migration**
  - Dev userData moves to `~/Library/Application Support/Steno Dev/`; recordings/transcripts remain in `~/Library/Application Support/stenoai/`.
  - Run `npm install` after pulling. If the Dock still shows the old tile from a prior run, log out and back in once. Packaged builds via `electron-builder` remain “Steno”.

<sup>Written for commit 172175d49c17f680c8c7d49badd09a5c1357afd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

