### PR TITLE
fix: calendar / hotkey starts a new recording during processing

### DIFF
--- a/app/renderer/src/components/home/UpcomingCard.tsx
+++ b/app/renderer/src/components/home/UpcomingCard.tsx
@@ -22,8 +22,14 @@ export function UpcomingCard({ event }: UpcomingCardProps) {
   // 'Note' placeholder), so the AI rename step skips it and the user
   // gets the meeting they expected. Doesn't open the join URL — the
   // Join / Start now buttons on the right own that action.
+  //
+  // Block only when a recording is *actively* in progress (recording /
+  // paused); 'processing' is fine — the previous note keeps summarising
+  // in the background queue while a new recording starts. Matches the
+  // Home empty-state CTA's gating so the two entry points behave the
+  // same way back-to-back.
   const onStart = () => {
-    if (recording.status !== 'idle') return;
+    if (recording.status === 'recording' || recording.status === 'paused') return;
     void recording.startRecording(event.title);
   };
 

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -191,8 +191,13 @@ export function useRecordingEvents() {
   React.useEffect(() => {
     const bridge = ipc();
     const toggle = () => {
+      // 'processing' is the post-stop, pre-summary state. Treat it like
+      // idle for start purposes — the previous note keeps summarising in
+      // the background queue while a new recording starts. Matches the
+      // Home empty-state CTA + UpcomingCard click behaviour so the hotkey
+      // doesn't silently no-op when a user is doing back-to-back notes.
       if (status === 'recording' || status === 'paused') void stopRecording();
-      else if (status === 'idle') void startRecording();
+      else void startRecording();
     };
     const offs = [
       bridge.on.toggleRecordingHotkey(toggle),
@@ -210,8 +215,13 @@ export function useRecordingEvents() {
       }),
       bridge.on.autoRecordRequested(({ sessionName }) => {
         // Suggested by the mic-monitor auto-detect notification ("Take Notes").
-        // Only fire if we're idle — user may have already manually started.
-        if (status === 'idle') void startRecording(sessionName ?? undefined);
+        // Allow start when idle OR when a previous note is still processing
+        // — the user explicitly opted in by clicking "Take Notes", and the
+        // background queue handles the previous summary fine. Only skip if
+        // an active recording (recording/paused) is already in progress —
+        // user already manually started or is mid-meeting.
+        if (status === 'recording' || status === 'paused') return;
+        void startRecording(sessionName ?? undefined);
       }),
       bridge.on.autoPauseRequested(() => {
         // Mic stopped on the meeting app — pause so we don't keep recording

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -157,8 +157,14 @@ export function Home({ mode }: HomeProps) {
     });
   }, [calendar.data, upcomingTickMs]);
 
+  // Same gating as Home's empty-state CTA and UpcomingCard's onStart:
+  // block only when actively recording; 'processing' is fine — the
+  // previous note keeps summarising in the background queue while a
+  // new recording starts.
+  const canStartNewRecording =
+    recording.status !== 'recording' && recording.status !== 'paused';
   const onStartAllDay = (title: string) => {
-    if (recording.status !== 'idle') return;
+    if (!canStartNewRecording) return;
     void recording.startRecording(title);
   };
   const [allDayExpanded, setAllDayExpanded] = React.useState(false);
@@ -394,7 +400,7 @@ export function Home({ mode }: HomeProps) {
                 expanded={allDayExpanded}
                 onToggle={() => setAllDayExpanded((v) => !v)}
                 onStart={onStartAllDay}
-                recordingIdle={recording.status === 'idle'}
+                canStart={canStartNewRecording}
               />
               <div className="flex flex-col gap-2">
                 {upcomingToday.map((event) => (
@@ -412,7 +418,7 @@ export function Home({ mode }: HomeProps) {
                 expanded={allDayExpanded}
                 onToggle={() => setAllDayExpanded((v) => !v)}
                 onStart={onStartAllDay}
-                recordingIdle={recording.status === 'idle'}
+                canStart={canStartNewRecording}
               />
               <div className="flex flex-col gap-2">
                 <UpcomingCard event={tomorrowPreview} />
@@ -428,7 +434,7 @@ export function Home({ mode }: HomeProps) {
                 expanded={allDayExpanded}
                 onToggle={() => setAllDayExpanded((v) => !v)}
                 onStart={onStartAllDay}
-                recordingIdle={recording.status === 'idle'}
+                canStart={canStartNewRecording}
               />
             </section>
           )}
@@ -548,7 +554,11 @@ interface AllDayInlineProps {
   expanded: boolean;
   onToggle: () => void;
   onStart: (title: string) => void;
-  recordingIdle: boolean;
+  /** Permission to start a new recording — true when idle OR processing
+   *  (a previous note still summarising in the background queue doesn't
+   *  block a new recording). False only when a recording is actively
+   *  in progress (recording / paused). */
+  canStart: boolean;
 }
 
 function AllDayInline({
@@ -556,7 +566,7 @@ function AllDayInline({
   expanded,
   onToggle,
   onStart,
-  recordingIdle,
+  canStart,
 }: AllDayInlineProps) {
   if (events.length === 0) return null;
   return (
@@ -579,7 +589,7 @@ function AllDayInline({
               key={e.id}
               type="button"
               onClick={() => onStart(e.title)}
-              disabled={!recordingIdle}
+              disabled={!canStart}
               title={`Start recording: ${e.title}`}
               className="-mx-1 rounded px-1 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
               style={{ color: 'var(--fg-1)' }}


### PR DESCRIPTION
## Summary

Home's empty-state CTA already allowed starting a new recording when a previous note was still in the post-stop \`processing\` state (the background queue handles summarisation, so a new recording is fine). The calendar event click, all-day chip, hotkey toggle, and auto-record-requested handler all silently no-op'd in this state — the user clicked / pressed and nothing happened.

Unified the gate across all start surfaces: **block only when actively recording (\`recording\` / \`paused\`)**. Both \`idle\` and \`processing\` allow a new recording.

### Sites changed

- \`UpcomingCard.onStart\` — calendar event card click
- \`Home.onStartAllDay\` — all-day chip click; \`canStartNewRecording\` flag passed to \`AllDayInline\` (also renames the prop \`recordingIdle\` → \`canStart\`)
- \`useRecordingEvents.toggle\` — hotkey
- \`useRecordingEvents.autoRecordRequested\` — mic-monitor "Take Notes" notification

## Test plan

- [ ] Start a recording, stop it, while the summary spinner is showing on the meeting detail / home processing dock: click an upcoming calendar event → new recording starts
- [ ] Same setup, click an all-day chip → new recording starts (chip is no longer disabled)
- [ ] Same setup, press the global record hotkey → new recording starts
- [ ] Same setup, click "Take Notes" on a mic-monitor "Meeting detected" notification → new recording starts
- [ ] Active recording (not processing): all four surfaces still respect the active recording — calendar click navigates to /recording (existing behaviour via UpcomingCard's other paths) or no-ops; hotkey stops it; all-day chip disabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent no-ops by allowing new recordings to start while a previous note is in `processing`. All start surfaces now block only when actively recording (`recording` or `paused`).

- **Bug Fixes**
  - Calendar event click (`UpcomingCard.onStart`): allow start unless `recording` or `paused`.
  - All-day chip (`Home.onStartAllDay`): enable during `processing`; pass `canStartNewRecording` to `AllDayInline` and rename prop `recordingIdle` → `canStart`.
  - Hotkey (`useRecordingEvents.toggle`): start when not actively recording, including `processing`.
  - Auto-record request (`useRecordingEvents.autoRecordRequested`): start on "Take Notes" unless `recording` or `paused`.

<sup>Written for commit ee982445c2402cd6c990e9e828c5ceee4525e761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

