### PR TITLE
OS-aware hero download + fix Windows release-asset race

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -93,7 +93,14 @@ jobs:
 
     - name: Build and notarize DMG for ${{ matrix.arch }}
       working-directory: app
-      run: npm run ${{ matrix.build_cmd }}
+      # --publish=never is critical: electron-builder has a `publish` config
+      # (github provider) and GH_TOKEN in env, so without this it auto-creates
+      # a DRAFT GitHub release for the tag and uploads the DMG there. That draft
+      # is redundant — the real release is created by the `release` job below
+      # (softprops/action-gh-release) from the CI artifacts — and worse, the
+      # Windows job (build-windows.yml) would race and upload its .exe onto that
+      # stray draft instead of the published release, 404'ing the website link.
+      run: npm run ${{ matrix.build_cmd }} -- --publish=never
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -189,10 +189,18 @@ jobs:
           # references it by its versioned name for auto-update.
           VER_EXE=$(ls app/dist/*-x64.exe | grep -v 'stenoAI-windows-x64.exe' | head -1)
           cp "$VER_EXE" "app/dist/stenoAI-windows-x64.exe"
-          # Wait up to ~30 min for build-release.yml to create the release.
+          # Wait up to ~30 min for build-release.yml to create the PUBLISHED
+          # release, then upload to it. We resolve the tag via the REST
+          # /releases/tags/:tag endpoint, which only ever returns the published
+          # (non-draft) release — never a draft. This is deliberate: if any
+          # stray draft for this tag exists, `gh release view/upload <tag>`
+          # would happily match it and our .exe would land on the draft instead
+          # of the release users actually download (a 404 on the website link).
+          # build-release.yml now passes --publish=never so no such draft should
+          # exist, but matching non-draft-only here makes that guarantee robust.
           for i in $(seq 1 60); do
-            if gh release view "$TAG" >/dev/null 2>&1; then
-              echo "Release $TAG exists — uploading Windows auto-update assets."
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" >/dev/null 2>&1; then
+              echo "Published release $TAG exists — uploading Windows auto-update assets."
               gh release upload "$TAG" \
                 app/dist/latest.yml \
                 app/dist/*-x64.exe \
@@ -202,8 +210,8 @@ jobs:
               echo "Uploaded Windows assets to release $TAG."
               exit 0
             fi
-            echo "Release $TAG not created yet (attempt $i/60) — waiting 30s…"
+            echo "Published release $TAG not created yet (attempt $i/60) — waiting 30s…"
             sleep 30
           done
-          echo "Release $TAG never appeared after ~30 min — failing so we notice."
+          echo "Published release $TAG never appeared after ~30 min — failing so we notice."
           exit 1

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -1,9 +1,24 @@
 import { useState, useEffect } from "react";
-import { Download, ArrowRight, ShieldCheck, Lock, Cpu } from "lucide-react";
+import { Download, ShieldCheck, Lock, Cpu } from "lucide-react";
 import { motion as Motion } from "framer-motion";
 import { trackDownload } from "../analytics";
 
 const DOWNLOAD_ARM = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+const DOWNLOAD_WIN = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
+
+const DL_MAC = { href: DOWNLOAD_ARM, arch: "arm64", label: "Download for Mac" };
+const DL_WIN = { href: DOWNLOAD_WIN, arch: "win-x64", label: "Download for Windows (alpha)" };
+
+// Best-effort client OS detection. Defaults to Mac (the primary, stable
+// build) for the first paint and for any non-Windows/non-Mac visitor.
+function detectOS() {
+  if (typeof navigator === "undefined") return "mac";
+  const hint = navigator.userAgentData?.platform || navigator.platform || "";
+  const ua = navigator.userAgent || "";
+  if (/win/i.test(hint) || /windows/i.test(ua)) return "windows";
+  if (/mac/i.test(hint) || /mac os/i.test(ua)) return "mac";
+  return "other";
+}
 
 function fmt(s) {
   const h = String(Math.floor(s / 3600)).padStart(2, "0");
@@ -14,11 +29,23 @@ function fmt(s) {
 
 export function Hero() {
   const [seconds, setSeconds] = useState(862);
+  const [os, setOs] = useState("mac");
 
   useEffect(() => {
     const t = setInterval(() => setSeconds((s) => s + 1), 1000);
     return () => clearInterval(t);
   }, []);
+
+  useEffect(() => {
+    setOs(detectOS());
+  }, []);
+
+  // Primary button follows the visitor's OS. When we're sure of the OS
+  // (detected mac or windows) we show only that one button; when it's
+  // unknown we offer both so the visitor can pick.
+  const primary = os === "windows" ? DL_WIN : DL_MAC;
+  const secondary = os === "windows" ? DL_MAC : DL_WIN;
+  const showSecondary = os === "other";
 
   return (
     <section className="pt-[40px] pb-[56px] md:pt-[56px] md:pb-[80px]">
@@ -60,12 +87,14 @@ export function Hero() {
             transition={{ duration: 0.5, delay: 0.15 }}
             className="flex gap-[10px] flex-wrap"
           >
-            <a href={DOWNLOAD_ARM} onClick={() => trackDownload('hero', 'arm64')} className="btn-base btn-primary inline-flex items-center gap-2 no-underline hover:no-underline">
-              <Download size={15} aria-hidden="true" /> Download for Mac
+            <a href={primary.href} onClick={() => trackDownload('hero', primary.arch)} className="btn-base btn-primary inline-flex items-center gap-2 no-underline hover:no-underline">
+              <Download size={15} aria-hidden="true" /> {primary.label}
             </a>
-            <a href="#how" className="btn-base btn-ghost inline-flex items-center gap-2 no-underline hover:no-underline">
-              See how it works <ArrowRight size={15} aria-hidden="true" />
-            </a>
+            {showSecondary && (
+              <a href={secondary.href} onClick={() => trackDownload('hero', secondary.arch)} className="btn-base btn-ghost inline-flex items-center gap-2 no-underline hover:no-underline">
+                <Download size={15} aria-hidden="true" /> {secondary.label}
+              </a>
+            )}
           </Motion.div>
 
           <Motion.div

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -15,6 +15,14 @@ function detectOS() {
   if (typeof navigator === "undefined") return "mac";
   const hint = navigator.userAgentData?.platform || navigator.platform || "";
   const ua = navigator.userAgent || "";
+  // Mobile/touch devices can't run the desktop app. iOS UAs contain
+  // "like Mac OS X" (and iPadOS reports platform "MacIntel"), which would
+  // otherwise match the mac check — guard them first and fall through to
+  // "other" so phones/tablets see both CTAs rather than a bogus Mac-only one.
+  const isIOS =
+    /iphone|ipad|ipod/i.test(ua) ||
+    (/mac/i.test(hint) && navigator.maxTouchPoints > 1);
+  if (isIOS || /android/i.test(ua)) return "other";
   if (/win/i.test(hint) || /windows/i.test(ua)) return "windows";
   if (/mac/i.test(hint) || /mac os/i.test(ua)) return "mac";
   return "other";


### PR DESCRIPTION
## Summary
- **Hero download is now OS-aware** (`website/src/sections/Hero.jsx`): detects the visitor's OS and shows a single download button when it's sure — "Download for Mac" on macOS, "Download for Windows (alpha)" on Windows. Unknown OSes (e.g. Linux) get both buttons so they can choose. First paint defaults to the single Mac button (no flicker).
- **Removed "See how it works"** from the hero CTA.
- **Fixed the CI race** that left the Windows `.exe` off published releases (the website "Download for Windows" link was 404'ing):
  - `build-release.yml`: the macOS `electron-builder` step ran with `GH_TOKEN` + a `publish` config but no `--publish=never`, so it auto-created a **draft** GitHub release. The real release is created later by `softprops/action-gh-release`. Added `--publish=never` to stop the stray draft.
  - `build-windows.yml`: the upload loop matched *any* release by tag, so it raced and uploaded the `.exe` onto that draft instead of the published release. Now waits for the **published** (non-draft) release via the `/releases/tags/:tag` REST endpoint before uploading.

## Note
The current v0.5.0 release was already recovered out-of-band (Windows assets copied from the orphan draft to the published release), so `releases/latest/download/stenoAI-windows-x64.exe` returns 200 today. This PR prevents the race from recurring on future releases.

## Testing
- `npm run lint` and `vite build` pass for the website.
- Workflow changes verified by tracing the v0.5.0 run logs (draft created at 21:25, Windows uploaded to it at 21:34, published release created at 21:35 without the assets).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the hero download button OS-aware and removes the extra CTA link. Fixes a CI race so the Windows installer always lands on the published release (no more 404s).

- New Features
  - OS-aware hero: detects macOS/Windows and shows one matching button; unknown OS shows both; defaults to Mac on first paint to avoid flicker.
  - Removes “See how it works” from the hero CTA.

- Bug Fixes
  - Website OS detection: don’t treat iOS/Android (incl. iPadOS) as macOS; mobile devices now see both buttons.
  - In `build-release.yml`, add `--publish=never` to `electron-builder` to stop draft releases; the real release is created by `softprops/action-gh-release`.
  - In `build-windows.yml`, wait for the published release via `/repos/:owner/:repo/releases/tags/:tag` before uploading so the `.exe` never lands on a draft.

<sup>Written for commit d61f74ebecb5f911c17802d5ae69f1071de18227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

