### PR TITLE
feat: AWS Bedrock as a cloud provider (Claude via bearer token)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -5427,6 +5427,33 @@ ipcMain.handle('set-cloud-model', async (event, model) => {
   }
 });
 
+ipcMain.handle('set-bedrock-region', async (event, region) => {
+  try {
+    const result = await runPythonScript('simple_recorder.py', ['set-bedrock-region', region]);
+    const jsonMatch = result.match(/\{.*\}/s);
+    if (jsonMatch) return JSON.parse(jsonMatch[0]);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('set-bedrock-inference-profile', async (event, profile) => {
+  try {
+    // Click's required=False + default='' lets us clear the field by passing
+    // the empty string; pass through as a single positional arg.
+    const result = await runPythonScript(
+      'simple_recorder.py',
+      ['set-bedrock-inference-profile', profile || ''],
+    );
+    const jsonMatch = result.match(/\{.*\}/s);
+    if (jsonMatch) return JSON.parse(jsonMatch[0]);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
 ipcMain.handle('test-remote-ollama', async (event, url) => {
   try {
     sendDebugLog(`Testing remote Ollama at: ${url}`);

--- a/app/preload.js
+++ b/app/preload.js
@@ -221,6 +221,8 @@ const stenoai = {
     setCloudApiKey: (key) => invoke('set-cloud-api-key', key),
     setCloudProvider: (p) => invoke('set-cloud-provider', p),
     setCloudModel: (m) => invoke('set-cloud-model', m),
+    setBedrockRegion: (region) => invoke('set-bedrock-region', region),
+    setBedrockInferenceProfile: (profile) => invoke('set-bedrock-inference-profile', profile),
     testCloudApi: () => invoke('test-cloud-api'),
   },
 

--- a/app/renderer/src/hooks/useAi.ts
+++ b/app/renderer/src/hooks/useAi.ts
@@ -85,6 +85,23 @@ export function useSetCloudModel() {
   });
 }
 
+export function useSetBedrockRegion() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (region: string) => unwrap(await ipc().ai.setBedrockRegion(region)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: aiKeys.provider() }),
+  });
+}
+
+export function useSetBedrockInferenceProfile() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (profile: string) =>
+      unwrap(await ipc().ai.setBedrockInferenceProfile(profile)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: aiKeys.provider() }),
+  });
+}
+
 export function useTestCloudApi() {
   return useMutation({
     mutationFn: async () => unwrap(await ipc().ai.testCloudApi()),

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -260,7 +260,7 @@ export type MicPermissionStatus =
   | 'unknown';
 
 export type AiProvider = 'local' | 'remote' | 'cloud' | 'adapter';
-export type CloudProvider = 'openai' | 'anthropic' | 'custom';
+export type CloudProvider = 'openai' | 'anthropic' | 'bedrock' | 'custom';
 
 // ---------- response envelopes ----------
 export type AppVersionResponse = Result<{ version: string; name: string }>;
@@ -392,6 +392,12 @@ export type GetAiProviderResponse = Result<{
   cloud_provider: CloudProvider;
   cloud_model: string;
   cloud_api_key_set: boolean;
+  /** AWS region used as the Bedrock endpoint host (defaults to us-east-1). */
+  bedrock_region: string;
+  /** Optional cross-region inference profile id. Empty when unset. */
+  bedrock_inference_profile: string;
+  /** Curated list of Claude-on-Bedrock model ids surfaced as the dropdown. */
+  bedrock_supported_models: string[];
 }>;
 
 export type AuthStatusResponse = Result<{ connected: boolean }>;
@@ -711,6 +717,8 @@ export interface StenoaiBridge {
     setCloudApiKey: RequestFn<[key: string], Result<Record<string, never>>>;
     setCloudProvider: RequestFn<[p: CloudProvider], Result<Record<string, never>>>;
     setCloudModel: RequestFn<[m: string], Result<Record<string, never>>>;
+    setBedrockRegion: RequestFn<[region: string], Result<Record<string, never>>>;
+    setBedrockInferenceProfile: RequestFn<[profile: string], Result<Record<string, never>>>;
     testCloudApi: RequestFn<[], Result<{ models?: string[] }>>;
   };
 

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -66,6 +66,8 @@ import {
 import {
   useAiProvider,
   useSetAiProvider,
+  useSetBedrockInferenceProfile,
+  useSetBedrockRegion,
   useSetCloudApiKey,
   useSetCloudApiUrl,
   useSetCloudModel,
@@ -1047,12 +1049,19 @@ function CloudProviderConfig() {
   const setCloudUrl = useSetCloudApiUrl();
   const setCloudKey = useSetCloudApiKey();
   const setCloudModel = useSetCloudModel();
+  const setBedrockRegion = useSetBedrockRegion();
+  const setBedrockProfile = useSetBedrockInferenceProfile();
   const testConnection = useTestCloudApi();
 
   const cloudProvider = provider.data?.cloud_provider ?? 'openai';
   const [apiUrl, setApiUrl] = React.useState('');
   const [apiKey, setApiKey] = React.useState('');
   const [model, setModel] = React.useState('gpt-4o-mini');
+  const [bedrockRegion, setBedrockRegionState] = React.useState('us-east-1');
+  const [bedrockProfile, setBedrockProfileState] = React.useState('');
+  // Bedrock has a curated dropdown of Claude model ids (from the backend) so
+  // the user doesn't have to know the exact `anthropic.claude-…:0` strings.
+  const bedrockModels = provider.data?.bedrock_supported_models ?? [];
   // When provider changes, the available-models cache is provider-specific
   // and the persisted model name swaps. Track which provider the model list
   // belongs to so we don't show OpenAI models against an Anthropic key.
@@ -1068,6 +1077,17 @@ function CloudProviderConfig() {
       setModel(provider.data.cloud_model);
     }
   }, [provider.data?.cloud_api_url, provider.data?.cloud_model]);
+
+  // Sync Bedrock fields from server-side state. Kept separate from the
+  // cloud_api_url/model sync because the deps array would conflate setter
+  // notifications across providers, causing the bedrock state to bounce
+  // when an unrelated openai-mode change lands.
+  React.useEffect(() => {
+    if (provider.data) {
+      setBedrockRegionState(provider.data.bedrock_region || 'us-east-1');
+      setBedrockProfileState(provider.data.bedrock_inference_profile || '');
+    }
+  }, [provider.data?.bedrock_region, provider.data?.bedrock_inference_profile]);
 
   // Reset the cached model list ONLY when the provider changes — otherwise
   // selecting a model triggers a model-name change which would dump the
@@ -1088,10 +1108,15 @@ function CloudProviderConfig() {
     testConnection.mutate();
   };
 
+  // Bedrock surfaces a curated list of Claude model ids from the backend, so
+  // the dropdown is populated immediately — no need to Test connection first.
+  // Other providers still gate the dropdown on a successful list-models call.
   const availableModels =
-    modelListFor === cloudProvider && testConnection.isSuccess
-      ? testConnection.data?.models ?? []
-      : [];
+    cloudProvider === 'bedrock'
+      ? bedrockModels
+      : modelListFor === cloudProvider && testConnection.isSuccess
+        ? testConnection.data?.models ?? []
+        : [];
   const showModelDropdown = availableModels.length > 0 && !customModelMode;
   // Persist the selected model immediately on change (Select doesn't fire
   // onBlur, so the previous "save on blur" pattern would lose the choice).
@@ -1126,10 +1151,55 @@ function CloudProviderConfig() {
           <SelectContent>
             <SelectItem value="openai">OpenAI</SelectItem>
             <SelectItem value="anthropic">Anthropic (Claude)</SelectItem>
+            <SelectItem value="bedrock">AWS Bedrock (Claude)</SelectItem>
             <SelectItem value="custom">Custom (OpenAI-compatible)</SelectItem>
           </SelectContent>
         </Select>
       </div>
+      {cloudProvider === 'bedrock' && (
+        <>
+          <div>
+            <label
+              className="mb-1 block text-[12px] font-medium uppercase"
+              style={{ letterSpacing: '0.06em', color: 'var(--fg-muted)' }}
+            >
+              AWS region
+            </label>
+            <Input
+              value={bedrockRegion}
+              onChange={(e) => setBedrockRegionState(e.target.value)}
+              placeholder="us-east-1"
+              onBlur={() =>
+                bedrockRegion && setBedrockRegion.mutate(bedrockRegion)
+              }
+              className="h-[30px] text-[13px]"
+            />
+          </div>
+          <div>
+            <label
+              className="mb-1 block text-[12px] font-medium uppercase"
+              style={{ letterSpacing: '0.06em', color: 'var(--fg-muted)' }}
+            >
+              Inference profile (optional)
+            </label>
+            <Input
+              value={bedrockProfile}
+              onChange={(e) => setBedrockProfileState(e.target.value)}
+              placeholder="us.anthropic.claude-…  (leave blank for direct invoke)"
+              onBlur={() => setBedrockProfile.mutate(bedrockProfile)}
+              className="h-[30px] text-[13px]"
+            />
+            <div
+              className="mt-1 text-[11.5px]"
+              style={{ color: 'var(--fg-muted)' }}
+            >
+              Optional cross-region inference profile. When set, Bedrock routes
+              the request across the profile's regions instead of pinning to
+              the region above.
+            </div>
+          </div>
+        </>
+      )}
       {cloudProvider === 'custom' && (
         <div>
           <label
@@ -1158,7 +1228,15 @@ function CloudProviderConfig() {
           type="password"
           value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}
-          placeholder={provider.data?.cloud_api_key_set ? '••••••••' : 'sk-…'}
+          placeholder={
+            provider.data?.cloud_api_key_set
+              ? '••••••••'
+              : cloudProvider === 'bedrock'
+                ? 'Bedrock API key (bearer token)'
+                : cloudProvider === 'anthropic'
+                  ? 'sk-ant-…'
+                  : 'sk-…'
+          }
           onBlur={() => apiKey && setCloudKey.mutate(apiKey)}
           className="h-[30px] text-[13px]"
         />
@@ -1195,7 +1273,13 @@ function CloudProviderConfig() {
             <Input
               value={model}
               onChange={(e) => setModel(e.target.value)}
-              placeholder={cloudProvider === 'anthropic' ? 'claude-…' : 'gpt-…'}
+              placeholder={
+                cloudProvider === 'bedrock'
+                  ? 'anthropic.claude-…-v1:0'
+                  : cloudProvider === 'anthropic'
+                    ? 'claude-…'
+                    : 'gpt-…'
+              }
               onBlur={() => model && setCloudModel.mutate(model)}
               className="h-[30px] text-[13px]"
             />
@@ -1211,7 +1295,7 @@ function CloudProviderConfig() {
             )}
           </div>
         )}
-        {availableModels.length === 0 && (
+        {availableModels.length === 0 && cloudProvider !== 'bedrock' && (
           <div className="mt-1 text-[11.5px]" style={{ color: 'var(--fg-muted)' }}>
             Test connection to load the list of available models.
           </div>

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1186,7 +1186,7 @@ function CloudProviderConfig() {
               value={bedrockProfile}
               onChange={(e) => setBedrockProfileState(e.target.value)}
               placeholder="us.anthropic.claude-…  (leave blank for direct invoke)"
-              onBlur={() => setBedrockProfile.mutate(bedrockProfile)}
+              onBlur={() => setBedrockProfile.mutate(bedrockProfile.trim())}
               className="h-[30px] text-[13px]"
             />
             <div

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1185,18 +1185,10 @@ function CloudProviderConfig() {
             <Input
               value={bedrockProfile}
               onChange={(e) => setBedrockProfileState(e.target.value)}
-              placeholder="us.anthropic.claude-…  (leave blank for direct invoke)"
+              placeholder="us.anthropic.claude-…"
               onBlur={() => setBedrockProfile.mutate(bedrockProfile.trim())}
               className="h-[30px] text-[13px]"
             />
-            <div
-              className="mt-1 text-[11.5px]"
-              style={{ color: 'var(--fg-muted)' }}
-            >
-              Optional cross-region inference profile. When set, Bedrock routes
-              the request across the profile's regions instead of pinning to
-              the region above.
-            </div>
           </div>
         </>
       )}

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3487,6 +3487,9 @@ def get_ai_provider():
         "cloud_api_key_set": bool(config.get_cloud_api_key()),
         "cloud_provider": config.get_cloud_provider(),
         "cloud_model": config.get_cloud_model(),
+        "bedrock_region": config.get_bedrock_region(),
+        "bedrock_inference_profile": config.get_bedrock_inference_profile(),
+        "bedrock_supported_models": list(config.SUPPORTED_BEDROCK_MODELS),
     }
     print(json.dumps(result))
 
@@ -3574,6 +3577,32 @@ def set_cloud_model(model):
 
 
 @cli.command()
+@click.argument('region')
+def set_bedrock_region(region):
+    """Set the AWS Bedrock region (e.g. us-east-1)"""
+    from src.config import get_config
+    config = get_config()
+    success = config.set_bedrock_region(region)
+    if success:
+        print(json.dumps({"success": True, "bedrock_region": region}))
+    else:
+        print(json.dumps({"success": False, "error": "Failed to save Bedrock region (empty?)"}))
+
+
+@cli.command()
+@click.argument('profile', required=False, default='')
+def set_bedrock_inference_profile(profile):
+    """Set the AWS Bedrock cross-region inference profile (empty clears)"""
+    from src.config import get_config
+    config = get_config()
+    success = config.set_bedrock_inference_profile(profile)
+    if success:
+        print(json.dumps({"success": True, "bedrock_inference_profile": profile}))
+    else:
+        print(json.dumps({"success": False, "error": "Failed to save Bedrock inference profile"}))
+
+
+@cli.command()
 @click.argument('url')
 def test_remote_ollama(url):
     """Test connection to a remote Ollama server"""
@@ -3609,6 +3638,51 @@ def test_cloud_api():
             models_page = client.models.list(limit=10)
             model_ids = [m.id for m in models_page.data]
             print(json.dumps({"success": True, "models": model_ids}))
+        elif cloud_provider == "bedrock":
+            # Bedrock doesn't expose a cheap list endpoint via the bearer-token
+            # API surface (ListFoundationModels needs SigV4). The Settings UI
+            # uses the curated SUPPORTED_BEDROCK_MODELS list directly, so the
+            # only thing left to verify is "does the key + region actually
+            # answer Converse?". Send a 1-token ping to the configured model.
+            import urllib.request
+            import urllib.error
+            import urllib.parse
+            region = config.get_bedrock_region()
+            profile = config.get_bedrock_inference_profile()
+            model_id = config.get_cloud_model()
+            target = profile or model_id
+            url = (
+                f"https://bedrock-runtime.{region}.amazonaws.com"
+                f"/model/{urllib.parse.quote(target, safe=':.-')}/converse"
+            )
+            body = json.dumps({
+                "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+                "inferenceConfig": {"maxTokens": 1},
+            }).encode("utf-8")
+            headers = {
+                "content-type": "application/json",
+                "authorization": f"Bearer {cloud_api_key}",
+            }
+            try:
+                req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    resp.read()  # we only care about the status code
+                # Surface the curated list as "models" so the UI's existing
+                # dropdown wiring lights up after a successful test.
+                print(json.dumps({
+                    "success": True,
+                    "models": list(config.SUPPORTED_BEDROCK_MODELS),
+                }))
+            except urllib.error.HTTPError as he:
+                detail = ""
+                try:
+                    detail = he.read().decode("utf-8", errors="replace")[:300]
+                except Exception:
+                    pass
+                print(json.dumps({
+                    "success": False,
+                    "error": f"Bedrock HTTP {he.code}: {detail or he.reason}",
+                }))
         else:
             from openai import OpenAI
             base_url = cloud_api_url if cloud_provider == "custom" and cloud_api_url else None

--- a/src/config.py
+++ b/src/config.py
@@ -553,7 +553,26 @@ class Config:
     # --- AI provider settings ---
 
     VALID_AI_PROVIDERS = ("local", "remote", "cloud", "adapter")
-    VALID_CLOUD_PROVIDERS = ("openai", "anthropic", "custom")
+    VALID_CLOUD_PROVIDERS = ("openai", "anthropic", "bedrock", "custom")
+
+    # AWS Bedrock has ~30 regions; we surface the common ones in the UI but
+    # accept any value as set_bedrock_region trusts the caller. Defaulting to
+    # us-east-1 because that's where new Bedrock features land first and the
+    # widest model selection lives.
+    DEFAULT_BEDROCK_REGION = "us-east-1"
+
+    # Claude on Bedrock — curated dropdown for the Settings UI. Bedrock model
+    # IDs are versioned (`:0`, `:1`, …) and prefixed with the model provider
+    # (`anthropic.`); cross-region inference profiles override these at call
+    # time when set. Keep this list small and current; users who want a model
+    # not on the list can paste it into the "Custom…" entry.
+    SUPPORTED_BEDROCK_MODELS = (
+        "anthropic.claude-sonnet-4-5-20250929-v2:0",
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "anthropic.claude-opus-4-1-20250805-v1:0",
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "anthropic.claude-3-5-haiku-20241022-v1:0",
+    )
 
     def get_ai_provider(self) -> str:
         """Get the configured AI provider ('local', 'remote', 'cloud', or
@@ -613,13 +632,56 @@ class Config:
     CLOUD_MODEL_DEFAULTS = {
         "openai": "gpt-4o-mini",
         "anthropic": "claude-haiku-4-5-20251001",
+        "bedrock": "anthropic.claude-haiku-4-5-20251001-v1:0",
         "custom": "gpt-4o-mini",
     }
 
     def get_cloud_provider(self) -> str:
-        """Get the cloud provider type ('openai', 'anthropic', or 'custom')."""
+        """Get the cloud provider type. One of VALID_CLOUD_PROVIDERS; falls
+        back to 'openai' for unknown values (e.g. config from a future
+        version with a provider this build doesn't know about)."""
         value = self._config.get("cloud_provider", "openai")
         return value if value in self.VALID_CLOUD_PROVIDERS else "openai"
+
+    # --- Bedrock-specific knobs ---
+    # Stored as plain config (not env-var-secret like the API key) because
+    # region + inference profile are not credentials. The API key still
+    # flows through STENOAI_CLOUD_API_KEY exactly like the other providers.
+
+    def get_bedrock_region(self) -> str:
+        """AWS region used as the Bedrock endpoint host. Defaults to us-east-1
+        when unset. Cross-region inference profiles override which regions
+        actually serve traffic but the request still has to land somewhere."""
+        value = self._config.get("bedrock_region")
+        if not isinstance(value, str) or not value.strip():
+            return self.DEFAULT_BEDROCK_REGION
+        return value.strip()
+
+    def set_bedrock_region(self, region: str) -> bool:
+        """Persist the AWS region. Accepts any non-empty string — Bedrock
+        validates the region on the wire, so a typo surfaces as a clear
+        404 / DNS error at request time rather than silently here."""
+        cleaned = (region or "").strip()
+        if not cleaned:
+            logger.error("Bedrock region cannot be empty")
+            return False
+        self._config["bedrock_region"] = cleaned
+        return self._save()
+
+    def get_bedrock_inference_profile(self) -> str:
+        """Optional cross-region inference profile ID, e.g.
+        'us.anthropic.claude-haiku-4-5-20251001-v1:0'. When set this is used
+        as the modelId in the Converse URL path so Bedrock routes the
+        request across the profile's regions instead of pinning to one.
+        Empty means 'use the bare model id'."""
+        value = self._config.get("bedrock_inference_profile", "")
+        return value if isinstance(value, str) else ""
+
+    def set_bedrock_inference_profile(self, profile: str) -> bool:
+        """Persist the inference profile. Empty string clears it — equivalent
+        to 'use the bare model id'."""
+        self._config["bedrock_inference_profile"] = (profile or "").strip()
+        return self._save()
 
     def set_cloud_provider(self, provider: str) -> bool:
         """Set the cloud provider type."""

--- a/src/config.py
+++ b/src/config.py
@@ -673,9 +673,16 @@ class Config:
         'us.anthropic.claude-haiku-4-5-20251001-v1:0'. When set this is used
         as the modelId in the Converse URL path so Bedrock routes the
         request across the profile's regions instead of pinning to one.
-        Empty means 'use the bare model id'."""
+        Empty means 'use the bare model id'.
+
+        Stripped on read so a whitespace-only stored value (e.g. from a
+        hand-edited config.json) doesn't survive the `target = profile or
+        model_id` check in _bedrock_chat and produce a URL with `%20`s in
+        place of the model id."""
         value = self._config.get("bedrock_inference_profile", "")
-        return value if isinstance(value, str) else ""
+        if not isinstance(value, str):
+            return ""
+        return value.strip()
 
     def set_bedrock_inference_profile(self, profile: str) -> bool:
         """Persist the inference profile. Empty string clears it — equivalent

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1007,6 +1007,22 @@ TRANSCRIPT:
                 except Exception as e:
                     logger.error(f"Anthropic streaming failed: {e}")
                     return
+            elif self.cloud_provider == "bedrock":
+                # Bedrock's /converse-stream uses amazon eventstream framing
+                # (binary, length-prefixed), which would need a dedicated
+                # parser to unwrap without boto3. For the initial Bedrock
+                # release we fall back to non-streaming Converse and yield
+                # the full response as a single chunk — the user sees the
+                # whole answer arrive at once instead of token-by-token.
+                # Acceptable for summarisation (already a long batch op);
+                # follow-up PR can add proper streaming.
+                try:
+                    text = self._bedrock_chat(prompt, timeout_seconds=7200)
+                    if text:
+                        yield text
+                except Exception as e:
+                    logger.error(f"Bedrock summarisation failed: {e}")
+                    return
             else:
                 try:
                     response = self.cloud_client.chat.completions.create(
@@ -1251,6 +1267,14 @@ ANSWER:"""
                     ) as stream:
                         for text in stream.text_stream:
                             yield text
+                elif self.cloud_provider == "bedrock":
+                    # Same eventstream parsing tradeoff as summarize_streaming
+                    # — fall back to non-streaming Converse and emit the full
+                    # answer in one yield. Interactive query so we keep the
+                    # 300 s ceiling that the OpenAI/Anthropic paths use.
+                    text = self._bedrock_chat(prompt, timeout_seconds=300)
+                    if text:
+                        yield text
                 else:
                     response = self.cloud_client.chat.completions.create(
                         model=self.model_name,

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -35,6 +35,10 @@ class OllamaSummarizer:
         self.cloud_provider = None
         self.ollama_process = None
         self.remote_url = config.get_remote_ollama_url()
+        # Bedrock-specific state. Lazily populated only when cloud_provider == 'bedrock'.
+        self.bedrock_api_key: Optional[str] = None
+        self.bedrock_region: str = ""
+        self.bedrock_inference_profile: str = ""
 
         if self.ai_provider == "adapter":
             # Adapter mode: route every AI request through the customer's
@@ -72,6 +76,21 @@ class OllamaSummarizer:
                     raise ImportError("anthropic package is required for Anthropic cloud mode. pip install anthropic")
                 self.anthropic_client = Anthropic(api_key=cloud_api_key)
                 logger.info(f"Anthropic provider initialized: model={self.model_name}")
+            elif self.cloud_provider == "bedrock":
+                # No SDK — we call Bedrock Converse directly over HTTPS with
+                # the bearer-token API key. Avoids boto3 (~10 MB) and the
+                # SigV4 signing machinery; the only thing we lose is the
+                # SDK's built-in retry / endpoint discovery, both of which
+                # we already handle in _bedrock_chat.
+                self.bedrock_api_key = cloud_api_key
+                self.bedrock_region = config.get_bedrock_region()
+                self.bedrock_inference_profile = config.get_bedrock_inference_profile()
+                logger.info(
+                    "Bedrock provider initialized: model=%s region=%s profile=%s",
+                    self.model_name,
+                    self.bedrock_region,
+                    self.bedrock_inference_profile or "(none)",
+                )
             else:
                 try:
                     from openai import OpenAI
@@ -325,6 +344,8 @@ class OllamaSummarizer:
         """
         if self.cloud_provider == "anthropic":
             return self._anthropic_chat(prompt, timeout_seconds)
+        if self.cloud_provider == "bedrock":
+            return self._bedrock_chat(prompt, timeout_seconds)
         return self._openai_chat(prompt, timeout_seconds)
 
     def _openai_chat(self, prompt: str, timeout_seconds: int = 300) -> str:
@@ -484,6 +505,110 @@ class OllamaSummarizer:
                 if attempt == max_retries - 1:
                     raise
         raise RuntimeError("Anthropic chat failed after all retries")
+
+    def _bedrock_chat(self, prompt: str, timeout_seconds: int = 300) -> str:
+        """Send a chat request via the AWS Bedrock Converse API.
+
+        Uses the Bedrock long-term API key (bearer token) directly — no
+        boto3, no SigV4 signing. Posts to
+        ``bedrock-runtime.{region}.amazonaws.com/model/{modelId}/converse``
+        with ``Authorization: Bearer <key>``. When an inference profile ID
+        is configured it replaces ``modelId`` in the URL so Bedrock can
+        route the request across regions.
+
+        Retry policy mirrors _anthropic_chat: 3 attempts with a 5 s gap,
+        and we short-circuit on auth failures (401/403) because retrying
+        a wrong key is pointless and slow.
+        """
+        import urllib.request
+        import urllib.error
+        import urllib.parse
+        import json as _json
+
+        if not self.bedrock_api_key:
+            raise RuntimeError("Bedrock API key is not configured.")
+        if not self.bedrock_region:
+            raise RuntimeError("Bedrock region is not configured.")
+
+        # Inference profile wins when set — same wire shape, different URL
+        # path. urllib.parse.quote keeps the ":0" version suffix intact
+        # (it's not a path separator, just a delimiter in the Bedrock ID).
+        target_id = self.bedrock_inference_profile or self.model_name
+        encoded_id = urllib.parse.quote(target_id, safe=":.-")
+        url = (
+            f"https://bedrock-runtime.{self.bedrock_region}.amazonaws.com"
+            f"/model/{encoded_id}/converse"
+        )
+        body = _json.dumps({
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"text": prompt}],
+                }
+            ],
+            # Same ceiling as the Anthropic direct path. Bedrock caps per-
+            # model; if the model has a lower max it'll truncate, not error.
+            "inferenceConfig": {"maxTokens": 8192},
+        }).encode("utf-8")
+        headers = {
+            "content-type": "application/json",
+            "authorization": f"Bearer {self.bedrock_api_key}",
+        }
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                if attempt > 0:
+                    logger.info(f"Bedrock API retry attempt {attempt + 1}/{max_retries}")
+                    time.sleep(5)
+                req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+                with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:
+                    payload = _json.loads(resp.read().decode("utf-8"))
+                # Converse response shape:
+                #   { "output": { "message": { "content": [ { "text": "..." } ] } }, ... }
+                # The content array can hold multiple blocks (e.g. tool_use,
+                # reasoning), but for plain prompts the first text block is
+                # the answer. Concatenate all text blocks defensively in
+                # case future models return multiple.
+                msg = (payload.get("output") or {}).get("message") or {}
+                content_blocks = msg.get("content") or []
+                texts = [
+                    (block.get("text") or "")
+                    for block in content_blocks
+                    if isinstance(block, dict) and block.get("text")
+                ]
+                joined = "".join(texts).strip()
+                if not joined:
+                    raise RuntimeError("Bedrock returned empty response")
+                return joined
+            except urllib.error.HTTPError as e:
+                # 401/403 = bad credentials, 404 = wrong region or model id.
+                # None of these recover with retries — abort early so the
+                # user sees the actual error rather than 15 s of silence.
+                err_body = ""
+                try:
+                    err_body = e.read().decode("utf-8", errors="replace")[:500]
+                except Exception:
+                    pass
+                if e.code in (401, 403):
+                    raise RuntimeError(
+                        f"Bedrock rejected the API key ({e.code}). "
+                        f"Verify the key has bedrock:InvokeModel access in {self.bedrock_region}."
+                    )
+                if e.code == 404:
+                    raise RuntimeError(
+                        f"Bedrock could not find model '{target_id}' in {self.bedrock_region}. "
+                        f"Check the model id and region, or set a cross-region inference profile. "
+                        f"Detail: {err_body}"
+                    )
+                logger.error(f"Bedrock API attempt {attempt + 1} failed: HTTP {e.code} {err_body}")
+                if attempt == max_retries - 1:
+                    raise RuntimeError(f"Bedrock HTTP {e.code}: {err_body}")
+            except Exception as e:
+                logger.error(f"Bedrock API attempt {attempt + 1} failed: {e}")
+                if attempt == max_retries - 1:
+                    raise
+        raise RuntimeError("Bedrock chat failed after all retries")
 
     def _create_permissive_prompt(self, transcript: str, language: str = "en", notes: str = None) -> str:
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,6 +198,17 @@ class ConfigBedrockSettingsTests(unittest.TestCase):
             self.assertTrue(config.set_bedrock_inference_profile(""))
             self.assertEqual(config.get_bedrock_inference_profile(), "")
 
+    def test_whitespace_inference_profile_stored_in_config_is_normalised(self):
+        # A hand-edited config.json with a whitespace-only inference profile
+        # would otherwise survive `target = profile or model_id` in
+        # _bedrock_chat (truthy string) and produce a URL with %20 in place
+        # of the model id. Belt-and-braces strip on read.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"bedrock_inference_profile": "   "}))
+            config = Config(config_path=path)
+            self.assertEqual(config.get_bedrock_inference_profile(), "")
+
     def test_bedrock_is_a_valid_cloud_provider(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -152,5 +152,70 @@ class ConfigKeepRecordingsTests(unittest.TestCase):
             self.assertFalse(reloaded.get_keep_recordings())
 
 
+class ConfigBedrockSettingsTests(unittest.TestCase):
+    def test_default_bedrock_region_is_us_east_1(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertEqual(config.get_bedrock_region(), "us-east-1")
+
+    def test_set_bedrock_region_persists_and_trims(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertTrue(config.set_bedrock_region("  eu-west-1  "))
+            self.assertEqual(config.get_bedrock_region(), "eu-west-1")
+            reloaded = Config(config_path=path)
+            self.assertEqual(reloaded.get_bedrock_region(), "eu-west-1")
+
+    def test_set_bedrock_region_rejects_empty(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            # Seed a known good value so we can assert it isn't clobbered.
+            config.set_bedrock_region("ap-southeast-2")
+            self.assertFalse(config.set_bedrock_region(""))
+            self.assertFalse(config.set_bedrock_region("   "))
+            self.assertEqual(config.get_bedrock_region(), "ap-southeast-2")
+
+    def test_default_inference_profile_is_empty_string(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertEqual(config.get_bedrock_inference_profile(), "")
+
+    def test_set_inference_profile_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            profile = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+            self.assertTrue(config.set_bedrock_inference_profile(profile))
+            self.assertEqual(config.get_bedrock_inference_profile(), profile)
+            reloaded = Config(config_path=path)
+            self.assertEqual(reloaded.get_bedrock_inference_profile(), profile)
+
+    def test_empty_inference_profile_clears_value(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            config.set_bedrock_inference_profile("us.anthropic.claude-x-v1:0")
+            self.assertTrue(config.set_bedrock_inference_profile(""))
+            self.assertEqual(config.get_bedrock_inference_profile(), "")
+
+    def test_bedrock_is_a_valid_cloud_provider(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertIn("bedrock", config.VALID_CLOUD_PROVIDERS)
+            self.assertTrue(config.set_cloud_provider("bedrock"))
+            self.assertEqual(config.get_cloud_provider(), "bedrock")
+
+    def test_bedrock_has_default_cloud_model(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            config.set_cloud_provider("bedrock")
+            # CLOUD_MODEL_DEFAULTS entry surfaces as the get_cloud_model
+            # fallback when no model has been remembered for this provider yet.
+            self.assertEqual(
+                config.get_cloud_model(),
+                "anthropic.claude-haiku-4-5-20251001-v1:0",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Adds **AWS Bedrock** as a fourth cloud-provider option in Settings → AI alongside OpenAI, Anthropic, and Custom. Uses Bedrock's long-term API key (bearer token) — no boto3, no SigV4 — so the bundle stays slim.

- **Auth**: Bedrock API key, sent as `Authorization: Bearer <key>`
- **Models**: Curated Claude-on-Bedrock dropdown (Sonnet 4.5, Haiku 4.5, Opus 4.1, Claude 3.5 Sonnet/Haiku)
- **Region**: Configurable field, default `us-east-1`
- **Inference profile**: Optional cross-region routing (e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`) — overrides the model id in the request URL when set

## What it looks like
Settings → AI → Service: choose **AWS Bedrock (Claude)** → fill in:
- API key (the Bedrock long-term key from the AWS console)
- AWS region (defaults to `us-east-1`)
- Inference profile (optional)
- Model (dropdown is populated from the curated backend list immediately)

Hit **Test connection** to verify the key + region answer Converse with a 1-token ping. The summariser then routes through `bedrock-runtime.{region}.amazonaws.com/model/{id}/converse` for every summary / chat.

## Why no boto3
The bearer-token API key path doesn't need SigV4, so a plain `urllib.request` POST is enough. Boto3 would add ~10 MB to the bundle and a fragile transitive-dep chain (botocore, s3transfer, jmespath) for no functional gain over the bearer auth we already use for the org adapter.

## Files
- `src/config.py` — `VALID_CLOUD_PROVIDERS` += `bedrock`, `SUPPORTED_BEDROCK_MODELS`, region + inference-profile getters/setters
- `src/summarizer.py` — new `_bedrock_chat` method; `__init__` Bedrock branch; dispatcher in `_cloud_chat`
- `simple_recorder.py` — `set-bedrock-region` / `set-bedrock-inference-profile` CLI commands; `test-cloud-api` Bedrock branch; `get-ai-provider` exposes the new fields + curated model list
- `app/main.js` + `app/preload.js` — IPC handlers + bridge
- `app/renderer/src/lib/ipc.ts` + `hooks/useAi.ts` — typed `ai.setBedrockRegion` / `ai.setBedrockInferenceProfile` + React Query hooks
- `app/renderer/src/routes/Settings.tsx` — UI: dropdown entry + conditional region/profile fields + placeholder updates
- `tests/test_config.py` — 8 new tests covering defaults, round-trip, empty-rejection, and Bedrock-as-cloud-provider integration

## Test plan
- [x] Backend: `python -m unittest discover tests` — 70 tests pass (62 existing + 8 new Bedrock)
- [x] Renderer: `npm run typecheck:renderer` clean; `vite build` succeeds
- [x] Smoke: constructed `OllamaSummarizer` with `cloud_provider=bedrock`, called `_bedrock_chat` with a fake key — got the expected `Bedrock rejected the API key (403). Verify the key has bedrock:InvokeModel access in us-east-1.` message
- [x] **Manual:** real Bedrock key on `us-east-1` → expect summary works against `anthropic.claude-haiku-4-5-20251001-v1:0` (no inference profile)
- [x] **Manual:** set an inference profile (e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`) → expect summary works via the profile path
- [x] **Manual:** wrong region → expect actionable 404 error mentioning region + model id

## Notes
- The Bedrock API key path requires `bedrock:InvokeModel` permission on the key. ListFoundationModels needs SigV4 so we don't try to enumerate models from the bearer token — we use the curated `SUPPORTED_BEDROCK_MODELS` list instead.
- Inference profiles are a 2024+ Bedrock concept for cross-region routing. The optional field is opt-in; users who don't need cross-region keep the field blank and the bare model id is used as-is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS Bedrock (Claude) as a new cloud provider using bearer-token auth. Users can pick a Claude model, set region, and optionally use an inference profile—no `boto3` or SigV4 needed.

- **New Features**
  - New provider: AWS Bedrock (Claude) in Settings → AI.
  - Auth via Bedrock long‑term API key (Authorization: Bearer …); no `boto3`.
  - Region field (default `us-east-1`) and optional cross‑region inference profile.
  - Curated Claude-on-Bedrock models appear immediately in the model dropdown.
  - Backend posts to Bedrock Converse with retries and clear 401/403/404 errors.
  - CLI/IP/renderer: setters for region/profile, updated placeholders, and Test connection pings Converse.
  - Simplified inference profile field (no helper line; bare placeholder).

- **Bug Fixes**
  - Fixed streaming crash: Bedrock now falls back to non‑streaming Converse and returns the full response as one chunk.
  - Normalized inference profile input: renderer trims on save and backend strips on read to prevent malformed URLs.

<sup>Written for commit 18982fab72f608b3f8c6b5d99a29b00d7f66900a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

