### PR TITLE
added settings to app menu

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -807,7 +807,35 @@ if (!gotSingleInstanceLock) {
   app.whenReady().then(async () => {
     // Set application menu with Help > Learn More
     const appMenu = Menu.buildFromTemplate([
-      { role: 'appMenu' },
+      {
+        // Custom appMenu to add Settings… with the conventional ⌘, shortcut
+        // (the default `{ role: 'appMenu' }` doesn't include Settings). Mirrors
+        // the tray's Settings item — both fire the same `tray-open-settings`
+        // IPC so the renderer wiring stays in one place.
+        label: app.name,
+        submenu: [
+          { role: 'about' },
+          { type: 'separator' },
+          {
+            label: 'Settings…',
+            accelerator: 'CmdOrCtrl+,',
+            click: () => {
+              showAndFocusWindow();
+              if (mainWindow) {
+                mainWindow.webContents.send('tray-open-settings');
+              }
+            }
+          },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' }
+        ]
+      },
       { role: 'fileMenu' },
       { role: 'editMenu' },
       { role: 'viewMenu' },


### PR DESCRIPTION
## Summary
- Adds a `Settings…` item to the macOS app menu (top-of-screen) with the conventional `⌘,` shortcut
- Replaces the default `{ role: 'appMenu' }` with a custom submenu that keeps About / Services / Hide / Quit in their standard positions
- Reuses the existing `tray-open-settings` IPC — renderer wiring (`App.tsx → navigate('/settings')`) covers both surfaces

## Test plan
- [ ] Launch the app, click `Steno` in the system menu bar → confirm `Settings…` appears with `⌘,`
- [ ] Press `⌘,` from anywhere in the app → lands on the Settings page
- [ ] Confirm About, Hide, Quit etc. still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Settings… item to the macOS app menu with the standard Cmd+, shortcut. Replaces the default app menu with a custom submenu that reuses the existing `tray-open-settings` IPC and keeps About, Services, Hide, and Quit in their usual places.

<sup>Written for commit 33ef4f80c708f905040997edefeca4df05102843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

