### PR TITLE
dynamic hero status based on recording + calendar

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -7435,8 +7435,9 @@ ipcMain.handle('get-calendar-events', async () => {
 });
 
 // Pick the calendar event most likely to be the one the user is joining now.
-// INTENTIONAL DUPLICATION: this algorithm is mirrored byte-for-byte in
-// `app/renderer/src/lib/calendar.ts` → `pickInProgressEvent`. The two
+// INTENTIONAL DUPLICATION: this algorithm is kept in lockstep with
+// `app/renderer/src/lib/calendar.ts` → `pickInProgressEvent` (same
+// constants, filters, and tie-break order). The two
 // surfaces (auto-detect-meeting notification here + hero copy in the
 // renderer) keep their own copy because main and renderer can't share
 // ESM modules. If you change the constants or matching rules, update

--- a/app/main.js
+++ b/app/main.js
@@ -7435,6 +7435,13 @@ ipcMain.handle('get-calendar-events', async () => {
 });
 
 // Pick the calendar event most likely to be the one the user is joining now.
+// INTENTIONAL DUPLICATION: this algorithm is mirrored byte-for-byte in
+// `app/renderer/src/lib/calendar.ts` → `pickInProgressEvent`. The two
+// surfaces (auto-detect-meeting notification here + hero copy in the
+// renderer) keep their own copy because main and renderer can't share
+// ESM modules. If you change the constants or matching rules, update
+// BOTH or the notification and the hero will disagree about what counts
+// as "in a meeting now".
 // Match window:
 //   - opens 5 min before the scheduled start (early-join grace)
 //   - closes at the scheduled end, OR 10 min after start, whichever is later

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -339,8 +339,15 @@
     letter-spacing: -0.025em;
     color: var(--fg-1);
     font-weight: 400;
+    /* Headline copy reacts to recording + calendar state; soften the
+       theme/colour swap so light/dark mode toggle isn't a hard pop. The
+       text content swap itself still pops — CSS can't tween text. */
+    transition: color var(--dur, 200ms) var(--ease, ease);
   }
-  .home-hello .faint { color: var(--fg-2); }
+  .home-hello .faint {
+    color: var(--fg-2);
+    transition: color var(--dur, 200ms) var(--ease, ease);
+  }
 
   /* Upcoming card — 3-column grid */
   .upcoming-card {

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -342,11 +342,11 @@
     /* Headline copy reacts to recording + calendar state; soften the
        theme/colour swap so light/dark mode toggle isn't a hard pop. The
        text content swap itself still pops — CSS can't tween text. */
-    transition: color var(--dur, 200ms) var(--ease, ease);
+    transition: color var(--dur-fast) var(--ease);
   }
   .home-hello .faint {
     color: var(--fg-2);
-    transition: color var(--dur, 200ms) var(--ease, ease);
+    transition: color var(--dur-fast) var(--ease);
   }
 
   /* Upcoming card — 3-column grid */

--- a/app/renderer/src/lib/calendar.ts
+++ b/app/renderer/src/lib/calendar.ts
@@ -1,0 +1,64 @@
+import type { CalendarEvent } from '@/lib/ipc';
+
+const EARLY_GRACE_MS = 5 * 60 * 1000;
+const LATE_FLOOR_MS = 10 * 60 * 1000;
+
+/**
+ * Find the calendar event the user is most likely "in" right now. Mirrors
+ * the backend's `pickCurrentCalendarEvent` in `app/main.js` so the hero
+ * and the auto-detect-meeting notification agree on what counts as
+ * "currently in a meeting":
+ *
+ *   - opens 5 min before the scheduled start (early-join grace)
+ *   - closes at the scheduled end, OR 10 min after start, whichever is later
+ *
+ * Priority when multiple events match the window:
+ *   1. Truly in-progress (now ∈ [start, end))   — latest-starting wins
+ *   2. Upcoming (start > now)                   — soonest wins
+ *   3. Recently ended but inside the late-floor — most recently ended wins
+ *
+ * All-day events are skipped (date-only `start` / `end` with no `T`
+ * separator) — they span midnight to midnight and would falsely match
+ * every recording all day.
+ */
+export function pickInProgressEvent(
+  events: CalendarEvent[] | null | undefined,
+  now: Date = new Date(),
+): CalendarEvent | null {
+  if (!events || events.length === 0) return null;
+
+  const nowMs = now.getTime();
+  type Candidate = { event: CalendarEvent; startMs: number; endMs: number };
+  const candidates: Candidate[] = [];
+
+  for (const e of events) {
+    if (!e || typeof e.start !== 'string' || typeof e.end !== 'string') continue;
+    if (!e.start.includes('T') || !e.end.includes('T')) continue;
+    const startMs = new Date(e.start).getTime();
+    const endMs = new Date(e.end).getTime();
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) continue;
+    const closesAt = Math.max(endMs, startMs + LATE_FLOOR_MS);
+    if (nowMs >= startMs - EARLY_GRACE_MS && nowMs < closesAt) {
+      candidates.push({ event: e, startMs, endMs });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  const inProgress = candidates.filter(
+    (c) => c.startMs <= nowMs && nowMs < c.endMs,
+  );
+  if (inProgress.length > 0) {
+    inProgress.sort((a, b) => b.startMs - a.startMs);
+    return inProgress[0].event;
+  }
+
+  const upcoming = candidates.filter((c) => c.startMs > nowMs);
+  if (upcoming.length > 0) {
+    upcoming.sort((a, b) => a.startMs - b.startMs);
+    return upcoming[0].event;
+  }
+
+  candidates.sort((a, b) => b.endMs - a.endMs);
+  return candidates[0].event;
+}

--- a/app/renderer/src/lib/calendar.ts
+++ b/app/renderer/src/lib/calendar.ts
@@ -6,8 +6,9 @@ const LATE_FLOOR_MS = 10 * 60 * 1000;
 /**
  * Find the calendar event the user is most likely "in" right now.
  *
- * INTENTIONAL DUPLICATION: this algorithm is mirrored byte-for-byte in
- * `app/main.js` → `pickCurrentCalendarEvent`. The main process can't
+ * INTENTIONAL DUPLICATION: this algorithm is kept in lockstep with
+ * `app/main.js` → `pickCurrentCalendarEvent` (same constants, filters, and
+ * tie-break order). The main process can't
  * import renderer ESM modules and the renderer can't import from main,
  * so the two surfaces (hero copy here + auto-detect-meeting
  * notification there) keep their own copy. If you change the constants
@@ -40,6 +41,13 @@ export function pickInProgressEvent(
   for (const e of events) {
     if (!e || typeof e.start !== 'string' || typeof e.end !== 'string') continue;
     if (!e.start.includes('T') || !e.end.includes('T')) continue;
+    // Match main.js's pickCurrentCalendarEvent: an all-day block spans
+    // midnight→midnight and would mistag every recording all day, and a
+    // declined meeting is one the user said no to. The 'T' guard above only
+    // catches date-only all-day events (Google); Outlook emits all-day with a
+    // T00:00:00 datetime, so the explicit is_all_day flag is load-bearing.
+    if (e.is_all_day === true) continue;
+    if (e.response_status === 'declined') continue;
     const startMs = new Date(e.start).getTime();
     const endMs = new Date(e.end).getTime();
     if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) continue;

--- a/app/renderer/src/lib/calendar.ts
+++ b/app/renderer/src/lib/calendar.ts
@@ -4,10 +4,16 @@ const EARLY_GRACE_MS = 5 * 60 * 1000;
 const LATE_FLOOR_MS = 10 * 60 * 1000;
 
 /**
- * Find the calendar event the user is most likely "in" right now. Mirrors
- * the backend's `pickCurrentCalendarEvent` in `app/main.js` so the hero
- * and the auto-detect-meeting notification agree on what counts as
- * "currently in a meeting":
+ * Find the calendar event the user is most likely "in" right now.
+ *
+ * INTENTIONAL DUPLICATION: this algorithm is mirrored byte-for-byte in
+ * `app/main.js` → `pickCurrentCalendarEvent`. The main process can't
+ * import renderer ESM modules and the renderer can't import from main,
+ * so the two surfaces (hero copy here + auto-detect-meeting
+ * notification there) keep their own copy. If you change the constants
+ * (EARLY_GRACE_MS, LATE_FLOOR_MS) or the matching/tie-break rules,
+ * update BOTH or the hero and the notification will disagree about
+ * what counts as "in a meeting now".
  *
  *   - opens 5 min before the scheduled start (early-join grace)
  *   - closes at the scheduled end, OR 10 min after start, whichever is later

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -425,20 +425,20 @@ export function Home({ mode }: HomeProps) {
     return pickInProgressEvent(calendar.data.events, new Date(upcomingTickMs));
   }, [calendar.data, upcomingTickMs]);
 
-  const nextSoonEvent = React.useMemo<CalendarEvent | null>(() => {
-    const nowMs = upcomingTickMs;
-    for (const e of upcomingToday) {
-      // Skip all-day blocks (date-only start/end, no 'T' separator) — they
-      // parse to midnight local and would show up as "Next meeting in 1
-      // min" / "ev at 1:00" right after midnight in tz's with positive UTC
-      // offset. Same guard as pickInProgressEvent and tomorrowPreview.
-      if (!e.start.includes('T') || !e.end.includes('T')) continue;
-      const start = new Date(e.start).getTime();
-      if (Number.isNaN(start)) continue;
-      if (start > nowMs) return e;
-    }
-    return null;
-  }, [upcomingToday, upcomingTickMs]);
+  // `upcomingToday` is already all-day/declined/NaN-filtered and sorted by
+  // start ascending, so the soonest still-future event is just the first one
+  // that starts after now — no need to re-apply the guards here.
+  const nextSoonEvent = React.useMemo<CalendarEvent | null>(
+    () =>
+      upcomingToday.find((e) => new Date(e.start).getTime() > upcomingTickMs) ??
+      null,
+    [upcomingToday, upcomingTickMs],
+  );
+
+  // Whether we have live calendar data to reason about. Distinguishes a
+  // genuinely clear day (connected, no events) from "no calendar connected"
+  // so the hero only claims "Clear day ahead" when it actually knows.
+  const calendarConnected = !!calendar.data && !calendar.data.needsAuth;
 
   const heroState = React.useMemo(
     () => ({
@@ -447,6 +447,7 @@ export function Home({ mode }: HomeProps) {
       inProgressEvent,
       nextSoonEvent,
       tomorrowPreview,
+      calendarConnected,
       now: upcomingTickMs,
     }),
     [
@@ -455,6 +456,7 @@ export function Home({ mode }: HomeProps) {
       inProgressEvent,
       nextSoonEvent,
       tomorrowPreview,
+      calendarConnected,
       upcomingTickMs,
     ],
   );
@@ -806,7 +808,20 @@ interface HeroState {
   inProgressEvent: CalendarEvent | null;
   nextSoonEvent: CalendarEvent | null;
   tomorrowPreview: CalendarEvent | null;
+  calendarConnected: boolean;
   now: number;
+}
+
+// True only when `now` is inside the event's real [start, end) — i.e. the
+// meeting has actually started. `pickInProgressEvent` also returns events in
+// the 5-min early-join grace and the late-join floor, which are the right
+// targets for the "start recording" CTA but must NOT drive present-tense
+// copy like "In a meeting now" (the meeting may not have begun yet).
+function eventIsNow(e: CalendarEvent, nowMs: number): boolean {
+  const startMs = new Date(e.start).getTime();
+  const endMs = new Date(e.end).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return false;
+  return startMs <= nowMs && nowMs < endMs;
 }
 
 // Headline. Recording state always wins over calendar state — when the
@@ -821,7 +836,12 @@ function heroHeadline(s: HeroState): string {
     case 'processing':
       return 'Processing your note';
   }
-  if (s.inProgressEvent) return 'In a meeting now';
+  // Only present-tense when the meeting has truly started — not during the
+  // early-join grace, which would tell the user they're "in" a meeting that
+  // hasn't begun. The pre-start case falls through to "Next meeting in N min".
+  if (s.inProgressEvent && eventIsNow(s.inProgressEvent, s.now)) {
+    return 'In a meeting now';
+  }
   if (s.nextSoonEvent) {
     const startMs = new Date(s.nextSoonEvent.start).getTime();
     if (!Number.isNaN(startMs)) {
@@ -834,10 +854,13 @@ function heroHeadline(s: HeroState): string {
       const mins = Math.max(1, Math.ceil(deltaMs / MIN_MS));
       if (mins < 60) return `Next meeting in ${mins} min${mins === 1 ? '' : 's'}`;
       const hrs = Math.max(1, Math.round(deltaMs / HOUR_MS));
-      return `First meeting in ${hrs} hr${hrs === 1 ? '' : 's'}`;
+      return `Next meeting in ${hrs} hr${hrs === 1 ? '' : 's'}`;
     }
   }
-  if (s.tomorrowPreview) return 'Clear day ahead';
+  // Reaching here means nothing is live or upcoming today. Only call the day
+  // "clear" when the calendar is actually connected — otherwise we don't know,
+  // so keep the neutral invitation.
+  if (s.calendarConnected) return 'Clear day ahead';
   return 'Ready to capture beautiful notes';
 }
 
@@ -856,27 +879,29 @@ function heroSubtitle(s: HeroState): string {
     return `${title} · ${RECORD_SHORTCUT} to stop`;
   }
   if (s.status === 'paused') {
-    // The global ⌘⇧R toggle stops the recording rather than resuming —
-    // resume is a click-only action on the bottom bar. Don't claim a
-    // shortcut here.
+    // ⌘⇧R is a record-toggle: while paused it STOPS (finalizes) the recording
+    // rather than resuming. Resume is a click-only action on the bottom bar,
+    // so point there instead of advertising a shortcut that would end the note.
     return 'Recording paused. Tap resume on the bar below to continue.';
   }
   if (s.status === 'processing') {
-    return `We'll have your notes ready in a moment.`;
+    return `We'll have your note ready in a moment.`;
   }
-  if (s.inProgressEvent) {
+  // Only when the meeting has truly started (mirrors the headline gate) — the
+  // pre-start grace falls through to the timed "starts at …" line below.
+  if (s.inProgressEvent && eventIsNow(s.inProgressEvent, s.now)) {
     return `Press ${RECORD_SHORTCUT} to start recording — or tap a meeting card below.`;
   }
   if (s.nextSoonEvent) {
     const startMs = new Date(s.nextSoonEvent.start).getTime();
     if (!Number.isNaN(startMs)) {
-      // Mirror the headline's `mins < 60` threshold (Math.ceil-based) so
-      // the title-at-time line and "Next meeting in N min" headline flip
-      // to "First meeting in 1 hr" at the same instant.
+      // Mirror the headline's `mins < 60` threshold (Math.ceil-based) so the
+      // title-at-time line and the "Next meeting in N min" headline flip to
+      // the hours wording at the same instant.
       const mins = Math.max(1, Math.ceil((startMs - s.now) / MIN_MS));
       if (mins < 60) {
         const at = HERO_TIME_FMT.format(new Date(startMs));
-        return `${s.nextSoonEvent.title} at ${at}.`;
+        return `${s.nextSoonEvent.title} at ${at} — ${RECORD_SHORTCUT} when you're ready.`;
       }
     }
     return RECORDING_HINT;

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -57,6 +57,10 @@ export function Home({ mode }: HomeProps) {
   const [upcomingTickMs, setUpcomingTickMs] = React.useState<number>(() => Date.now());
   React.useEffect(() => {
     if (mode !== 'home') return;
+    // Refresh immediately on (re)entering Home, otherwise the hero copy
+    // is whatever `upcomingTickMs` was when the user last navigated away
+    // — potentially many minutes stale until the 60s interval fires.
+    setUpcomingTickMs(Date.now());
     const id = setInterval(() => setUpcomingTickMs(Date.now()), 60_000);
     return () => clearInterval(id);
   }, [mode]);
@@ -783,10 +787,18 @@ function AllDayInline({ events, expanded, onToggle }: AllDayInlineProps) {
 const RECORD_SHORTCUT = shortcut('⌘⇧R', 'Ctrl+Shift+R');
 const RECORDING_HINT = `Start recording from the top-right, or from anywhere with ${RECORD_SHORTCUT}.`;
 
+// Cached at module load to avoid rebuilding on every render. We don't
+// react to system-locale changes mid-session — that would require a full
+// app relaunch on macOS anyway, and creating an Intl.DateTimeFormat per
+// render isn't free. If we ever start supporting in-app locale toggles
+// we'd need to move this inside the function.
 const HERO_TIME_FMT = new Intl.DateTimeFormat(undefined, {
   hour: 'numeric',
   minute: '2-digit',
 });
+
+const HOUR_MS = 60 * 60 * 1000;
+const MIN_MS = 60 * 1000;
 
 interface HeroState {
   status: 'idle' | 'recording' | 'paused' | 'processing';
@@ -813,9 +825,16 @@ function heroHeadline(s: HeroState): string {
   if (s.nextSoonEvent) {
     const startMs = new Date(s.nextSoonEvent.start).getTime();
     if (!Number.isNaN(startMs)) {
-      const mins = Math.max(0, Math.round((startMs - s.now) / 60000));
-      if (mins < 60) return `Next meeting in ${mins} min${mins === 1 ? '' : 's'}`;
-      const hrs = Math.round(mins / 60);
+      const deltaMs = startMs - s.now;
+      if (deltaMs < HOUR_MS) {
+        // Math.ceil + Math.max(1) keeps the headline non-zero and avoids
+        // the boundary jitter that Math.round would cause around 0 mins
+        // (would print "0 mins") and around 60 mins (would round up into
+        // the hour branch one tick early).
+        const mins = Math.max(1, Math.ceil(deltaMs / MIN_MS));
+        return `Next meeting in ${mins} min${mins === 1 ? '' : 's'}`;
+      }
+      const hrs = Math.round(deltaMs / HOUR_MS);
       return `First meeting in ${hrs} hr${hrs === 1 ? '' : 's'}`;
     }
   }
@@ -851,8 +870,10 @@ function heroSubtitle(s: HeroState): string {
   }
   if (s.nextSoonEvent) {
     const startMs = new Date(s.nextSoonEvent.start).getTime();
-    const startMins = Math.round((startMs - s.now) / 60000);
-    if (!Number.isNaN(startMs) && startMins < 60) {
+    // Use the raw ms delta so the subtitle's "<60 min" threshold flips at
+    // the same moment the headline does — keeps them in sync at the
+    // boundary instead of one flipping a tick before the other.
+    if (!Number.isNaN(startMs) && startMs - s.now < HOUR_MS) {
       const at = HERO_TIME_FMT.format(new Date(startMs));
       return `${s.nextSoonEvent.title} at ${at}.`;
     }

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -826,15 +826,14 @@ function heroHeadline(s: HeroState): string {
     const startMs = new Date(s.nextSoonEvent.start).getTime();
     if (!Number.isNaN(startMs)) {
       const deltaMs = startMs - s.now;
-      if (deltaMs < HOUR_MS) {
-        // Math.ceil + Math.max(1) keeps the headline non-zero and avoids
-        // the boundary jitter that Math.round would cause around 0 mins
-        // (would print "0 mins") and around 60 mins (would round up into
-        // the hour branch one tick early).
-        const mins = Math.max(1, Math.ceil(deltaMs / MIN_MS));
-        return `Next meeting in ${mins} min${mins === 1 ? '' : 's'}`;
-      }
-      const hrs = Math.round(deltaMs / HOUR_MS);
+      // Compute mins first and gate on the rounded value: Math.ceil rounds
+      // anything in (59 min, 60 min) up to 60, and "60 mins" reads
+      // unnaturally — fall straight through to "1 hr" instead. The
+      // Math.max(1) keeps the headline non-zero in the last 30 seconds
+      // before start.
+      const mins = Math.max(1, Math.ceil(deltaMs / MIN_MS));
+      if (mins < 60) return `Next meeting in ${mins} min${mins === 1 ? '' : 's'}`;
+      const hrs = Math.max(1, Math.round(deltaMs / HOUR_MS));
       return `First meeting in ${hrs} hr${hrs === 1 ? '' : 's'}`;
     }
   }
@@ -870,12 +869,15 @@ function heroSubtitle(s: HeroState): string {
   }
   if (s.nextSoonEvent) {
     const startMs = new Date(s.nextSoonEvent.start).getTime();
-    // Use the raw ms delta so the subtitle's "<60 min" threshold flips at
-    // the same moment the headline does — keeps them in sync at the
-    // boundary instead of one flipping a tick before the other.
-    if (!Number.isNaN(startMs) && startMs - s.now < HOUR_MS) {
-      const at = HERO_TIME_FMT.format(new Date(startMs));
-      return `${s.nextSoonEvent.title} at ${at}.`;
+    if (!Number.isNaN(startMs)) {
+      // Mirror the headline's `mins < 60` threshold (Math.ceil-based) so
+      // the title-at-time line and "Next meeting in N min" headline flip
+      // to "First meeting in 1 hr" at the same instant.
+      const mins = Math.max(1, Math.ceil((startMs - s.now) / MIN_MS));
+      if (mins < 60) {
+        const at = HERO_TIME_FMT.format(new Date(startMs));
+        return `${s.nextSoonEvent.title} at ${at}.`;
+      }
     }
     return RECORDING_HINT;
   }

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/hooks/useCalendarEvents';
 import { useFolders } from '@/hooks/useFolders';
 import { ipc, type CalendarEvent, type Meeting } from '@/lib/ipc';
+import { pickInProgressEvent } from '@/lib/calendar';
 import { navigate } from '@/lib/router';
 
 interface HomeProps {
@@ -411,7 +412,50 @@ export function Home({ mode }: HomeProps) {
   const emptyStateCalendarNudge = renderCalendarNudge(false);
   const homeCalendarNudge = renderCalendarNudge(true);
 
-  const greeting = `Ready to capture beautiful notes`;
+  // Hero state inputs. All recompute on the existing 60s tick — no new
+  // intervals. `inProgressEvent` uses the same matching window as the
+  // backend's auto-detect (5 min early grace, 10 min late floor) so the
+  // hero copy and the "Meeting detected" notification agree.
+  const inProgressEvent = React.useMemo<CalendarEvent | null>(() => {
+    if (!calendar.data || calendar.data.needsAuth) return null;
+    return pickInProgressEvent(calendar.data.events, new Date(upcomingTickMs));
+  }, [calendar.data, upcomingTickMs]);
+
+  const nextSoonEvent = React.useMemo<CalendarEvent | null>(() => {
+    const nowMs = upcomingTickMs;
+    for (const e of upcomingToday) {
+      // Skip all-day blocks (date-only start/end, no 'T' separator) — they
+      // parse to midnight local and would show up as "Next meeting in 1
+      // min" / "ev at 1:00" right after midnight in tz's with positive UTC
+      // offset. Same guard as pickInProgressEvent and tomorrowPreview.
+      if (!e.start.includes('T') || !e.end.includes('T')) continue;
+      const start = new Date(e.start).getTime();
+      if (Number.isNaN(start)) continue;
+      if (start > nowMs) return e;
+    }
+    return null;
+  }, [upcomingToday, upcomingTickMs]);
+
+  const heroState = React.useMemo(
+    () => ({
+      status: recording.status,
+      sessionName: recording.sessionName,
+      inProgressEvent,
+      nextSoonEvent,
+      tomorrowPreview,
+      now: upcomingTickMs,
+    }),
+    [
+      recording.status,
+      recording.sessionName,
+      inProgressEvent,
+      nextSoonEvent,
+      tomorrowPreview,
+      upcomingTickMs,
+    ],
+  );
+  const greeting = heroHeadline(heroState);
+  const heroSub = heroSubtitle(heroState);
   const dateStr = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
     month: 'long',
@@ -497,7 +541,7 @@ export function Home({ mode }: HomeProps) {
                 className="max-w-[52ch] text-sm leading-[1.55]"
                 style={{ color: 'var(--fg-2)' }}
               >
-                {`Start recording from the top-right, or from anywhere with ${shortcut('⌘⇧R', 'Ctrl+Shift+R')}.`}
+                {heroSub}
               </p>
             </div>
           )}
@@ -700,7 +744,6 @@ function SectionHead({ title, count, action }: SectionHeadProps) {
   );
 }
 
-
 interface AllDayInlineProps {
   events: CalendarEvent[];
   expanded: boolean;
@@ -733,6 +776,96 @@ function AllDayInline({ events, expanded, onToggle }: AllDayInlineProps) {
       )}
     </div>
   );
+}
+
+// Default subtitle — also used as the empty/idle fallback. Cached so it
+// renders the same string each call without rebuilding the shortcut.
+const RECORD_SHORTCUT = shortcut('⌘⇧R', 'Ctrl+Shift+R');
+const RECORDING_HINT = `Start recording from the top-right, or from anywhere with ${RECORD_SHORTCUT}.`;
+
+const HERO_TIME_FMT = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: '2-digit',
+});
+
+interface HeroState {
+  status: 'idle' | 'recording' | 'paused' | 'processing';
+  sessionName: string | null;
+  inProgressEvent: CalendarEvent | null;
+  nextSoonEvent: CalendarEvent | null;
+  tomorrowPreview: CalendarEvent | null;
+  now: number;
+}
+
+// Headline. Recording state always wins over calendar state — when the
+// user is recording / paused / processing they want status, not a
+// schedule. Idle falls through to the calendar-driven copy.
+function heroHeadline(s: HeroState): string {
+  switch (s.status) {
+    case 'recording':
+      return 'Recording';
+    case 'paused':
+      return 'Recording paused';
+    case 'processing':
+      return 'Processing your note';
+  }
+  if (s.inProgressEvent) return 'In a meeting now';
+  if (s.nextSoonEvent) {
+    const startMs = new Date(s.nextSoonEvent.start).getTime();
+    if (!Number.isNaN(startMs)) {
+      const mins = Math.max(0, Math.round((startMs - s.now) / 60000));
+      if (mins < 60) return `Next meeting in ${mins} min${mins === 1 ? '' : 's'}`;
+      const hrs = Math.round(mins / 60);
+      return `First meeting in ${hrs} hr${hrs === 1 ? '' : 's'}`;
+    }
+  }
+  if (s.tomorrowPreview) return 'Clear day ahead';
+  return 'Ready to capture beautiful notes';
+}
+
+// Subtitle. Mirrors the headline cases. Keeps the recording shortcut hint
+// as the default fallback so the page always tells the user how to act.
+function heroSubtitle(s: HeroState): string {
+  if (s.status === 'recording') {
+    // Source of truth for "what we're capturing" is the active session
+    // name — the user may have started a recording titled after one
+    // event while a different calendar event is also concurrently in
+    // progress, and the subtitle should reflect what they actually hit
+    // record on. ⌘⇧R is a record-toggle per main.js's global shortcut
+    // so "to stop" is accurate when already recording.
+    const title =
+      s.sessionName?.trim() || s.inProgressEvent?.title?.trim() || 'In progress';
+    return `${title} · ${RECORD_SHORTCUT} to stop`;
+  }
+  if (s.status === 'paused') {
+    // The global ⌘⇧R toggle stops the recording rather than resuming —
+    // resume is a click-only action on the bottom bar. Don't claim a
+    // shortcut here.
+    return 'Recording paused. Tap resume on the bar below to continue.';
+  }
+  if (s.status === 'processing') {
+    return `We'll have your notes ready in a moment.`;
+  }
+  if (s.inProgressEvent) {
+    return `Press ${RECORD_SHORTCUT} to start recording — or tap a meeting card below.`;
+  }
+  if (s.nextSoonEvent) {
+    const startMs = new Date(s.nextSoonEvent.start).getTime();
+    const startMins = Math.round((startMs - s.now) / 60000);
+    if (!Number.isNaN(startMs) && startMins < 60) {
+      const at = HERO_TIME_FMT.format(new Date(startMs));
+      return `${s.nextSoonEvent.title} at ${at}.`;
+    }
+    return RECORDING_HINT;
+  }
+  if (s.tomorrowPreview) {
+    const startMs = new Date(s.tomorrowPreview.start).getTime();
+    if (!Number.isNaN(startMs)) {
+      const at = HERO_TIME_FMT.format(new Date(startMs));
+      return `Next up: ${s.tomorrowPreview.title} tomorrow at ${at}.`;
+    }
+  }
+  return RECORDING_HINT;
 }
 
 function firstFolderName(


### PR DESCRIPTION
## Summary
Hero on Home was two static lines (`Ready to capture beautiful notes.` + a generic ⌘⇧R hint). Now it reacts to recording state + calendar state.

**State matrix (recording state wins over calendar state):**

| State | H1 | Subtitle |
|---|---|---|
| `recording` | `Recording` | `<sessionName> · ⌘⇧R to stop` |
| `paused` | `Recording paused` | `Tap resume on the bar below to continue.` |
| `processing` | `Processing your note` | `We'll have your notes ready in a moment.` |
| idle + event in progress | `In a meeting now` | `Press ⌘⇧R to start recording — or tap a meeting card below.` |
| idle + event in <60 min | `Next meeting in N min` | `<title> at <time>` |
| idle + event later today | `First meeting in N hr(s)` | recording hint |
| idle + no today + tomorrow has event | `Clear day ahead` | `Next up: <title> tomorrow at <time>.` |
| idle + no events / disconnected | `Ready to capture beautiful notes` | recording hint |

**Implementation:**
- New pure helper `app/renderer/src/lib/calendar.ts` ports the backend's `pickCurrentCalendarEvent` matching window (5-min early grace, 10-min late floor, all-day skip via `T` separator check) so the hero and the auto-detect-meeting notification agree on what counts as "in a meeting now."
- Three derived memos in Home: `inProgressEvent`, `nextSoonEvent`, `tomorrowPreview`. All recompute on the existing 60s `upcomingTickMs` tick — no new intervals.
- `heroHeadline` / `heroSubtitle` are pure functions of `(recording, inProgressEvent, nextSoonEvent, tomorrowPreview, now)`. Easy to unit-test, no React inside.
- CSS `transition: color` on `.home-hello` softens theme swaps; text content swap still pops (CSS can't tween text — accepted in the plan).
- All-day events filtered from `nextSoonEvent` / `tomorrowPreview` / `inProgressEvent` via the `T` separator check, so the hero never counts down to an OOO block parsed as 00:00 local.
- Recording subtitle prefers `recording.sessionName` over `inProgressEvent.title` — if you started a recording titled `ev` while `some meeting` is also calendar-active, the hero reflects what you actually hit record on.

**Notes:**
- No backend changes, no new IPC, no new deps.
- Independent of PR #144 (calendar prioritization). When #144 lands, `nextSoonEvent` could optionally tighten to also check `e.is_all_day === true` — minor follow-up.
- Recording / Paused / Processing rows are a corner case: `App.tsx` auto-redirects from `/` to `/recording` when a recording starts, so the only path to seeing them is the user manually clicking Home in the sidebar mid-recording. Kept anyway — cheap and makes the hero robust regardless of route.

## Test plan
- [ ] Idle + no events → `Ready to capture beautiful notes.` + recording hint. Disconnect calendar, same fallback.
- [ ] Idle + event in ~30 min → `Next meeting in 30 mins.` + `<title> at <time>.`
- [ ] Idle + event in ~3 hrs → `First meeting in 3 hrs.` + recording hint.
- [ ] Idle + event currently happening → `In a meeting now.` + nudge subtitle. Wait 60s, confirm tick refresh.
- [ ] Idle + all-day event only → fallback (not "Next meeting in 1 min" pointing to the all-day block).
- [ ] Start recording → hero swaps to `Recording.` + `<sessionName> · ⌘⇧R to stop`.
- [ ] Pause → `Recording paused.` + resume hint.
- [ ] Stop → `Processing your note.` briefly, then back to idle.
- [ ] No events today, has events tomorrow → `Clear day ahead.` + `Next up: <title> tomorrow at <time>.`
- [ ] Switch system locale (US ↔ DE) → time format follows (`7:00 AM` vs `07:00`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Home hero dynamic based on recording and calendar state, replacing static copy with context-aware status and hints. Tightens event matching and copy so the hero agrees with the auto-detect notification and avoids premature “in a meeting” or “clear day” claims.

- **New Features**
  - Dynamic headline/subtitle for Recording, Paused, Processing, or idle (in-progress, starting soon, later today, tomorrow, or no events). Headline uses “Next meeting in N min/hr”.
  - Recording state wins over calendar; subtitle prefers `sessionName` and shows `⌘⇧R` where relevant.
  - New `app/renderer/src/lib/calendar.ts` `pickInProgressEvent` mirrors main’s rules (5‑min early, 10‑min late) with cross‑refs; filters all‑day (incl. Outlook `is_all_day`) and declined events.
  - No new intervals; hero recomputes on the 60s tick; `heroHeadline`/`heroSubtitle` are pure; soft color transitions on `.home-hello` and `.home-hello .faint` using `--dur-fast`/`--ease`.

- **Bug Fixes**
  - Only say “In a meeting now” after the meeting actually starts (early-join grace shows “Next meeting in N min” instead).
  - “Clear day ahead” only when the calendar is connected; otherwise keep the neutral invite.
  - Keep renderer and main in sync by guarding declined and all‑day events; derive `nextSoonEvent` from filtered `upcomingToday` to avoid drift.
  - Refresh hero immediately when returning to Home; collapse “60 mins” to “1 hr” and switch headline/subtitle at the same instant; copy tweaks (“your note”, “Next meeting in N hr”, add record hint under <60 min).

<sup>Written for commit 1f61e732c9e35b23351aed57c343e29c7b0e4c13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

