### PR TITLE
perf(parakeet): offline-first model loading + smarter warm-up

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -879,12 +879,14 @@ function spawnParakeetWarmup() {
 }
 
 function rewarmParakeet(reason) {
-  if (loadTranscriptionEngine() !== 'parakeet') return;
-  // Don't compete with an active recording — the model is already resident in
-  // the recording subprocess, so a re-warm would only duplicate the mmap.
+  // Cheap in-memory guards first, so a throttled or mid-recording focus event
+  // doesn't pay the loadTranscriptionEngine() file read. Don't compete with an
+  // active recording — the model is already resident in the recording
+  // subprocess, so a re-warm would only duplicate the mmap.
   if (currentRecordingProcess !== null || systemAudioRecordingActive || liveTranscribeProcess) return;
   const now = Date.now();
   if (now - lastParakeetWarmupAt < PARAKEET_REWARM_THROTTLE_MS) return;
+  if (loadTranscriptionEngine() !== 'parakeet') return;
   lastParakeetWarmupAt = now;
   sendDebugLog(`[parakeet-warmup] re-warm (${reason})`);
   spawnParakeetWarmup();
@@ -2329,6 +2331,9 @@ function spawnLiveTranscribe(sessionName) {
     liveTranscribeProcess = null;
     liveTranscribeSessionName = null;
     liveTranscribeStdoutBuf = '';
+    // Clear the load clock if the sidecar died before LIVE_READY, so a later
+    // path can't log a duration against this stale stamp.
+    parakeetLoadStartedAt = 0;
   });
 
   liveTranscribeProcess.on('error', (err) => {

--- a/app/main.js
+++ b/app/main.js
@@ -738,6 +738,10 @@ function createWindow(options = {}) {
     }
   });
 
+  // Returning to the window is the strongest "about to record" signal — keep
+  // the Parakeet model hot. Throttled + recording-guarded inside rewarmParakeet.
+  mainWindow.on('focus', () => rewarmParakeet('window-focus'));
+
   mainWindow.on('closed', () => {
     mainWindow = null;
     rendererShortcutReady = false;
@@ -845,9 +849,51 @@ function updateTrayMenu() {
   tray.setContextMenu(contextMenu);
 }
 
+// ── Parakeet warm-up ────────────────────────────────────────────────────
+// The backend is stateless, so the model is reloaded once per recording
+// subprocess. We pre-load it into the OS page cache at launch and again at
+// recording-intent moments — the page cache can be evicted hours after
+// launch, which is a big part of "first record is sometimes slow." Re-warming
+// on window focus / activate / a renderer hint keeps it hot right before the
+// user records. Module-scoped so createWindow's focus handler can reach it.
+let lastParakeetWarmupAt = 0;
+const PARAKEET_REWARM_THROTTLE_MS = 5 * 60 * 1000;
+// Stamped when a live transcription subprocess spawns; logged against
+// LIVE_READY to measure real model-load latency in the field.
+let parakeetLoadStartedAt = 0;
+
+function spawnParakeetWarmup() {
+  try {
+    const warmupProc = spawn(getBackendPath(), ['warmup-parakeet'], {
+      cwd: getBackendCwd(),
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    warmupProc.unref();
+    warmupProc.on('error', (err) => {
+      sendDebugLog(`[parakeet-warmup] spawn failed (non-fatal): ${err.message}`);
+    });
+  } catch (e) {
+    sendDebugLog(`[parakeet-warmup] startup error (non-fatal): ${e.message}`);
+  }
+}
+
+function rewarmParakeet(reason) {
+  if (loadTranscriptionEngine() !== 'parakeet') return;
+  // Don't compete with an active recording — the model is already resident in
+  // the recording subprocess, so a re-warm would only duplicate the mmap.
+  if (currentRecordingProcess !== null || systemAudioRecordingActive || liveTranscribeProcess) return;
+  const now = Date.now();
+  if (now - lastParakeetWarmupAt < PARAKEET_REWARM_THROTTLE_MS) return;
+  lastParakeetWarmupAt = now;
+  sendDebugLog(`[parakeet-warmup] re-warm (${reason})`);
+  spawnParakeetWarmup();
+}
+
 if (!gotSingleInstanceLock) {
   app.quit();
 } else {
+  ipcMain.on('warmup-parakeet-hint', () => rewarmParakeet('renderer-hint'));
   app.on('second-instance', (event, argv) => {
     const shortcutUrl = extractShortcutUrlFromArgv(argv);
     if (shortcutUrl) {
@@ -1050,18 +1096,8 @@ if (!gotSingleInstanceLock) {
     // (Parakeet model would be downloading or absent) and gated on
     // model presence by the CLI command itself (no-ops when missing).
     if (loadTranscriptionEngine() === 'parakeet') {
-      try {
-        const warmupProc = spawn(getBackendPath(), ['warmup-parakeet'], {
-          cwd: getBackendCwd(),
-          stdio: 'ignore',
-        });
-        warmupProc.unref();
-        warmupProc.on('error', (err) => {
-          sendDebugLog(`[parakeet-warmup] spawn failed (non-fatal): ${err.message}`);
-        });
-      } catch (e) {
-        sendDebugLog(`[parakeet-warmup] startup error (non-fatal): ${e.message}`);
-      }
+      lastParakeetWarmupAt = Date.now();
+      spawnParakeetWarmup();
     }
 
     createWindow();
@@ -1178,6 +1214,7 @@ if (!gotSingleInstanceLock) {
   });
 
   app.on('activate', () => {
+    rewarmParakeet('activate');
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       // Only show if the window has finished its initial load.
@@ -2259,6 +2296,7 @@ function spawnLiveTranscribe(sessionName) {
   const env = Object.keys(aiEnv).length > 0
     ? { ...require('process').env, ...aiEnv }
     : undefined;
+  parakeetLoadStartedAt = Date.now();
   liveTranscribeProcess = spawn(getBackendPath(), ['transcribe-stream'], {
     cwd: getBackendCwd(),
     env,
@@ -2326,6 +2364,10 @@ function spawnLiveTranscribe(sessionName) {
 function handleLiveTranscribeLine(line) {
   const sessionName = liveTranscribeSessionName;
   if (line.startsWith('LIVE_READY:')) {
+    if (parakeetLoadStartedAt) {
+      sendDebugLog(`[parakeet-load] model ready in ${Date.now() - parakeetLoadStartedAt}ms (transcribe-stream)`);
+      parakeetLoadStartedAt = 0;
+    }
     liveTranscriptState.ready = true;
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('live-transcript-ready', { sessionName });
@@ -2927,6 +2969,9 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
     // the WAV via WhisperTranscriber.
     const recordArgs = ['record', '7200', actualSessionName];
     if (liveEnabled) recordArgs.push('--live');
+    // Only the --live (Parakeet) path emits LIVE_READY; stamp the load clock
+    // so we can log model-load latency against it below.
+    if (liveEnabled) parakeetLoadStartedAt = Date.now();
     currentRecordingProcess = spawn(getBackendPath(), recordArgs, {
       cwd: getBackendCwd(),
       env: Object.keys(recordEnv).length > 0 ? { ...require('process').env, ...recordEnv } : undefined
@@ -2991,6 +3036,10 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
         } else if (line.startsWith('LIVE_READY:')) {
           // Model finished loading — UI uses this to swap "Loading…" for
           // the empty consent-only state.
+          if (parakeetLoadStartedAt) {
+            sendDebugLog(`[parakeet-load] model ready in ${Date.now() - parakeetLoadStartedAt}ms (record --live)`);
+            parakeetLoadStartedAt = 0;
+          }
           liveTranscriptState.ready = true;
           if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.webContents.send('live-transcript-ready', {

--- a/app/preload.js
+++ b/app/preload.js
@@ -107,6 +107,10 @@ const stenoai = {
     pickAudioFile: () => invoke('select-audio-file'),
     getQueue: () => invoke('get-queue-status'),
     getDir: () => invoke('get-recordings-dir'),
+    // Hint that a recording may be imminent (e.g. user landed on Home) so
+    // main can re-warm the Parakeet model into the OS page cache. Throttled
+    // main-side; safe to call freely. Fire-and-forget.
+    hintWarmup: () => send('warmup-parakeet-hint'),
   },
 
   liveTranscript: {

--- a/app/renderer/src/components/LiveDock.tsx
+++ b/app/renderer/src/components/LiveDock.tsx
@@ -33,11 +33,25 @@ export function LiveDock() {
   // sidecar, so its status would sit at 'loading' forever. Only meaningful
   // while actively recording.
   const live = useLiveTranscript(liveAvailable ? recording.sessionName : null);
-  const preparing = isRecording && live.status === 'loading';
-  const prepareLabel = preparing
+  const loadingModel = isRecording && live.status === 'loading';
+  // Delay the pill label by ~500ms so a warm-cache load (the common case
+  // after the offline-loading fix) goes straight to "Recording" with no
+  // "Preparing…" flash. Labels stay short and glanceable — the full
+  // reassurance sentence lives in the transcript panel — so swapping the
+  // label doesn't resize/reflow the centered dock.
+  const [showPreparing, setShowPreparing] = React.useState(false);
+  React.useEffect(() => {
+    if (!loadingModel) return;
+    const id = window.setTimeout(() => setShowPreparing(true), 500);
+    return () => {
+      window.clearTimeout(id);
+      setShowPreparing(false);
+    };
+  }, [loadingModel]);
+  const prepareLabel = showPreparing
     ? live.slow
-      ? 'Still preparing — first launch can take a moment'
-      : 'Preparing transcription…'
+      ? 'Still preparing…'
+      : 'Preparing…'
     : null;
 
   const onPauseToggle = () => {

--- a/app/renderer/src/components/LiveDock.tsx
+++ b/app/renderer/src/components/LiveDock.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Pause, Play, Square } from 'lucide-react';
 import { AudioWave } from '@/components/AudioWave';
 import { useRecording } from '@/hooks/useRecording';
+import { useLiveTranscript } from '@/hooks/useLiveTranscript';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { useTranscriptionEngine } from '@/hooks/useModels';
 import { formatElapsed } from '@/lib/utils';
@@ -26,6 +27,19 @@ export function LiveDock() {
   const isRecording = recording.status === 'recording';
   const stopped = !paused && !isRecording;
 
+  // Surface model warm-up on the pill itself, since the transcript panel
+  // (which already shows a loading state) is usually closed while recording.
+  // Gated to Parakeet via `liveAvailable` — Whisper never spawns the live
+  // sidecar, so its status would sit at 'loading' forever. Only meaningful
+  // while actively recording.
+  const live = useLiveTranscript(liveAvailable ? recording.sessionName : null);
+  const preparing = isRecording && live.status === 'loading';
+  const prepareLabel = preparing
+    ? live.slow
+      ? 'Still preparing — first launch can take a moment'
+      : 'Preparing transcription…'
+    : null;
+
   const onPauseToggle = () => {
     if (paused) void recording.resumeRecording();
     else if (isRecording) void recording.pauseRecording();
@@ -49,6 +63,7 @@ export function LiveDock() {
           paused={paused}
           stopped={stopped}
           elapsedSeconds={recording.elapsed}
+          prepareLabel={prepareLabel}
         />
         {/* Transcript toggle — Parakeet only. Whisper recordings have no
             live drawer (post-stop pipeline produces the final transcript
@@ -118,12 +133,23 @@ function RecordingPill({
   paused,
   stopped,
   elapsedSeconds,
+  prepareLabel,
 }: {
   paused: boolean;
   stopped: boolean;
   elapsedSeconds: number;
+  prepareLabel?: string | null;
 }) {
-  const label = stopped ? 'Processing' : paused ? 'Paused' : 'Recording';
+  // While the model warms, the recording is already capturing audio — keep
+  // the wave + elapsed timer and only swap the label so the user sees we're
+  // recording but transcription isn't live yet.
+  const label = prepareLabel
+    ? prepareLabel
+    : stopped
+      ? 'Processing'
+      : paused
+        ? 'Paused'
+        : 'Recording';
   const active = !stopped;
   return (
     <span

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -40,7 +40,7 @@ export function LiveTranscriptBar() {
   const isRecording = recording.status === 'recording';
   const stopped = !paused && !isRecording;
 
-  const { status, segments, error } = useLiveTranscript(sessionName);
+  const { status, segments, error, slow } = useLiveTranscript(sessionName);
 
   const open = useLiveTranscriptOpen((s) => s.open);
   const setOpen = useLiveTranscriptOpen((s) => s.setOpen);
@@ -164,6 +164,7 @@ export function LiveTranscriptBar() {
             error={error}
             segments={filtered}
             filtering={query.trim().length > 0}
+            slow={slow}
           />
         </div>
 
@@ -215,9 +216,10 @@ interface BodyStateProps {
   error: { stage: string; message?: string } | null;
   segments: ReturnType<typeof useLiveTranscript>['segments'];
   filtering: boolean;
+  slow: boolean;
 }
 
-function LiveTranscriptBodyState({ status, error, segments, filtering }: BodyStateProps) {
+function LiveTranscriptBodyState({ status, error, segments, filtering, slow }: BodyStateProps) {
   if (status === 'error' && error) {
     return (
       <EmptyState
@@ -232,7 +234,11 @@ function LiveTranscriptBodyState({ status, error, segments, filtering }: BodySta
     return (
       <EmptyState
         title="Loading speech model…"
-        subtitle="Parakeet is warming up. Audio is being captured."
+        subtitle={
+          slow
+            ? 'Still warming up — first launch can take a moment. Audio is being captured.'
+            : 'Parakeet is warming up. Audio is being captured.'
+        }
       />
     );
   }

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -233,7 +233,7 @@ function LiveTranscriptBodyState({ status, error, segments, filtering, slow }: B
   if (status === 'loading') {
     return (
       <EmptyState
-        title="Loading speech model…"
+        title="Preparing transcription…"
         subtitle={
           slow
             ? 'Still warming up — first launch can take a moment. Audio is being captured.'

--- a/app/renderer/src/hooks/useLiveTranscript.ts
+++ b/app/renderer/src/hooks/useLiveTranscript.ts
@@ -14,6 +14,10 @@ export interface UseLiveTranscriptResult {
   /** Last error reported by the Python consumer (model load failure, MLX
    *  missing, etc.). Null on success. */
   error: { stage: string; message?: string } | null;
+  /** True once the model has been in `loading` for longer than the soft
+   *  threshold (~2s) — lets the UI soften "preparing" copy to acknowledge
+   *  an unavoidable cold load rather than looking frozen. */
+  slow: boolean;
 }
 
 /**
@@ -145,5 +149,17 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
         ? 'streaming'
         : 'loading';
 
-  return { status, segments, error };
+  // Flip `slow` once the model has been loading past the soft threshold. The
+  // 2s mark is where an unavoidable cold load stops reading as a blink and
+  // starts feeling like a hang. Resets whenever we leave the loading state
+  // (ready/error/new session), so it only ever describes the current load.
+  const [slow, setSlow] = React.useState(false);
+  React.useEffect(() => {
+    setSlow(false);
+    if (status !== 'loading') return;
+    const id = window.setTimeout(() => setSlow(true), 2000);
+    return () => window.clearTimeout(id);
+  }, [status, sessionName]);
+
+  return { status, segments, error, slow };
 }

--- a/app/renderer/src/hooks/useLiveTranscript.ts
+++ b/app/renderer/src/hooks/useLiveTranscript.ts
@@ -151,14 +151,18 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
 
   // Flip `slow` once the model has been loading past the soft threshold. The
   // 2s mark is where an unavoidable cold load stops reading as a blink and
-  // starts feeling like a hang. Resets whenever we leave the loading state
-  // (ready/error/new session), so it only ever describes the current load.
+  // starts feeling like a hang. The timer (and its reset) live off the effect
+  // body — set on timeout, cleared on leaving the loading state — so we never
+  // call setState synchronously during render. `sessionName` in the deps
+  // restarts the clock for each new recording.
   const [slow, setSlow] = React.useState(false);
   React.useEffect(() => {
-    setSlow(false);
     if (status !== 'loading') return;
     const id = window.setTimeout(() => setSlow(true), 2000);
-    return () => window.clearTimeout(id);
+    return () => {
+      window.clearTimeout(id);
+      setSlow(false);
+    };
   }, [status, sessionName]);
 
   return { status, segments, error, slow };

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -581,6 +581,9 @@ export interface StenoaiBridge {
     pause: RequestFn<[], PauseRecordingResponse>;
     resume: RequestFn<[], ResumeRecordingResponse>;
     reportSystemAudioState: SendFn<[active: boolean]>;
+    /** Hint that a recording may be imminent so main can re-warm the Parakeet
+     *  model. Throttled main-side. Fire-and-forget. */
+    hintWarmup: SendFn<[]>;
     enableLoopbackAudio: RequestFn<[], void>;
     disableLoopbackAudio: RequestFn<[], void>;
     getSystemAudioSupport: RequestFn<

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -15,7 +15,7 @@ import {
   useOutlookCalendarAuth,
 } from '@/hooks/useCalendarEvents';
 import { useFolders } from '@/hooks/useFolders';
-import type { CalendarEvent, Meeting } from '@/lib/ipc';
+import { ipc, type CalendarEvent, type Meeting } from '@/lib/ipc';
 import { navigate } from '@/lib/router';
 
 interface HomeProps {
@@ -58,6 +58,15 @@ export function Home({ mode }: HomeProps) {
     if (mode !== 'home') return;
     const id = setInterval(() => setUpcomingTickMs(Date.now()), 60_000);
     return () => clearInterval(id);
+  }, [mode]);
+
+  // Landing on Home is a recording-intent signal — nudge main to re-warm the
+  // Parakeet model so the first record isn't a cold load. Fire-and-forget;
+  // main throttles + skips while recording, so calling on every Home entry is
+  // safe.
+  React.useEffect(() => {
+    if (mode !== 'home') return;
+    ipc().recording.hintWarmup();
   }, [mode]);
 
   // Today's relevant events: anything that overlaps with today AND

--- a/src/_parakeet_mlx.py
+++ b/src/_parakeet_mlx.py
@@ -59,6 +59,13 @@ def _load_model(model_id: str):
         cached = _MODEL_CACHE.get(model_id)
         if cached is not None:
             return cached
+        # Force offline resolution when the model is already cached so this
+        # load makes no HuggingFace Hub network call. MUST run before the hub
+        # is imported transitively by parakeet-mlx — huggingface_hub reads
+        # HF_HUB_OFFLINE at import time. Gated on is_installed inside, so a
+        # fresh download is left online.
+        from src.parakeet_models import maybe_enable_offline
+        maybe_enable_offline(model_id)
         try:
             from parakeet_mlx import from_pretrained
         except ImportError as e:

--- a/src/_parakeet_onnx.py
+++ b/src/_parakeet_onnx.py
@@ -84,6 +84,13 @@ def _load_model(model_id: str) -> tuple[Any, Any]:
         cached = _MODEL_CACHE.get(model_id)
         if cached is not None:
             return cached
+        # Force offline resolution when the model is already cached so this
+        # load makes no HuggingFace Hub network call. MUST run before onnx-asr
+        # (and thus huggingface_hub) is imported — HF_HUB_OFFLINE is read at
+        # import time. Gated on is_installed inside, so a fresh download is
+        # left online.
+        from src.parakeet_models import maybe_enable_offline
+        maybe_enable_offline(model_id)
         try:
             import onnx_asr
         except ImportError as e:

--- a/src/parakeet_models.py
+++ b/src/parakeet_models.py
@@ -75,6 +75,11 @@ def is_installed(model_id: str = DEFAULT_MODEL_ID) -> bool:
     Checks the HuggingFace cache directly so we don't import parakeet-mlx
     (and trigger model loading) just to answer the question — Settings polls
     this on tab load and the import cost would visibly stall the UI.
+
+    MUST stay free of any ``huggingface_hub`` import: ``maybe_enable_offline``
+    sets ``HF_HUB_OFFLINE`` and relies on the hub being import-deferred until
+    ``_load_model`` runs. Importing the hub here would snapshot the env too
+    early and silently defeat offline mode.
     """
     cache_dir = _hf_cache_dir_for(model_id)
     snapshots = cache_dir / "snapshots"

--- a/src/parakeet_models.py
+++ b/src/parakeet_models.py
@@ -86,6 +86,34 @@ def is_installed(model_id: str = DEFAULT_MODEL_ID) -> bool:
     return False
 
 
+def maybe_enable_offline(model_id: str = DEFAULT_MODEL_ID) -> bool:
+    """Force fully-offline HuggingFace resolution when the model is already
+    on disk, so loading a cached model makes ZERO network calls (and can't
+    hang on a flaky network). Returns whether offline mode was enabled.
+
+    ``huggingface_hub`` reads ``HF_HUB_OFFLINE`` once, at import time, so this
+    must run BEFORE the hub is first imported. The backends call it at the top
+    of ``_load_model``, immediately before importing parakeet-mlx / onnx-asr,
+    which is the latest-safe and only symmetric point.
+
+    Gated on ``is_installed`` so a first-ever run (model absent) is left
+    online and ``download`` proceeds normally — offline-loading a
+    just-downloaded model is correct. Edge case: ``is_installed`` only checks
+    that a snapshot dir is non-empty, so a corrupt/partial snapshot would read
+    as installed and offline mode would then block a repair re-fetch. Low
+    probability and accepted — the existing code already trusts
+    ``is_installed``.
+
+    ``setdefault`` so an operator who explicitly exported ``HF_HUB_OFFLINE=0``
+    for debugging isn't overridden.
+    """
+    if not is_installed(model_id):
+        return False
+    os.environ.setdefault("HF_HUB_OFFLINE", "1")
+    os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+    return True
+
+
 def download(
     model_id: str = DEFAULT_MODEL_ID,
     progress_callback: Optional[Callable[[str], None]] = None,

--- a/tests/test_parakeet_models.py
+++ b/tests/test_parakeet_models.py
@@ -39,10 +39,13 @@ class MaybeEnableOfflineTests(unittest.TestCase):
 
     def test_does_not_override_explicit_operator_value(self):
         os.environ["HF_HUB_OFFLINE"] = "0"
+        os.environ["TRANSFORMERS_OFFLINE"] = "0"
         with patch("src.parakeet_models.is_installed", return_value=True):
             parakeet_models.maybe_enable_offline("some/model")
-        # setdefault must leave an explicit debug override (e.g. =0) intact.
+        # setdefault must leave explicit debug overrides (e.g. =0) intact for
+        # both flags.
         self.assertEqual(os.environ.get("HF_HUB_OFFLINE"), "0")
+        self.assertEqual(os.environ.get("TRANSFORMERS_OFFLINE"), "0")
 
 
 if __name__ == "__main__":

--- a/tests/test_parakeet_models.py
+++ b/tests/test_parakeet_models.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from src import parakeet_models
+
+
+class MaybeEnableOfflineTests(unittest.TestCase):
+    def setUp(self):
+        # Snapshot the two env vars we touch so each test runs from a known
+        # clean slate and never leaks state into the rest of the suite.
+        self._saved = {
+            k: os.environ.get(k)
+            for k in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE")
+        }
+        for k in self._saved:
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_enables_offline_when_installed(self):
+        with patch("src.parakeet_models.is_installed", return_value=True):
+            enabled = parakeet_models.maybe_enable_offline("some/model")
+        self.assertTrue(enabled)
+        self.assertEqual(os.environ.get("HF_HUB_OFFLINE"), "1")
+        self.assertEqual(os.environ.get("TRANSFORMERS_OFFLINE"), "1")
+
+    def test_noop_when_not_installed(self):
+        with patch("src.parakeet_models.is_installed", return_value=False):
+            enabled = parakeet_models.maybe_enable_offline("some/model")
+        self.assertFalse(enabled)
+        self.assertIsNone(os.environ.get("HF_HUB_OFFLINE"))
+        self.assertIsNone(os.environ.get("TRANSFORMERS_OFFLINE"))
+
+    def test_does_not_override_explicit_operator_value(self):
+        os.environ["HF_HUB_OFFLINE"] = "0"
+        with patch("src.parakeet_models.is_installed", return_value=True):
+            parakeet_models.maybe_enable_offline("some/model")
+        # setdefault must leave an explicit debug override (e.g. =0) intact.
+        self.assertEqual(os.environ.get("HF_HUB_OFFLINE"), "0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Parakeet transcription model loads were **intermittently slow** ("at times takes too long to load"). Root cause: every model load — even when the model is fully cached on disk — made a **HuggingFace Hub network round-trip** (no offline flag anywhere), so a slow/flaky network stalled the load (and could hang it outright). This PR makes cached loads fully offline, plus adds load-time feedback and a smarter warm-up.

The persistent ASR daemon (the only thing that removes the *constant* per-process parse cost) is intentionally **out of scope** — it contradicts the stateless-CLI architecture and doesn't target the *intermittent* slowness users actually report. See "Deferred" below.

## What changed

**1. Offline-mode loading (the headline fix)** — `src/parakeet_models.py`, `src/_parakeet_mlx.py`, `src/_parakeet_onnx.py`
- New `maybe_enable_offline()` sets `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` (via `setdefault`, so an explicit operator override stands) **when the model is already installed**.
- Called at the top of `_load_model` in both backends, immediately **before** the lazy `huggingface_hub` import (the hub reads the flag at import time). This is the single symmetric chokepoint.
- Gated on `is_installed()` so a fresh download stays online — verified the `download-parakeet-model` path is unaffected.

**2. Slow-load feedback** — `useLiveTranscript.ts`, `LiveDock.tsx`, `LiveTranscriptBar.tsx`, `app/main.js`
- `useLiveTranscript` exposes a `slow` flag (2s). The recording pill shows a short "Preparing…" / "Still preparing…" label while the model warms — **gated to Parakeet, and behind a 500ms delay so a warm load doesn't flash**. The transcript panel copy rhymes ("Preparing transcription…").
- `main.js` logs real model-load latency against `LIVE_READY` for field measurement.

**3. Proactive re-warm** — `app/main.js`, `app/preload.js`, `app/renderer/src/lib/ipc.ts`, `Home.tsx`
- Shared `spawnParakeetWarmup()` + throttled `rewarmParakeet()` (5-min throttle, skips while recording) re-warm the OS page cache on window focus / app activate / a `warmup-parakeet-hint` IPC from Home — so first-record stays fast hours after launch (page cache can be evicted). `windowsHide:true` on the spawn.

## Cross-platform

- Offline mechanism is platform-neutral (`HF_HUB_OFFLINE` honored by `huggingface_hub` on both backends); the `_load_model` edit is identical in the two already-platform-exclusive modules. macOS (MLX) and Windows (ONNX) both covered; Windows path validated by CI (`onnx-selftest`).

## Verification

- **Review:** luffy autonomous loop — QA + Product + Engineer senior reviewers, 2 iterations to clean (iter 1 caught a pill layout-shift + mediums, all fixed; iter 2 clean).
- **Offline loading, dev (CLI A/B, poisoned Hub endpoint):** fix active → **0.67s**; `HF_HUB_OFFLINE=0` → **10.7s** (stalled on the dead endpoint). Probe: model-absent path correctly stays online (download not blocked).
- **Offline loading, packaged bundle** (`pyinstaller` build, same A/B): **0.69s vs 10.7s** — confirms the bundled `huggingface_hub` honors the flag, i.e. the fix is real in production, not dev-only.
- **Gates:** `ruff` clean on changed files, full Python suite (93) passes incl. new `tests/test_parakeet_models.py`, renderer typecheck clean.

## Known limitations / deferred

- Pill/re-warm verified by review only (GUI surface) — manual eyeball recommended; no bundle-specific risk (same Vite build).
- Persistent ASR daemon — separate, larger plan.
- In-process dummy inference (warm first-utterance compile) — revisit if field load-timing logs justify.
- Minor: `is_installed()` trusts a non-empty snapshot dir, so a corrupt/partial snapshot would read as installed and offline could block a repair re-fetch (documented in code; accepted, consistent with existing trust in `is_installed`).

## Test plan for reviewer

- `pyinstaller stenoai.spec --noconfirm`, then against `dist/stenoai/stenoai`: `time HF_ENDPOINT=http://192.0.2.1 ./dist/stenoai/stenoai warmup-parakeet` (fast) vs `time HF_HUB_OFFLINE=0 HF_ENDPOINT=http://192.0.2.1 ./dist/stenoai/stenoai warmup-parakeet` (~10s stall).
- Dev app: force a cold load (`sudo purge`) then start a recording to see the "Preparing…" pill; idle >5 min and refocus to see `[parakeet-warmup] re-warm` in the debug log.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Parakeet loads offline-first when the model is already cached and add a smarter warm-up so first-record stays fast. Adds short “Preparing…” UI copy and logs model-load time for field visibility.

- **New Features**
  - Offline loading: `maybe_enable_offline()` sets `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` before `huggingface_hub` import when the model is installed; wired into both MLX and ONNX loaders. Fresh downloads stay online.
  - Smarter warm-up: shared `spawnParakeetWarmup()` + throttled `rewarmParakeet()` (5 min) re-warm on window focus, app activate, and a Home-page hint; skipped while recording; `windowsHide:true`.
  - Load-time feedback: `useLiveTranscript` exposes `slow` (2s). Recording pill shows “Preparing…”/“Still preparing…” with a 500ms delay to avoid flash; transcript bar mirrors the copy.
  - Telemetry: logs `[parakeet-load] model ready in …ms` on `LIVE_READY` for both live and record paths.
  - Tests: add unit tests for offline enablement and respecting explicit env overrides.

<sup>Written for commit 3f5807632f126e7af47d50779d35f221e3488dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

