### PR TITLE
lifecycle polish: outlook redirect uri, exit code, summarizer cleanup

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -5897,7 +5897,11 @@ function startOutlookAuth() {
 
     server.listen(0, '127.0.0.1', () => {
       const port = server.address().port;
-      const redirectUri = `http://localhost:${port}`;
+      // Use the literal IP we listen on. `localhost` resolves via the host
+      // resolver, which a tampered /etc/hosts or local DNS could point
+      // elsewhere — a low-but-not-zero risk for OAuth callback hijack on
+      // shared dev machines. 127.0.0.1 bypasses name resolution entirely.
+      const redirectUri = `http://127.0.0.1:${port}`;
 
       const authParams = new URLSearchParams({
         client_id: OUTLOOK_CLIENT_ID,
@@ -5925,7 +5929,9 @@ function startOutlookAuth() {
 
 function exchangeOutlookCodeForTokens(code, codeVerifier, port) {
   return new Promise((resolve, reject) => {
-    const redirectUri = `http://localhost:${port}`;
+    // Must match the redirect_uri used in startOutlookAuth's auth request.
+    // See the comment there — bypass name resolution by using the IP literal.
+    const redirectUri = `http://127.0.0.1:${port}`;
     const postData = new URLSearchParams({
       code,
       client_id: OUTLOOK_CLIENT_ID,

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -673,11 +673,16 @@ def start(session_name):
     def signal_handler(signum, frame):
         """Handle SIGTERM/SIGINT gracefully by stopping recording and processing"""
         nonlocal processing_started
-        
+        # Track real failures so we exit non-zero on the way out. Previously
+        # the handler always exited 0 even when transcription/summarization
+        # threw — Electron read that as success and the renderer would
+        # navigate to a non-existent meeting.
+        had_failure = False
+
         # Different handling for different signals
         signal_name = "SIGINT" if signum == 2 else f"SIGTERM" if signum == 15 else f"Signal {signum}"
         print(f"\n🛑 Received {signal_name} - stopping recording and processing...")
-        
+
         # Prevent double processing if multiple signals received
         if processing_started:
             print("⚠️ Processing already started - please wait for completion...")
@@ -685,28 +690,28 @@ def start(session_name):
                 print("🔄 Ignoring SIGTERM during transcription/summarization")
                 return
             sys.exit(0)
-            
+
         if recording_started and recorder:
             processing_started = True
             try:
                 final_path = recorder.stop_recording()
                 if final_path:
                     print(f"✅ Recording saved: {final_path}")
-                    
+
                     # Check file size
                     from pathlib import Path
                     file_size = Path(final_path).stat().st_size
                     print(f"📏 File size: {file_size / 1024:.1f} KB")
-                    
+
                     if file_size >= 1000:  # At least 1KB of audio data
                         print("🔄 Starting transcription and summarization pipeline...")
-                        
+
                         # Process recording with proper async handling
                         try:
                             import asyncio
                             loop = asyncio.new_event_loop()
                             asyncio.set_event_loop(loop)
-                            
+
                             _notes_text = recorder._load_user_notes(session_name, recorder.output_dir)
 
                             print("📝 Starting transcription...")
@@ -721,17 +726,22 @@ def start(session_name):
                             print(f"❌ Processing pipeline failed: {e}", flush=True)
                             import traceback
                             traceback.print_exc()
+                            had_failure = True
                     else:
+                        # Recording succeeded but was too short to process —
+                        # not a failure, just nothing to do.
                         print("⚠️ Recording too short - skipping processing")
                 else:
                     print("❌ No recording data to save")
+                    had_failure = True
             except Exception as e:
                 print(f"❌ Error during signal handling: {e}")
                 import traceback
                 traceback.print_exc()
+                had_failure = True
 
         print("🏁 Recording session ended")
-        sys.exit(0)
+        sys.exit(1 if had_failure else 0)
 
     # Register signal handlers for graceful shutdown
     signal.signal(signal.SIGTERM, signal_handler)

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -983,11 +983,15 @@ TRANSCRIPT:
                 self.ollama_process.terminate()
                 self.ollama_process.wait(timeout=10)
                 logger.info("Ollama service process terminated")
-            except:
+            except (subprocess.TimeoutExpired, ProcessLookupError, OSError) as e:
+                # terminate didn't take (or the process is already gone) —
+                # escalate to SIGKILL. ProcessLookupError on the second
+                # try just means it died in the gap, which is fine.
+                logger.warning(f"Ollama terminate failed ({e}); escalating to kill")
                 try:
                     self.ollama_process.kill()
                     logger.info("Ollama service process killed")
-                except:
+                except (ProcessLookupError, OSError):
                     pass
             self.ollama_process = None
     


### PR DESCRIPTION
## Summary
Three small, independent fixes batched together — each ~5-15 lines, low risk, no design choices.

### 1. Outlook OAuth redirect URI uses IP, not hostname (`app/main.js:5900, :5928`)
The loopback server listens on `127.0.0.1`, but the `redirect_uri` we send to Microsoft and reuse during token exchange was `http://localhost:${port}`. On a machine with a tampered `/etc/hosts` (or a local DNS shenanigan), `localhost` could resolve elsewhere — a narrow but real OAuth callback hijack vector on shared dev machines. Bypass name resolution by using the IP literal in both places. Must match between the auth request and the token exchange or Microsoft rejects the code.

### 2. Recording `signal_handler` exits non-zero on real failures (`simple_recorder.py:734`)
Previously the SIGTERM/SIGINT handler always exited with code 0, even when transcription or summarization threw. Electron reads exit code as the success signal — the renderer then navigated to a non-existent meeting. Now we track `had_failure` across the three failure points (processing pipeline exception, no recording data, generic handler exception) and `sys.exit(1 if had_failure else 0)`.

"Recording too short" is intentionally NOT a failure — the recording itself succeeded, there's just nothing to process.

### 3. `Summarizer.cleanup` catches specific exceptions (`src/summarizer.py:986`)
Two bare `except:` blocks around the Ollama process termination → kill escalation. Replaced with `(subprocess.TimeoutExpired, ProcessLookupError, OSError)` on the terminate-then-kill path and `(ProcessLookupError, OSError)` on the final kill attempt. Also adds a warning log when terminate fails so we can see escalation in the wild rather than swallowing it silently. Won't catch `SystemExit` / `KeyboardInterrupt` anymore — those propagate, which is the right behaviour.

## Why bundle these
All three are mechanical, low-risk fixes.

## Test plan
- [x] `node --check app/main.js`, `python -c "import ast; ast.parse(...)"` for both Python files.
- [ ] Manual: connect Outlook calendar — auth + token-refresh should still succeed end-to-end (the `redirect_uri` change must match between auth-request and token-exchange or Microsoft rejects).
- [ ] Manual: trigger a recording stop where transcription fails (e.g., kill Ollama mid-summarize). Confirm the Python process exits non-zero and Electron surfaces the failure to the renderer (no more silent "navigate to missing meeting").
- [ ] Manual: exit the app cleanly with an active Ollama session — confirm no spurious warning logs from cleanup.

## What's not in this PR (also from the audit)
- Path validation on `reprocess-meeting`/`regen-meeting-title`/`query-transcript`/`query-transcript-stream` handlers — going as its own focused PR since it's security-sensitive.
- State RMW race lock — needs design choice on cross-platform locking primitive.
- Renderer sandbox flip — explicitly flagged "investigate first" in the audit; may be intentional for CoreAudio Tap compatibility.
- Live-transcribe sidecar cleanup (audit finding #7) — turned out to be a non-issue. `stop-recording-ui` already calls `stopLiveTranscribe()` at `:2822`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Outlook OAuth redirect to 127.0.0.1, fix recorder exit codes on real failures, and make summarizer cleanup safer with explicit exceptions and warning logs.

- **Bug Fixes**
  - Outlook OAuth: Use http://127.0.0.1:${port} for both auth and token exchange to bypass hostname resolution and prevent callback hijack; values now match exactly.
  - Recorder: SIGINT/SIGTERM handler exits with code 1 on pipeline errors or missing data (but not on “recording too short”), preventing the app from navigating to a non-existent meeting.
  - Summarizer: Replace bare excepts with specific exceptions when terminating the Ollama process, add a warning log on escalate-to-kill, and let SystemExit/KeyboardInterrupt propagate.

<sup>Written for commit e470f8846220d8e51d7db8de3367766db0cbb380. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

