### PR TITLE
fix: pre-release polish — org logout, parakeet warmup, pause, diarisation, live partial window

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -6921,7 +6921,18 @@ async function adapterFetch(pathname, opts = {}) {
     body = { detail: text };
   }
   if (!res.ok) {
-    if (res.status === 401) clearOrgSession();
+    if (res.status === 401) {
+      // Server-side session revocation / token reuse / org removed our
+      // user. Same response surface as a sign-out: clear the local
+      // session AND restore the pre-adapter provider. Without the
+      // restore, ai_provider stays on 'adapter' with no session, and
+      // the next summarisation call errors out with "adapter not
+      // configured". Fire-and-forget — the awaiting caller already
+      // has an HTTP error to handle and shouldn't block on a Python
+      // subprocess.
+      clearOrgSession();
+      restorePreAdapterProvider().catch(() => {});
+    }
     const err = new Error(body.detail || ('HTTP ' + res.status));
     err.status = res.status;
     throw err;
@@ -7541,7 +7552,13 @@ ipcMain.on('org-chat-stream', async (event, streamId, payload) => {
     if (!res.ok) {
       let detail = '';
       try { detail = await res.text(); } catch (_) {}
-      if (res.status === 401) clearOrgSession();
+      if (res.status === 401) {
+        // Same reasoning as the orgFetch 401 path above — clear the
+        // session AND restore pre-adapter provider so future processing
+        // doesn't hit "adapter not configured".
+        clearOrgSession();
+        restorePreAdapterProvider().catch(() => {});
+      }
       safeSend('query-done', { queryId: streamId, success: false, error: `HTTP ${res.status}: ${detail.slice(0, 200)}` });
       return;
     }

--- a/app/main.js
+++ b/app/main.js
@@ -887,6 +887,28 @@ if (!gotSingleInstanceLock) {
       }
     }
 
+    // Pre-load Parakeet weights in a background subprocess so the first
+    // recording's `record --live` / `transcribe-stream` spawn sees the
+    // model file already in the OS page cache. Saves ~1 s off the
+    // visible "first record after launch" latency. Fire-and-forget —
+    // never block window creation on it. Skipped for Whisper users
+    // (Parakeet model would be downloading or absent) and gated on
+    // model presence by the CLI command itself (no-ops when missing).
+    if (loadTranscriptionEngine() === 'parakeet') {
+      try {
+        const warmupProc = spawn(getBackendPath(), ['warmup-parakeet'], {
+          cwd: getBackendCwd(),
+          stdio: 'ignore',
+        });
+        warmupProc.unref();
+        warmupProc.on('error', (err) => {
+          sendDebugLog(`[parakeet-warmup] spawn failed (non-fatal): ${err.message}`);
+        });
+      } catch (e) {
+        sendDebugLog(`[parakeet-warmup] startup error (non-fatal): ${e.message}`);
+      }
+    }
+
     createWindow();
     if (!IS_E2E) createTray();
     setupAutoUpdater();

--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -276,6 +276,16 @@ export function useSystemAudioCapture() {
             // Re-check each callback so a flip to whisper mid-recording
             // stops pushing (chunks would otherwise stack up in main).
             if (!liveTapEnabledRef.current) return;
+            // MediaRecorder.pause() halts the WebM file growth but the
+            // underlying MediaStream keeps flowing — without this guard
+            // we'd keep feeding the live consumer audio during a pause
+            // and the transcript would keep growing after the user
+            // explicitly told us to stop. Drop the chunk buffer too so
+            // the half-collected samples don't leak across the pause.
+            if (isPausedRef.current) {
+              tapBuffer.length = 0;
+              return;
+            }
             const input = ev.inputBuffer.getChannelData(0);
             for (let i = 0; i < input.length; i += DECIMATION) {
               tapBuffer.push(input[i]);

--- a/app/renderer/src/lib/liveRmsBuffer.ts
+++ b/app/renderer/src/lib/liveRmsBuffer.ts
@@ -60,6 +60,12 @@ export function pushRmsSample(sample: LiveRmsSample): void {
  * Decide who spoke during [startSec, endSec] from the energy ratio
  * between channels.
  *
+ *  - System below SPEECH_FLOOR: loopback is silent (noise floor only),
+ *    so there's no plausible Others speaker. Tag You regardless of
+ *    mic. Without this, mic-only recordings with system_audio_enabled
+ *    set to true (default) would occasionally mis-tag random segments
+ *    as Others because mic-quantisation noise nudged sysMean past
+ *    micMean during a silent dip.
  *  - Ratio >= 1.5 in either direction: confident attribution.
  *  - Ratio between (1/1.5, 1.5): both channels roughly equal energy.
  *    This is the bleed case (mic picks up speaker echo at similar
@@ -77,6 +83,12 @@ export function pushRmsSample(sample: LiveRmsSample): void {
  * is quiet.
  */
 const SPEAKER_RATIO_THRESHOLD = 1.5;
+// Empirical RMS floor below which "system audio" is just the loopback's
+// noise floor, not real audio. Conversational speech reaching the
+// loopback typically reads 0.01-0.05; this catches "silence-with-
+// quantisation-noise" at 0.001-0.003 and prevents it from triggering
+// an Others attribution against a quiet mic dip.
+const SPEECH_FLOOR = 0.005;
 
 /** Lower-bound binary search for the first index with `tSec >= target`.
  *  Buffer is monotonic by tSec (we push from setInterval, time only
@@ -116,8 +128,10 @@ export function decideSpeaker(startSec: number, endSec: number): LiveSpeaker {
   if (count === 0) return 'You';
   const micMean = micSum / count;
   const sysMean = sysSum / count;
-  if (sysMean === 0) return micMean === 0 ? 'You' : 'You';
-  if (micMean === 0) return 'Others';
+  // No real audio on the loopback — system_audio is enabled but nothing
+  // is actually playing. There's no plausible 'Others' speaker, so
+  // don't let mic-quantisation noise tag random segments as Others.
+  if (sysMean < SPEECH_FLOOR) return 'You';
   if (micMean >= sysMean * SPEAKER_RATIO_THRESHOLD) return 'You';
   if (sysMean >= micMean * SPEAKER_RATIO_THRESHOLD) return 'Others';
   return 'You';

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1102,6 +1102,37 @@ def parakeet_status_cmd():
     }))
 
 
+@cli.command(name='warmup-parakeet')
+def warmup_parakeet_cmd():
+    """Pre-load Parakeet weights to warm the OS page cache.
+
+    Fired by Electron at app launch (best-effort, non-blocking). The
+    subprocess loads the model end-to-end and exits — when the actual
+    recording subprocess later spawns and calls ``ensure_loaded``, the
+    model files are already in the OS page cache so disk I/O is
+    near-instant. Does NOT eliminate the per-subprocess MLX parse cost
+    (that requires a long-running daemon), but it shaves the visible
+    portion of "first record after launch is slow" by ~1 s on modern
+    SSDs and more on cold caches.
+
+    Silent on success — Electron parses only the exit code. On
+    'model not installed' (fresh user before Setup runs), exits 0
+    without loading; the cost of trying to load a missing model is
+    higher than just skipping.
+    """
+    from src.parakeet_models import is_installed, DEFAULT_MODEL_ID
+    if not is_installed(DEFAULT_MODEL_ID):
+        return
+    try:
+        from src.parakeet import ensure_loaded
+        ensure_loaded()
+    except Exception as e:
+        # Best-effort: a warmup failure must never block app startup.
+        # Log to stderr so the Electron debug log captures it, but
+        # exit 0 so main.js doesn't surface it as an error to the user.
+        print(f"warmup-parakeet failed: {e}", file=sys.stderr)
+
+
 @cli.command(name='download-parakeet-model')
 @click.argument('model_id', required=False)
 def download_parakeet_model_cmd(model_id):

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1286,15 +1286,20 @@ class _LiveVadPipeline:
       * Preroll ring holds the most recent ``PREROLL_CHUNKS`` chunks of
         pre-speech audio so the first syllable of every utterance is
         recovered after VAD fires (Silero always trips slightly late).
-      * Partials see only the trailing ``PARTIAL_WINDOW_S`` of the
-        utterance — re-transcribing the whole utterance every 400 ms
-        would be O(n²).
+      * Partials see the trailing ``PARTIAL_WINDOW_S`` of the utterance.
+        At 15 s, a 4-5 sentence monologue stays fully visible in the live
+        bubble (the prior 5 s window meant the rolling view dropped
+        earlier sentences off-screen during continuous speech). Parakeet
+        decodes 15 s in ~150-250 ms on Apple Silicon, comfortably under
+        the 400 ms partial interval. Going wider (e.g. matching MAX at
+        30 s) would risk decode time creeping past the interval and
+        back-pressuring the stdin pipe.
       * Final fires on Silero's SpeechEnd OR when the utterance hits
         ``MAX_UTTERANCE_S`` so a monologue still produces output.
     """
 
     PARTIAL_INTERVAL_S = 0.4
-    PARTIAL_WINDOW_S = 5.0
+    PARTIAL_WINDOW_S = 15.0
     MIN_UTTERANCE_S = 0.5
     MAX_UTTERANCE_S = 30.0
     PREROLL_CHUNKS = 2  # ≈ 512 ms at 256 ms per callback

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -208,65 +208,122 @@ def _token_jaccard(a: str, b: str) -> float:
     return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
 
 
-def _drop_per_segment_bleed(mic_segments: list, system_segments: list) -> list:
-    """Drop system_segments that are clearly mic-bleed echoes.
+def _segment_rms(wav_path, start_sec: float, end_sec: float) -> float:
+    """Mean RMS amplitude of a [start_sec, end_sec] slice in a 16-bit
+    PCM WAV. Used by per-segment bleed correction to identify which
+    channel carries the direct signal vs the attenuated echo.
 
-    For each system segment, find any mic segment whose start time is
-    within PER_SEGMENT_BLEED_WINDOW_S and compute Jaccard. If the best
-    match exceeds PER_SEGMENT_BLEED_JACCARD, the system segment is
-    treated as a bleed echo of the mic and dropped. Catches the
-    "Estimated, underpowered, and under the radar" → "Estimated,
-    underpowered, and under the radar" duplication that whole-transcript
-    Jaccard misses when 1-2 ASR word swaps per segment drag the aggregate
-    below BLEED_JACCARD_THRESHOLD.
+    Returns 0.0 on any error so the caller falls back to the
+    conservative "drop system" default.
+    """
+    import wave
+    try:
+        with wave.open(str(wav_path), 'rb') as wf:
+            sr = wf.getframerate()
+            n_frames_total = wf.getnframes()
+            start_frame = max(0, int(start_sec * sr))
+            end_frame = min(n_frames_total, int(end_sec * sr))
+            duration_frames = end_frame - start_frame
+            if duration_frames <= 0:
+                return 0.0
+            wf.setpos(start_frame)
+            raw = wf.readframes(duration_frames)
+            return _rms_of_pcm16(raw, duration_frames)
+    except Exception:
+        return 0.0
+
+
+def _drop_per_segment_bleed(
+    mic_segments: list,
+    system_segments: list,
+    mic_path=None,
+    system_path=None,
+):
+    """Drop the bleed-echo side of each Jaccard-matched (mic, system) pair.
+
+    Returns the (possibly-trimmed) mic_segments and system_segments lists.
+
+    The naive version of this function assumed system = bleed echo of
+    mic, but in the headphone-less case it's typically the opposite:
+    the mic picks up the speaker echo of Others' speech, so the *mic*
+    segment is the bleed and system has the clean direct signal. We
+    decide per-pair by comparing RMS over the segment's time range on
+    each channel — the channel with HIGHER RMS holds the direct signal,
+    the lower-RMS one is the attenuated echo and gets dropped.
+
+    When ``mic_path`` / ``system_path`` aren't supplied (test paths or
+    a defensive caller), we fall back to the historical behaviour of
+    dropping the system side.
     """
     if not mic_segments or not system_segments:
-        return system_segments
-    kept: list = []
-    dropped_count = 0
-    for sys_seg in system_segments:
+        return mic_segments, system_segments
+
+    drop_mic: set = set()
+    drop_sys: set = set()
+    can_compare_rms = mic_path is not None and system_path is not None
+
+    for i_sys, sys_seg in enumerate(system_segments):
         sys_text = (sys_seg.get("text") or "").strip()
-        if not sys_text:
-            kept.append(sys_seg)
-            continue
-        # Length gate. A short system utterance against a likewise-short
-        # mic utterance ("Yes" vs "Yes") trivially matches and would be
-        # falsely dropped as bleed. Character-based so it works for
-        # CJK / Thai / scripts without inter-word spaces.
-        if len(sys_text) < PER_SEGMENT_BLEED_MIN_CHARS:
-            kept.append(sys_seg)
+        if not sys_text or len(sys_text) < PER_SEGMENT_BLEED_MIN_CHARS:
             continue
         sys_start = float(sys_seg.get("start") or 0.0)
+        sys_end = float(sys_seg.get("end") or sys_start)
         best_jaccard = 0.0
-        for mic_seg in mic_segments:
+        best_mic_idx = -1
+        for i_mic, mic_seg in enumerate(mic_segments):
+            if i_mic in drop_mic:
+                continue
             mic_start = float(mic_seg.get("start") or 0.0)
             if abs(sys_start - mic_start) > PER_SEGMENT_BLEED_WINDOW_S:
                 continue
             mic_text = (mic_seg.get("text") or "").strip()
-            if not mic_text:
-                continue
-            # Same guard on the mic side — comparing a substantial system
-            # line against a brief mic "ok" ack would give Jaccard ≈ 0
-            # anyway, but skipping avoids the spurious work.
-            if len(mic_text) < PER_SEGMENT_BLEED_MIN_CHARS:
+            if not mic_text or len(mic_text) < PER_SEGMENT_BLEED_MIN_CHARS:
                 continue
             jac = _token_jaccard(sys_text, mic_text)
             if jac > best_jaccard:
                 best_jaccard = jac
-        if best_jaccard >= PER_SEGMENT_BLEED_JACCARD:
-            dropped_count += 1
-            logger.debug(
-                "Per-segment bleed: dropping system %r (Jaccard=%.2f)",
-                sys_text[:60], best_jaccard,
-            )
+                best_mic_idx = i_mic
+        if best_jaccard < PER_SEGMENT_BLEED_JACCARD or best_mic_idx < 0:
+            continue
+
+        # Bleed pair confirmed. Decide which side to drop.
+        if can_compare_rms:
+            mic_seg = mic_segments[best_mic_idx]
+            mic_start = float(mic_seg.get("start") or 0.0)
+            mic_end = float(mic_seg.get("end") or mic_start)
+            mic_rms = _segment_rms(mic_path, mic_start, mic_end)
+            sys_rms = _segment_rms(system_path, sys_start, sys_end)
+            # Tie-break / RMS unreadable → fall back to historical behaviour
+            # (drop system) so we never delete real user mic content on
+            # ambiguous evidence.
+            if mic_rms > sys_rms:
+                drop_sys.add(i_sys)
+                logger.debug(
+                    "Per-segment bleed: dropping system %r "
+                    "(Jaccard=%.2f, mic_rms=%.4f > sys_rms=%.4f)",
+                    sys_text[:60], best_jaccard, mic_rms, sys_rms,
+                )
+            else:
+                drop_mic.add(best_mic_idx)
+                logger.debug(
+                    "Per-segment bleed: dropping mic %r "
+                    "(Jaccard=%.2f, sys_rms=%.4f >= mic_rms=%.4f)",
+                    (mic_segments[best_mic_idx].get("text") or "")[:60],
+                    best_jaccard, sys_rms, mic_rms,
+                )
         else:
-            kept.append(sys_seg)
-    if dropped_count:
+            drop_sys.add(i_sys)
+
+    if drop_sys or drop_mic:
         logger.info(
-            "Per-segment bleed correction: dropped %d/%d system segments",
-            dropped_count, len(system_segments),
+            "Per-segment bleed correction: dropped %d/%d system, %d/%d mic",
+            len(drop_sys), len(system_segments),
+            len(drop_mic), len(mic_segments),
         )
-    return kept
+
+    kept_mic = [s for i, s in enumerate(mic_segments) if i not in drop_mic]
+    kept_sys = [s for i, s in enumerate(system_segments) if i not in drop_sys]
+    return kept_mic, kept_sys
 
 
 # Try Parakeet first (preferred — same engine as live, arm64 Macs only).
@@ -779,19 +836,23 @@ class WhisperTranscriber:
 
             # Speaker-bleed correction runs in two passes:
             #
-            # 1. Per-segment: drop individual system segments that are
-            #    nearly identical to a mic segment at the same point in
-            #    time. Catches the localised case where most of the call
-            #    is fine but specific lines echo (or where ASR word-level
-            #    differences hide aggregate bleed behind the whole-
-            #    transcript threshold).
+            # 1. Per-segment: drop the bleed-echo side of each Jaccard-
+            #    matched (mic, system) pair. Decides which side is the
+            #    echo by comparing per-segment RMS on the split channel
+            #    WAVs — the channel with higher RMS holds the direct
+            #    signal. Without that RMS step we'd always drop system,
+            #    which is wrong in the headphone-less case where the
+            #    mic is the one picking up the echo of Others' speech.
             # 2. Whole-transcript: if what's LEFT of the system channel
             #    still overlaps mic >= BLEED_JACCARD_THRESHOLD, the
             #    remaining content is also bleed — collapse to mic-only.
             #    The first pass usually handles things and this is a
             #    backstop for catastrophic bleed.
             if mic_segments and system_segments:
-                system_segments = _drop_per_segment_bleed(mic_segments, system_segments)
+                mic_segments, system_segments = _drop_per_segment_bleed(
+                    mic_segments, system_segments,
+                    mic_path=mic_path, system_path=system_path,
+                )
             if mic_segments and system_segments:
                 mic_text = ' '.join(s.get('text', '') for s in mic_segments)
                 sys_text = ' '.join(s.get('text', '') for s in system_segments)

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -295,12 +295,14 @@ def _drop_per_segment_bleed(
             sys_rms = _segment_rms(system_path, sys_start, sys_end)
             # Tie-break / RMS unreadable → fall back to historical behaviour
             # (drop system) so we never delete real user mic content on
-            # ambiguous evidence.
-            if mic_rms > sys_rms:
+            # ambiguous evidence. >= covers the genuine-tie case AND the
+            # both-zero case (_segment_rms returns 0.0 on any read error),
+            # both of which should keep mic and drop system.
+            if mic_rms >= sys_rms:
                 drop_sys.add(i_sys)
                 logger.debug(
                     "Per-segment bleed: dropping system %r "
-                    "(Jaccard=%.2f, mic_rms=%.4f > sys_rms=%.4f)",
+                    "(Jaccard=%.2f, mic_rms=%.4f >= sys_rms=%.4f)",
                     sys_text[:60], best_jaccard, mic_rms, sys_rms,
                 )
             else:


### PR DESCRIPTION
## Summary

Six bug fixes identified during pre-release smoke testing. Each is a small, contained change; opened together because they ship together as a polish pass before the next release.

### 1. Org signout / 401 → restore AI provider (\`app/main.js\`)

\`clearOrgSession()\` was called from three paths: explicit logout, JWT-expired check (both already restored \`ai_provider\`), and 401 responses on the shared adapter helper + org-chat-stream — which did NOT. On server-side session revocation (adapter restart with new signing key, user removed from org), local config stayed on \`ai_provider='adapter'\` with no live session, and the next summarisation failed with "adapter not configured". Both 401 paths now call \`restorePreAdapterProvider().catch(...)\` fire-and-forget.

### 2. Pre-load Parakeet at app launch (\`simple_recorder.py\`, \`app/main.js\`)

New \`stenoai warmup-parakeet\` CLI calls \`ensure_loaded()\` then exits. Fired after \`app.whenReady()\` before \`createWindow()\`, gated on \`loadTranscriptionEngine() === 'parakeet'\`. Warms the OS page cache so the first recording's subprocess reads model weights from RAM instead of disk — shaves ~1 s off "first record after launch". Full daemon mode (instant recording, model resident in RAM across the whole session) is the long-term answer but a bigger architectural shift — deferred.

### 3. Pause halts live transcription on the system-audio path (\`useSystemAudioCapture.ts\`)

\`MediaRecorder.pause()\` stops WebM file growth but the underlying MediaStream keeps flowing → the ScriptProcessor tap kept pushing audio chunks → Python kept transcribing during what the user thought was a pause. Added \`isPausedRef.current\` gate in the tap callback; clear the in-progress chunk buffer on pause so half-collected samples don't leak across. Mic-only path was already fine (\`src/audio_recorder._audio_callback\` already gates queue.put on pause).

### 4. Live diarisation: noise-floor false Others tags (\`liveRmsBuffer.ts\`)

Added \`SPEECH_FLOOR = 0.005\` in \`decideSpeaker\`. Below the floor we treat the loopback as silent (no plausible Others speaker) and tag You. Prevents mic-quantisation noise during silent dips from nudging \`sysMean\` past \`micMean\` and triggering a false Others attribution. Threshold stays at 1.5x symmetric — conservative change, no asymmetric tuning yet.

### 4b. Post-stop bleed correction picks the clean channel by RMS (\`src/transcriber.py\`)

\`_drop_per_segment_bleed\` previously always dropped the system segment on a Jaccard match, assuming "system is the bleed echo of mic". In the **headphone-less case** it's the opposite — mic captured the speaker echo, system has the clean signal. Dropping system left the attenuated mic-bleed version labeled \`[You]\` (visible as "system audio content appearing on the You side" in the diarised transcript).

Fix: new \`_segment_rms(wav_path, start, end)\` helper. For each Jaccard-matched (mic, sys) pair, compare per-segment RMS on the split channels and drop whichever has lower RMS — the attenuated echo by physics. The channel with higher RMS holds the direct signal and stays. Function signature changed to return \`(mic_segments, system_segments)\` tuple.

### 5. Widen live partial window 5 → 15 s (\`simple_recorder.py\`)

Long continuous monologues displayed only the most recent ~5 s in the live transcript box (PARTIAL_WINDOW_S = 5), then suddenly produced the full paragraph at VAD-end. User couldn't follow the conversation in the live view. Widened to 15 s — each partial now decodes the last 15 s (4-5 sentences typically), so the live bubble keeps everything from the current turn visible. Parakeet decodes 15 s in ~150-250 ms, comfortably under the 400 ms partial interval. Single-line change. No flicker, no mid-sentence cuts.

Per-turn bubble accumulation (Granola-style: each speaker turn becomes its own settled bubble visible during recording, not just post-stop) is the long-term target but requires real-time speaker-switch detection — deferred.

## Known gap (NOT addressed by this PR)

- **True overlap diarisation without headphones**: when both speakers are active simultaneously, my RMS comparison can't reliably separate them. Mic captures user + speaker bleed mixed; Parakeet transcribes some interpretation of that mix. Real fix is **acoustic echo cancellation** (subtract system audio from mic before VAD) — real DSP work, biggest single accuracy improvement we could ship later.
- **Per-turn live bubbles** (Granola-style): every speaker turn becomes its own settled bubble visible during recording. Requires real-time speaker-switch detection without the per-sentence flicker our earlier Option C attempt had. Deferred to a future PR.

## Test plan

- [x] Sign in to org → sign out → confirm \`ai_provider\` drops back to its pre-adapter value (or 'local' if no marker)
- [x] Sign in to org → revoke server-side / let token expire mid-session → confirm 401 handler restores ai_provider
- [x] Cold launch → click record → time the gap before the live transcript first responds (should be ~1 s faster than before)
- [x] Record → click pause → confirm live transcript stops updating until resume
- [x] Record without headphones, only speaker plays Other audio → live transcript bubbles stay green/right (no random Others tags)
- [x] Same setup, stop and let it process → post-stop transcript no longer puts system-audio content on the You side
- [x] Record with one speaker monologuing for 25-30+ s continuously → in-progress live bubble shows ~4-5 sentences (not just the last 1-2); full paragraph still produced at VAD-end as the final

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-release polish that fixes org logout, pause, and diarisation issues, improves live transcript readability, and warms up Parakeet to cut first-record latency by ~1s.

- **Bug Fixes**
  - Restore pre-adapter `ai_provider` on 401 org responses to prevent “adapter not configured”.
  - Pause now halts live transcription on system-audio capture and clears the tap buffer.
  - Add a speech floor to stop false “Others” tags during silence in live diarisation.
  - Post-stop diarisation: per-segment bleed now drops the lower-RMS side; ties/unreadable RMS keep mic (drop system) to avoid deleting user speech.

- **New Features**
  - Pre-load Parakeet at app launch via `warmup-parakeet` for faster first recording.
  - Expand live partial window from 5s to 15s for better in-progress readability within the 400ms cadence.

<sup>Written for commit ba3e32d23879c56091ed6e1bea3cabb23b78e33b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

