### PR TITLE
Local Ollama: context cap + num_ctx so long-meeting summaries cover the whole meeting

### DIFF
--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -778,7 +778,9 @@ function parseMarkdownBlocks(text: string): MarkdownBlock[] {
       flushBullets();
     } else {
       flushBullets();
-      blocks.push({ type: 'paragraph', text: line });
+      // Strip blockquote markers (e.g. the local-model truncation note,
+      // "> Note: …") rather than rendering a literal "> " prefix.
+      blocks.push({ type: 'paragraph', text: line.replace(/^>\s+/, '') });
     }
   }
   flushBullets();

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -108,6 +108,33 @@ def _start_summary_heartbeat(label: str = "summarize", interval_s: int = 60, max
     return stop
 
 
+# The deterministic truncation note the local summariser appends to the
+# streamed markdown (src.summarizer.LOCAL_TRUNCATION_USER_NOTE). Detected by
+# prefix rather than importing the constant so the lightweight parse/list
+# paths don't pull in the summarizer module (ollama client etc.).
+_TRUNCATION_NOTE_PREFIX = '> Note: this meeting was longer than the local AI model'
+
+
+def _extract_truncation_note(text: str) -> Optional[str]:
+    """Return the truncation note's content (sans blockquote marker) if the
+    markdown contains one, else None.
+
+    The note trails the last model section in the streamed markdown, so the
+    section parsers drop it from their structured fields; callers fold it
+    into the ``summary`` field instead so it survives into the meeting view,
+    copy, and share — not just the transient streaming view.
+    """
+    if not text:
+        return None
+    for line in text.split('\n'):
+        stripped = line.strip()
+        if stripped.startswith(_TRUNCATION_NOTE_PREFIX):
+            # removeprefix, not lstrip('> ') — lstrip strips a char SET and
+            # would chew any leading '>'/space run; the marker is exactly '> '.
+            return stripped.removeprefix('> ').strip()
+    return None
+
+
 def _render_frontmatter(meta: dict) -> list[str]:
     """Render a meeting .md YAML frontmatter block (including the enclosing
     ``---`` fences) from a flat dict, with the type-specific scalar
@@ -276,8 +303,16 @@ class SimpleRecorder:
         if current_topic_title:
             discussion_areas.append({"title": current_topic_title, "analysis": '\n'.join(current_topic_lines).strip()})
 
+        summary = ' '.join(summary_parts)
+        # Fold the local-model truncation note into the summary so it
+        # survives into the structured view (the section loop above drops
+        # non-bullet lines under ## Action Items, where the note trails).
+        truncation_note = _extract_truncation_note(md_text)
+        if truncation_note and truncation_note not in summary:
+            summary = (summary + '\n\n' + truncation_note).strip()
+
         return {
-            "summary": ' '.join(summary_parts),
+            "summary": summary,
             "participants": participants,
             "discussion_areas": discussion_areas,
             "key_points": key_points,
@@ -2394,9 +2429,24 @@ def _parse_meeting_markdown(md_path):
         if meta.get('error'):
             session_info['error'] = meta.get('error')
 
+    # Fold the local-model truncation note into the summary — same reason as
+    # _parse_streamed_markdown: it trails the last section in the saved body
+    # and would otherwise vanish from the meeting view / copy / share.
+    # Scan only the summary sections, NOT the transcript: the saved .md
+    # embeds the full transcript under ## Transcript, which is arbitrary user
+    # speech that could coincidentally contain the note's wording and be
+    # mis-folded into the summary. The note always trails a summary section
+    # (typically ## Action Items), so excluding the transcript is sufficient
+    # and stays robust if the note trails a different last section.
+    summary = sections.get('summary', '')
+    note_search = '\n'.join(v for k, v in sections.items() if k != 'transcript')
+    truncation_note = _extract_truncation_note(note_search)
+    if truncation_note and truncation_note not in summary:
+        summary = (summary + '\n\n' + truncation_note).strip()
+
     return {
         'session_info': session_info,
-        'summary': sections.get('summary', ''),
+        'summary': summary,
         'participants': participants,
         'discussion_areas': discussion_areas,
         'key_points': key_points,

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -16,6 +16,50 @@ from . import ollama_manager
 logger = logging.getLogger(__name__)
 
 
+# Context handling for the bundled LOCAL Ollama only. Small local models
+# default to a tiny context (~2-4k tokens), so a long meeting's transcript
+# silently overruns it and the summary covers only the start of the meeting.
+# Two local-only measures fix that without touching cloud/remote/adapter
+# providers (frontier cloud windows fit whole meetings; a remote Ollama's
+# host owns its own num_ctx):
+#
+# * ``LOCAL_OLLAMA_NUM_CTX`` is passed as a benign options hint to the local
+#   chat calls so the model actually uses an 8k window.
+# * ``LOCAL_TRANSCRIPT_CHAR_CAP`` bounds the transcript itself: ~(8192 ctx
+#   - ~1500 prompt/response tokens) * ~4 chars/token. Over-cap transcripts
+#   keep the head and tail (60/40) joined by an explicit marker — head+tail
+#   rather than head-only so the meeting's close and action items survive.
+#   (The 4 chars/token heuristic under-counts CJK text, which can still
+#   overflow; an acceptable approximation for the default path.)
+#
+# The in-prompt marker is deliberately neutral — a small model treats it as
+# a gap in the conversation. The user-facing explanation is appended
+# deterministically to the streamed summary (see
+# ``summarize_transcript_streaming``) rather than trusted to the model to
+# echo, which would be both unreliable and an invitation to garble it into
+# the summary body.
+#
+# These are fixed, NOT sized from the model's own context_length, on purpose.
+# A larger num_ctx scales the KV-cache RAM linearly, so sizing it up to a
+# big-context model's capacity (e.g. a 128k/256k local model) would reintroduce
+# the out-of-memory failure that PR #175 just fixed for transcription — on the
+# low-end machines that run small local models. 8k is a conservative floor that
+# covers most meetings while staying RAM-safe across the local model lineup.
+# Capability-aware sizing (min(model_ctx, RAM-derived ceiling)) is a tracked
+# follow-up; it needs reliable host-RAM awareness to be safe.
+LOCAL_OLLAMA_NUM_CTX = 8192
+LOCAL_TRANSCRIPT_CHAR_CAP = 24000
+LOCAL_TRANSCRIPT_TRUNCATION_NOTE = (
+    "\n\n[... middle portion of the transcript omitted ...]\n\n"
+)
+LOCAL_TRUNCATION_USER_NOTE = (
+    "\n\n> Note: this meeting was longer than the local AI model's context "
+    "window, so the summary is based on the beginning and end of the "
+    "transcript. For full-length summaries, switch to a cloud model in "
+    "Settings.\n"
+)
+
+
 def bedrock_converse_url(region: str, target_id: str) -> str:
     """Build the Bedrock Converse REST URL for a region + model/profile id.
 
@@ -633,11 +677,59 @@ class OllamaSummarizer:
                     raise
         raise RuntimeError("Bedrock chat failed after all retries")
 
+    def _is_local_ollama(self) -> bool:
+        """True only for the bundled local Ollama — the one provider whose
+        context window we own. adapter/cloud/remote manage their own."""
+        return self.ai_provider not in ("adapter", "cloud", "remote")
+
+    def _local_chat_options(self) -> Optional[Dict[str, Any]]:
+        """Options for ``client.chat`` — num_ctx hint for local Ollama only.
+
+        Returns ``None`` (the ollama client's default) for remote so the
+        remote host's own configuration stays authoritative.
+        """
+        if self._is_local_ollama():
+            return {"num_ctx": LOCAL_OLLAMA_NUM_CTX}
+        return None
+
+    def _transcript_over_local_cap(self, transcript: str) -> bool:
+        """True when ``_cap_transcript_for_local`` would truncate — i.e. the
+        user-facing truncation note should accompany the summary."""
+        return (
+            self._is_local_ollama()
+            and bool(transcript)
+            and len(transcript) > LOCAL_TRANSCRIPT_CHAR_CAP
+        )
+
+    def _cap_transcript_for_local(self, transcript: str) -> str:
+        """Bound a transcript to the local model's context budget.
+
+        No-op for cloud/remote/adapter providers and for transcripts under
+        the cap. Over the cap, keeps the first 60% + last 40% of the budget
+        joined by a neutral gap marker — see the constants block at the top
+        of this module for the rationale.
+        """
+        if not self._transcript_over_local_cap(transcript):
+            return transcript
+        head_budget = int(LOCAL_TRANSCRIPT_CHAR_CAP * 0.6)
+        tail_budget = LOCAL_TRANSCRIPT_CHAR_CAP - head_budget
+        logger.info(
+            "Transcript (%d chars) exceeds local context cap (%d); "
+            "keeping head %d + tail %d chars",
+            len(transcript), LOCAL_TRANSCRIPT_CHAR_CAP, head_budget, tail_budget,
+        )
+        return (
+            transcript[:head_budget]
+            + LOCAL_TRANSCRIPT_TRUNCATION_NOTE
+            + transcript[-tail_budget:]
+        )
+
     def _create_permissive_prompt(self, transcript: str, language: str = "en", notes: str = None) -> str:
         """
         Create an enhanced prompt with discussion_areas and improved extraction.
         Uses more examples in schema to permit more detailed summaries.
         """
+        transcript = self._cap_transcript_for_local(transcript)
         # Build language instruction
         if language and language not in ("en", "auto"):
             from .config import get_config
@@ -811,6 +903,7 @@ Return ONLY the response in this exact JSON format:
                                     'content': prompt
                                 }
                             ],
+                            options=self._local_chat_options(),
                         )
                         break  # Success, exit retry loop
 
@@ -942,6 +1035,7 @@ Return ONLY the response in this exact JSON format:
     
     def _create_markdown_prompt(self, transcript: str, language: str = "en", notes: str = None) -> str:
         """Create a prompt that asks the LLM to output markdown directly."""
+        transcript = self._cap_transcript_for_local(transcript)
         # Language instruction. The four ## section headers must stay in English
         # because simple_recorder._parse_streamed_markdown matches on them
         # literally; the body content is what gets translated.
@@ -1064,6 +1158,7 @@ TRANSCRIPT:
                     return
         else:
             # Ollama (local or remote)
+            yielded_any = False
             try:
                 if self.ai_provider != "remote":
                     self._ensure_ollama_ready()
@@ -1071,14 +1166,23 @@ TRANSCRIPT:
                     model=self.model_name,
                     messages=[{'role': 'user', 'content': prompt}],
                     stream=True,
+                    options=self._local_chat_options(),
                 )
                 for chunk in response:
                     content = chunk.get('message', {}).get('content', '')
                     if content:
+                        yielded_any = True
                         yield content
             except Exception as e:
+                # Fall through (don't return) so a partial summary still
+                # gets the truncation note below — a truncated AND partial
+                # summary is the case most in need of the caveat.
                 logger.error(f"Ollama streaming failed: {e}")
-                return
+            # The transcript was capped for the local model's context — tell
+            # the user deterministically rather than hoping the model echoes
+            # the in-prompt gap marker.
+            if yielded_any and self._transcript_over_local_cap(transcript):
+                yield LOCAL_TRUNCATION_USER_NOTE
 
     def test_connection(self) -> bool:
         """
@@ -1176,6 +1280,17 @@ TRANSCRIPT:
             A short title string, or None if generation failed
         """
         try:
+            # The deterministic truncation note may trail the streamed
+            # summary — strip it so "switch to a cloud model in Settings"
+            # can't distract a small model into titling the meeting after it.
+            # Both forms: raw ("> Note: …", from streamed_md) and folded
+            # (no blockquote marker, from a parsed summary via regen-title).
+            if summary:
+                raw_note = LOCAL_TRUNCATION_USER_NOTE.strip()
+                folded_note = raw_note.removeprefix('> ').strip()
+                for form in (raw_note, folded_note):
+                    if form in summary:
+                        summary = summary.replace(form, '').strip()
             # Use summary if available, otherwise fall back to first part of transcript
             context = summary if summary else transcript[:2000]
             if not context or context.strip() == "":
@@ -1247,6 +1362,12 @@ TITLE:"""
             return None
 
     def _build_query_prompt(self, transcript: str, question: str, language: str = "en") -> str:
+        # Same local-context discipline as the summary prompt builders: a
+        # long meeting silently overruns a small local model's window and
+        # the answer would be computed against only the head of the
+        # transcript with no indication. Head+tail beats silent overrun,
+        # though an answer living in the omitted middle is still possible.
+        transcript = self._cap_transcript_for_local(transcript)
         if language and language not in ("en", "auto"):
             from .config import get_config
             language_name = get_config().get_language_name(language)
@@ -1322,6 +1443,7 @@ ANSWER:"""
                     model=self.model_name,
                     messages=[{"role": "user", "content": prompt}],
                     stream=True,
+                    options=self._local_chat_options(),
                 )
                 for chunk in stream:
                     content = chunk['message']['content']
@@ -1379,6 +1501,7 @@ ANSWER:"""
                                     'content': prompt
                                 }
                             ],
+                            options=self._local_chat_options(),
                         )
                         break
 

--- a/tests/test_summarizer_context_cap.py
+++ b/tests/test_summarizer_context_cap.py
@@ -1,0 +1,190 @@
+"""Tests for the local-Ollama context cap (src/summarizer.py).
+
+Small local models silently overrun their context on long transcripts and
+summarise only the meeting's start. The cap applies ONLY to the bundled
+local Ollama: cloud/remote/adapter providers must see the full transcript,
+and only local chat calls get the num_ctx options hint.
+"""
+
+import unittest
+import unittest.mock
+from unittest.mock import MagicMock
+
+from src.summarizer import (
+    LOCAL_OLLAMA_NUM_CTX,
+    LOCAL_TRANSCRIPT_CHAR_CAP,
+    LOCAL_TRANSCRIPT_TRUNCATION_NOTE,
+    LOCAL_TRUNCATION_USER_NOTE,
+    OllamaSummarizer,
+)
+
+
+def _build_summarizer(ai_provider: str) -> OllamaSummarizer:
+    # Bypass __init__ — it spins up Ollama / validates cloud keys. The
+    # methods under test only need ai_provider (+ model/client for chat).
+    s = OllamaSummarizer.__new__(OllamaSummarizer)
+    s.ai_provider = ai_provider
+    s.model_name = "test-model"
+    s.client = MagicMock()
+    # __del__ → cleanup() reads this; without it GC logs an AttributeError.
+    s.ollama_process = None
+    return s
+
+
+def _long_transcript() -> str:
+    head = "HEAD-MARKER " + ("alpha " * 4000)
+    tail = ("omega " * 4000) + " TAIL-MARKER"
+    assert len(head) + len(tail) > LOCAL_TRANSCRIPT_CHAR_CAP
+    return head + tail
+
+
+class CapTranscriptTests(unittest.TestCase):
+    def test_local_long_transcript_truncated_with_marker_head_and_tail(self):
+        s = _build_summarizer("local")
+        out = s._cap_transcript_for_local(_long_transcript())
+        self.assertLessEqual(
+            len(out), LOCAL_TRANSCRIPT_CHAR_CAP + len(LOCAL_TRANSCRIPT_TRUNCATION_NOTE)
+        )
+        self.assertIn(LOCAL_TRANSCRIPT_TRUNCATION_NOTE, out)
+        self.assertTrue(out.startswith("HEAD-MARKER"))
+        self.assertTrue(out.endswith("TAIL-MARKER"))
+
+    def test_local_short_transcript_unchanged(self):
+        s = _build_summarizer("local")
+        short = "a short meeting about nothing"
+        self.assertEqual(s._cap_transcript_for_local(short), short)
+
+    def test_cloud_remote_adapter_never_truncated(self):
+        long = _long_transcript()
+        for provider in ("cloud", "remote", "adapter"):
+            s = _build_summarizer(provider)
+            self.assertEqual(s._cap_transcript_for_local(long), long, provider)
+
+    def test_empty_transcript_unchanged(self):
+        s = _build_summarizer("local")
+        self.assertEqual(s._cap_transcript_for_local(""), "")
+
+    def test_markdown_prompt_builder_applies_cap_for_local(self):
+        s = _build_summarizer("local")
+        prompt = s._create_markdown_prompt(_long_transcript())
+        self.assertIn(LOCAL_TRANSCRIPT_TRUNCATION_NOTE, prompt)
+
+    def test_permissive_prompt_builder_applies_cap_for_local(self):
+        s = _build_summarizer("local")
+        prompt = s._create_permissive_prompt(_long_transcript())
+        self.assertIn(LOCAL_TRANSCRIPT_TRUNCATION_NOTE, prompt)
+
+    def test_markdown_prompt_builder_leaves_cloud_alone(self):
+        s = _build_summarizer("cloud")
+        prompt = s._create_markdown_prompt(_long_transcript())
+        self.assertNotIn(LOCAL_TRANSCRIPT_TRUNCATION_NOTE, prompt)
+        self.assertIn("TAIL-MARKER", prompt)
+
+
+class NumCtxOptionsTests(unittest.TestCase):
+    def test_local_chat_options_carry_num_ctx(self):
+        s = _build_summarizer("local")
+        self.assertEqual(s._local_chat_options(), {"num_ctx": LOCAL_OLLAMA_NUM_CTX})
+
+    def test_non_local_chat_options_are_none(self):
+        for provider in ("cloud", "remote", "adapter"):
+            s = _build_summarizer(provider)
+            self.assertIsNone(s._local_chat_options(), provider)
+
+    def test_streaming_chat_passes_num_ctx_for_local(self):
+        s = _build_summarizer("local")
+        s._ensure_ollama_ready = MagicMock()
+        s.client.chat.return_value = iter(
+            [{"message": {"content": "chunk"}}]
+        )
+        chunks = list(s.summarize_transcript_streaming("short transcript"))
+        self.assertEqual(chunks, ["chunk"])
+        kwargs = s.client.chat.call_args.kwargs
+        self.assertEqual(kwargs.get("options"), {"num_ctx": LOCAL_OLLAMA_NUM_CTX})
+
+    def test_streaming_chat_omits_num_ctx_for_remote(self):
+        s = _build_summarizer("remote")
+        s.client.chat.return_value = iter(
+            [{"message": {"content": "chunk"}}]
+        )
+        list(s.summarize_transcript_streaming("short transcript"))
+        kwargs = s.client.chat.call_args.kwargs
+        self.assertIsNone(kwargs.get("options"))
+
+
+class DeterministicUserNoteTests(unittest.TestCase):
+    """The user-facing truncation note is appended deterministically to the
+    streamed summary — never trusted to the model to echo the in-prompt
+    gap marker."""
+
+    def _stream(self, s, transcript):
+        s._ensure_ollama_ready = MagicMock()
+        s.client.chat.return_value = iter([{"message": {"content": "summary text"}}])
+        return list(s.summarize_transcript_streaming(transcript))
+
+    def test_note_appended_when_local_and_truncated(self):
+        s = _build_summarizer("local")
+        chunks = self._stream(s, _long_transcript())
+        self.assertEqual(chunks[-1], LOCAL_TRUNCATION_USER_NOTE)
+
+    def test_no_note_when_local_and_short(self):
+        s = _build_summarizer("local")
+        chunks = self._stream(s, "short transcript")
+        self.assertNotIn(LOCAL_TRUNCATION_USER_NOTE, chunks)
+
+    def test_no_note_when_stream_yielded_nothing(self):
+        # A failed/empty stream must not produce a summary consisting of
+        # only the truncation note.
+        s = _build_summarizer("local")
+        s._ensure_ollama_ready = MagicMock()
+        s.client.chat.return_value = iter([])
+        chunks = list(s.summarize_transcript_streaming(_long_transcript()))
+        self.assertEqual(chunks, [])
+
+    def test_no_note_for_remote(self):
+        s = _build_summarizer("remote")
+        chunks = self._stream(s, _long_transcript())
+        self.assertNotIn(LOCAL_TRUNCATION_USER_NOTE, chunks)
+
+
+class QueryPathContextTests(unittest.TestCase):
+    """The query/chat path gets the same local-context discipline as the
+    summary path: capped prompt + num_ctx options for local only."""
+
+    def test_query_prompt_caps_for_local(self):
+        s = _build_summarizer("local")
+        prompt = s._build_query_prompt(_long_transcript(), "what happened?")
+        self.assertIn(LOCAL_TRANSCRIPT_TRUNCATION_NOTE, prompt)
+
+    def test_query_prompt_full_for_cloud(self):
+        s = _build_summarizer("cloud")
+        prompt = s._build_query_prompt(_long_transcript(), "what happened?")
+        self.assertNotIn(LOCAL_TRANSCRIPT_TRUNCATION_NOTE, prompt)
+        self.assertIn("TAIL-MARKER", prompt)
+
+    def test_streaming_query_passes_num_ctx_for_local(self):
+        import src.summarizer as summarizer_mod
+        s = _build_summarizer("local")
+        s._ensure_ollama_ready = MagicMock()
+        fake_client = MagicMock()
+        fake_client.chat.return_value = iter([{"message": {"content": "answer"}}])
+        with unittest.mock.patch.object(
+            summarizer_mod.ollama, "Client", return_value=fake_client
+        ):
+            chunks = list(s.query_transcript_streaming("a transcript", "q?"))
+        self.assertEqual(chunks, ["answer"])
+        kwargs = fake_client.chat.call_args.kwargs
+        self.assertEqual(kwargs.get("options"), {"num_ctx": LOCAL_OLLAMA_NUM_CTX})
+
+    def test_nonstreaming_query_passes_num_ctx_for_local(self):
+        s = _build_summarizer("local")
+        s._ensure_ollama_ready = MagicMock()
+        s.client.chat.return_value = {"message": {"content": "answer"}}
+        out = s.query_transcript("a transcript", "q?")
+        self.assertEqual(out, "answer")
+        kwargs = s.client.chat.call_args.kwargs
+        self.assertEqual(kwargs.get("options"), {"num_ctx": LOCAL_OLLAMA_NUM_CTX})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_truncation_note_persistence.py
+++ b/tests/test_truncation_note_persistence.py
@@ -1,0 +1,125 @@
+"""The local-model truncation note must survive past the streaming view.
+
+The note trails the streamed markdown (after ## Action Items), so the
+section parsers would silently drop it from the structured fields the
+meeting view / copy / share are built from. Both parsers fold it into the
+``summary`` field instead.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from simple_recorder import (
+    SimpleRecorder,
+    _extract_truncation_note,
+    _parse_meeting_markdown,
+)
+from src.summarizer import LOCAL_TRUNCATION_USER_NOTE
+
+_STREAMED_MD = f"""## Summary
+A quarterly planning discussion.
+
+## Key Topics
+### Budget
+Reviewed the budget.
+
+## Key Points
+- Budget approved
+
+## Action Items
+- Send the deck
+{LOCAL_TRUNCATION_USER_NOTE}"""
+
+
+class ExtractTruncationNoteTests(unittest.TestCase):
+    def test_extracts_note_content_without_blockquote_marker(self):
+        note = _extract_truncation_note(_STREAMED_MD)
+        self.assertIsNotNone(note)
+        self.assertFalse(note.startswith(">"))
+        self.assertIn("longer than the local AI model", note)
+
+    def test_none_when_absent(self):
+        self.assertIsNone(_extract_truncation_note("## Summary\nshort meeting"))
+        self.assertIsNone(_extract_truncation_note(""))
+
+    def test_matches_the_summarizer_constant(self):
+        """The prefix-based detection must actually match the constant the
+        summarizer emits — guards against the two drifting apart."""
+        self.assertIsNotNone(_extract_truncation_note(LOCAL_TRUNCATION_USER_NOTE))
+
+
+class ParsedSummaryCarriesNoteTests(unittest.TestCase):
+    def test_parse_streamed_markdown_folds_note_into_summary(self):
+        parsed = SimpleRecorder._parse_streamed_markdown(_STREAMED_MD)
+        self.assertIn("longer than the local AI model", parsed["summary"])
+        self.assertIn("A quarterly planning discussion.", parsed["summary"])
+        # The note is NOT misparsed as an action item.
+        self.assertEqual(parsed["action_items"], ["Send the deck"])
+
+    def test_parse_streamed_markdown_without_note_unchanged(self):
+        parsed = SimpleRecorder._parse_streamed_markdown(
+            "## Summary\nShort meeting.\n\n## Action Items\n- Do the thing"
+        )
+        self.assertEqual(parsed["summary"], "Short meeting.")
+
+    def test_parse_meeting_markdown_folds_note_into_summary(self):
+        md = f"""---
+title: "Planning"
+date: "2026-06-12T10:00:00"
+duration_seconds: 7200
+language: "en"
+is_diarised: false
+---
+
+{_STREAMED_MD}
+
+## Transcript
+
+a long transcript
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            md_path = Path(tmp_dir) / "planning_summary.md"
+            md_path.write_text(md, encoding="utf-8")
+            parsed = _parse_meeting_markdown(md_path)
+        self.assertIn("longer than the local AI model", parsed["summary"])
+        self.assertEqual(parsed["action_items"], ["Send the deck"])
+
+    def test_note_not_duplicated_if_already_in_summary(self):
+        note_text = LOCAL_TRUNCATION_USER_NOTE.strip().lstrip("> ")
+        md = (
+            f"## Summary\nShort. {note_text}\n\n"
+            f"## Action Items\n- x\n{LOCAL_TRUNCATION_USER_NOTE}"
+        )
+        parsed = SimpleRecorder._parse_streamed_markdown(md)
+        self.assertEqual(parsed["summary"].count("longer than the local AI model"), 1)
+
+    def test_parse_meeting_markdown_ignores_note_text_in_transcript(self):
+        """A transcript that coincidentally contains the note's wording must
+        NOT be folded into the summary — only a real note trailing a summary
+        section counts. Guards the _parse_meeting_markdown body-vs-sections fix."""
+        note_text = LOCAL_TRUNCATION_USER_NOTE.strip().lstrip("> ")
+        md = f"""---
+title: "Planning"
+date: "2026-06-12T10:00:00"
+duration_seconds: 600
+language: "en"
+is_diarised: false
+---
+
+## Summary
+A short meeting.
+
+## Action Items
+- Send the deck
+
+## Transcript
+
+So I said {note_text} and then we moved on.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            md_path = Path(tmp_dir) / "planning_summary.md"
+            md_path.write_text(md, encoding="utf-8")
+            parsed = _parse_meeting_markdown(md_path)
+        self.assertNotIn("longer than the local AI model", parsed["summary"])
+        self.assertEqual(parsed["summary"], "A short meeting.")


### PR DESCRIPTION
Split out of #176 per review discussion.

### Problem
Long transcripts silently overrun small local models' default 2–4k context. On overflow Ollama drops the **oldest** tokens — including the prompt instructions at the head — so summaries covered only part of the meeting or came back malformed. Affects the default `llama3.2:3b` on every long meeting.

### Change (local Ollama only — cloud/remote/adapter byte-identical, tested)
- `num_ctx=8192` passed to the local Ollama chat calls (summary streaming + non-streaming + the Ask/chat query path).
- Transcripts over ~24k chars are capped to head 60% + tail 40% joined by a neutral in-prompt gap marker — head+tail so the meeting's close and action items survive.
- A user-facing note ("this meeting was longer than the local AI model's context window…") is appended **deterministically** to the streamed summary when capping occurred — never trusted to the model to echo — and folded into the parsed `summary` field by both md parsers so it survives into the meeting view, copy, and share. `generate_title` strips it from its context.

### Verified at runtime (on the original branch)
A 33k-char transcript reprocessed on local Ollama produced action items from the transcript **tail** ("send the revised budget by Friday") — proving the capping preserves the close — plus the note in the stream, the saved `.md`, and the parsed `list-meetings` summary. Short transcripts get no note. 23 new tests.

### Known limitation / planned follow-up (the reason this was split out)
The 8192/24k sizing is fixed per *provider*, not per *model*. Registry models with large native context (qwen3.5:9b, deepseek-r1:14b, gpt-oss:20b — all 128k-native) get clamped and could see the truncation note on meetings they'd handle natively. Planned fix before merge: a `num_ctx` field per `SUPPORTED_MODELS` registry entry (8192 for the 3–4B models, 32768 for 9B+ — which covers any transcript the 2-hour recording cap can produce), with the char cap derived from it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make long local-model summaries and Ask answers cover the whole meeting by using an 8k context window and head+tail transcript capping, with a clear truncation note that persists in the summary. Cloud/remote/adapter providers are unchanged.

- **New Features**
  - Pass `options: { num_ctx: 8192 }` to local Ollama chat calls (summary and Ask; streaming and non-streaming).
  - Cap transcripts over ~24k chars to head 60% + tail 40% with a neutral gap marker across all prompt builders.
  - Append a deterministic truncation note at the end of the streamed summary when capping occurs; fold it into the parsed `summary` from both streamed and saved markdown; `generate_title` strips it; renderer removes the leading `>` for clean display.

- **Bug Fixes**
  - Prevent local summaries from dropping instructions and end-of-meeting details due to small default context windows.

<sup>Written for commit 40fa4230ab2e763e32e4e993dc7e8638d51e8fef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

