### PR TITLE
recorder state: atomic writes + better error handling

### DIFF
--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -141,10 +141,13 @@ class SimpleRecorder:
         try:
             with open(self.state_file, 'r') as f:
                 return json.load(f)
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
             # Corrupt state — most likely a non-atomic write was killed
             # mid-flight before save_state's tempfile + rename pattern was
-            # in place. Quarantine the file so a human can inspect it.
+            # in place. UnicodeDecodeError covers the case where binary
+            # garbage from a partial write fails UTF-8 decoding before
+            # json.load even sees it. Both are "content unparseable" —
+            # quarantine and return default.
             logger.error(f"State file corrupt at {self.state_file}: {e}")
             try:
                 quarantine = self.state_file.with_suffix(self.state_file.suffix + '.corrupt')

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -19,8 +19,10 @@ import click
 import asyncio
 import logging
 import json
+import os
 import re
 import sys
+import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
@@ -61,6 +63,47 @@ _AUTO_NAMED_PATTERN = re.compile(
     r'|.+ — \d{4}-\d{2}-\d{2} \d{2}:\d{2})$'
 )
 
+def _atomic_write_json(path: Path, payload) -> None:
+    """Write `payload` as JSON to `path` atomically.
+
+    Uses tempfile + os.replace within the same directory so the rename
+    is a single filesystem operation. On POSIX and Windows, os.replace
+    is atomic — a crash mid-write leaves the prior file intact (or
+    nothing, on first write) rather than a half-written file that
+    subsequent reads would misparse.
+
+    Used for `recorder_state.json` (where a corrupt file means we lose
+    track of a live recording) and the final summary JSON (where a
+    corrupt file means a finished meeting's processing is lost).
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # NamedTemporaryFile in the same dir guarantees os.replace stays on
+    # one filesystem. delete=False so we can rename rather than auto-clean.
+    tmp = tempfile.NamedTemporaryFile(
+        mode='w',
+        dir=str(path.parent),
+        prefix=f'.{path.name}.',
+        suffix='.tmp',
+        delete=False,
+        encoding='utf-8',
+    )
+    try:
+        with tmp as f:
+            json.dump(payload, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp.name, path)
+    except Exception:
+        # Best-effort cleanup of the orphan temp file. Don't mask the
+        # original error.
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+
+
 class SimpleRecorder:
     """Simple audio recorder and transcriber."""
     
@@ -86,19 +129,47 @@ class SimpleRecorder:
         self.persistent_recorder = None
         
     def get_state(self) -> dict:
-        """Get current recorder state."""
-        if self.state_file.exists():
+        """Get current recorder state.
+
+        Distinguishes "file missing" (normal — return default) from "file
+        unreadable / corrupt" (real failure — log and quarantine so the
+        user can recover the file and we don't pretend we were idle while
+        an orphan subprocess may still be writing audio).
+        """
+        if not self.state_file.exists():
+            return {"recording": False, "current_file": None, "session_name": None}
+        try:
+            with open(self.state_file, 'r') as f:
+                return json.load(f)
+        except json.JSONDecodeError as e:
+            # Corrupt state — most likely a non-atomic write was killed
+            # mid-flight before save_state's tempfile + rename pattern was
+            # in place. Quarantine the file so a human can inspect it.
+            logger.error(f"State file corrupt at {self.state_file}: {e}")
             try:
-                with open(self.state_file, 'r') as f:
-                    return json.load(f)
-            except:
-                pass
+                quarantine = self.state_file.with_suffix(self.state_file.suffix + '.corrupt')
+                self.state_file.replace(quarantine)
+                logger.error(f"Moved corrupt state aside to {quarantine}")
+            except OSError as move_err:
+                logger.error(f"Failed to quarantine corrupt state file: {move_err}")
+        except OSError as e:
+            # Permission / IO error reading the file. Don't pretend we're
+            # idle — surface this loudly so the user can fix file perms or
+            # disk issues instead of silently losing recording state.
+            logger.error(f"Failed to read state file {self.state_file}: {e}")
         return {"recording": False, "current_file": None, "session_name": None}
-    
+
     def save_state(self, state: dict):
-        """Save recorder state."""
-        with open(self.state_file, 'w') as f:
-            json.dump(state, f, indent=2)
+        """Save recorder state atomically.
+
+        Writes to a tempfile in the same directory (so os.replace is an
+        atomic rename within one filesystem) and then renames over the
+        real path. A crash mid-write either leaves the prior valid state
+        intact or leaves an orphan tempfile alongside it — never a
+        partially-written recorder_state.json that get_state would
+        misread as "idle" while audio is still being captured.
+        """
+        _atomic_write_json(self.state_file, state)
 
     def _resolve_output_language(self, configured_language: str, detected_language: Optional[str] = None) -> str:
         """Resolve which language should be used for summary/title/query output."""
@@ -493,9 +564,12 @@ Transcript:
             "user_notes": notes_text,
         }
         
-        with open(summary_path, 'w') as f:
-            json.dump(complete_data, f, indent=2)
-        
+        # Atomic write: a crash here previously left a half-written
+        # multi-MB summary JSON and the source WAV gets deleted below,
+        # so the meeting was unrecoverable. Now the prior file (if any)
+        # stays intact unless the new one writes fully.
+        _atomic_write_json(summary_path, complete_data)
+
         print(f"✅ Complete processing saved: {summary_path}")
         
         # Clean up WAV file after successful processing

--- a/tests/test_recorder_state.py
+++ b/tests/test_recorder_state.py
@@ -1,0 +1,169 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from simple_recorder import SimpleRecorder, _atomic_write_json
+
+
+class AtomicWriteJsonTests(unittest.TestCase):
+    def test_writes_valid_json_to_new_path(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "state.json"
+            payload = {"recording": True, "session_name": "Daily"}
+
+            _atomic_write_json(target, payload)
+
+            self.assertTrue(target.exists())
+            with open(target, "r") as f:
+                self.assertEqual(json.load(f), payload)
+
+    def test_replaces_existing_file_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "state.json"
+            target.write_text('{"prior": true}')
+
+            _atomic_write_json(target, {"replaced": True})
+
+            with open(target, "r") as f:
+                self.assertEqual(json.load(f), {"replaced": True})
+
+    def test_failed_write_preserves_existing_file(self):
+        """If json.dump raises mid-flight, the original file must remain intact
+        and the temp file must be cleaned up — that's the whole point of the
+        atomic-rename pattern."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "state.json"
+            target.write_text('{"prior": "intact"}')
+
+            # A payload that can't be JSON-serialised forces json.dump to raise.
+            unserialisable = {"obj": object()}
+
+            with self.assertRaises(TypeError):
+                _atomic_write_json(target, unserialisable)
+
+            # Original file untouched.
+            with open(target, "r") as f:
+                self.assertEqual(json.load(f), {"prior": "intact"})
+
+            # No stray *.tmp files left behind in the directory.
+            stray_temps = [
+                p for p in Path(tmp_dir).iterdir() if p.name.endswith(".tmp")
+            ]
+            self.assertEqual(stray_temps, [])
+
+    def test_creates_parent_directory_if_missing(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "nested" / "deeper" / "state.json"
+            _atomic_write_json(target, {"ok": True})
+            self.assertTrue(target.exists())
+
+
+class GetStateTests(unittest.TestCase):
+    """get_state distinguishes 'missing' (return default) from 'corrupt'
+    (quarantine + return default + log) from 'unreadable' (log + return
+    default). Previously it swallowed all three identically via a bare
+    `except:`."""
+
+    def _recorder_in(self, tmp_dir):
+        """Build a SimpleRecorder rooted at tmp_dir for its state file.
+        Patches the data-dirs side effect since we don't need real data
+        dirs for these tests."""
+        with patch("src.config.get_data_dirs") as mock_dirs:
+            base = Path(tmp_dir)
+            mock_dirs.return_value = {
+                "recordings": base / "rec",
+                "transcripts": base / "trs",
+                "output": base / "out",
+            }
+            recorder = SimpleRecorder()
+        # Redirect the state file into our tmp dir for isolation.
+        recorder.state_file = Path(tmp_dir) / "recorder_state.json"
+        return recorder
+
+    def test_missing_file_returns_default(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recorder = self._recorder_in(tmp_dir)
+            self.assertEqual(
+                recorder.get_state(),
+                {"recording": False, "current_file": None, "session_name": None},
+            )
+
+    def test_valid_state_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recorder = self._recorder_in(tmp_dir)
+            payload = {
+                "recording": True,
+                "current_file": "/tmp/x.wav",
+                "session_name": "Test",
+            }
+            recorder.save_state(payload)
+            self.assertEqual(recorder.get_state(), payload)
+
+    def test_corrupt_json_is_quarantined(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recorder = self._recorder_in(tmp_dir)
+            recorder.state_file.write_text('{"recording": tru')  # truncated
+
+            result = recorder.get_state()
+
+            # Returns default rather than crashing.
+            self.assertEqual(
+                result,
+                {"recording": False, "current_file": None, "session_name": None},
+            )
+            # Original is gone — moved aside.
+            self.assertFalse(recorder.state_file.exists())
+            # Quarantined copy exists alongside, preserving the corrupt bytes
+            # so a human can inspect them.
+            quarantine = recorder.state_file.with_suffix(
+                recorder.state_file.suffix + ".corrupt"
+            )
+            self.assertTrue(quarantine.exists())
+            self.assertEqual(quarantine.read_text(), '{"recording": tru')
+
+    def test_unreadable_file_does_not_quarantine(self):
+        """A permission error is transient (user could fix it). Don't
+        destroy the file — just log and return default."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recorder = self._recorder_in(tmp_dir)
+            recorder.state_file.write_text('{"recording": true}')
+
+            with patch("builtins.open", side_effect=PermissionError("denied")):
+                result = recorder.get_state()
+
+            self.assertEqual(
+                result,
+                {"recording": False, "current_file": None, "session_name": None},
+            )
+            # File is still where it was — we don't move it aside on a
+            # transient OS error.
+            self.assertTrue(recorder.state_file.exists())
+
+    def test_save_state_is_atomic_under_crash(self):
+        """Simulate a crash by making json.dump raise after partial work.
+        The prior state file must survive intact."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recorder = self._recorder_in(tmp_dir)
+            recorder.save_state({"recording": False, "current_file": None})
+
+            original_dump = json.dump
+
+            def explode(*_args, **_kwargs):
+                raise RuntimeError("simulated crash mid-write")
+
+            with patch("simple_recorder.json.dump", side_effect=explode):
+                with self.assertRaises(RuntimeError):
+                    recorder.save_state({"recording": True, "current_file": "/x.wav"})
+
+            # Prior state preserved.
+            self.assertEqual(
+                json.loads(recorder.state_file.read_text()),
+                {"recording": False, "current_file": None},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recorder_state.py
+++ b/tests/test_recorder_state.py
@@ -124,6 +124,28 @@ class GetStateTests(unittest.TestCase):
             self.assertTrue(quarantine.exists())
             self.assertEqual(quarantine.read_text(), '{"recording": tru')
 
+    def test_invalid_utf8_is_quarantined(self):
+        """A partial write can leave the file with bytes that aren't valid
+        UTF-8 — open(..., 'r') raises UnicodeDecodeError before json.load
+        sees it. That's the same 'content unparseable' failure mode as
+        JSONDecodeError and must be quarantined, not propagated."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recorder = self._recorder_in(tmp_dir)
+            # 0xFF / 0xFE are not valid leading UTF-8 bytes.
+            recorder.state_file.write_bytes(b'\xff\xfe\x00\x01')
+
+            result = recorder.get_state()
+
+            self.assertEqual(
+                result,
+                {"recording": False, "current_file": None, "session_name": None},
+            )
+            self.assertFalse(recorder.state_file.exists())
+            quarantine = recorder.state_file.with_suffix(
+                recorder.state_file.suffix + ".corrupt"
+            )
+            self.assertTrue(quarantine.exists())
+
     def test_unreadable_file_does_not_quarantine(self):
         """A permission error is transient (user could fix it). Don't
         destroy the file — just log and return default."""


### PR DESCRIPTION
## Summary
- `recorder_state.json` and the final summary JSON are now written atomically via tempfile + `os.replace`. A crash mid-write leaves the prior file intact rather than producing corrupt JSON that the next launch silently swallows.
- `get_state` distinguishes three cases instead of one: missing file (return default silently — normal), corrupt JSON (log + quarantine to `*.corrupt` + return default), unreadable file (log + return default, don't move it).
- Replaces the bare `except:` in `get_state` with typed `(json.JSONDecodeError, OSError)` handlers.

## Why
Previously a power loss / SIGKILL / OOM during `save_state` truncated `recorder_state.json` to garbage. `get_state` then quietly returned the "not recording" default, so an orphan `record` subprocess could keep capturing audio while the app thought it was idle. The atomic write means the prior valid state survives the crash; the typed exceptions mean a corrupt file is loud (logged + quarantined) so we don't lose recording state silently.

Same fix applied to the multi-MB summary JSON write at `:496` — previously a crash there left the meeting unrecoverable because the source WAV is deleted right after.

## Test plan
- [x] New `tests/test_recorder_state.py`: 9 unit tests cover `_atomic_write_json` (basic write, replace, failed-write preserves existing, parent dir creation) and `get_state` triage (missing, valid round-trip, corrupt-quarantined, unreadable-not-quarantined, save-atomic-under-crash). All pass: `python -m unittest tests.test_recorder_state`.
- [ ] Manual: simulate a crash mid-recording (`kill -9 <stenoai pid>` during an active recording). Restart app. Confirm prior state file is intact or — if it was already corrupt — moved to `recorder_state.json.corrupt` rather than silently discarded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make recorder state and meeting summary writes atomic to prevent corrupt JSON after crashes. Improve state reads so we don’t silently lose recording state, including quarantining invalid UTF-8 files.

- **Bug Fixes**
  - Atomic writes for `recorder_state.json` and the final summary via tempfile + `os.replace`; previous file stays intact on crash.
  - `get_state` now distinguishes missing (default), corrupt (invalid JSON or UTF-8: log + move to `*.corrupt`), and unreadable (log only).
  - Replaced bare `except` with typed handlers: `json.JSONDecodeError` and `UnicodeDecodeError` trigger quarantine; `OSError` logs only.

<sup>Written for commit d9d74414ed190b9ad9ee59f5d9c12486bdef4ee6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

