### PR TITLE
fix: org sign-in resets to local LLM — config-wipe root cause + org-adapter hard lock

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -5817,6 +5817,16 @@ function reconcileAiProviderWithOrgSession() {
     return Promise.resolve(null);
   }
   return enqueueProviderStateOp(async () => {
+    // Re-check the memo now that we actually run: a burst of callers with a
+    // cold memo enqueues several runs, and by the time the later ones
+    // execute, the first has already confirmed consistency — skip their
+    // subprocess spawns instead of repeating the full check serially.
+    if (
+      lastConsistentCheck.generation === orgSessionGeneration &&
+      Date.now() - lastConsistentCheck.at < RECONCILE_CONSISTENT_TTL_MS
+    ) {
+      return null;
+    }
     const genAtRead = orgSessionGeneration;
     const { session, exists, decryptFailed } = loadOrgSessionEx();
     if (decryptFailed) return null; // transient — never act on it
@@ -5895,12 +5905,22 @@ async function doRestorePreAdapterProvider() {
   }
   const restored = loadPreAdapterProvider() || 'local';
   sendDebugLog(`Org sign-out: restoring ai_provider from adapter to ${restored}`);
+  let restoreLanded = true;
   try {
-    await runPythonScript('simple_recorder.py', ['set-ai-provider', restored]);
+    const out = await runPythonScript('simple_recorder.py', ['set-ai-provider', restored]);
+    // The CLI prints {"success": false} with exit 0 on a failed config
+    // save — treat that as a failure, same as the relock path does.
+    const jsonMatch = out.match(/\{.*\}/s);
+    if (jsonMatch && JSON.parse(jsonMatch[0]).success === false) {
+      throw new Error('set-ai-provider reported a failed config save');
+    }
   } catch (e) {
+    restoreLanded = false;
     sendDebugLog(`restore to ${restored} failed: ${e.message}`);
   }
-  clearPreAdapterProvider();
+  // Keep the marker when the restore didn't land — it's the only record
+  // of the user's pre-adapter choice, and a later retry needs it.
+  if (restoreLanded) clearPreAdapterProvider();
 }
 
 ipcMain.handle('get-ai-provider', async () => {
@@ -5939,36 +5959,44 @@ ipcMain.handle('get-ai-provider', async () => {
 ipcMain.handle('set-ai-provider', async (event, provider) => {
   try {
     sendDebugLog(`Setting AI provider to: ${provider}`);
-    if (provider !== 'adapter') {
-      // Hard lock: while a valid org session exists the provider is
-      // managed by the organisation. The Settings picker is disabled too —
-      // this backstops any other IPC caller and future UI paths, and it
-      // leaves the restore marker untouched. Fail closed on a decrypt
-      // failure (locked keychain): the user IS signed in, the session is
-      // just transiently unreadable, and letting the switch through would
-      // have the next reconcile fight them.
-      const { session, decryptFailed } = loadOrgSessionEx();
-      const sessionValid = Boolean(
-        session && session.adapterUrl && session.token && !isJwtExpired(session.token)
-      );
-      if (sessionValid || decryptFailed) {
-        sendDebugLog(`Org lock: rejecting set-ai-provider ${provider} (${decryptFailed ? 'session unreadable' : 'org session active'})`);
-        return {
-          success: false,
-          managedByOrg: true,
-          error: 'AI provider is managed by your organisation while you are signed in.',
-        };
+    // Queued so a manual write can't interleave with an in-flight
+    // reconcile or sign-out restore (last-writer-wins races on the same
+    // config value); the org-lock gate is evaluated inside the op so it
+    // sees post-queue session state.
+    return await enqueueProviderStateOp(async () => {
+      if (provider !== 'adapter') {
+        // Hard lock: while a valid org session exists the provider is
+        // managed by the organisation. The Settings picker is disabled
+        // too — this backstops any other IPC caller and future UI paths,
+        // and it leaves the restore marker untouched. Fail closed on a
+        // decrypt failure (locked keychain): the user IS signed in, the
+        // session is just transiently unreadable, and letting the switch
+        // through would have the next reconcile fight them.
+        const { session, decryptFailed } = loadOrgSessionEx();
+        const sessionValid = Boolean(
+          session && session.adapterUrl && session.token && !isJwtExpired(session.token)
+        );
+        if (sessionValid || decryptFailed) {
+          sendDebugLog(`Org lock: rejecting set-ai-provider ${provider} (${decryptFailed ? 'session unreadable' : 'org session active'})`);
+          return {
+            success: false,
+            managedByOrg: true,
+            error: 'AI provider is managed by your organisation while you are signed in.',
+          };
+        }
+        // A manual switch away from 'adapter' invalidates the pre-adapter
+        // marker — without this, a user who auto-switched on sign-in and
+        // then manually moved to a different provider would still be
+        // restored to the stale "before adapter" value on sign-out.
+        clearPreAdapterProvider();
       }
-      // A manual switch away from 'adapter' invalidates the pre-adapter
-      // marker — without this, a user who auto-switched on sign-in and
-      // then manually moved to a different provider would still be
-      // restored to the stale "before adapter" value on sign-out.
-      clearPreAdapterProvider();
-    }
-    const result = await runPythonScript('simple_recorder.py', ['set-ai-provider', provider]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    if (jsonMatch) return JSON.parse(jsonMatch[0]);
-    return { success: true, ai_provider: provider };
+      // Provider state is changing under the memo's feet.
+      lastConsistentCheck = { generation: -1, at: 0 };
+      const result = await runPythonScript('simple_recorder.py', ['set-ai-provider', provider]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      if (jsonMatch) return JSON.parse(jsonMatch[0]);
+      return { success: true, ai_provider: provider };
+    });
   } catch (error) {
     sendDebugLog(`Error setting AI provider: ${error.message}`);
     return { success: false, error: error.message };

--- a/app/main.js
+++ b/app/main.js
@@ -1107,6 +1107,11 @@ if (!gotSingleInstanceLock) {
     setupAutoUpdater();
     setupAutoMeetingDetector();
 
+    // Hard lock: reconcile ai_provider with the org session once at startup
+    // (belt-and-braces for tray-only starts; the sidebar's org-status call
+    // triggers the same coalesced reconcile). Fire-and-forget.
+    reconcileAiProviderWithOrgSession().catch(() => {});
+
     // Auto-pause active recordings when the machine sleeps (lid close etc.)
     // and offer a Resume prompt on wake — see autoPauseForSleep. Processing
     // watchdogs are frozen across the sleep so their deadline can't elapse
@@ -5759,25 +5764,69 @@ function clearPreAdapterProvider() {
   } catch (_) {}
 }
 
-// Auto-switch helpers wired into the org sign-in / sign-out flow so a
-// user doesn't have to paste an Anthropic key in Settings > AI just to
-// summarise — the adapter brokers AI for them once they're signed in.
-// Switches from ANY non-adapter provider (local / remote / cloud) on
-// sign-in; remembers the previous choice so sign-out restores it. The
-// customer's ask was zero-config for org users, which means even users
-// already on 'cloud' (because they had no other option at the time)
-// shouldn't have to manually toggle to take advantage of the adapter.
+// Bidirectional reconciliation between the org session and the Python-side
+// ai_provider. Hard-lock policy: while a valid org session exists the
+// provider must be 'adapter' — the adapter brokers AI for org users
+// (zero-config was the customer ask), and any drift (a wiped config.json,
+// a hand edit, a CLI call) self-heals on the next check. The reverse
+// direction keeps the old stale-adapter recovery: config says 'adapter'
+// but the session file is genuinely gone → restore the remembered
+// pre-adapter provider so the next AI call doesn't die with "adapter not
+// configured".
+//
+// A safeStorage decrypt failure (locked keychain right after wake, denied
+// prompt) is transient and changes NOTHING — acting on it is how signed-in
+// users used to end up silently summarising on local llama. Expired-but-
+// present sessions are also left alone here: expiry is owned by org-status
+// and adapterFetch's 401 path (clear session + restore provider), and
+// acting on it from two places would race.
+//
+// Coalesced: concurrent triggers (get-ai-provider, org-status, startup,
+// sign-in) share one in-flight run. Returns the provider as re-read from
+// disk after any write — never an assumed value.
+let aiProviderReconcileInFlight = null;
+function reconcileAiProviderWithOrgSession() {
+  if (aiProviderReconcileInFlight) return aiProviderReconcileInFlight;
+  aiProviderReconcileInFlight = (async () => {
+    const { session, exists, decryptFailed } = loadOrgSessionEx();
+    if (decryptFailed) return null; // transient — never act on it
+    const current = await readAiProvider();
+    const sessionValid = Boolean(
+      session && session.adapterUrl && session.token && !isJwtExpired(session.token)
+    );
+    if (sessionValid && current !== 'adapter') {
+      // Seed the restore marker only when none exists: in a drift repair
+      // `current` may be a wiped-to-default 'local' while the marker still
+      // holds the user's true pre-sign-in choice (e.g. 'cloud').
+      const hadMarker = loadPreAdapterProvider() !== null;
+      if (!hadMarker) savePreAdapterProvider(current);
+      sendDebugLog(`Org lock: switching ai_provider from ${current} to adapter (org session active)`);
+      try {
+        await runPythonScript('simple_recorder.py', ['set-ai-provider', 'adapter']);
+      } catch (e) {
+        sendDebugLog(`Org lock: switch to adapter failed: ${e.message}`);
+        // Don't leave a marker WE created if the switch never landed; a
+        // pre-existing marker stays — it still describes the user's choice.
+        if (!hadMarker) clearPreAdapterProvider();
+      }
+      return await readAiProvider();
+    }
+    if (!exists && current === 'adapter') {
+      sendDebugLog('Org lock: ai_provider=adapter but no org session backing it; restoring pre-adapter provider');
+      await restorePreAdapterProvider();
+      return await readAiProvider();
+    }
+    return current;
+  })().finally(() => {
+    aiProviderReconcileInFlight = null;
+  });
+  return aiProviderReconcileInFlight;
+}
+
+// Wired into the org sign-in flows (password + Google SSO). Kept as a named
+// wrapper so the call sites read as intent; the reconcile does the work.
 async function autoSwitchToAdapterOnSignIn() {
-  const current = await readAiProvider();
-  if (current === 'adapter') return;
-  sendDebugLog(`Org sign-in: switching ai_provider from ${current} to adapter (will restore ${current} on sign-out)`);
-  savePreAdapterProvider(current);
-  try {
-    await runPythonScript('simple_recorder.py', ['set-ai-provider', 'adapter']);
-  } catch (e) {
-    sendDebugLog(`auto-switch to adapter failed: ${e.message}`);
-    clearPreAdapterProvider(); // don't leave a stale marker if the switch never landed
-  }
+  await reconcileAiProviderWithOrgSession();
 }
 
 // On sign-out (or stale-session clear), restore the pre-adapter provider
@@ -5806,44 +5855,23 @@ ipcMain.handle('get-ai-provider', async () => {
     // Override cloud_api_key_set with safeStorage check
     jsonData.cloud_api_key_set = hasCloudApiKey();
 
-    // Stale-adapter recovery. The existing JWT-expiry / 401 / explicit-
-    // logout paths all call restorePreAdapterProvider, but there's a
-    // gap: if the org_session.json file goes missing without one of
-    // those triggers firing (manually deleted, migrated config without
-    // session, crashed mid-sign-out), the Python config stays on
-    // 'adapter' and the next AI call dies with "adapter not configured".
-    // Treat the first get-ai-provider read on startup as the
-    // reconciliation point: if Python says adapter but no session backs
-    // it, restore the pre-adapter provider and reflect the new value in
-    // this response so the renderer's first paint is already consistent
-    // and the next AI call lands on a working provider.
-    if (jsonData.ai_provider === 'adapter' && !loadOrgSession()) {
-      const target = loadPreAdapterProvider() || 'local';
-      sendDebugLog(
-        `Stale adapter detected: ai_provider='adapter' but no org session backing it. Restoring to '${target}'.`,
-      );
-      try {
-        await restorePreAdapterProvider();
-        // restorePreAdapterProvider swallows its own internal
-        // set-ai-provider failure (it just logs and returns), so a
-        // successful return doesn't guarantee the Python config was
-        // actually written. Re-read the truth from Python and only
-        // patch the response if the restore landed — otherwise return
-        // the unchanged 'adapter' value so the renderer doesn't show
-        // a state that diverges from disk.
-        const verifyResult = await runPythonScript('simple_recorder.py', ['get-ai-provider'], true);
-        const verified = JSON.parse(verifyResult.trim());
-        if (verified.ai_provider && verified.ai_provider !== 'adapter') {
-          jsonData.ai_provider = verified.ai_provider;
-        } else {
-          sendDebugLog(`Stale-adapter recovery did not write — Python still on '${verified.ai_provider}'.`);
-        }
-      } catch (e) {
-        sendDebugLog(`Stale-adapter recovery failed: ${e.message}`);
-        // Leave jsonData.ai_provider as 'adapter' — the next AI call
-        // will fail with the existing "adapter not configured" error,
-        // which is the pre-fix behaviour, not a regression.
+    // Reconcile the provider with org-session reality before answering, so
+    // the renderer's first paint already reflects a working provider:
+    //  - valid session but provider drifted (wiped config, hand edit, CLI
+    //    call) → relock to 'adapter' (hard-lock policy)
+    //  - provider says 'adapter' but the session file is gone (manually
+    //    deleted, crashed mid-sign-out) → restore the pre-adapter provider
+    // Decrypt failures (locked keychain) deliberately change nothing. The
+    // reconcile re-reads the provider from disk after any write, so the
+    // patched response never diverges from what Python persisted.
+    try {
+      const reconciled = await reconcileAiProviderWithOrgSession();
+      if (reconciled && reconciled !== jsonData.ai_provider) {
+        jsonData.ai_provider = reconciled;
       }
+    } catch (e) {
+      sendDebugLog(`AI provider reconcile failed: ${e.message}`);
+      // Return the unreconciled value — pre-fix behaviour, not a regression.
     }
 
     return { success: true, ...jsonData };
@@ -5856,11 +5884,26 @@ ipcMain.handle('get-ai-provider', async () => {
 ipcMain.handle('set-ai-provider', async (event, provider) => {
   try {
     sendDebugLog(`Setting AI provider to: ${provider}`);
-    // A manual switch away from 'adapter' invalidates the pre-adapter
-    // marker — without this, a user who auto-switched on sign-in and
-    // then manually moved to a different provider would still be
-    // restored to the stale "before adapter" value on sign-out.
-    if (provider !== 'adapter') clearPreAdapterProvider();
+    if (provider !== 'adapter') {
+      // Hard lock: while a valid org session exists the provider is
+      // managed by the organisation. Reject the change (the Settings
+      // picker is disabled too — this is defense in depth for CLI/IPC
+      // paths) and leave the restore marker untouched.
+      const session = loadOrgSession();
+      if (session && session.adapterUrl && session.token && !isJwtExpired(session.token)) {
+        sendDebugLog(`Org lock: rejecting set-ai-provider ${provider} while org session is active`);
+        return {
+          success: false,
+          managedByOrg: true,
+          error: 'AI provider is managed by your organisation while you are signed in.',
+        };
+      }
+      // A manual switch away from 'adapter' invalidates the pre-adapter
+      // marker — without this, a user who auto-switched on sign-in and
+      // then manually moved to a different provider would still be
+      // restored to the stale "before adapter" value on sign-out.
+      clearPreAdapterProvider();
+    }
     const result = await runPythonScript('simple_recorder.py', ['set-ai-provider', provider]);
     const jsonMatch = result.match(/\{.*\}/s);
     if (jsonMatch) return JSON.parse(jsonMatch[0]);
@@ -7615,16 +7658,33 @@ function saveOrgSession(session) {
   }
 }
 
-function loadOrgSession() {
+// Read the org session distinguishing the three states callers care about:
+//   file missing        → { session: null, exists: false, decryptFailed: false }
+//   present, unreadable → { session: null, exists: true,  decryptFailed: true  }
+//   present, readable   → { session,      exists: true,  decryptFailed: false }
+// The middle state matters: safeStorage.decryptString throws while the
+// keychain is locked (right after wake / login, or a denied prompt after an
+// app re-sign) — treating that like "signed out" is exactly what used to
+// downgrade signed-in users to local AI via the stale-adapter recovery.
+function loadOrgSessionEx() {
+  const p = getOrgSessionPath();
+  if (!fs.existsSync(p)) return { session: null, exists: false, decryptFailed: false };
   try {
-    const p = getOrgSessionPath();
-    if (!fs.existsSync(p)) return null;
     const encrypted = fs.readFileSync(p);
-    return JSON.parse(safeStorage.decryptString(encrypted));
+    return {
+      session: JSON.parse(safeStorage.decryptString(encrypted)),
+      exists: true,
+      decryptFailed: false,
+    };
   } catch (e) {
     console.error('Failed to load org session:', e.message);
-    return null;
+    sendDebugLog(`org session present but unreadable (keychain locked?): ${e.message}`);
+    return { session: null, exists: true, decryptFailed: true };
   }
+}
+
+function loadOrgSession() {
+  return loadOrgSessionEx().session;
 }
 
 function clearOrgSession() {
@@ -7815,6 +7875,11 @@ ipcMain.handle('org-status', async () => {
     restorePreAdapterProvider().catch(() => {});
     return { signedIn: false, everSignedIn };
   }
+  // Hard lock: heal any provider drift while the session is valid.
+  // Fire-and-forget — this handler is hot (sidebar polls it) and must
+  // not block on a Python subprocess; the reconcile is coalesced so
+  // repeated calls share one run.
+  reconcileAiProviderWithOrgSession().catch(() => {});
   return {
     signedIn: true,
     everSignedIn,

--- a/app/main.js
+++ b/app/main.js
@@ -5801,6 +5801,16 @@ function enqueueProviderStateOp(op) {
 // current and abort its write instead of acting on stale state.
 let orgSessionGeneration = 0;
 
+// Start of the current decrypt-failure streak (null while reads succeed or
+// no session file exists). Distinguishes a transiently locked keychain
+// (seconds-to-minutes after boot/wake) from a session that will never
+// decrypt again (corrupt file, lost keychain entry after an OS reinstall) —
+// the org-lock gate fails closed only inside this grace window, so a
+// permanently unreadable session can't lock the user out of provider
+// changes forever.
+let orgSessionDecryptFailingSince = null;
+const DECRYPT_FAILURE_GRACE_MS = 10 * 60 * 1000;
+
 // Memo of the last reconcile that confirmed session/provider consistency.
 // org-status is refetched on focus/mount by the sidebar; without this every
 // refetch would spawn a Python subprocess (~100-300ms PyInstaller startup)
@@ -5809,22 +5819,36 @@ let orgSessionGeneration = 0;
 let lastConsistentCheck = { generation: -1, at: 0 };
 const RECONCILE_CONSISTENT_TTL_MS = 30_000;
 
-function reconcileAiProviderWithOrgSession() {
-  if (
+function reconcileAiProviderWithOrgSession(opts = {}) {
+  const { knownProvider } = opts;
+  const memoFresh = () =>
     lastConsistentCheck.generation === orgSessionGeneration &&
-    Date.now() - lastConsistentCheck.at < RECONCILE_CONSISTENT_TTL_MS
-  ) {
-    return Promise.resolve(null);
+    Date.now() - lastConsistentCheck.at < RECONCILE_CONSISTENT_TTL_MS;
+  let bypassMemo = false;
+  if (memoFresh()) {
+    if (knownProvider === undefined) return Promise.resolve(null);
+    // The caller just read the provider from disk (get-ai-provider passes
+    // its own response in). Cross-check it against the session file — a
+    // sync read, no subprocess — so external drift inside the memo's TTL
+    // (terminal CLI call, hand-edited config) is caught immediately
+    // instead of after the memo expires.
+    const { exists, decryptFailed } = loadOrgSessionEx();
+    const consistent = decryptFailed
+      ? true // transient — never act on it
+      : exists
+        ? knownProvider === 'adapter'
+        : knownProvider !== 'adapter';
+    if (consistent) return Promise.resolve(null);
+    bypassMemo = true;
   }
   return enqueueProviderStateOp(async () => {
     // Re-check the memo now that we actually run: a burst of callers with a
     // cold memo enqueues several runs, and by the time the later ones
     // execute, the first has already confirmed consistency — skip their
     // subprocess spawns instead of repeating the full check serially.
-    if (
-      lastConsistentCheck.generation === orgSessionGeneration &&
-      Date.now() - lastConsistentCheck.at < RECONCILE_CONSISTENT_TTL_MS
-    ) {
+    // Skipped when this run was enqueued BECAUSE of a memo-contradicting
+    // drift observation — that drift still needs repairing.
+    if (!bypassMemo && memoFresh()) {
       return null;
     }
     const genAtRead = orgSessionGeneration;
@@ -5940,7 +5964,12 @@ ipcMain.handle('get-ai-provider', async () => {
     // reconcile re-reads the provider from disk after any write, so the
     // patched response never diverges from what Python persisted.
     try {
-      const reconciled = await reconcileAiProviderWithOrgSession();
+      // knownProvider lets the reconcile detect drift even inside its
+      // consistency-memo window — this handler already paid for a fresh
+      // disk read, so the cross-check costs nothing.
+      const reconciled = await reconcileAiProviderWithOrgSession({
+        knownProvider: jsonData.ai_provider,
+      });
       if (reconciled && reconciled !== jsonData.ai_provider) {
         jsonData.ai_provider = reconciled;
       }
@@ -5976,7 +6005,18 @@ ipcMain.handle('set-ai-provider', async (event, provider) => {
         const sessionValid = Boolean(
           session && session.adapterUrl && session.token && !isJwtExpired(session.token)
         );
-        if (sessionValid || decryptFailed) {
+        // Fail closed on decrypt failure only inside the grace window — a
+        // streak that has lasted longer than a keychain-unlock plausibly
+        // can means the session will never decrypt again, and rejecting
+        // forever would dead-end the user.
+        const decryptRecentlyFailed =
+          decryptFailed &&
+          orgSessionDecryptFailingSince !== null &&
+          Date.now() - orgSessionDecryptFailingSince < DECRYPT_FAILURE_GRACE_MS;
+        if (decryptFailed && !decryptRecentlyFailed) {
+          sendDebugLog(`Org lock: allowing set-ai-provider ${provider} — session unreadable for >${DECRYPT_FAILURE_GRACE_MS / 60000}min, treating as dead`);
+        }
+        if (sessionValid || decryptRecentlyFailed) {
           sendDebugLog(`Org lock: rejecting set-ai-provider ${provider} (${decryptFailed ? 'session unreadable' : 'org session active'})`);
           return {
             success: false,
@@ -7758,15 +7798,20 @@ function saveOrgSession(session) {
 // downgrade signed-in users to local AI via the stale-adapter recovery.
 function loadOrgSessionEx() {
   const p = getOrgSessionPath();
-  if (!fs.existsSync(p)) return { session: null, exists: false, decryptFailed: false };
+  if (!fs.existsSync(p)) {
+    orgSessionDecryptFailingSince = null;
+    return { session: null, exists: false, decryptFailed: false };
+  }
   try {
     const encrypted = fs.readFileSync(p);
+    orgSessionDecryptFailingSince = null;
     return {
       session: JSON.parse(safeStorage.decryptString(encrypted)),
       exists: true,
       decryptFailed: false,
     };
   } catch (e) {
+    if (orgSessionDecryptFailingSince === null) orgSessionDecryptFailingSince = Date.now();
     console.error('Failed to load org session:', e.message);
     sendDebugLog(`org session present but unreadable (keychain locked?): ${e.message}`);
     return { session: null, exists: true, decryptFailed: true };

--- a/app/main.js
+++ b/app/main.js
@@ -7804,12 +7804,13 @@ function loadOrgSessionEx() {
   }
   try {
     const encrypted = fs.readFileSync(p);
+    // Decrypt + parse BEFORE clearing the streak — clearing first would
+    // reset it moments before the decrypt throws, and the catch below
+    // would restamp it to now on every call, so the grace window could
+    // never elapse and the org lock would stay fail-closed forever.
+    const session = JSON.parse(safeStorage.decryptString(encrypted));
     orgSessionDecryptFailingSince = null;
-    return {
-      session: JSON.parse(safeStorage.decryptString(encrypted)),
-      exists: true,
-      decryptFailed: false,
-    };
+    return { session, exists: true, decryptFailed: false };
   } catch (e) {
     if (orgSessionDecryptFailingSince === null) orgSessionDecryptFailingSince = Date.now();
     console.error('Failed to load org session:', e.message);

--- a/app/main.js
+++ b/app/main.js
@@ -5733,7 +5733,7 @@ async function readAiProvider() {
 // user manually picks a non-adapter provider — at that point there's
 // no longer a stale value to restore to.
 function getPreAdapterProviderPath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.pre-adapter-provider');
+  return path.join(getUserDataDir(), '.pre-adapter-provider');
 }
 
 function loadPreAdapterProvider() {
@@ -7611,7 +7611,7 @@ ipcMain.handle('outlook-auth-disconnect', async () => {
 // it goes through these IPC handlers.
 
 function getOrgSessionPath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.org-session');
+  return path.join(getUserDataDir(), '.org-session');
 }
 
 // Decode the JWT's payload segment and check whether it's already past its
@@ -7703,7 +7703,7 @@ function clearOrgSession() {
 // nothing; enterprise users get a one-click recovery path after their first
 // connection. Empty file content; existence is the only signal.
 function getOrgKnownMarkerPath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.org-known');
+  return path.join(getUserDataDir(), '.org-known');
 }
 
 function markOrgKnown() {
@@ -7732,7 +7732,7 @@ function hasOrgEverBeenSignedIn() {
 // files stay byte-stable and the share/unshare cycle leaves no residue in
 // the user's notes.
 function getOrgBackupStatePath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.org-backup-state.json');
+  return path.join(getUserDataDir(), '.org-backup-state.json');
 }
 
 function loadOrgBackupState() {

--- a/app/main.js
+++ b/app/main.js
@@ -5781,13 +5781,43 @@ function clearPreAdapterProvider() {
 // and adapterFetch's 401 path (clear session + restore provider), and
 // acting on it from two places would race.
 //
-// Coalesced: concurrent triggers (get-ai-provider, org-status, startup,
-// sign-in) share one in-flight run. Returns the provider as re-read from
-// disk after any write — never an assumed value.
-let aiProviderReconcileInFlight = null;
+// Serialized, not merely coalesced: every provider-state mutation (this
+// reconcile AND the sign-out restore) runs through one queue, so a sign-out's
+// restore can never interleave with an in-flight reconcile's write — the
+// race that could strand ai_provider='adapter' with no session, or clobber
+// the restore marker. Late callers get a FRESH run that starts after the
+// previous one finishes, so a sign-in that lands while a pre-sign-in run is
+// in flight still gets post-sign-in truth.
+let providerStateQueue = Promise.resolve();
+function enqueueProviderStateOp(op) {
+  const run = providerStateQueue.then(op);
+  // Keep the chain alive whether the op resolves or rejects.
+  providerStateQueue = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+// Bumped whenever the org session file changes (save or clear) so a queued
+// reconcile can detect that the session it read mid-run is no longer
+// current and abort its write instead of acting on stale state.
+let orgSessionGeneration = 0;
+
+// Memo of the last reconcile that confirmed session/provider consistency.
+// org-status is refetched on focus/mount by the sidebar; without this every
+// refetch would spawn a Python subprocess (~100-300ms PyInstaller startup)
+// for a no-op check. The memoed fast path returns null ("nothing to
+// change") so callers never patch their response from a possibly-stale memo.
+let lastConsistentCheck = { generation: -1, at: 0 };
+const RECONCILE_CONSISTENT_TTL_MS = 30_000;
+
 function reconcileAiProviderWithOrgSession() {
-  if (aiProviderReconcileInFlight) return aiProviderReconcileInFlight;
-  aiProviderReconcileInFlight = (async () => {
+  if (
+    lastConsistentCheck.generation === orgSessionGeneration &&
+    Date.now() - lastConsistentCheck.at < RECONCILE_CONSISTENT_TTL_MS
+  ) {
+    return Promise.resolve(null);
+  }
+  return enqueueProviderStateOp(async () => {
+    const genAtRead = orgSessionGeneration;
     const { session, exists, decryptFailed } = loadOrgSessionEx();
     if (decryptFailed) return null; // transient — never act on it
     const current = await readAiProvider();
@@ -5795,6 +5825,10 @@ function reconcileAiProviderWithOrgSession() {
       session && session.adapterUrl && session.token && !isJwtExpired(session.token)
     );
     if (sessionValid && current !== 'adapter') {
+      if (orgSessionGeneration !== genAtRead) {
+        sendDebugLog('Org lock: session changed mid-reconcile; aborting relock');
+        return null;
+      }
       // Seed the restore marker only when none exists: in a drift repair
       // `current` may be a wiped-to-default 'local' while the marker still
       // holds the user's true pre-sign-in choice (e.g. 'cloud').
@@ -5802,25 +5836,38 @@ function reconcileAiProviderWithOrgSession() {
       if (!hadMarker) savePreAdapterProvider(current);
       sendDebugLog(`Org lock: switching ai_provider from ${current} to adapter (org session active)`);
       try {
-        await runPythonScript('simple_recorder.py', ['set-ai-provider', 'adapter']);
+        const out = await runPythonScript('simple_recorder.py', ['set-ai-provider', 'adapter']);
+        // The CLI prints {"success": false} with exit 0 on a failed config
+        // save — surface that as a failure too, not just spawn errors.
+        const jsonMatch = out.match(/\{.*\}/s);
+        if (jsonMatch && JSON.parse(jsonMatch[0]).success === false) {
+          throw new Error('set-ai-provider reported a failed config save');
+        }
       } catch (e) {
         sendDebugLog(`Org lock: switch to adapter failed: ${e.message}`);
         // Don't leave a marker WE created if the switch never landed; a
         // pre-existing marker stays — it still describes the user's choice.
         if (!hadMarker) clearPreAdapterProvider();
+        return await readAiProvider();
       }
-      return await readAiProvider();
+      const settled = await readAiProvider();
+      if (orgSessionGeneration === genAtRead && settled === 'adapter') {
+        lastConsistentCheck = { generation: orgSessionGeneration, at: Date.now() };
+      }
+      return settled;
     }
     if (!exists && current === 'adapter') {
+      if (orgSessionGeneration !== genAtRead) return null;
       sendDebugLog('Org lock: ai_provider=adapter but no org session backing it; restoring pre-adapter provider');
-      await restorePreAdapterProvider();
+      // Direct call, not the queued wrapper — we already hold the queue.
+      await doRestorePreAdapterProvider();
       return await readAiProvider();
     }
+    if (orgSessionGeneration === genAtRead) {
+      lastConsistentCheck = { generation: orgSessionGeneration, at: Date.now() };
+    }
     return current;
-  })().finally(() => {
-    aiProviderReconcileInFlight = null;
   });
-  return aiProviderReconcileInFlight;
 }
 
 // Wired into the org sign-in flows (password + Google SSO). Kept as a named
@@ -5832,7 +5879,15 @@ async function autoSwitchToAdapterOnSignIn() {
 // On sign-out (or stale-session clear), restore the pre-adapter provider
 // if we still have it. Falls back to 'local' if the marker is missing
 // (e.g. user manually switched to adapter without coming via auto-switch).
-async function restorePreAdapterProvider() {
+// Serialized on the same queue as the reconcile so the two state machines
+// can't interleave; doRestorePreAdapterProvider is the unqueued body, used
+// by the reconcile when it already holds the queue.
+function restorePreAdapterProvider() {
+  return enqueueProviderStateOp(doRestorePreAdapterProvider);
+}
+
+async function doRestorePreAdapterProvider() {
+  lastConsistentCheck = { generation: -1, at: 0 }; // state is changing
   const current = await readAiProvider();
   if (current !== 'adapter') {
     clearPreAdapterProvider(); // tidy: if not on adapter, the marker is stale
@@ -5886,12 +5941,18 @@ ipcMain.handle('set-ai-provider', async (event, provider) => {
     sendDebugLog(`Setting AI provider to: ${provider}`);
     if (provider !== 'adapter') {
       // Hard lock: while a valid org session exists the provider is
-      // managed by the organisation. Reject the change (the Settings
-      // picker is disabled too — this is defense in depth for CLI/IPC
-      // paths) and leave the restore marker untouched.
-      const session = loadOrgSession();
-      if (session && session.adapterUrl && session.token && !isJwtExpired(session.token)) {
-        sendDebugLog(`Org lock: rejecting set-ai-provider ${provider} while org session is active`);
+      // managed by the organisation. The Settings picker is disabled too —
+      // this backstops any other IPC caller and future UI paths, and it
+      // leaves the restore marker untouched. Fail closed on a decrypt
+      // failure (locked keychain): the user IS signed in, the session is
+      // just transiently unreadable, and letting the switch through would
+      // have the next reconcile fight them.
+      const { session, decryptFailed } = loadOrgSessionEx();
+      const sessionValid = Boolean(
+        session && session.adapterUrl && session.token && !isJwtExpired(session.token)
+      );
+      if (sessionValid || decryptFailed) {
+        sendDebugLog(`Org lock: rejecting set-ai-provider ${provider} (${decryptFailed ? 'session unreadable' : 'org session active'})`);
         return {
           success: false,
           managedByOrg: true,
@@ -7651,6 +7712,7 @@ function saveOrgSession(session) {
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     const encrypted = safeStorage.encryptString(JSON.stringify(session));
     fs.writeFileSync(getOrgSessionPath(), encrypted);
+    orgSessionGeneration++;
     return true;
   } catch (e) {
     console.error('Failed to save org session:', e.message);
@@ -7691,6 +7753,7 @@ function clearOrgSession() {
   try {
     const p = getOrgSessionPath();
     if (fs.existsSync(p)) fs.unlinkSync(p);
+    orgSessionGeneration++;
     return true;
   } catch (e) {
     return false;
@@ -7861,7 +7924,15 @@ ipcMain.handle('org-status', async () => {
   const knownBefore = hasOrgEverBeenSignedIn();
   if (session && !knownBefore) markOrgKnown();
   const everSignedIn = knownBefore || Boolean(session);
-  if (!session) return { signedIn: false, everSignedIn };
+  if (!session) {
+    // The session file may have vanished without a sign-out/expiry trigger
+    // (crashed mid-sign-out, manual delete) while Python still says
+    // 'adapter' — heal that here too, not just in get-ai-provider. The
+    // reconcile no-ops on decrypt failures, so a locked keychain landing
+    // in this branch changes nothing.
+    reconcileAiProviderWithOrgSession().catch(() => {});
+    return { signedIn: false, everSignedIn };
+  }
   // Previously this returned signedIn:true as long as the session file
   // existed, even if the JWT had long since expired. The renderer would
   // happily show a "signed in" sticker until the user actually triggered
@@ -7876,9 +7947,9 @@ ipcMain.handle('org-status', async () => {
     return { signedIn: false, everSignedIn };
   }
   // Hard lock: heal any provider drift while the session is valid.
-  // Fire-and-forget — this handler is hot (sidebar polls it) and must
-  // not block on a Python subprocess; the reconcile is coalesced so
-  // repeated calls share one run.
+  // Fire-and-forget — this handler is hot (the sidebar refetches it on
+  // focus/mount) and must not block on a Python subprocess; the memoed
+  // fast path makes repeated consistent checks free.
   reconcileAiProviderWithOrgSession().catch(() => {});
   return {
     signedIn: true,

--- a/app/renderer/src/hooks/useOrg.ts
+++ b/app/renderer/src/hooks/useOrg.ts
@@ -47,6 +47,11 @@ export function useOrgSession() {
     const delay = Math.max(0, Math.min(exp * 1000 - Date.now(), MAX_TIMEOUT));
     const id = setTimeout(() => {
       qc.invalidateQueries({ queryKey: orgKeys.status() });
+      // The expiry-triggered org-status call also restores the Python-side
+      // ai_provider, so the provider query must refetch too — otherwise
+      // Settings > AI keeps showing "Organisation" while disk says the
+      // restored provider.
+      qc.invalidateQueries({ queryKey: aiKeys.all });
     }, delay);
     return () => clearTimeout(id);
   }, [exp, qc]);

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -910,12 +910,16 @@ function AiTab() {
     <section data-settings-tab="ai">
       <SettingRow
         label="AI provider"
-        description="Where models run. Local keeps all data on your device."
+        description={
+          orgSignedIn
+            ? "Managed by your organisation while you're signed in. Sign out under Settings > Organisation to change it."
+            : 'Where models run. Local keeps all data on your device.'
+        }
       >
         <Select
           value={current}
           onValueChange={(v) => setProvider.mutate(v as AiProvider)}
-          disabled={!provider.data}
+          disabled={!provider.data || orgSignedIn}
         >
           <SelectTrigger className={cn(COMPACT_TRIGGER, 'min-w-[180px]')}>
             <SelectValue />

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -962,7 +962,11 @@ function AiTab() {
       {current === 'cloud' && <CloudProviderConfig />}
       {current === 'adapter' && <AdapterProviderInfo signedIn={orgSignedIn} />}
 
-      {current !== 'cloud' && current !== 'adapter' && (
+      {/* orgSignedIn check: while locked, the provider is (or is about to
+          be reconciled to) 'adapter' — never show a local model list under
+          the "Managed by your organisation" copy, even if the cached
+          provider value is momentarily stale. */}
+      {current !== 'cloud' && current !== 'adapter' && !orgSignedIn && (
         <>
           <SectionHeading>Model</SectionHeading>
           <ModelList />

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3381,7 +3381,10 @@ def list_models():
         result = {
             "current_model": current_model,
             "supported_models": models,
-            "provider": "local"
+            # The actual configured provider ('local', 'cloud', 'adapter').
+            # This used to be hardcoded "local", which made debug logs claim
+            # a local provider while summaries went through the org adapter.
+            "provider": provider
         }
 
     print(json.dumps(result, indent=2))

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -19,10 +19,8 @@ import click
 import asyncio
 import logging
 import json
-import os
 import re
 import sys
-import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
@@ -72,45 +70,12 @@ _AUTO_NAMED_PATTERN = re.compile(
     r'|.+ — \d{4}-\d{2}-\d{2} \d{2}:\d{2})$'
 )
 
-def _atomic_write_json(path: Path, payload) -> None:
-    """Write `payload` as JSON to `path` atomically.
-
-    Uses tempfile + os.replace within the same directory so the rename
-    is a single filesystem operation. On POSIX and Windows, os.replace
-    is atomic — a crash mid-write leaves the prior file intact (or
-    nothing, on first write) rather than a half-written file that
-    subsequent reads would misparse.
-
-    Used for `recorder_state.json` (where a corrupt file means we lose
-    track of a live recording) and the final summary JSON (where a
-    corrupt file means a finished meeting's processing is lost).
-    """
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # NamedTemporaryFile in the same dir guarantees os.replace stays on
-    # one filesystem. delete=False so we can rename rather than auto-clean.
-    tmp = tempfile.NamedTemporaryFile(
-        mode='w',
-        dir=str(path.parent),
-        prefix=f'.{path.name}.',
-        suffix='.tmp',
-        delete=False,
-        encoding='utf-8',
-    )
-    try:
-        with tmp as f:
-            json.dump(payload, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp.name, path)
-    except Exception:
-        # Best-effort cleanup of the orphan temp file. Don't mask the
-        # original error.
-        try:
-            os.unlink(tmp.name)
-        except OSError:
-            pass
-        raise
+# Shared atomic JSON writer (tempfile + os.replace + Windows PermissionError
+# retry). One implementation for recorder_state.json, the summary JSON, and
+# config.json — re-exported here so existing imports keep working. The
+# canonical copy lives in src.config because this module already imports
+# from src (the reverse import would be circular).
+from src.config import _atomic_write_json  # noqa: E402
 
 
 def _start_summary_heartbeat(label: str = "summarize", interval_s: int = 60, max_beats: int = 30):

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,10 @@ Handles storing and loading user preferences like model selection.
 import json
 import logging
 import os
+import shutil
 import sys
+import tempfile
+import time
 import uuid
 from pathlib import Path
 from typing import Optional, Dict, Any
@@ -15,6 +18,55 @@ from typing import Optional, Dict, Any
 from src.whisper_models import SUPPORTED_WHISPER_MODELS as _WHISPER_REGISTRY
 
 logger = logging.getLogger(__name__)
+
+
+def _atomic_write_json(path: Path, payload) -> None:
+    """Write `payload` as JSON to `path` atomically.
+
+    Same tempfile + os.replace pattern as recorder_state.json (see
+    simple_recorder._atomic_write_json — duplicated here because
+    simple_recorder imports this module, not the other way around).
+    config.json is read by many concurrent CLI subprocesses; a plain
+    truncate-and-rewrite lets a reader see a torn file, fall back to
+    defaults, and (pre-fix) persist those defaults over the user's
+    real settings.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(
+        mode='w',
+        dir=str(path.parent),
+        prefix=f'.{path.name}.',
+        suffix='.tmp',
+        delete=False,
+        encoding='utf-8',
+    )
+    try:
+        json.dump(payload, tmp, indent=2)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        # Windows can transiently refuse the replace while another
+        # process holds the destination open for read; a couple of
+        # short retries cover that without a platform gate.
+        for attempt in range(3):
+            try:
+                os.replace(tmp.name, path)
+                return
+            except PermissionError:
+                if attempt == 2:
+                    raise
+                time.sleep(0.05)
+    except Exception:
+        try:
+            tmp.close()
+        except Exception:
+            pass
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
 
 
 def get_user_data_dir() -> Path:
@@ -196,6 +248,10 @@ class Config:
         # "fresh install" from "loaded existing file" by inspecting self._config
         # alone (whisper_model and friends are in the defaults dict).
         self._existed_at_load = self.config_path.exists()
+        # Set by _load() when an existing config file could not be parsed.
+        # Migrations check it so a corrupt (or torn, mid-write) read never
+        # gets its in-memory defaults persisted over the recoverable file.
+        self._load_failed = False
         self._config: Dict[str, Any] = self._load()
         self._migrate_cloud_model_map()
         self._migrate_whisper_model()
@@ -210,6 +266,8 @@ class Config:
         Asian-language workflows aren't silently swapped under them; the
         Settings → Transcribe tab is how they opt into Parakeet.
         """
+        if self._load_failed:
+            return  # never persist defaults over a corrupt-but-recoverable file
         if self._config.get("transcription_engine") in self.VALID_TRANSCRIPTION_ENGINES:
             return
         self._config["transcription_engine"] = (
@@ -225,6 +283,8 @@ class Config:
         - Any other previously-supported but now-retired tier
           (tiny/base/medium/large-v3) → 'small' (the safe default).
         """
+        if self._load_failed:
+            return  # never persist defaults over a corrupt-but-recoverable file
         current = self._config.get("whisper_model")
         if current is None or current in self.SUPPORTED_WHISPER_MODELS:
             return
@@ -239,14 +299,18 @@ class Config:
         'cloud_models' map. Runs at load time (before any setters can change
         the provider) so the legacy value is correctly attributed to whichever
         provider was active when it was last saved."""
+        if self._load_failed:
+            # _load() returned defaults for a corrupt-but-present file. The
+            # defaults carry a legacy 'cloud_model', so without this guard the
+            # migration below would _save() and overwrite the recoverable file.
+            self._config["cloud_models"] = {}
+            return
         if isinstance(self._config.get("cloud_models"), dict):
             return  # Already migrated.
         legacy = self._config.get("cloud_model")
         has_legacy_value = isinstance(legacy, str) and legacy.strip()
         if not has_legacy_value:
-            # Nothing to migrate. Don't write — if _load() returned defaults
-            # because the existing file was corrupt/unreadable, persisting an
-            # empty cloud_models map would overwrite the recoverable file.
+            # Nothing to migrate; don't write just to persist an empty map.
             self._config["cloud_models"] = {}
             return
         current_provider = self._config.get("cloud_provider", "openai")
@@ -256,25 +320,49 @@ class Config:
         self._save()
 
     def _load(self) -> Dict[str, Any]:
-        """Load configuration from file."""
+        """Load configuration from file.
+
+        A parse failure on an existing file is retried once (a torn read
+        racing a writer heals in milliseconds). If it still fails, the
+        corrupt file is backed up to config.json.corrupt and we run on
+        in-memory defaults with self._load_failed set — migrations skip
+        writing so the original on disk stays recoverable.
+        """
         if not self.config_path.exists():
             logger.info(f"Config file not found, creating default at {self.config_path}")
             return self._get_default_config()
 
+        last_error = None
+        for attempt in range(2):
+            try:
+                with open(self.config_path, 'r') as f:
+                    config = json.load(f)
+                    logger.info(f"Loaded config from {self.config_path}")
+                    return config
+            except Exception as e:
+                last_error = e
+                if attempt == 0:
+                    time.sleep(0.2)
+
+        self._load_failed = True
+        backup_path = self.config_path.with_name(self.config_path.name + ".corrupt")
         try:
-            with open(self.config_path, 'r') as f:
-                config = json.load(f)
-                logger.info(f"Loaded config from {self.config_path}")
-                return config
-        except Exception as e:
-            logger.error(f"Error loading config: {e}, using defaults")
-            return self._get_default_config()
+            shutil.copy2(self.config_path, backup_path)
+            logger.error(
+                f"Error loading config: {last_error}. Using defaults in memory; "
+                f"corrupt file backed up to {backup_path}"
+            )
+        except Exception as backup_error:
+            logger.error(
+                f"Error loading config: {last_error}. Using defaults in memory; "
+                f"backup to {backup_path} also failed: {backup_error}"
+            )
+        return self._get_default_config()
 
     def _save(self) -> bool:
-        """Save configuration to file."""
+        """Save configuration to file (atomic tempfile + os.replace)."""
         try:
-            with open(self.config_path, 'w') as f:
-                json.dump(self._config, f, indent=2)
+            _atomic_write_json(self.config_path, self._config)
             logger.info(f"Saved config to {self.config_path}")
             return True
         except Exception as e:

--- a/src/config.py
+++ b/src/config.py
@@ -23,13 +23,14 @@ logger = logging.getLogger(__name__)
 def _atomic_write_json(path: Path, payload) -> None:
     """Write `payload` as JSON to `path` atomically.
 
-    Same tempfile + os.replace pattern as recorder_state.json (see
-    simple_recorder._atomic_write_json — duplicated here because
-    simple_recorder imports this module, not the other way around).
-    config.json is read by many concurrent CLI subprocesses; a plain
-    truncate-and-rewrite lets a reader see a torn file, fall back to
-    defaults, and (pre-fix) persist those defaults over the user's
-    real settings.
+    Same tempfile + os.replace pattern as simple_recorder._atomic_write_json
+    (recorder_state.json / summary JSON). Kept as a separate copy for now to
+    avoid churn in the recorder-state write path; consolidating both into a
+    shared src helper (and giving recorder_state the PermissionError retry
+    below) is a tracked follow-up. config.json is read by many concurrent
+    CLI subprocesses; a plain truncate-and-rewrite lets a reader see a torn
+    file, fall back to defaults, and (pre-fix) persist those defaults over
+    the user's real settings.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -337,6 +338,10 @@ class Config:
             try:
                 with open(self.config_path, 'r') as f:
                     config = json.load(f)
+                    if not isinstance(config, dict):
+                        # `null` / `[]` parse fine but crash every get/set
+                        # later; route them through the corrupt-file path.
+                        raise ValueError("config.json root is not an object")
                     logger.info(f"Loaded config from {self.config_path}")
                     return config
             except Exception as e:

--- a/src/config.py
+++ b/src/config.py
@@ -23,14 +23,15 @@ logger = logging.getLogger(__name__)
 def _atomic_write_json(path: Path, payload) -> None:
     """Write `payload` as JSON to `path` atomically.
 
-    Same tempfile + os.replace pattern as simple_recorder._atomic_write_json
-    (recorder_state.json / summary JSON). Kept as a separate copy for now to
-    avoid churn in the recorder-state write path; consolidating both into a
-    shared src helper (and giving recorder_state the PermissionError retry
-    below) is a tracked follow-up. config.json is read by many concurrent
-    CLI subprocesses; a plain truncate-and-rewrite lets a reader see a torn
-    file, fall back to defaults, and (pre-fix) persist those defaults over
-    the user's real settings.
+    The shared atomic writer for every JSON file the CLI persists —
+    config.json here, recorder_state.json and the final summary JSON via
+    the re-export in simple_recorder. tempfile + os.replace in the same
+    directory keeps the rename a single filesystem operation on POSIX and
+    Windows, so a crash mid-write leaves the prior file intact rather
+    than a half-written one. config.json in particular is read by many
+    concurrent CLI subprocesses; a plain truncate-and-rewrite lets a
+    reader see a torn file, fall back to defaults, and (pre-fix) persist
+    those defaults over the user's real settings.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -70,6 +70,21 @@ class CorruptConfigTests(unittest.TestCase):
             # In-memory we run on defaults.
             self.assertEqual(config.get_ai_provider(), "local")
 
+    def test_non_dict_json_takes_corrupt_path(self):
+        # `null` and `[]` parse as valid JSON but would crash every config
+        # accessor — they must route through the corrupt-file recovery too.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text("null")
+
+            with patch("src.config.time.sleep"):
+                config = Config(config_path=path)
+
+            self.assertTrue(config._load_failed)
+            self.assertEqual(path.read_text(), "null")
+            self.assertTrue((Path(tmp_dir) / "config.json.corrupt").exists())
+            self.assertEqual(config.get_ai_provider(), "local")
+
     def test_torn_read_retry_heals(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / "config.json"

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -1,0 +1,124 @@
+"""Persistence safety for config.json.
+
+config.json is read and written by many concurrent short-lived CLI
+subprocesses. These tests pin down the two guarantees that prevent a
+settings wipe (the "org user silently reset to local llama" bug):
+
+1. _save() is atomic — a reader never sees a torn file, and a failed
+   save leaves the previous file intact.
+2. A corrupt (or torn) existing file is never overwritten by the
+   load-time migrations persisting in-memory defaults.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.config import Config
+
+
+class AtomicSaveTests(unittest.TestCase):
+    def test_save_leaves_valid_json_and_no_tmp_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertTrue(config.set_ai_provider("cloud"))
+
+            on_disk = json.loads(path.read_text())
+            self.assertEqual(on_disk["ai_provider"], "cloud")
+            leftovers = [p for p in Path(tmp_dir).iterdir() if p.suffix == ".tmp"]
+            self.assertEqual(leftovers, [])
+
+    def test_failed_save_preserves_previous_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertTrue(config.set_ai_provider("cloud"))
+            before = path.read_text()
+
+            with patch("src.config.json.dump", side_effect=OSError("disk full")):
+                success = config.set_ai_provider("remote")
+
+            self.assertFalse(success)
+            # On-disk file is the previous, fully-valid version — not torn.
+            self.assertEqual(path.read_text(), before)
+            self.assertEqual(json.loads(before)["ai_provider"], "cloud")
+
+
+class CorruptConfigTests(unittest.TestCase):
+    def _write_corrupt(self, tmp_dir: str) -> Path:
+        path = Path(tmp_dir) / "config.json"
+        path.write_text('{"ai_provider": "adapter", "model": "llam')  # torn write
+        return path
+
+    def test_corrupt_config_is_not_overwritten_by_migrations(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = self._write_corrupt(tmp_dir)
+            corrupt_bytes = path.read_bytes()
+
+            with patch("src.config.time.sleep"):
+                config = Config(config_path=path)
+
+            self.assertTrue(config._load_failed)
+            # The recoverable original is untouched and backed up.
+            self.assertEqual(path.read_bytes(), corrupt_bytes)
+            backup = Path(tmp_dir) / "config.json.corrupt"
+            self.assertTrue(backup.exists())
+            self.assertEqual(backup.read_bytes(), corrupt_bytes)
+            # In-memory we run on defaults.
+            self.assertEqual(config.get_ai_provider(), "local")
+
+    def test_torn_read_retry_heals(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"ai_provider": "adapter", "cloud_models": {}}))
+
+            real_load = json.load
+            calls = {"n": 0}
+
+            def flaky_load(f):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise json.JSONDecodeError("torn", "", 0)
+                return real_load(f)
+
+            with patch("src.config.json.load", side_effect=flaky_load), \
+                    patch("src.config.time.sleep"):
+                config = Config(config_path=path)
+
+            self.assertFalse(config._load_failed)
+            self.assertEqual(config.get_ai_provider(), "adapter")
+
+    def test_set_after_corrupt_load_writes_valid_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = self._write_corrupt(tmp_dir)
+            with patch("src.config.time.sleep"):
+                config = Config(config_path=path)
+
+            self.assertTrue(config.set_ai_provider("cloud"))
+            on_disk = json.loads(path.read_text())
+            self.assertEqual(on_disk["ai_provider"], "cloud")
+            # The pre-wipe original stays available for recovery.
+            self.assertTrue((Path(tmp_dir) / "config.json.corrupt").exists())
+
+
+class MigrationStillRunsOnHealthyLoadTests(unittest.TestCase):
+    def test_legacy_cloud_model_still_migrates(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({
+                "cloud_model": "gpt-4o-mini",
+                "cloud_provider": "openai",
+            }))
+
+            config = Config(config_path=path)
+
+            self.assertEqual(config._config["cloud_models"], {"openai": "gpt-4o-mini"})
+            on_disk = json.loads(path.read_text())
+            self.assertEqual(on_disk["cloud_models"], {"openai": "gpt-4o-mini"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the enterprise bug where a signed-in org user's summaries silently ran on local llama3.2:3b: the config could be wiped to defaults by a torn read, a locked keychain downgraded the provider, and nothing ever repaired the drift. The provider is now hard-locked to the org adapter while a session is valid.

### 1. Config wipe root cause (the actual bug)
`ConfigManager._save()` truncate-rewrote `config.json` non-atomically while concurrent CLI subprocesses read it. A reader hitting a torn file fell back to defaults, and `_migrate_cloud_model_map()` then **persisted those defaults** (the defaults dict carries a legacy `cloud_model`) — wiping `ai_provider` to `local` while the org session stayed alive. Now: atomic writes (tempfile + `os.replace`, Windows `PermissionError` retry), one retried read for torn files, corrupt files backed up to `config.json.corrupt`, and a `_load_failed` flag that stops every load-time migration from writing over a recoverable file. Non-dict JSON (`null`/`[]`) routes through the same recovery. 7 new tests.

### 2. Hard lock: ai_provider == adapter while signed in
`reconcileAiProviderWithOrgSession()` in main.js repairs both directions: valid session + drifted provider → relock to adapter (seeding the restore marker only when none exists, so a wiped-to-default `local` can't clobber a user's real pre-sign-in choice); provider says adapter + session file genuinely gone → the old stale-adapter restore. All provider-state mutations (reconcile, sign-out restore, the `set-ai-provider` IPC write) run through one serialized queue with a session-generation guard, and a 30s consistency memo keeps hot paths (org-status focus refetches) free of subprocess spawns. Hooked into get-ai-provider (awaited, response patched from disk truth), org-status (both branches), startup, and both sign-in flows. `set-ai-provider` rejects non-adapter values while locked.

### 3. Keychain decrypt failures are transient, not sign-outs
`loadOrgSessionEx()` distinguishes a missing session file from an undecryptable one (locked keychain right after wake/login). Decrypt failures no longer trigger the stale-adapter downgrade — the second silent path to local — and the `set-ai-provider` gate fails closed on them.

### 4. UX + smaller fixes
- Settings > AI: picker disabled while signed in with "Managed by your organisation while you're signed in. Sign out under Settings > Organisation to change it."; Model list hidden while locked; JWT-expiry timer also refreshes the provider query.
- `list-models` reports the actual provider (was hardcoded `"local"` — it misled the debugging of this very bug).
- Org session/marker paths resolve via `getUserDataDir()` (byte-identical on macOS; fixes a bogus `~/Library` tree on Windows).

### Review & verification
- Three-reviewer loop (QA/Product/Eng), clean confirming pass at critical/high in 2 iterations; residual mediums (set-ai-provider queue bypass, memo re-check, restore marker kept on failed write) fixed after. Gates: 144 Python tests, ruff clean on changed files, `node --check`, renderer typecheck.
- Runtime-verified with the rebuilt PyInstaller bundle + dev Electron against a localhost mock adapter: corrupt/`null` config preserved on disk with `.corrupt` backup and clean setter recovery; GUI sign-in → picker locks; `set-ai-provider local` from a terminal while signed in → snaps back to adapter on the next Settings open; IPC switch while locked rejected with `managedByOrg`; sign-out restores the prior provider, end-state config byte-identical to pre-test.

### Known gaps
- External drift is healed on the next `get-ai-provider` fetch even inside the 30s consistency-memo window (the handler cross-checks its fresh disk read against the session file); a summary triggered before any such fetch could still use the drifted provider once.
- During a locked-keychain window the sidebar shows signed-out and the picker enables (org-status collapses decrypt-failure to `signedIn:false`); switches are still rejected, so no drift — a `keychainLocked` flag in org-status is a follow-up.
- Windows-alpha org sessions under the old hardcoded path are orphaned by fix 4 (silent one-time sign-out).
- Pre-existing: Settings deep-links (`?tab=`) only apply on mount; `npm run test:e2e` references a missing `e2e/` dir; renderer eslint config broken with eslint 9.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the enterprise bug where signed-in org users were silently downgraded to local by making config writes safe and hard-locking the provider to the org adapter while a session is valid. Also fixes the decrypt-failure grace window so it actually expires, avoiding permanent lockouts.

- **Bug Fixes**
  - Atomic `config.json` writes via a shared helper (tempfile + `os.replace` with Windows retry); also used by recorder state and summary JSON. Failed saves leave the previous file intact.
  - One retry on torn reads; corrupt files backed up to `config.json.corrupt`; non-dict JSON (`null`/`[]`) handled.
  - Load-time migrations skip writes after a failed load so defaults never overwrite a recoverable file.
  - Keychain decrypt failures no longer trigger stale-adapter downgrades; the lock gate fails closed only within a 10‑minute grace window, and the window now expires correctly (permanent unreadable sessions no longer block changes).
  - `list-models` returns the actual provider; org session/marker paths resolve via `getUserDataDir()`; `set-ai-provider` handles CLI `success:false` and keeps the restore marker if a restore doesn’t land.

- **New Features**
  - Hard lock: while a valid org session exists, `ai_provider` is forced to `adapter`; drift auto-heals.
  - Reconcile runs on startup, `get-ai-provider`, `org-status`, and both sign-in flows; `get-ai-provider` passes its fresh read to catch drift even inside the 30s memo window.
  - Provider-state mutations (reconcile, sign-out restore, manual set) are serialized; a session-generation guard prevents races.
  - `set-ai-provider` rejects non-adapter values while locked (fails closed within the grace window).
  - Settings > AI: picker disabled with clear copy; model list hidden while locked; provider query refetches on JWT expiry.

<sup>Written for commit c1edc97e3626026f5f598fe44a74ec760aa5e040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

