### PR TITLE
chore(release): prep v0.5.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI powered intelligence layer for confidential conversations",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",


### PR DESCRIPTION
Patch release: version bump 0.5.0 → 0.5.1. Ships the Windows app-icon fix (#170), the release-asset race fix (#168), and the win-build dev helper (#169).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release v0.5.1. Bumps the app version and ships the Windows app icon fix, more reliable release-asset uploads, and a Windows build helper for development.

<sup>Written for commit 6d05936fb7314cf09293dc3f3bf4ec0030e8e788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

