### PR TITLE
calendar connect nudge

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stenoai",
-  "version": "0.2.13",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stenoai",
-      "version": "0.2.13",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
@@ -102,7 +102,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -636,6 +635,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -657,6 +657,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2993,7 +2994,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3004,7 +3004,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3078,7 +3077,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -3337,7 +3335,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3371,7 +3368,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4199,7 +4195,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4746,7 +4741,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5023,8 +5019,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5088,7 +5083,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -5204,7 +5198,6 @@
       "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.0.tgz",
       "integrity": "sha512-in5jnW/Ywy3Rh3FPr4MR80exPEkywKYAmDJRZ/gIKlr8VXEi3zXgiAZbf0Si7KRccHTF2y8euVMRz7M6HqTjMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^5.0.0",
         "@types/node": "^24.9.0",
@@ -5313,6 +5306,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5333,6 +5327,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5348,6 +5343,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5358,6 +5354,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -5683,7 +5680,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8612,6 +8608,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9302,7 +9299,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9487,6 +9483,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9504,6 +9501,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9715,7 +9713,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9725,7 +9722,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10107,6 +10103,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11052,6 +11049,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -11171,7 +11169,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11386,7 +11383,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11675,7 +11671,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -11998,7 +11993,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -167,6 +167,69 @@ export function Home({ mode }: HomeProps) {
   const googleAuth = useGoogleCalendarAuth();
   const outlookAuth = useOutlookCalendarAuth();
 
+  // Rendered both in the empty-state Welcome screen (brand-new users with
+  // zero meetings — exactly who needs to discover calendar integration)
+  // and in the regular Home above the Upcoming section. Extracted here
+  // so both branches use the same JSX instead of drifting.
+  const calendarNudge = showCalendarNudge ? (
+    <div
+      className="flex items-center gap-2 text-xs"
+      style={{ color: 'var(--fg-2)' }}
+    >
+      {!calendarNudgeExpanded ? (
+        <button
+          type="button"
+          onClick={() => setCalendarNudgeExpanded(true)}
+          className="-mx-1 flex flex-1 items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-[color:var(--surface-hover)]"
+          style={{ color: 'var(--fg-2)' }}
+        >
+          <Calendar className="size-3.5 flex-shrink-0" />
+          <span>Connect a calendar to see today's meetings.</span>
+        </button>
+      ) : (
+        <>
+          <Calendar
+            className="size-3.5 flex-shrink-0"
+            style={{ color: 'var(--fg-2)' }}
+          />
+          <span>Connect:</span>
+          <button
+            type="button"
+            onClick={() => googleAuth.connect.mutate()}
+            disabled={
+              googleAuth.connect.isPending || outlookAuth.connect.isPending
+            }
+            className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
+            style={{ color: 'var(--fg-1)' }}
+          >
+            {googleAuth.connect.isPending ? 'Connecting…' : 'Google'}
+          </button>
+          <button
+            type="button"
+            onClick={() => outlookAuth.connect.mutate()}
+            disabled={
+              googleAuth.connect.isPending || outlookAuth.connect.isPending
+            }
+            className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
+            style={{ color: 'var(--fg-1)' }}
+          >
+            {outlookAuth.connect.isPending ? 'Connecting…' : 'Outlook'}
+          </button>
+        </>
+      )}
+      <button
+        type="button"
+        onClick={onDismissCalendarNudge}
+        aria-label="Dismiss"
+        title="Dismiss"
+        className="ml-auto rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)]"
+        style={{ color: 'var(--fg-2)' }}
+      >
+        <X className="size-3" />
+      </button>
+    </div>
+  ) : null;
+
   const greeting = `Ready to capture beautiful notes`;
   const dateStr = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
@@ -229,6 +292,9 @@ export function Home({ mode }: HomeProps) {
               <span>from anywhere</span>
             </p>
           </div>
+          {calendarNudge && (
+            <div className="w-full max-w-[420px]">{calendarNudge}</div>
+          )}
         </div>
       ) : (
         <>
@@ -255,66 +321,7 @@ export function Home({ mode }: HomeProps) {
             </div>
           )}
 
-          {showCalendarNudge && (
-            <div
-              className="mb-8 flex items-center gap-2 text-xs"
-              style={{ color: 'var(--fg-2)' }}
-            >
-              {!calendarNudgeExpanded ? (
-                <button
-                  type="button"
-                  onClick={() => setCalendarNudgeExpanded(true)}
-                  className="-mx-1 flex flex-1 items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-[color:var(--surface-hover)]"
-                  style={{ color: 'var(--fg-2)' }}
-                >
-                  <Calendar className="size-3.5 flex-shrink-0" />
-                  <span>Connect a calendar to see today's meetings.</span>
-                </button>
-              ) : (
-                <>
-                  <Calendar
-                    className="size-3.5 flex-shrink-0"
-                    style={{ color: 'var(--fg-2)' }}
-                  />
-                  <span>Connect:</span>
-                  <button
-                    type="button"
-                    onClick={() => googleAuth.connect.mutate()}
-                    disabled={
-                      googleAuth.connect.isPending ||
-                      outlookAuth.connect.isPending
-                    }
-                    className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
-                    style={{ color: 'var(--fg-1)' }}
-                  >
-                    {googleAuth.connect.isPending ? 'Connecting…' : 'Google'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => outlookAuth.connect.mutate()}
-                    disabled={
-                      googleAuth.connect.isPending ||
-                      outlookAuth.connect.isPending
-                    }
-                    className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
-                    style={{ color: 'var(--fg-1)' }}
-                  >
-                    {outlookAuth.connect.isPending ? 'Connecting…' : 'Outlook'}
-                  </button>
-                </>
-              )}
-              <button
-                type="button"
-                onClick={onDismissCalendarNudge}
-                aria-label="Dismiss"
-                title="Dismiss"
-                className="ml-auto rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)]"
-                style={{ color: 'var(--fg-2)' }}
-              >
-                <X className="size-3" />
-              </button>
-            </div>
-          )}
+          {calendarNudge && <div className="mb-8">{calendarNudge}</div>}
 
           {upcomingToday.length > 0 && mode === 'home' && (
             <section className="mb-10">

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ChevronLeft, ChevronRight, PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
+import { Calendar, ChevronLeft, ChevronRight, PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import { UpcomingCard } from '@/components/home/UpcomingCard';
 import { PreviousRow } from '@/components/home/PreviousRow';
@@ -8,7 +8,11 @@ import { AppIcon } from '@/components/ui/app-icon';
 import { KbdKey } from '@/components/ui/kbd';
 import { useMeetings } from '@/hooks/useMeetings';
 import { useRecording } from '@/hooks/useRecording';
-import { useCalendarEvents } from '@/hooks/useCalendarEvents';
+import {
+  useCalendarEvents,
+  useGoogleCalendarAuth,
+  useOutlookCalendarAuth,
+} from '@/hooks/useCalendarEvents';
 import { useFolders } from '@/hooks/useFolders';
 import type { CalendarEvent, Meeting } from '@/lib/ipc';
 import { shortcut } from '@/lib/utils';
@@ -129,6 +133,40 @@ export function Home({ mode }: HomeProps) {
   }, [mode, previous, search]);
   const groups = React.useMemo(() => groupPrevious(filtered), [filtered]);
 
+  // Calendar-connect nudge: most new users don't realise StenoAI can
+  // surface their meetings until something tells them. Show a small
+  // dismissible line on Home when calendar is unconnected; persist the
+  // dismissal in localStorage so we don't nag the same person twice.
+  const NUDGE_KEY = 'home.calendarNudge.dismissed';
+  const [calendarNudgeDismissed, setCalendarNudgeDismissed] =
+    React.useState<boolean>(() => {
+      try {
+        return localStorage.getItem(NUDGE_KEY) === 'true';
+      } catch {
+        return false;
+      }
+    });
+  const onDismissCalendarNudge = () => {
+    try {
+      localStorage.setItem(NUDGE_KEY, 'true');
+    } catch {
+      // Private mode / quota errors — just hide locally for this session.
+    }
+    setCalendarNudgeDismissed(true);
+  };
+  const showCalendarNudge =
+    mode === 'home' &&
+    calendar.data?.needsAuth === true &&
+    !calendarNudgeDismissed;
+
+  // Inline provider picker for the nudge. Collapsed by default — clicking
+  // the message expands it to surface Google / Outlook buttons right
+  // where the user is, so we don't make them hunt through Settings.
+  const [calendarNudgeExpanded, setCalendarNudgeExpanded] =
+    React.useState<boolean>(false);
+  const googleAuth = useGoogleCalendarAuth();
+  const outlookAuth = useOutlookCalendarAuth();
+
   const greeting = `Ready to capture beautiful notes`;
   const dateStr = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
@@ -214,6 +252,67 @@ export function Home({ mode }: HomeProps) {
               >
                 {summaryLine(upcomingToday.length)}
               </p>
+            </div>
+          )}
+
+          {showCalendarNudge && (
+            <div
+              className="mb-8 flex items-center gap-2 text-xs"
+              style={{ color: 'var(--fg-2)' }}
+            >
+              {!calendarNudgeExpanded ? (
+                <button
+                  type="button"
+                  onClick={() => setCalendarNudgeExpanded(true)}
+                  className="-mx-1 flex flex-1 items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-[color:var(--surface-hover)]"
+                  style={{ color: 'var(--fg-2)' }}
+                >
+                  <Calendar className="size-3.5 flex-shrink-0" />
+                  <span>Connect a calendar to see today's meetings.</span>
+                </button>
+              ) : (
+                <>
+                  <Calendar
+                    className="size-3.5 flex-shrink-0"
+                    style={{ color: 'var(--fg-2)' }}
+                  />
+                  <span>Connect:</span>
+                  <button
+                    type="button"
+                    onClick={() => googleAuth.connect.mutate()}
+                    disabled={
+                      googleAuth.connect.isPending ||
+                      outlookAuth.connect.isPending
+                    }
+                    className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
+                    style={{ color: 'var(--fg-1)' }}
+                  >
+                    {googleAuth.connect.isPending ? 'Connecting…' : 'Google'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => outlookAuth.connect.mutate()}
+                    disabled={
+                      googleAuth.connect.isPending ||
+                      outlookAuth.connect.isPending
+                    }
+                    className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
+                    style={{ color: 'var(--fg-1)' }}
+                  >
+                    {outlookAuth.connect.isPending ? 'Connecting…' : 'Outlook'}
+                  </button>
+                </>
+              )}
+              <button
+                type="button"
+                onClick={onDismissCalendarNudge}
+                aria-label="Dismiss"
+                title="Dismiss"
+                className="ml-auto rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)]"
+                style={{ color: 'var(--fg-2)' }}
+              >
+                <X className="size-3" />
+              </button>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
Small dismissible one-liner on Home when no calendar is connected, so new users discover the feature without hunting through Settings.

- Renders when `mode === 'home'` and `calendar.data?.needsAuth === true` and not previously dismissed (`localStorage['home.calendarNudge.dismissed']`).
- Collapsed: `📅  Connect a calendar to see today's meetings.` + dismiss `×`. Whole message is one click target.
- Click the message → expands inline to `📅  Connect:  [Google]  [Outlook]  ×`. No navigation; provider picker is right where the user already is.
- Click a provider → existing `useGoogleCalendarAuth` / `useOutlookCalendarAuth` connect mutation fires (system browser OAuth). Button shows `Connecting…` while pending; the other provider is disabled during that window.
- On success, `googleAuthChanged` / `outlookAuthChanged` IPC events invalidate the calendar query, `needsAuth` flips false, and the nudge auto-hides.
- Dismiss `×` writes `true` to localStorage and stays hidden across relaunches. Wrapped in try/catch so private-mode / quota errors silently fall back to in-session dismissal.

No backend changes. No new IPC. No new deps.

## Test plan
- [ ] Disconnect calendar in Settings → relaunch app → confirm nudge shows under hero.
- [ ] Click the message → expands to show Google + Outlook buttons.
- [ ] Click Google → browser OAuth opens; on success the nudge disappears without manual reload.
- [ ] Click Outlook → same.
- [ ] Click dismiss `×` while collapsed → nudge gone. Relaunch app → still gone (localStorage persists).
- [ ] Connect a calendar without using the nudge → nudge also disappears (since `needsAuth` is what gates it).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a small, dismissible calendar connect nudge on Home and the empty welcome screen when no calendar is connected, with inline Google/Outlook buttons. Dismissal persists across launches and the nudge auto-hides after a successful auth.

- **New Features**
  - Renders only when `mode === 'home'`, `calendar.data?.needsAuth === true`, and not previously dismissed; shown in both the empty-state Welcome view and regular Home.
  - Collapsed one-liner expands on click to show inline provider buttons; whole row is clickable.
  - Buttons trigger existing `useGoogleCalendarAuth` / `useOutlookCalendarAuth` mutations; show “Connecting…” and disable the other provider while pending.
  - On success, `googleAuthChanged` / `outlookAuthChanged` invalidate the calendar query so `needsAuth` flips false and the nudge hides.
  - Dismiss `×` stores the flag; storage errors fall back to session-only dismissal.

<sup>Written for commit 109599064085958fb272d7b97a66d92a776f5dd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

