### PR TITLE
fix(windows): embed app icon in exe

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -182,8 +182,7 @@
         }
       ],
       "artifactName": "stenoAI-windows-${version}-${arch}.${ext}",
-      "compression": "store",
-      "signAndEditExecutable": false
+      "compression": "store"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## Problem
On Windows the app shipped with the default **Electron icon** instead of the Steno icon — in Explorer, the Start-menu shortcut, and the taskbar — despite a correct `build/icon.ico`.

## Root cause
The `win` block in `app/package.json` had `signAndEditExecutable: false`. That flag (default `true`) controls **both** code-signing **and** the `rcedit` pass that embeds the icon + version metadata into `Steno.exe`. Disabling it to skip signing also disabled the rcedit edit, so the exe kept the stock Electron icon and metadata. The recent all-BMP `icon.ico` re-encoding work was correct, but this flag was silently throwing it away.

## Fix
Remove `signAndEditExecutable: false` (reverts to the `true` default, re-enabling the rcedit icon embed). Signing stays off via `CSC_IDENTITY_AUTO_DISCOVERY=false` in `build-windows.yml` (no cert configured), so the alpha build still ships unsigned — it just gets its icon back.

## Testing
- CI Windows build green: https://github.com/ruzin/stenoai/actions/runs/27239399750
- Verified the built `Steno.exe` carries the Steno icon (not the Electron atom) in a Windows VM.

macOS build is unaffected (change is inside the `win` block only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows build so `Steno.exe` embeds the Steno icon instead of the default Electron icon. Explorer, Start menu, and taskbar now show the correct app icon.

- **Bug Fixes**
  - Removed `signAndEditExecutable: false` from the `win` config in `app/package.json`, restoring the `rcedit` step that embeds icon and version metadata.
  - Code signing stays off via `CSC_IDENTITY_AUTO_DISCOVERY=false` in CI; build remains unsigned.
  - Verified in a Windows VM and via CI artifacts.

<sup>Written for commit 6dd04e7b60e42cba69cf64aa17ea985338bd8903. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

