### PR TITLE
calendar nudge: cancellable OAuth + UX polish / hero cta instant download

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -6015,13 +6015,41 @@ function deleteOutlookTokens() {
 
 // ── Google Calendar: OAuth2 Flow with PKCE ──────────────────────────────
 
+// Tracks an in-flight OAuth handshake so `google-auth-cancel` can close
+// the loopback server and reject the pending promise — otherwise the
+// user is stuck on "Connecting…" until the timeout fires.
+let activeGoogleAuth = null;
+
+function cancelActiveGoogleAuth() {
+  if (!activeGoogleAuth) return false;
+  const handle = activeGoogleAuth;
+  activeGoogleAuth = null;
+  if (handle.timeoutId) clearTimeout(handle.timeoutId);
+  // Flip the closure flag first so an in-flight token exchange knows to
+  // throw away its result instead of saving tokens.
+  if (handle.markCancelled) handle.markCancelled();
+  try { handle.server.close(); } catch (_) {}
+  handle.reject(new Error('Cancelled'));
+  return true;
+}
+
 function startGoogleAuth() {
   return new Promise((resolve, reject) => {
+    // If a previous click is still pending, abort it before starting a
+    // new flow — keeps state from desyncing if the user double-clicks.
+    cancelActiveGoogleAuth();
+
     // Generate PKCE code verifier and challenge
     const codeVerifier = crypto.randomBytes(32).toString('base64url');
     const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
     const state = crypto.randomBytes(16).toString('hex');
     let timeoutId = null;
+    let isCancelled = false;
+    const clearActive = () => {
+      if (activeGoogleAuth && activeGoogleAuth.server === server) {
+        activeGoogleAuth = null;
+      }
+    };
 
     // Start temporary HTTP server on loopback for OAuth redirect
     const server = http.createServer(async (req, res) => {
@@ -6048,6 +6076,7 @@ function startGoogleAuth() {
           res.end('<html><body><h2>Authorization denied</h2><p>You can close this tab.</p></body></html>');
           server.close();
           if (timeoutId) clearTimeout(timeoutId);
+          clearActive();
           reject(new Error(`Auth denied: ${error}`));
           return;
         }
@@ -6061,6 +6090,17 @@ function startGoogleAuth() {
         // Exchange code for tokens
         const port = server.address().port;
         const tokens = await exchangeCodeForTokens(code, codeVerifier, port);
+        // The user may have cancelled while we were waiting on Google's
+        // /token endpoint. Discard the tokens rather than silently
+        // persist them — otherwise the next calendar poll would surface
+        // a "ghost" connection seconds after the user said "Cancel".
+        // Still respond to the open browser tab so it doesn't spin
+        // forever — the request only ends when we write a body.
+        if (isCancelled) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;"><h2>Cancelled</h2><p>You can close this tab.</p></body></html>');
+          return;
+        }
         saveGoogleTokens(tokens);
 
         res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -6068,6 +6108,7 @@ function startGoogleAuth() {
 
         server.close();
         if (timeoutId) clearTimeout(timeoutId);
+        clearActive();
 
         // Notify renderer and bring app to foreground
         if (mainWindow && !mainWindow.isDestroyed()) {
@@ -6082,6 +6123,7 @@ function startGoogleAuth() {
         res.end('<html><body><h2>Authentication failed</h2><p>Please try again.</p></body></html>');
         server.close();
         if (timeoutId) clearTimeout(timeoutId);
+        clearActive();
         reject(err);
       }
     });
@@ -6110,9 +6152,16 @@ function startGoogleAuth() {
     timeoutId = setTimeout(() => {
       if (server.listening) {
         server.close();
-        reject(new Error('OAuth timeout: no response within 5 minutes'));
+        clearActive();
+        reject(new Error('Timed out — no response from Google.'));
       }
-    }, 5 * 60 * 1000);
+    }, 60 * 1000);
+    activeGoogleAuth = {
+      server,
+      reject,
+      timeoutId,
+      markCancelled: () => { isCancelled = true; },
+    };
   });
 }
 
@@ -6295,12 +6344,34 @@ function fetchCalendarEvents(accessToken, maxResults = 7, signal) {
 
 // ── Outlook Calendar: OAuth2 Flow with PKCE ─────────────────────────────
 
+// Mirror of activeGoogleAuth — see comment there.
+let activeOutlookAuth = null;
+
+function cancelActiveOutlookAuth() {
+  if (!activeOutlookAuth) return false;
+  const handle = activeOutlookAuth;
+  activeOutlookAuth = null;
+  if (handle.timeoutId) clearTimeout(handle.timeoutId);
+  if (handle.markCancelled) handle.markCancelled();
+  try { handle.server.close(); } catch (_) {}
+  handle.reject(new Error('Cancelled'));
+  return true;
+}
+
 function startOutlookAuth() {
   return new Promise((resolve, reject) => {
+    cancelActiveOutlookAuth();
+
     const codeVerifier = crypto.randomBytes(32).toString('base64url');
     const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
     const state = crypto.randomBytes(16).toString('hex');
     let timeoutId = null;
+    let isCancelled = false;
+    const clearActive = () => {
+      if (activeOutlookAuth && activeOutlookAuth.server === server) {
+        activeOutlookAuth = null;
+      }
+    };
 
     const server = http.createServer(async (req, res) => {
       try {
@@ -6327,6 +6398,7 @@ function startOutlookAuth() {
           res.end('<html><body><h2>Authorization denied</h2><p>You can close this tab.</p></body></html>');
           server.close();
           if (timeoutId) clearTimeout(timeoutId);
+          clearActive();
           reject(new Error(`Auth denied: ${error}`));
           return;
         }
@@ -6339,6 +6411,14 @@ function startOutlookAuth() {
 
         const port = server.address().port;
         const tokens = await exchangeOutlookCodeForTokens(code, codeVerifier, port);
+        // See the Google counterpart — discard tokens if the user
+        // cancelled while we awaited Microsoft's /token endpoint, and
+        // still send a response so the open browser tab doesn't hang.
+        if (isCancelled) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;"><h2>Cancelled</h2><p>You can close this tab.</p></body></html>');
+          return;
+        }
         saveOutlookTokens(tokens);
 
         res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -6346,6 +6426,7 @@ function startOutlookAuth() {
 
         server.close();
         if (timeoutId) clearTimeout(timeoutId);
+        clearActive();
 
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send('outlook-auth-changed');
@@ -6359,6 +6440,7 @@ function startOutlookAuth() {
         res.end('<html><body><h2>Authentication failed</h2><p>Please try again.</p></body></html>');
         server.close();
         if (timeoutId) clearTimeout(timeoutId);
+        clearActive();
         reject(err);
       }
     });
@@ -6389,9 +6471,16 @@ function startOutlookAuth() {
     timeoutId = setTimeout(() => {
       if (server.listening) {
         server.close();
-        reject(new Error('OAuth timeout: no response within 5 minutes'));
+        clearActive();
+        reject(new Error('Timed out — no response from Outlook.'));
       }
-    }, 5 * 60 * 1000);
+    }, 60 * 1000);
+    activeOutlookAuth = {
+      server,
+      reject,
+      timeoutId,
+      markCancelled: () => { isCancelled = true; },
+    };
   });
 }
 
@@ -6666,6 +6755,11 @@ ipcMain.handle('google-auth-status', async () => {
   }
 });
 
+ipcMain.handle('google-auth-cancel', async () => {
+  const cancelled = cancelActiveGoogleAuth();
+  return { success: true, cancelled };
+});
+
 ipcMain.handle('google-auth-disconnect', async () => {
   try {
     // Best-effort token revocation
@@ -6895,6 +6989,11 @@ ipcMain.handle('outlook-auth-status', async () => {
   } catch (error) {
     return { success: false, connected: false };
   }
+});
+
+ipcMain.handle('outlook-auth-cancel', async () => {
+  const cancelled = cancelActiveOutlookAuth();
+  return { success: true, cancelled };
 });
 
 ipcMain.handle('outlook-auth-disconnect', async () => {

--- a/app/main.js
+++ b/app/main.js
@@ -6149,6 +6149,13 @@ function startGoogleAuth() {
       shell.openExternal(authUrl);
     });
 
+    // 60s, not 5min. A real Google OAuth flow (consent + maybe MFA)
+    // completes in seconds. The old 5-minute ceiling left users staring
+    // at "Connecting…" for 5 full minutes if they closed the browser tab
+    // — the inline Cancel button in the nudge mitigates this, but the
+    // tighter ceiling is the safety net for users who walk away. The
+    // org-SSO flow elsewhere in this file is a different beast and keeps
+    // its own (longer) timeout.
     timeoutId = setTimeout(() => {
       if (server.listening) {
         server.close();
@@ -6468,6 +6475,7 @@ function startOutlookAuth() {
       shell.openExternal(authUrl);
     });
 
+    // See the Google counterpart for the 60s-vs-5min rationale.
     timeoutId = setTimeout(() => {
       if (server.listening) {
         server.close();

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,8 @@
     "postinstall": "node scripts/patch-electron-dev.js",
     "start": "npm run build:renderer && electron .",
     "start:nobuild": "electron .",
+    "start:empty": "../dev/scripts/empty-state.sh --quit-app && npm start",
+    "start:restore": "../dev/scripts/empty-state.sh --restore --quit-app && npm start",
     "dev:renderer": "vite",
     "build:renderer": "vite build",
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",

--- a/app/preload.js
+++ b/app/preload.js
@@ -229,11 +229,13 @@ const stenoai = {
   calendar: {
     google: {
       connect: () => invoke('google-auth-start'),
+      cancel: () => invoke('google-auth-cancel'),
       status: () => invoke('google-auth-status'),
       disconnect: () => invoke('google-auth-disconnect'),
     },
     outlook: {
       connect: () => invoke('outlook-auth-start'),
+      cancel: () => invoke('outlook-auth-cancel'),
       status: () => invoke('outlook-auth-status'),
       disconnect: () => invoke('outlook-auth-disconnect'),
     },

--- a/app/renderer/src/hooks/useCalendarEvents.ts
+++ b/app/renderer/src/hooks/useCalendarEvents.ts
@@ -60,11 +60,17 @@ export function useGoogleCalendarAuth() {
     mutationFn: async () => unwrap(await ipc().calendar.google.connect()),
     onSuccess: () => qc.invalidateQueries({ queryKey: calendarKeys.all }),
   });
+  // No invalidate on cancel — there's nothing to refetch; the connect
+  // mutation will reject with "Cancelled" and the renderer falls back to
+  // its un-pending state on its own.
+  const cancel = useMutation({
+    mutationFn: async () => unwrap(await ipc().calendar.google.cancel()),
+  });
   const disconnect = useMutation({
     mutationFn: async () => unwrap(await ipc().calendar.google.disconnect()),
     onSuccess: () => qc.invalidateQueries({ queryKey: calendarKeys.all }),
   });
-  return { status, connect, disconnect };
+  return { status, connect, cancel, disconnect };
 }
 
 export function useOutlookCalendarAuth() {
@@ -81,9 +87,12 @@ export function useOutlookCalendarAuth() {
     mutationFn: async () => unwrap(await ipc().calendar.outlook.connect()),
     onSuccess: () => qc.invalidateQueries({ queryKey: calendarKeys.all }),
   });
+  const cancel = useMutation({
+    mutationFn: async () => unwrap(await ipc().calendar.outlook.cancel()),
+  });
   const disconnect = useMutation({
     mutationFn: async () => unwrap(await ipc().calendar.outlook.disconnect()),
     onSuccess: () => qc.invalidateQueries({ queryKey: calendarKeys.all }),
   });
-  return { status, connect, disconnect };
+  return { status, connect, cancel, disconnect };
 }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -725,11 +725,13 @@ export interface StenoaiBridge {
   calendar: {
     google: {
       connect: RequestFn<[], Result<Record<string, never>>>;
+      cancel: RequestFn<[], Result<{ cancelled: boolean }>>;
       status: RequestFn<[], AuthStatusResponse>;
       disconnect: RequestFn<[], Result<Record<string, never>>>;
     };
     outlook: {
       connect: RequestFn<[], Result<Record<string, never>>>;
+      cancel: RequestFn<[], Result<{ cancelled: boolean }>>;
       status: RequestFn<[], AuthStatusResponse>;
       disconnect: RequestFn<[], Result<Record<string, never>>>;
     };

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
+import { Calendar, ChevronRight, PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
 import { shortcut } from '@/lib/utils';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import { UpcomingCard } from '@/components/home/UpcomingCard';
@@ -200,14 +200,6 @@ export function Home({ mode }: HomeProps) {
         return false;
       }
     });
-  const onDismissCalendarNudge = () => {
-    try {
-      localStorage.setItem(NUDGE_KEY, 'true');
-    } catch {
-      // Private mode / quota errors — just hide locally for this session.
-    }
-    setCalendarNudgeDismissed(true);
-  };
   const showCalendarNudge =
     mode === 'home' &&
     calendar.data?.needsAuth === true &&
@@ -221,68 +213,170 @@ export function Home({ mode }: HomeProps) {
   const googleAuth = useGoogleCalendarAuth();
   const outlookAuth = useOutlookCalendarAuth();
 
+  // Which provider's OAuth handshake (if any) is currently in flight.
+  // Tracks the most recently clicked provider so a Cancel after the user
+  // somehow ended up with both pending hits the right one (defensive —
+  // the UI normally swaps to the Cancel row on first click, so both-pending
+  // shouldn't be reachable, but cheap to guard).
+  const googlePending = googleAuth.connect.isPending;
+  const outlookPending = outlookAuth.connect.isPending;
+  const [lastStartedProvider, setLastStartedProvider] =
+    React.useState<'google' | 'outlook' | null>(null);
+  const pendingProvider: 'google' | 'outlook' | null = React.useMemo(() => {
+    if (googlePending && outlookPending) return lastStartedProvider;
+    if (googlePending) return 'google';
+    if (outlookPending) return 'outlook';
+    return null;
+  }, [googlePending, outlookPending, lastStartedProvider]);
+  const startConnect = (provider: 'google' | 'outlook') => {
+    setLastStartedProvider(provider);
+    if (provider === 'google') googleAuth.connect.mutate();
+    else outlookAuth.connect.mutate();
+  };
+  const onCancelPending = () => {
+    if (pendingProvider === 'google') googleAuth.cancel.mutate();
+    else if (pendingProvider === 'outlook') outlookAuth.cancel.mutate();
+  };
+
+  // Surface the most recent rejection message inline (e.g. "Auth denied",
+  // "Timed out — no response from Google."). Filter out "Cancelled" since
+  // user-initiated cancels don't need to be reported back to the user.
+  // Prefer the error of the last-attempted provider so a stale error from
+  // an earlier try-then-switch doesn't shadow the newer one.
+  const errorOrder =
+    lastStartedProvider === 'outlook'
+      ? [outlookAuth.connect.error?.message, googleAuth.connect.error?.message]
+      : [googleAuth.connect.error?.message, outlookAuth.connect.error?.message];
+  const connectError = errorOrder.find((m) => m && m !== 'Cancelled');
+  // Self-clear so a stale error doesn't sit in the UI forever once the
+  // user has read it. 12s gives a comfortable read window for the longest
+  // message we produce (the timeout line) without feeling sticky. No
+  // separate X on the error row — the nudge already has one dismiss X
+  // and stacking two looks like competing affordances; the user can also
+  // clear by retrying (useMutation auto-resets) or wait out the timer.
+  // Inlined reset calls + connectError-only deps: a useCallback closing
+  // over `googleAuth.connect`/`outlookAuth.connect` would re-create each
+  // render (React Query returns a fresh result object per render — only
+  // the methods on it are referentially stable), which would restart
+  // this timer on every render and the auto-clear would never fire.
+  React.useEffect(() => {
+    if (!connectError) return;
+    const id = setTimeout(() => {
+      googleAuth.connect.reset();
+      outlookAuth.connect.reset();
+    }, 12000);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectError]);
+
+  // Hide the nudge — and abort any in-flight handshake so we don't leak
+  // a loopback server (and silently save tokens) after the user has said
+  // "go away".
+  const onDismissCalendarNudge = () => {
+    if (pendingProvider === 'google') googleAuth.cancel.mutate();
+    else if (pendingProvider === 'outlook') outlookAuth.cancel.mutate();
+    try {
+      localStorage.setItem(NUDGE_KEY, 'true');
+    } catch {
+      // Private mode / quota errors — just hide locally for this session.
+    }
+    setCalendarNudgeDismissed(true);
+  };
+
   // Rendered both in the empty-state Welcome screen (brand-new users with
   // zero meetings — exactly who needs to discover calendar integration)
-  // and in the regular Home above the Upcoming section. Extracted here
-  // so both branches use the same JSX instead of drifting.
-  const calendarNudge = showCalendarNudge ? (
-    <div
-      className="flex items-center gap-2 text-xs"
-      style={{ color: 'var(--fg-2)' }}
-    >
-      {!calendarNudgeExpanded ? (
-        <button
-          type="button"
-          onClick={() => setCalendarNudgeExpanded(true)}
-          className="-mx-1 flex flex-1 items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-[color:var(--surface-hover)]"
-          style={{ color: 'var(--fg-2)' }}
+  // and in the regular Home above the Upcoming section. Empty state hides
+  // the dismiss X — the nudge is the only secondary affordance there, so
+  // letting users wipe it out leaves nothing to discover calendar from.
+  const renderCalendarNudge = (withDismiss: boolean) =>
+    showCalendarNudge ? (
+      <div className="flex flex-col gap-1">
+        <div
+          className="flex items-center gap-3 text-xs"
+          style={{ color: 'var(--fg-muted)' }}
         >
-          <Calendar className="size-3.5 flex-shrink-0" />
-          <span>Connect a calendar to see today's meetings.</span>
-        </button>
-      ) : (
-        <>
-          <Calendar
-            className="size-3.5 flex-shrink-0"
-            style={{ color: 'var(--fg-2)' }}
-          />
-          <span>Connect:</span>
-          <button
-            type="button"
-            onClick={() => googleAuth.connect.mutate()}
-            disabled={
-              googleAuth.connect.isPending || outlookAuth.connect.isPending
-            }
-            className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
-            style={{ color: 'var(--fg-1)' }}
+          {!calendarNudgeExpanded ? (
+            <button
+              type="button"
+              onClick={() => setCalendarNudgeExpanded(true)}
+              className="group -mx-1 flex flex-1 items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-[color:var(--surface-hover)]"
+              style={{ color: 'var(--fg-muted)' }}
+            >
+              <Calendar className="size-3.5 flex-shrink-0" />
+              <span>Connect your calendar to see today's meetings.</span>
+              {!withDismiss && (
+                <ChevronRight className="size-3 flex-shrink-0 opacity-60 transition-transform group-hover:translate-x-0.5" />
+              )}
+            </button>
+          ) : pendingProvider ? (
+            <>
+              <Calendar
+                className="size-3.5 flex-shrink-0"
+                style={{ color: 'var(--fg-muted)' }}
+              />
+              <span>
+                Connecting to {pendingProvider === 'google' ? 'Google' : 'Outlook'}
+                …
+              </span>
+              <button
+                type="button"
+                onClick={onCancelPending}
+                className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)]"
+                style={{ color: 'var(--fg-1)' }}
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <Calendar
+                className="size-3.5 flex-shrink-0"
+                style={{ color: 'var(--fg-muted)' }}
+              />
+              <span>Connect:</span>
+              <button
+                type="button"
+                onClick={() => startConnect('google')}
+                className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)]"
+                style={{ color: 'var(--fg-1)' }}
+              >
+                Google
+              </button>
+              <button
+                type="button"
+                onClick={() => startConnect('outlook')}
+                className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)]"
+                style={{ color: 'var(--fg-1)' }}
+              >
+                Outlook
+              </button>
+            </>
+          )}
+          {withDismiss && (
+            <button
+              type="button"
+              onClick={onDismissCalendarNudge}
+              aria-label="Dismiss"
+              title="Dismiss"
+              className="ml-auto rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)]"
+              style={{ color: 'var(--fg-muted)' }}
+            >
+              <X className="size-3" />
+            </button>
+          )}
+        </div>
+        {connectError && !pendingProvider && (
+          <div
+            className="pl-[1.625rem] text-xs"
+            style={{ color: 'var(--fg-muted)' }}
           >
-            {googleAuth.connect.isPending ? 'Connecting…' : 'Google'}
-          </button>
-          <button
-            type="button"
-            onClick={() => outlookAuth.connect.mutate()}
-            disabled={
-              googleAuth.connect.isPending || outlookAuth.connect.isPending
-            }
-            className="rounded px-2 py-0.5 transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
-            style={{ color: 'var(--fg-1)' }}
-          >
-            {outlookAuth.connect.isPending ? 'Connecting…' : 'Outlook'}
-          </button>
-        </>
-      )}
-      <button
-        type="button"
-        onClick={onDismissCalendarNudge}
-        aria-label="Dismiss"
-        title="Dismiss"
-        className="ml-auto rounded p-1 transition-colors hover:bg-[color:var(--surface-hover)]"
-        style={{ color: 'var(--fg-2)' }}
-      >
-        <X className="size-3" />
-      </button>
-    </div>
-  ) : null;
+            {connectError}
+          </div>
+        )}
+      </div>
+    ) : null;
+  const emptyStateCalendarNudge = renderCalendarNudge(false);
+  const homeCalendarNudge = renderCalendarNudge(true);
 
   const greeting = `Ready to capture beautiful notes`;
   const dateStr = new Date().toLocaleDateString(undefined, {
@@ -346,8 +440,8 @@ export function Home({ mode }: HomeProps) {
               <span>from anywhere</span>
             </p>
           </div>
-          {calendarNudge && (
-            <div className="w-full max-w-[420px]">{calendarNudge}</div>
+          {emptyStateCalendarNudge && (
+            <div className="pt-8">{emptyStateCalendarNudge}</div>
           )}
         </div>
       ) : (
@@ -375,7 +469,9 @@ export function Home({ mode }: HomeProps) {
             </div>
           )}
 
-          {calendarNudge && <div className="mb-8">{calendarNudge}</div>}
+          {homeCalendarNudge && (
+            <div className="mb-8 w-fit">{homeCalendarNudge}</div>
+          )}
 
           {upcomingToday.length > 0 && mode === 'home' && (
             <section className="mb-10">

--- a/dev/scripts/empty-state.sh
+++ b/dev/scripts/empty-state.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Simulate the brand-new-user empty state by moving meeting data
+# (recordings/, transcripts/, output/) into a timestamped backup
+# inside the same app-support directory. OAuth tokens, config,
+# chat history, and Electron caches are left alone so login state
+# survives.
+#
+# Development utility only — lives in dev/ so PyInstaller (which bundles
+# scripts/ into the DMG) never ships it. Both the dev Electron build and
+# the packaged StenoAI write to the same ~/Library/Application Support/
+# path, so quit any running app before invoking — or pass --quit-app to
+# have this script do it for you (used by `npm run start:empty`).
+#
+# Usage:
+#   dev/scripts/empty-state.sh                       # back up current data
+#   dev/scripts/empty-state.sh --restore             # restore latest backup
+#   dev/scripts/empty-state.sh --list                # show all backups
+#   dev/scripts/empty-state.sh --quit-app            # quit app, then back up
+#   dev/scripts/empty-state.sh --restore --quit-app  # quit app, then restore
+
+set -euo pipefail
+
+DATA_DIR="$HOME/Library/Application Support/stenoai"
+BACKUP_PREFIX="_backup_"
+MOVED_DIRS=(recordings transcripts output)
+
+if [ ! -d "$DATA_DIR" ]; then
+  echo "stenoai data directory not found: $DATA_DIR"
+  echo "Run the app at least once before using this script."
+  exit 1
+fi
+
+quit_running_apps() {
+  # Packaged builds. Names vary across forks/rebrands; ignore failures
+  # so the script keeps going whichever (if any) is installed.
+  for name in "Steno" "Steno Dev" "StenoAI"; do
+    osascript -e "tell application \"$name\" to quit" 2>/dev/null || true
+  done
+  # Dev Electron started from this repo. The cmdline includes the repo
+  # path so we can target only OUR Electron, not unrelated apps.
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  pkill -f "Electron\\.app/Contents/MacOS/Electron .*${repo_root}" 2>/dev/null || true
+  # Give the OS a moment to flush file handles / finish quitting before
+  # we start moving directories out from under it.
+  sleep 0.5
+}
+
+refuse_if_recording() {
+  if pgrep -f "stenoai record" >/dev/null 2>&1; then
+    echo "A 'stenoai record' subprocess is running. Quit the app first,"
+    echo "or re-run with --quit-app."
+    exit 1
+  fi
+}
+
+list_backups() {
+  shopt -s nullglob
+  local backups=("$DATA_DIR/$BACKUP_PREFIX"*)
+  if [ ${#backups[@]} -eq 0 ]; then
+    echo "No backups found in: $DATA_DIR"
+    return
+  fi
+  echo "Backups in: $DATA_DIR"
+  for b in "${backups[@]}"; do
+    printf "  %s\n" "$(basename "$b")"
+  done
+}
+
+backup_to_empty() {
+  refuse_if_recording
+
+  local has_data=false
+  for d in "${MOVED_DIRS[@]}"; do
+    if [ -d "$DATA_DIR/$d" ]; then
+      has_data=true
+      break
+    fi
+  done
+  if [ "$has_data" = false ]; then
+    echo "No data to back up — already in empty state."
+    return
+  fi
+
+  local stamp
+  stamp=$(date +%Y%m%d_%H%M%S)
+  local backup="$DATA_DIR/${BACKUP_PREFIX}${stamp}"
+  mkdir -p "$backup"
+
+  for d in "${MOVED_DIRS[@]}"; do
+    if [ -d "$DATA_DIR/$d" ]; then
+      mv "$DATA_DIR/$d" "$backup/"
+    fi
+  done
+
+  echo "Moved meeting data to: $backup"
+}
+
+restore_latest() {
+  refuse_if_recording
+
+  shopt -s nullglob
+  local backups=("$DATA_DIR/$BACKUP_PREFIX"*)
+  if [ ${#backups[@]} -eq 0 ]; then
+    echo "No backups found in: $DATA_DIR"
+    exit 1
+  fi
+
+  # Sort lexicographically — timestamp prefix makes that == chronological.
+  IFS=$'\n' backups=($(printf '%s\n' "${backups[@]}" | sort))
+  unset IFS
+  local latest="${backups[${#backups[@]}-1]}"
+
+  # The app auto-creates these dirs on launch — clear empty ones so the
+  # restore can land. Refuse if any has real content, so we never
+  # silently bury the user's data.
+  for d in "${MOVED_DIRS[@]}"; do
+    if [ -d "$DATA_DIR/$d" ] && [ -d "$latest/$d" ]; then
+      if [ -z "$(ls -A "$DATA_DIR/$d")" ]; then
+        rmdir "$DATA_DIR/$d"
+      else
+        echo "Refusing to restore: '$d' already exists and has content."
+        echo "Move or remove it first, or pick a different backup manually."
+        exit 1
+      fi
+    fi
+  done
+
+  for d in "${MOVED_DIRS[@]}"; do
+    if [ -d "$latest/$d" ]; then
+      mv "$latest/$d" "$DATA_DIR/"
+    fi
+  done
+
+  rmdir "$latest" 2>/dev/null || true
+  echo "Restored from: $(basename "$latest")"
+}
+
+ACTION="empty"
+QUIT_APP=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --restore)  ACTION="restore" ;;
+    --list)     ACTION="list" ;;
+    --quit-app) QUIT_APP=true ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--restore|--list] [--quit-app]"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ "$QUIT_APP" = true ]; then
+  quit_running_apps
+fi
+
+case "$ACTION" in
+  empty)   backup_to_empty ;;
+  restore) restore_latest ;;
+  list)    list_backups ;;
+esac

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -60,7 +60,7 @@ export function Hero() {
             transition={{ duration: 0.5, delay: 0.15 }}
             className="flex gap-[10px] flex-wrap"
           >
-            <a href="#download" onClick={() => trackDownload('hero', 'unknown')} className="btn-base btn-primary inline-flex items-center gap-2 no-underline hover:no-underline">
+            <a href={DOWNLOAD_ARM} onClick={() => trackDownload('hero', 'arm64')} className="btn-base btn-primary inline-flex items-center gap-2 no-underline hover:no-underline">
               <Download size={15} aria-hidden="true" /> Download for Mac
             </a>
             <a href="#how" className="btn-base btn-ghost inline-flex items-center gap-2 no-underline hover:no-underline">


### PR DESCRIPTION
## Summary
- **Cancellable OAuth**: new `*-auth-cancel` IPC closes the loopback server, rejects the pending mutation, and skips token-save if cancel lands during the in-flight token exchange. Timeout shortened 5min → 60s with friendlier message. Browser tab gets a "Cancelled" response so it doesn't hang.
- **Home nudge UX**: chevron hint on the collapsed pill (empty state only), copy fix ("Connect your calendar…"), muted grey to match surrounding tertiary text, content-sized in non-empty Home so it doesn't stretch full width, dismiss X cancels any in-flight handshake before hiding, inline error message under the row with 12s auto-clear.
- **Dev utility** (`dev/scripts/empty-state.sh`) + `npm run start:empty` / `start:restore`: quits any running app, swaps meeting data in/out of a timestamped backup, then launches — for quick empty-state iteration. Lives in `dev/` so PyInstaller's `scripts/` bundling doesn't ship it.
- **Hero CTA**: marketing site "Download for Mac" button now links straight to the latest arm64 DMG instead of scrolling to the `#download` section.

## Test plan
- [ ] Empty state: click nudge → see chevron, click Google → "Connecting to Google…" + Cancel → click Cancel → returns to picker, no error shown
- [ ] Close the OAuth browser tab without completing → after 60s, see "Timed out — no response from Google." → auto-clears after 12s
- [ ] Decline in OAuth screen → see "Auth denied: access_denied" inline → auto-clears
- [ ] Cancel while mid token-exchange (close tab right after redirect) → no ghost tokens saved, no UI bounce to "connected", browser tab gets a "Cancelled" page
- [ ] Non-empty Home: nudge sits left-aligned, X dismisses entire nudge; dismissing during pending cancels the handshake
- [ ] `npm run start:empty` quits the dev Electron + launches into empty state
- [ ] `npm run start:restore` restores meeting data + launches
- [ ] Marketing site hero "Download for Mac" downloads the arm64 DMG directly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make calendar OAuth cancellable and polish the Home nudge. Prevent ghost connections, add friendlier 60s timeouts, ship an empty‑state dev script, and make the website hero button download the arm64 DMG directly.

- **New Features**
  - Cancellable Google/Outlook OAuth via `google-auth-cancel` and `outlook-auth-cancel`; starting a new connect cancels any prior flow; 60s timeout with clear copy and a "Cancelled" page in the browser.
  - Renderer updates: cancel methods in hooks; Home nudge shows a Cancel action while connecting; dismiss X also cancels; inline error under the row auto-clears after 12s; copy, chevron hint (empty state, no X), muted text, and content-sized width in non-empty Home.
  - Dev utility: `dev/scripts/empty-state.sh` with `npm run start:empty` and `npm run start:restore` for quick empty‑state iteration.
  - Website: hero "Download for Mac" now links to the latest arm64 DMG.

- **Bug Fixes**
  - No ghost tokens saved if cancel lands during the token exchange; UI no longer bounces to "connected."
  - Browser tab no longer hangs after cancel or denial; it always receives a response.
  - Prevent double‑click desync by aborting any in‑flight OAuth before starting a new one.

<sup>Written for commit 3c1c92c481e20c4d5804b2e26733947f9af2c482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

