### PR TITLE
detect and kill orphan record subprocess on launch

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -759,7 +759,11 @@ if (!gotSingleInstanceLock) {
           currentRecordingProcess.kill('SIGTERM');
           currentRecordingProcess = null;
           currentRecordingSessionName = null;
-          clearRecordPidSidecarSync();
+          // Intentionally do NOT clear the sidecar here. SIGTERM is async;
+          // if the subprocess doesn't honour it before Electron exits, we
+          // need the sidecar to survive so the next launch can detect and
+          // reap the orphan. The 'close' event handler clears the sidecar
+          // when the process actually exits — that's the right moment.
         }
         if (systemAudioRecordingActive && mainWindow && !mainWindow.isDestroyed()) {
           try {
@@ -2239,10 +2243,15 @@ function isOrphanedRecordProcess(pid, expectedBackendPath) {
   try {
     const { execSync } = require('child_process');
     const cmd = execSync(`ps -p ${pid} -o command=`, { timeout: 1500 }).toString().trim();
-    // Match by basename so dev (`dist/stenoai/stenoai`) and packaged
-    // (`<resourcesPath>/stenoai/stenoai`) both resolve correctly.
+    // The first whitespace-separated token in `ps -o command=` is argv[0]
+    // — the executable path. Match its basename against ours so dev
+    // (`dist/stenoai/stenoai`) and packaged (`<resourcesPath>/stenoai/stenoai`)
+    // both resolve, but a stranger that merely *mentions* "stenoai" in its
+    // arguments doesn't get killed.
     const binaryName = path.basename(expectedBackendPath);
-    return Boolean(binaryName) && cmd.includes(binaryName);
+    if (!binaryName) return false;
+    const argv0 = cmd.split(/\s+/)[0] || '';
+    return path.basename(argv0) === binaryName;
   } catch (_) {
     // ps unavailable or pid disappeared between the kill(0) and the ps;
     // err on the side of "not orphan" rather than signalling a stranger.

--- a/app/main.js
+++ b/app/main.js
@@ -759,6 +759,7 @@ if (!gotSingleInstanceLock) {
           currentRecordingProcess.kill('SIGTERM');
           currentRecordingProcess = null;
           currentRecordingSessionName = null;
+          clearRecordPidSidecarSync();
         }
         if (systemAudioRecordingActive && mainWindow && !mainWindow.isDestroyed()) {
           try {
@@ -841,6 +842,16 @@ if (!gotSingleInstanceLock) {
       } catch (e) {
         sendDebugLog(`[sysaudio] startup probe failed: ${e.message}`);
       }
+    }
+
+    // Reap any orphan recording subprocess left over from a prior crash
+    // before creating the window. We don't want to surface "Recording in
+    // progress" UI while the prior orphan still holds the mic / writes to
+    // disk. Failures here are non-fatal — the helper logs and returns.
+    try {
+      await cleanupOrphanRecording();
+    } catch (e) {
+      sendDebugLog(`[orphan-cleanup] unexpected error during startup cleanup: ${e.message}`);
     }
 
     createWindow();
@@ -2173,6 +2184,120 @@ let systemAudioRecordingActive = false;  // Track system audio recording for tra
 let currentRecordingProcess = null;
 let currentRecordingSessionName = null;  // Surfaced in get-queue-status so renderer knows which meeting is live
 let processingQueue = [];
+
+// ── Orphan-recording cleanup ────────────────────────────────────────────
+//
+// When the user starts a recording, we spawn the Python `record` subprocess
+// as a child of Electron. If Electron crashes between start and stop (renderer
+// OOM, native module segfault, force-quit), the OS *usually* tears the child
+// down via broken stdio pipes — but not always, and not immediately. To
+// guarantee the next launch ends any orphan rather than leaving it writing
+// audio in the background, we persist the spawned PID + backend path to a
+// sidecar file. On startup we read the sidecar and, if the recorded PID is
+// still alive AND still looks like our backend, signal it to exit and remove
+// the sidecar.
+//
+// Lives in its own sidecar file rather than `recorder_state.json` so it stays
+// purely a renderer/main-side concern — the Python state file format doesn't
+// change.
+const RECORD_PID_SIDECAR_FILENAME = 'last-record.json';
+function recordPidSidecarPath() {
+  return path.join(app.getPath('userData'), RECORD_PID_SIDECAR_FILENAME);
+}
+
+function writeRecordPidSidecarSync(info) {
+  const filePath = recordPidSidecarPath();
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(tmpPath, JSON.stringify(info), 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (e) {
+    sendDebugLog(`[orphan-cleanup] Failed to write PID sidecar: ${e.message}`);
+    try { if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath); } catch (_) {}
+  }
+}
+
+function clearRecordPidSidecarSync() {
+  try {
+    const filePath = recordPidSidecarPath();
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  } catch (e) {
+    sendDebugLog(`[orphan-cleanup] Failed to clear PID sidecar: ${e.message}`);
+  }
+}
+
+// Returns true only when (a) the PID is alive and (b) it looks like our
+// backend binary. The `ps` check guards against PID reuse — a long-since-dead
+// orphan whose PID was recycled to an unrelated process must not be killed.
+function isOrphanedRecordProcess(pid, expectedBackendPath) {
+  try {
+    process.kill(pid, 0); // throws ESRCH if no such process
+  } catch (_) {
+    return false;
+  }
+  try {
+    const { execSync } = require('child_process');
+    const cmd = execSync(`ps -p ${pid} -o command=`, { timeout: 1500 }).toString().trim();
+    // Match by basename so dev (`dist/stenoai/stenoai`) and packaged
+    // (`<resourcesPath>/stenoai/stenoai`) both resolve correctly.
+    const binaryName = path.basename(expectedBackendPath);
+    return Boolean(binaryName) && cmd.includes(binaryName);
+  } catch (_) {
+    // ps unavailable or pid disappeared between the kill(0) and the ps;
+    // err on the side of "not orphan" rather than signalling a stranger.
+    return false;
+  }
+}
+
+async function cleanupOrphanRecording() {
+  const filePath = recordPidSidecarPath();
+  if (!fs.existsSync(filePath)) return;
+
+  let info;
+  try {
+    info = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch (e) {
+    sendDebugLog(`[orphan-cleanup] PID sidecar unreadable, removing: ${e.message}`);
+    try { fs.unlinkSync(filePath); } catch (_) {}
+    return;
+  }
+
+  const pid = info && info.pid;
+  const backendPath = info && info.backendPath;
+  const sessionName = (info && info.sessionName) || '';
+  if (!Number.isInteger(pid) || !backendPath) {
+    try { fs.unlinkSync(filePath); } catch (_) {}
+    return;
+  }
+
+  if (!isOrphanedRecordProcess(pid, backendPath)) {
+    sendDebugLog(`[orphan-cleanup] pid=${pid} is not our backend; clearing sidecar`);
+    try { fs.unlinkSync(filePath); } catch (_) {}
+    return;
+  }
+
+  sendDebugLog(`[orphan-cleanup] Orphan record subprocess detected pid=${pid} session="${sessionName}"; sending SIGTERM`);
+  try { process.kill(pid, 'SIGTERM'); } catch (_) {}
+
+  // Wait up to 5s for clean exit, then escalate to SIGKILL.
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (_) {
+      sendDebugLog(`[orphan-cleanup] pid=${pid} exited cleanly`);
+      try { fs.unlinkSync(filePath); } catch (_) {}
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  sendDebugLog(`[orphan-cleanup] pid=${pid} still alive after SIGTERM; sending SIGKILL`);
+  try { process.kill(pid, 'SIGKILL'); } catch (_) {}
+  try { fs.unlinkSync(filePath); } catch (_) {}
+}
+// ── End orphan-recording cleanup ────────────────────────────────────────
 // Live-transcript ring buffer for the in-flight recording. Populated by the
 // Python `record --live` subprocess's LIVE_SEG: stdout lines. The renderer
 // subscribes to `live-transcript-chunk` for new entries and calls
@@ -2526,6 +2651,14 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
       env: Object.keys(recordEnv).length > 0 ? { ...require('process').env, ...recordEnv } : undefined
     });
     currentRecordingSessionName = actualSessionName;
+    // Persist {pid, sessionName, backendPath} so the next launch can detect
+    // an orphan if Electron crashes between here and the close handler.
+    writeRecordPidSidecarSync({
+      pid: currentRecordingProcess.pid,
+      sessionName: actualSessionName,
+      startedAt: Date.now(),
+      backendPath: getBackendPath(),
+    });
     // Reset the live transcript buffer for this session. We do it here
     // (before spawn parses anything) so a late-mounting LiveTranscriptPanel
     // can never see a stale segments array from a previous recording.
@@ -2717,6 +2850,9 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
     currentRecordingProcess.on('close', (code) => {
       console.log(`Recording process closed with code ${code}`);
       sendDebugLog(`Recording process completed with exit code: ${code}`);
+      // Normal exit — drop the orphan-detection sidecar so the next launch
+      // doesn't try to kill a long-dead PID (or worse, a recycled one).
+      clearRecordPidSidecarSync();
       currentRecordingProcess = null;
       currentRecordingSessionName = null;
       resetRecordingRuntimeState();


### PR DESCRIPTION
## Summary
When Electron crashes mid-recording (renderer OOM, native segfault, force-quit), the Python `record` subprocess can survive and keep writing audio to disk. This PR detects that orphan on the next launch and reaps it before showing any UI.

- New module-level helpers in `app/main.js`: `recordPidSidecarPath`, `writeRecordPidSidecarSync`, `clearRecordPidSidecarSync`, `isOrphanedRecordProcess`, `cleanupOrphanRecording`.
- After spawning the `record` subprocess we write `{pid, sessionName, startedAt, backendPath}` to `<userData>/last-record.json` via tempfile + rename.
- On normal close, on user-confirmed quit-while-recording, and on a corrupt sidecar — the sidecar is cleared.
- On `app.whenReady()` (before `createWindow`) we call `cleanupOrphanRecording`. It only signals a PID if the PID is alive AND `ps -p <pid> -o command=` shows our backend binary basename — guards against PID reuse killing a stranger. SIGTERM with a 5s grace, then SIGKILL.

## Scope (deliberate)
- **Does not** add `detached: true` to the spawn call. That would change stdio plumbing in ways that affect the live-transcribe parser; orphan-cleanup-on-startup alone solves the user-visible problem without touching the hot path.
- **Does not** modify the Python state file. PID tracking lives in its own sidecar (`last-record.json`) under `userData/`, so this PR has zero overlap with #fix/recorder-state-atomic.

## Test plan
Manual only — testing this end-to-end requires faking a parent crash. The sidecar helpers are tightly coupled to Electron globals (`app.getPath`, `sendDebugLog`); extracting them to a unit-testable module is a follow-up I deliberately skipped to keep this PR focused.

- [ ] Start a recording. Run `kill -9 <electron-pid>` from a separate terminal mid-recording. Confirm a stale Python `stenoai` subprocess survives (`ps aux | grep stenoai`).
- [ ] Relaunch the app. Watch the debug log — expect `[orphan-cleanup] Orphan record subprocess detected pid=...` followed by `[orphan-cleanup] pid=... exited cleanly` (or SIGKILL escalation if it didn't honour SIGTERM).
- [ ] Confirm `<userData>/last-record.json` is removed after cleanup.
- [ ] Normal start/stop flow: confirm `last-record.json` is created on spawn and removed on clean close.
- [ ] Edge case: launch with no prior recording (sidecar absent) — `cleanupOrphanRecording` should no-op silently.

## Notes
- Sidecar path uses `app.getPath('userData')` so the test override `STENOAI_USER_DATA_DIR` (line 23) works without changes.
- PR is independent of #fix/recorder-state-atomic and can merge in either order — no file overlap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and stops any orphaned recording subprocess on app launch so we don’t keep the mic or write audio after a crash. Stores the child PID in a sidecar on spawn and clears it only when the process actually exits.

- **Bug Fixes**
  - Run orphan cleanup on `app.whenReady()` before creating the window.
  - Persist `{pid, sessionName, startedAt, backendPath}` to `<userData>/last-record.json` via atomic write; clear on `close` or corrupt read, but keep it if quitting before `close` to catch stubborn children.
  - Verify the PID is ours using `ps -p <pid> -o command=` and compare `argv[0]`’s basename before signaling; send SIGTERM (5s grace) then SIGKILL; errors are logged and non-fatal.
  - No changes to spawn detachment or Python state; tracking lives only in the sidecar.

<sup>Written for commit cd336e2673c68b2857cb2b7d9ff0c0ac2dec962a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

