### PR TITLE
feat(windows): experimental system-audio loopback capture

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -78,7 +78,9 @@ if (!app.isPackaged) {
 // returning silent right channels in our tests on macOS 26; CoreAudio Tap
 // matches Meetily's default and is the path our Info.plist + entitlements
 // are prepared for. Older macOS (< 14.4) is gated out at the UI layer.
-initMain({ forceCoreAudioTap: true });
+// Only force the tap on macOS — on Windows it's irrelevant (Chromium uses
+// WASAPI loopback) and passing it would be a no-op at best.
+initMain({ forceCoreAudioTap: process.platform === 'darwin' });
 
 // CoreAudio Process Taps require macOS 14.4+. Returns false on non-macOS or
 // older versions so the renderer can disable the system-audio toggle rather
@@ -92,6 +94,38 @@ function isCoreAudioTapSupported() {
   } catch (_) {
     return false;
   }
+}
+
+// Whether system-audio (loopback) capture is available on this OS at all.
+// macOS: CoreAudio Process Tap (14.4+). Windows: electron-audio-loopback uses
+// Chromium's WASAPI loopback on Windows 10+ (both Win10 and Win11 report major
+// version 10). Linux: not wired. Drives the Settings/MainToolbar toggle.
+function isSystemAudioSupported() {
+  if (process.platform === 'darwin') return isCoreAudioTapSupported();
+  if (process.platform === 'win32') {
+    try {
+      const maj = parseInt(process.getSystemVersion().split('.')[0], 10) || 0;
+      return maj >= 10;
+    } catch (_) {
+      return true; // assume a modern Windows if the version probe fails
+    }
+  }
+  return false;
+}
+
+// Per-OS user data dir, mirroring src/config.get_user_data_dir(). Used by the
+// few synchronous config reads on the Electron side so they resolve the right
+// path on Windows/Linux instead of the macOS literal.
+function getUserDataDir() {
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai');
+  }
+  if (process.platform === 'win32') {
+    const base = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    return path.join(base, 'stenoai');
+  }
+  const base = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+  return path.join(base, 'stenoai');
 }
 
 let mainWindow;
@@ -1147,14 +1181,19 @@ ipcMain.handle('request-microphone-permission', async () => {
 // than letting the user produce silent recordings.
 ipcMain.handle('get-system-audio-support', async () => {
   try {
-    const supported = isCoreAudioTapSupported();
+    const supported = isSystemAudioSupported();
+    // Windows loopback works but is pending hardware verification, so the UI
+    // labels it experimental and ships it opt-in (default off).
+    const experimental = process.platform === 'win32';
     let screenPermission = 'unknown';
     let osVersion = '';
     if (process.platform === 'darwin') {
       try { osVersion = process.getSystemVersion(); } catch (_) {}
       try { screenPermission = systemPreferences.getMediaAccessStatus('screen'); } catch (_) {}
+    } else {
+      try { osVersion = process.getSystemVersion(); } catch (_) {}
     }
-    return { success: true, supported, osVersion, screenPermission };
+    return { success: true, supported, experimental, platform: process.platform, osVersion, screenPermission };
   } catch (error) {
     return { success: false, error: error.message };
   }
@@ -2281,16 +2320,21 @@ function stopLiveTranscribe() {
 }
 
 function loadSystemAudioEnabled() {
-  if (!isCoreAudioTapSupported()) return false;
+  if (!isSystemAudioSupported()) return false;
+  // Default differs by platform: macOS ships system audio ON (CoreAudio tap is
+  // verified); Windows ships it OFF (opt-in/experimental — see src/config.py).
+  const defaultOn = process.platform === 'darwin';
   try {
-    const cfgPath = path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', 'config.json');
-    if (!fs.existsSync(cfgPath)) return true; // new install → CoreAudio default
+    const cfgPath = path.join(getUserDataDir(), 'config.json');
+    if (!fs.existsSync(cfgPath)) return defaultOn; // new install
     const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
-    // `false` only when the user has explicitly opted out; an absent key
-    // means "haven't been asked yet" → treat as the new default.
-    return cfg.system_audio_enabled !== false;
+    // Honour an explicit boolean; an absent key means "haven't been asked
+    // yet" → fall back to the platform default.
+    return typeof cfg.system_audio_enabled === 'boolean'
+      ? cfg.system_audio_enabled
+      : defaultOn;
   } catch (_) {
-    return false;
+    return defaultOn;
   }
 }
 
@@ -2302,7 +2346,7 @@ function loadSystemAudioEnabled() {
 // Config._migrate_transcription_engine.
 function loadTranscriptionEngine() {
   try {
-    const cfgPath = path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', 'config.json');
+    const cfgPath = path.join(getUserDataDir(), 'config.json');
     if (!fs.existsSync(cfgPath)) return 'parakeet';
     const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
     const engine = cfg.transcription_engine;
@@ -2318,7 +2362,7 @@ function loadTranscriptionEngine() {
 // the truth lives in one place.
 function loadAutoDetectMeetingsEnabled() {
   try {
-    const cfgPath = path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', 'config.json');
+    const cfgPath = path.join(getUserDataDir(), 'config.json');
     if (!fs.existsSync(cfgPath)) return true;
     const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
     return cfg.auto_detect_meetings_enabled !== false;

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -3,7 +3,6 @@ import { MessageSquare, Moon, MoreHorizontal, Monitor, PanelLeftClose, PanelLeft
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { AudioWave } from '@/components/AudioWave';
-import { isMac } from '@/lib/utils';
 import {
   Popover,
   PopoverContent,
@@ -12,6 +11,7 @@ import {
 import {
   useSetSystemAudio,
   useSystemAudioSetting,
+  useSystemAudioSupport,
 } from '@/hooks/useSettings';
 import type { RecordingStatus } from '@/hooks/useRecording';
 import { useTheme } from '@/hooks/useTheme';
@@ -160,7 +160,13 @@ export function MainToolbar({
 function RecordingOptionsPopover() {
   const systemAudio = useSystemAudioSetting();
   const setSystemAudio = useSetSystemAudio();
+  const systemAudioSupport = useSystemAudioSupport();
   const enabled = systemAudio.data ?? false;
+  // Show the toggle wherever loopback capture is available (macOS 14.4+ or
+  // Windows 10+), not just on mac. Hidden while support is still loading or
+  // on unsupported OSes.
+  const showSystemAudio = systemAudioSupport.data?.supported === true;
+  const experimental = systemAudioSupport.data?.experimental === true;
 
   return (
     <Popover>
@@ -184,7 +190,7 @@ function RecordingOptionsPopover() {
             </p>
           </div>
 
-          {isMac && (
+          {showSystemAudio && (
             <div
               className="flex items-start gap-3 rounded-md border p-3"
               style={{ borderColor: 'var(--border-subtle)' }}
@@ -197,6 +203,11 @@ function RecordingOptionsPopover() {
                     className="text-sm font-medium"
                   >
                     Record system audio
+                    {experimental && (
+                      <span className="ml-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                        Experimental
+                      </span>
+                    )}
                   </label>
                   <Switch
                     id="maintoolbar-system-audio"
@@ -206,8 +217,9 @@ function RecordingOptionsPopover() {
                   />
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Capture both sides of calls on macOS. Grants microphone
-                  permission on first use.
+                  {experimental
+                    ? 'Capture both sides of calls (experimental on Windows). Verify your first recording captures system audio.'
+                    : 'Capture both sides of calls on macOS. Grants microphone permission on first use.'}
                 </p>
               </div>
             </div>

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -585,7 +585,13 @@ export interface StenoaiBridge {
     disableLoopbackAudio: RequestFn<[], void>;
     getSystemAudioSupport: RequestFn<
       [],
-      Result<{ supported: boolean; osVersion: string; screenPermission: string }>
+      Result<{
+        supported: boolean;
+        osVersion: string;
+        screenPermission: string;
+        experimental?: boolean;
+        platform?: string;
+      }>
     >;
     writeSystemAudioBlob: RequestFn<
       [bytes: Uint8Array, name: string],

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -750,11 +750,13 @@ function GeneralTab() {
       <SettingRow
         label="Record system audio"
         description={
-          !isMac
-            ? 'Capture audio from virtual meetings (macOS only for now; Windows support is on the roadmap).'
-            : systemAudioSupport.data && !systemAudioSupport.data.supported
+          systemAudioSupport.data && !systemAudioSupport.data.supported
+            ? isMac
               ? `Capture audio from virtual meetings (requires macOS 14.4+, you're on ${systemAudioSupport.data.osVersion || 'an older version'})`
-              : 'Capture audio from virtual meetings (requires macOS 14.4+)'
+              : 'Capture audio from virtual meetings (not supported on this OS).'
+            : systemAudioSupport.data?.experimental
+              ? 'Capture audio from virtual meetings (experimental on Windows — verify your first recording captures system audio).'
+              : 'Capture audio from virtual meetings (requires macOS 14.4+).'
         }
       >
         <Switch

--- a/src/config.py
+++ b/src/config.py
@@ -287,10 +287,14 @@ class Config:
             "model": self.DEFAULT_MODEL,
             "notifications_enabled": True,
             "telemetry_enabled": True,
-            # Default ON — CoreAudio Process Tap captures system audio
-            # alongside the mic on macOS 14.4+. Older macOS auto-falls back
-            # to mic-only via main.js's loadSystemAudioEnabled() OS gate.
-            "system_audio_enabled": True,
+            # Default ON on macOS — CoreAudio Process Tap captures system
+            # audio alongside the mic on macOS 14.4+. Older macOS auto-falls
+            # back to mic-only via main.js's loadSystemAudioEnabled() OS gate.
+            # Default OFF on Windows/Linux: the cross-platform loopback path
+            # (electron-audio-loopback / Chromium WASAPI) works but is still
+            # pending hardware verification, so it ships opt-in/experimental —
+            # users enable it explicitly in Settings.
+            "system_audio_enabled": sys.platform == "darwin",
             # Default ON — surfaces a "Meeting detected" notification when
             # any non-Steno app starts capturing the mic. Helper is gated
             # to macOS 14+ in main.js; users can flip off in Settings.


### PR DESCRIPTION
Stacked on #160. Un-gates system-audio (loopback) capture on Windows.

## What this does
The renderer dual-stream capture (`useSystemAudioCapture`) is already platform-agnostic — it uses `electron-audio-loopback`, which supports **Windows 10+** via Chromium's WASAPI loopback. The only mac-specific pieces were the UI gate and the forced CoreAudio tap. This un-gates Windows.

- `isSystemAudioSupported()` — macOS 14.4+ **or** Windows 10+
- `initMain` forces the CoreAudio tap only on darwin (irrelevant on Windows)
- `get-system-audio-support` reports `supported` + an `experimental` flag on Windows
- `getUserDataDir()` helper mirrors `src/config.get_user_data_dir()`; the three synchronous config readers now use it instead of the macOS-literal path (fixes a known limitation from #160)
- `src/config.py`: `system_audio_enabled` defaults **ON only on macOS**, **OFF (opt-in)** on Windows/Linux
- renderer: MainToolbar + Settings show the toggle wherever supported, labelled **Experimental** on Windows

## Safety
Default-off on Windows → the mic-only path is unchanged unless a user explicitly opts in. No existing Windows installs to migrate (unreleased alpha).

## ⚠️ Needs Windows hardware verification
I could not test on Windows hardware. Before merge, a tester must confirm on real Windows 10/11:
- [ ] Settings shows the 'Record system audio (Experimental)' toggle, enabled
- [ ] Toggling on + recording captures **both** mic and system audio
- [ ] The stereo split diarises to `[You]`/`[Others]` correctly
- [ ] Toggling off cleanly reverts to mic-only

## Out of scope
Auto-detect-meetings (`mic-monitor`) remains mac-only — that genuinely needs a new WASAPI session-enumeration helper. This PR is recording/diarisation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable experimental system-audio (loopback) capture on Windows 10+ and show the toggle in the UI when supported. macOS behavior is unchanged; Windows ships opt-in with clear labeling.

- **New Features**
  - Enable Windows support via `electron-audio-loopback` (WASAPI); marked Experimental and default OFF. macOS keeps CoreAudio tap and default ON.
  - Add OS support check (macOS 14.4+ or Windows 10+) and expose it via IPC, including `experimental`, `platform`, and `osVersion`.
  - Show “Record system audio” in Main Toolbar and Settings on supported OSes, with Windows-specific “Experimental” label and guidance.

- **Bug Fixes**
  - Use a per-OS user data dir for synchronous config reads in Electron, fixing path assumptions on Windows/Linux for `system_audio_enabled`, `transcription_engine`, and `auto_detect_meetings`.

<sup>Written for commit 9d7c23cd63621413ae47d3b9543918ba3aab26b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

