### PR TITLE
ci(windows): build on backend-touching PRs + on main, not a dead branch

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,9 +1,10 @@
 name: Build Windows installer
 
 # End-to-end Windows build: PyInstaller backend (with onnx-asr Parakeet + whisper.cpp)
-# + Electron NSIS installer + zip. Runs on every push to feat/windows-port-v2 so
-# we can iterate quickly, and on tag pushes so released versions get a Windows
-# asset uploaded alongside the macOS DMG produced by build-release.yml.
+# + Electron NSIS installer + zip. Runs on PRs that touch the Python backend /
+# spec (see the paths filter below), on pushes to main, and on tag pushes so
+# released versions get a Windows asset uploaded alongside the macOS DMG
+# produced by build-release.yml. Also dispatchable manually for any branch.
 #
 # Code signing is intentionally off for the alpha — installers ship unsigned
 # and trigger SmartScreen on first run. Add WINDOWS_CERT secrets + the signing
@@ -13,9 +14,17 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/windows-port-v2
+      - main
     tags:
       - 'v*.*.*'
+  pull_request:
+    # Only run on PRs that could affect the Windows backend/bundle, so the
+    # heavy build stays off renderer-only and macOS-only PRs.
+    paths:
+      - '**.py'
+      - 'requirements.txt'
+      - 'stenoai.spec'
+      - '.github/workflows/build-windows.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

`build-windows.yml` only auto-triggered on **pushes to `feat/windows-port-v2`** — a branch that merged long ago (PR #160, shipped in v0.5.x). In practice that means Windows CI has been running **only on release tags and manual dispatch**: shared-code PRs merged to `main` with **no Windows build until release time**.

That's a real gap for a cross-platform app. The Parakeet offline-loading PR (#173), for example, touches the shared `src/_parakeet_onnx.py` path — and without this change it gets no Windows ONNX smoke (`onnx-selftest`) unless someone remembers to dispatch the workflow by hand.

## Change

- **Add a `pull_request` trigger**, **paths-filtered** to the things that can break the Windows backend/bundle (`**.py`, `requirements.txt`, `stenoai.spec`, this workflow) — so renderer-only and macOS-only PRs stay cheap and don't pay the heavy Windows build.
- **Trigger on push to `main`** so every merge gets a fresh Windows build (integration safety net).
- **Drop the dead `feat/windows-port-v2` branch trigger.**
- Keep `tags` (release assets) and `workflow_dispatch` (manual, any branch).

No job/step logic changes — triggers only.

## Notes

- The `paths` filter is intentionally backend-focused. It does **not** include `app/**` JS — a main.js platform-gating bug wouldn't trigger it. That's a deliberate cost trade-off (including `**.js` would fire on nearly every frontend PR); if you'd rather also catch Electron-packaging changes, adding `app/package.json` is a cheap middle ground. Happy to adjust.
- `paths` is only on `pull_request`, not on `push`, so a release **tag** always builds regardless of what changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Windows build workflow on backend-touching PRs and on pushes to `main` so we catch breakages before merge, not just on tags or manual runs. This replaces the old trigger tied to a merged branch.

- **Refactors**
  - Add `pull_request` trigger with paths filter: `**.py`, `requirements.txt`, `stenoai.spec`, `.github/workflows/build-windows.yml`.
  - Trigger on `push` to `main`; remove `feat/windows-port-v2` branch trigger.
  - Keep tag builds (`v*.*.*`) and `workflow_dispatch`.
  - No job or step changes; triggers only.

<sup>Written for commit 6fa04a798c193d2c78df8526f0bbb800dad58ebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

