### PR TITLE
chore(release): prep v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
+- **2026-06-09** 🪟 Windows alpha — Steno now runs on Windows 10/11 (x64). Record, live Parakeet transcription, summaries, and system-audio diarisation all work; ships as an unsigned installer for now (SmartScreen warns on first launch), with transcription on CPU via ONNX Runtime.
 - **2026-06-09** ☁️ AWS Bedrock as a cloud AI provider — Bring your own Bedrock API key to route summaries through Claude on AWS. Application inference profile ARNs work too, so governed environments with IAM policies that allow `bedrock:InvokeModel` on application profiles only are supported out of the box.
 - **2026-06-09** 📅 Calendar polish round — Cancellable Google + Outlook OAuth from the calendar nudge, declined events drop at the IPC boundary (covers organiser-then-declined edge case), 3-per-page `<` / `>` pagination on busy days, full-card rendering for all-day blocks, and a 2-minute background poll that survives route changes.
 - **2026-06-07** 🎙️ Live transcription with Parakeet TDT v3 — Real-time on-screen transcripts during recording via Apple Silicon's MLX backend. Sentences appear as you speak in a Granola-style chat-bubble view; speakers are attributed to You vs Others in real time.
-- **2026-06-07** 🎛️ Choose your transcription engine — Settings → Transcribe now offers Parakeet (default, live + post-stop, 25 European languages) or Whisper (post-stop only, 99 languages incl. Chinese, Japanese, Arabic, Hindi). Existing Whisper users keep Whisper; new installs default to Parakeet.
 
 
 ## Features

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "AI powered intelligence layer for confidential conversations",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",


### PR DESCRIPTION
Version bump 0.4.2 → 0.5.0 and README 'What's New' rotation (Windows alpha headline). The annotated tag push (the release trigger) is held until the Windows icon is verified on a clean VM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v0.5.0 by bumping the version and updating the README to headline the Windows alpha. The annotated tag will be pushed after verifying the Windows icon on a clean VM.

<sup>Written for commit c879d695e1b49ecca12da30a167a5c18a0ef4dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

