### PR TITLE
test(e2e): PR2 — transcription-pipeline T2 smoke (HEARTBEAT + summary)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -176,6 +176,11 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Uses whisper.cpp (CPU), NOT parakeet-mlx: GitHub-hosted macOS runners are
+  # headless VMs with no Metal GPU, so MLX can't load there ("Failed to load the
+  # default metallib"). The plumbing + HEARTBEAT smoke is engine-agnostic, so
+  # whisper exercises the same process-streaming path. Parakeet is covered on
+  # real Macs locally / via /verify (and a future Metal-capable nightly runner).
   t2-pipeline-macos:
     name: T2 pipeline (transcribe + summarize)
     runs-on: macos-latest
@@ -206,14 +211,14 @@ jobs:
       - name: Ensure no stray Ollama
         run: pkill -f ollama || true
 
-      # Cache the Parakeet weights (~572 MB) so only the first run pays the
-      # download; later runs restore in ~30 s. Keyed on the model id so a model
-      # bump busts the cache. The model is NOT bundled — it downloads on use.
-      - name: Cache Parakeet model
+      # Cache the whisper ggml weights (~466 MB for 'small') so only the first
+      # run pays the download; later runs restore in ~30 s. The model is NOT
+      # bundled — it downloads on use into pywhispercpp's models dir.
+      - name: Cache whisper model
         uses: actions/cache@v4
         with:
-          path: ~/.cache/huggingface
-          key: hf-parakeet-mlx-community-parakeet-tdt-0.6b-v3
+          path: ~/Library/Application Support/pywhispercpp/models
+          key: whisper-small-ggml
 
       - name: Install Electron dependencies
         working-directory: app
@@ -224,14 +229,15 @@ jobs:
         run: npm run build:renderer
 
       # Pre-download the model (no-op when the cache restored) so the test isn't
-      # racing a ~572 MB download inside its timeout. download-parakeet-model
-      # exits 0 even on failure (it prints {"success": false}), so verify the
-      # model is actually installed — otherwise the spec would silently skip
-      # green and we'd ship "passing" with zero pipeline coverage.
-      - name: Ensure Parakeet model present
+      # racing the download inside its timeout. pull-whisper-model exits 0 even
+      # on failure, so verify the model is actually installed — otherwise the
+      # spec would silently skip green and we'd ship "passing" with zero pipeline
+      # coverage.
+      - name: Ensure whisper model present
         run: |
-          ./dist/stenoai/stenoai download-parakeet-model
-          ./dist/stenoai/stenoai parakeet-status | grep -q '"installed": true'
+          ./dist/stenoai/stenoai pull-whisper-model small
+          ./dist/stenoai/stenoai list-whisper-models \
+            | python3 -c "import sys,json; sys.exit(0 if json.load(sys.stdin)['supported_models']['small']['installed'] else 1)"
 
       # Playwright exits 0 when --grep matches no tests. Assert the tagged spec
       # is actually selected so a future rename / dropped @pipeline tag can't
@@ -240,8 +246,10 @@ jobs:
         working-directory: app
         run: npm run test:e2e -- --project=t2 --grep @pipeline --list | grep -q '@pipeline'
 
-      - name: Run T2 pipeline
+      - name: Run T2 pipeline (whisper)
         working-directory: app
+        env:
+          STENOAI_E2E_ENGINE: whisper
         run: npm run test:e2e -- --project=t2 --grep @pipeline
 
       - name: Upload report on failure

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,15 +158,85 @@ jobs:
         working-directory: app
         run: npm run build:renderer
 
-      - name: Run T2
+      # Exclude @pipeline — the transcription smoke needs the Parakeet model and
+      # runs in its own model-bearing job (t2-pipeline-macos) so this job stays
+      # fast and model-free.
+      - name: Run T2 (org-lock, model-free)
         working-directory: app
-        run: npm run test:e2e -- --project=t2
+        run: npm run test:e2e -- --project=t2 --grep-invert @pipeline
 
       - name: Upload report on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-t2-report
+          path: |
+            app/playwright-report
+            app/test-results
+          retention-days: 7
+          if-no-files-found: ignore
+
+  t2-pipeline-macos:
+    name: T2 pipeline (transcribe + summarize)
+    runs-on: macos-latest
+    needs: build-backend-macos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Download backend bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-backend-macos
+          path: dist/stenoai
+
+      - name: Restore exec bits on bundled binaries
+        run: |
+          find dist/stenoai -type f \( -name stenoai -o -name ffmpeg -o -name ollama \) \
+            -exec chmod +x {} +
+          test -x dist/stenoai/stenoai
+
+      - name: Ensure no stray Ollama
+        run: pkill -f ollama || true
+
+      # Cache the Parakeet weights (~572 MB) so only the first run pays the
+      # download; later runs restore in ~30 s. Keyed on the model id so a model
+      # bump busts the cache. The model is NOT bundled — it downloads on use.
+      - name: Cache Parakeet model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-parakeet-mlx-community-parakeet-tdt-0.6b-v3
+
+      - name: Install Electron dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build:renderer
+
+      # Pre-download the model (no-op when the cache restored) so the test isn't
+      # racing a ~572 MB download inside its timeout.
+      - name: Ensure Parakeet model present
+        run: ./dist/stenoai/stenoai download-parakeet-model
+
+      - name: Run T2 pipeline
+        working-directory: app
+        run: npm run test:e2e -- --project=t2 --grep @pipeline
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-t2-pipeline-report
           path: |
             app/playwright-report
             app/test-results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -224,9 +224,21 @@ jobs:
         run: npm run build:renderer
 
       # Pre-download the model (no-op when the cache restored) so the test isn't
-      # racing a ~572 MB download inside its timeout.
+      # racing a ~572 MB download inside its timeout. download-parakeet-model
+      # exits 0 even on failure (it prints {"success": false}), so verify the
+      # model is actually installed — otherwise the spec would silently skip
+      # green and we'd ship "passing" with zero pipeline coverage.
       - name: Ensure Parakeet model present
-        run: ./dist/stenoai/stenoai download-parakeet-model
+        run: |
+          ./dist/stenoai/stenoai download-parakeet-model
+          ./dist/stenoai/stenoai parakeet-status | grep -q '"installed": true'
+
+      # Playwright exits 0 when --grep matches no tests. Assert the tagged spec
+      # is actually selected so a future rename / dropped @pipeline tag can't
+      # silently run zero tests and pass (the keystone-test-vanishes failure).
+      - name: Guard — @pipeline test is selected
+        working-directory: app
+        run: npm run test:e2e -- --project=t2 --grep @pipeline --list | grep -q '@pipeline'
 
       - name: Run T2 pipeline
         working-directory: app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,13 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
   - **T2 — `*.t2.spec.ts`**: the real bundled backend + mock org adapter / Ollama
     (`e2e/fixtures/`). Proves end-to-end wiring.
   - **`@pipeline` (a T2 spec)**: the transcription→summarize smoke drives a synthetic
-    WAV through the real pipeline and asserts HEARTBEAT + a summary written. It needs the
-    **Parakeet model** (not bundled — downloads on first use), so it's tagged `@pipeline`
-    and split out: `--grep @pipeline` runs it (CI's `t2-pipeline-macos` job caches the
-    model), `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine
-    without the model **skips** it (loudly) rather than failing.
+    WAV through the real pipeline and asserts HEARTBEAT + a summary written. The engine is
+    env-selected (`STENOAI_E2E_ENGINE`): **parakeet** locally (the Mac-divergent path) but
+    **whisper** in CI — GitHub-hosted macOS runners have no Metal GPU, so parakeet-mlx can't
+    load there. Models aren't bundled (download on use), so it's tagged `@pipeline` and split
+    out: `--grep @pipeline` runs it (CI's `t2-pipeline-macos` job caches a whisper model),
+    `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
+    active engine's model **skips** it (loudly) rather than failing.
 - **Isolation keystone:** every test sets `STENOAI_USER_DATA_DIR` to a temp dir, which
   both `getUserDataDir()` (main.js) and `get_user_data_dir()` (`src/config.py`) honor,
   so a test can never read/write the real `~/Library/Application Support/stenoai`. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     stubs in `app/e2e-mock-ipc.js`). No Python/Ollama/network — fully hermetic.
   - **T2 — `*.t2.spec.ts`**: the real bundled backend + mock org adapter / Ollama
     (`e2e/fixtures/`). Proves end-to-end wiring.
+  - **`@pipeline` (a T2 spec)**: the transcription→summarize smoke drives a synthetic
+    WAV through the real pipeline and asserts HEARTBEAT + a summary written. It needs the
+    **Parakeet model** (not bundled — downloads on first use), so it's tagged `@pipeline`
+    and split out: `--grep @pipeline` runs it (CI's `t2-pipeline-macos` job caches the
+    model), `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine
+    without the model **skips** it (loudly) rather than failing.
 - **Isolation keystone:** every test sets `STENOAI_USER_DATA_DIR` to a temp dir, which
   both `getUserDataDir()` (main.js) and `get_user_data_dir()` (`src/config.py`) honor,
   so a test can never read/write the real `~/Library/Application Support/stenoai`. The

--- a/app/main.js
+++ b/app/main.js
@@ -611,7 +611,12 @@ function getAllowedBaseDirs() {
   const projectRoot = path.join(__dirname, '..');
   const dirs = [
     projectRoot,
-    path.join(os.homedir(), 'Library', 'Application Support', 'stenoai')
+    // getUserDataDir() rather than a macOS literal: cross-platform (the old
+    // hardcoded ~/Library path is wrong on Windows/Linux) and it honors
+    // STENOAI_USER_DATA_DIR. In production this resolves to the same per-OS
+    // data dir as before; under e2e it's the isolated temp dir, so a test can
+    // hand the app a WAV from its temp recordings folder.
+    getUserDataDir()
   ];
   if (_cachedCustomStoragePath) {
     dirs.push(_cachedCustomStoragePath);

--- a/e2e/fixtures/make-wav.js
+++ b/e2e/fixtures/make-wav.js
@@ -1,0 +1,46 @@
+// Generate a synthetic mono 16 kHz 16-bit PCM WAV with a real RIFF header (not
+// null bytes — mirrors the on-the-fly idea from tests/test_audio_preprocess.py
+// but produces a file the transcriber actually decodes). A low sine tone is
+// enough: Parakeet returns an empty transcript on non-speech, which is exactly
+// what the plumbing + HEARTBEAT smoke wants — the pipeline still runs end to
+// end and emits HEARTBEAT. Stays well above the transcriber's 1 KB stub floor
+// (5 s ≈ 160 KB). No checked-in binary fixtures.
+const fs = require('fs');
+
+function makeWav(
+  filePath,
+  { seconds = 5, sampleRate = 16000, freq = 220, amplitude = 0.05 } = {},
+) {
+  const numSamples = Math.floor(seconds * sampleRate);
+  const dataBytes = numSamples * 2; // 16-bit mono
+  const buf = Buffer.alloc(44 + dataBytes);
+
+  // RIFF/WAVE header
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(36 + dataBytes, 4);
+  buf.write('WAVE', 8);
+  // fmt chunk
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16); // PCM fmt chunk size
+  buf.writeUInt16LE(1, 20); // audio format = PCM
+  buf.writeUInt16LE(1, 22); // channels = 1
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28); // byte rate (sampleRate * blockAlign)
+  buf.writeUInt16LE(2, 32); // block align (channels * bytesPerSample)
+  buf.writeUInt16LE(16, 34); // bits per sample
+  // data chunk
+  buf.write('data', 36);
+  buf.writeUInt32LE(dataBytes, 40);
+
+  for (let i = 0; i < numSamples; i++) {
+    const sample = Math.round(
+      amplitude * 32767 * Math.sin((2 * Math.PI * freq * i) / sampleRate),
+    );
+    buf.writeInt16LE(sample, 44 + i * 2);
+  }
+
+  fs.writeFileSync(filePath, buf);
+  return filePath;
+}
+
+module.exports = { makeWav };

--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -20,9 +20,32 @@ const OLLAMA_PORT = 11434;
 function startMockOllama() {
   return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
+      // /api/tags — the summarizer's _ensure_model_available() reads each
+      // entry's `model` field (ollama-python maps it there, not `name`); if the
+      // configured model isn't found it tries to PULL it, so we must list it
+      // under `model` or the pull path 404s and crashes summarisation.
       if (req.method === 'GET' && req.url === '/api/tags') {
         res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(JSON.stringify({ models: [{ name: 'llama3.2:3b' }] }));
+        res.end(
+          JSON.stringify({
+            models: [
+              {
+                name: 'llama3.2:3b',
+                model: 'llama3.2:3b',
+                modified_at: '2024-01-01T00:00:00Z',
+                size: 2019393189,
+                digest: 'mock',
+              },
+            ],
+          }),
+        );
+        return;
+      }
+      // /api/pull — defensive: if the model is ever considered missing, answer
+      // a success stream rather than 404 so summarisation doesn't crash.
+      if (req.method === 'POST' && req.url === '/api/pull') {
+        res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+        res.end(JSON.stringify({ status: 'success' }) + '\n');
         return;
       }
       if (req.method === 'POST' && req.url === '/api/chat') {

--- a/e2e/fixtures/real-user-data.ts
+++ b/e2e/fixtures/real-user-data.ts
@@ -1,0 +1,29 @@
+import { existsSync, statSync } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
+
+/**
+ * Mirror app/main.js getUserDataDir() / src/config.get_user_data_dir() for the
+ * PRODUCTION (no-override) location. Computed independently of the code under
+ * test on purpose: if a keystone bug broke getUserDataDir(), sharing the prod
+ * helper would make both the app and the assertion wrong in the same direction
+ * and the "real dir untouched" check would pass falsely.
+ */
+export function realUserDataDir(): string {
+  if (process.platform === 'darwin') {
+    return path.join(homedir(), 'Library', 'Application Support', 'stenoai');
+  }
+  if (process.platform === 'win32') {
+    const base = process.env.APPDATA || path.join(homedir(), 'AppData', 'Roaming');
+    return path.join(base, 'stenoai');
+  }
+  const base = process.env.XDG_DATA_HOME || path.join(homedir(), '.local', 'share');
+  return path.join(base, 'stenoai');
+}
+
+/** Stat signature (exists + mtime + size) so a test can prove a path was untouched. */
+export function fileSig(p: string): string {
+  if (!existsSync(p)) return 'absent';
+  const s = statSync(p);
+  return `${s.mtimeMs}:${s.size}`;
+}

--- a/e2e/specs/org-lock-lifecycle.t2.spec.ts
+++ b/e2e/specs/org-lock-lifecycle.t2.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { startMockAdapter } from '../fixtures/mock-adapter';
-import { existsSync, readFileSync, statSync } from 'fs';
-import { homedir } from 'os';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 
 /**
@@ -12,28 +12,6 @@ import path from 'path';
  * A test that fails to isolate but passes is worse than no test, so the real
  * dir is asserted byte-for-byte untouched.
  */
-
-// Mirror app/main.js getUserDataDir() / src/config.get_user_data_dir() for the
-// production (no-override) location, so we can assert it stays untouched.
-function realUserDataDir(): string {
-  if (process.platform === 'darwin') {
-    return path.join(homedir(), 'Library', 'Application Support', 'stenoai');
-  }
-  if (process.platform === 'win32') {
-    const base = process.env.APPDATA || path.join(homedir(), 'AppData', 'Roaming');
-    return path.join(base, 'stenoai');
-  }
-  const base = process.env.XDG_DATA_HOME || path.join(homedir(), '.local', 'share');
-  return path.join(base, 'stenoai');
-}
-
-// Stat signature (exists + mtime + size) so we can prove a file was untouched.
-function fileSig(p: string): string {
-  if (!existsSync(p)) return 'absent';
-  const s = statSync(p);
-  return `${s.mtimeMs}:${s.size}`;
-}
-
 test('real org sign-in persists session + config into the temp dir, real dir untouched', async ({
   launchApp,
   userDataDir,

--- a/e2e/specs/transcription-pipeline.t2.spec.ts
+++ b/e2e/specs/transcription-pipeline.t2.spec.ts
@@ -20,12 +20,25 @@ import { execSync } from 'child_process';
  * its own model-bearing job and keep the org-lock T2 model-free.
  */
 
+// Engine: parakeet locally (the Mac-divergent path), whisper in CI. GitHub-hosted
+// macOS runners have no Metal GPU, so parakeet-mlx can't load there — whisper.cpp
+// (CPU) exercises the same process-streaming plumbing + HEARTBEAT. Set via env so
+// the spec is unchanged either way.
+const ENGINE: 'parakeet' | 'whisper' =
+  process.env.STENOAI_E2E_ENGINE === 'whisper' ? 'whisper' : 'parakeet';
+const WHISPER_MODEL = 'small'; // smallest registered model (466 MB)
+
 // The preload surface the renderer sees (app/preload.js), narrowed to what this
 // spec drives. e2e/ lives outside renderer/, so window.stenoai isn't ambiently
 // typed here — declare just the slice we use rather than reaching for `any`.
 type StenoWindow = Window & {
   stenoai: {
     parakeetModels: { status: () => Promise<{ installed?: boolean }> };
+    whisperModels: {
+      list: () => Promise<{ supported_models?: Record<string, { installed?: boolean }> }>;
+      set: (name: string) => Promise<unknown>;
+    };
+    transcriptionEngine: { set: (engine: string) => Promise<unknown> };
     recording: { processSystemAudio: (p: string, name: string) => Promise<{ success?: boolean }> };
     on: { debugLog: (cb: (line: unknown) => void) => void };
   };
@@ -53,16 +66,36 @@ test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real 
   try {
     const { page } = await launchApp();
 
-    // Parakeet weights aren't bundled. Without them transcription can't run, and
-    // this is a pipeline smoke, not a model-download test — skip loudly rather
-    // than hang/fail. CI installs the model before this spec.
-    const status = await page.evaluate(() => (window as StenoWindow).stenoai.parakeetModels.status());
-    if (!status?.installed) {
-      // eslint-disable-next-line no-console
-      console.warn('[t2:@pipeline] SKIPPED: Parakeet model not installed on this runner.');
-      test.info().annotations.push({ type: 'skip-reason', description: 'Parakeet model not installed' });
+    // Select the engine in the per-test config (the backend reads it at process
+    // time). For whisper, also pin the small model so we don't need the larger
+    // default.
+    await page.evaluate((e) => (window as StenoWindow).stenoai.transcriptionEngine.set(e), ENGINE);
+    if (ENGINE === 'whisper') {
+      await page.evaluate((m) => (window as StenoWindow).stenoai.whisperModels.set(m), WHISPER_MODEL);
     }
-    test.skip(!status?.installed, 'Parakeet model not installed');
+
+    // Models aren't bundled — they download on use. Without the active engine's
+    // model transcription can't run, and this is a pipeline smoke, not a
+    // model-download test — skip loudly rather than hang/fail. CI installs the
+    // model before this spec.
+    const modelReady =
+      ENGINE === 'whisper'
+        ? await page.evaluate(
+            async (m) =>
+              !!(await (window as StenoWindow).stenoai.whisperModels.list())?.supported_models?.[m]
+                ?.installed,
+            WHISPER_MODEL,
+          )
+        : await page.evaluate(
+            async () =>
+              (await (window as StenoWindow).stenoai.parakeetModels.status())?.installed === true,
+          );
+    if (!modelReady) {
+      // eslint-disable-next-line no-console
+      console.warn(`[t2:@pipeline] SKIPPED: ${ENGINE} model not installed on this runner.`);
+      test.info().annotations.push({ type: 'skip-reason', description: `${ENGINE} model not installed` });
+    }
+    test.skip(!modelReady, `${ENGINE} model not installed`);
 
     // Write the WAV into the temp recordings dir — an allowed base dir now that
     // getAllowedBaseDirs() honors getUserDataDir().

--- a/e2e/specs/transcription-pipeline.t2.spec.ts
+++ b/e2e/specs/transcription-pipeline.t2.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { makeWav } from '../fixtures/make-wav';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { mkdirSync, existsSync } from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+/**
+ * T2 — real-backend transcription pipeline smoke (@pipeline). Drives a synthetic
+ * WAV through the app's streaming pipeline (process-streaming) and asserts it
+ * runs end to end: HEARTBEAT markers observed on the debug-log channel, a
+ * summary written into the temp dir, and the real user-data dir untouched.
+ *
+ * Plumbing + HEARTBEAT only — never asserts transcript text (a sine WAV is
+ * non-speech, so Parakeet returns an empty transcript; the pipeline still
+ * completes and writes the summary). This is the one genuinely Mac-divergent
+ * path (parakeet-mlx), so it needs the Parakeet model present — CI installs it
+ * (cached); a dev machine without it skips. Tagged @pipeline so CI can run it in
+ * its own model-bearing job and keep the org-lock T2 model-free.
+ */
+
+// The preload surface the renderer sees (app/preload.js), narrowed to what this
+// spec drives. e2e/ lives outside renderer/, so window.stenoai isn't ambiently
+// typed here — declare just the slice we use rather than reaching for `any`.
+type StenoWindow = Window & {
+  stenoai: {
+    parakeetModels: { status: () => Promise<{ installed?: boolean }> };
+    recording: { processSystemAudio: (p: string, name: string) => Promise<{ success?: boolean }> };
+    on: { debugLog: (cb: (line: unknown) => void) => void };
+  };
+  __hb?: string[];
+};
+
+test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // The pipeline (model load + transcribe + summarise) can outlast Playwright's
+  // 30 s default, especially on a cold CI runner — give it room above the
+  // file-poll timeout below.
+  test.setTimeout(180_000);
+
+  // Mock Ollama on the hardcoded 11434 so summarisation never reaches a real
+  // LLM. Kill any stray real Ollama first; the successful bind then proves the
+  // port is ours (plan risk 2). The app probes /api/tags and skips its own
+  // `ollama serve` on the mock's 200.
+  killOllama();
+  const ollama = await startMockOllama();
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  try {
+    const { page } = await launchApp();
+
+    // Parakeet weights aren't bundled. Without them transcription can't run, and
+    // this is a pipeline smoke, not a model-download test — skip loudly rather
+    // than hang/fail. CI installs the model before this spec.
+    const status = await page.evaluate(() => (window as StenoWindow).stenoai.parakeetModels.status());
+    if (!status?.installed) {
+      // eslint-disable-next-line no-console
+      console.warn('[t2:@pipeline] SKIPPED: Parakeet model not installed on this runner.');
+      test.info().annotations.push({ type: 'skip-reason', description: 'Parakeet model not installed' });
+    }
+    test.skip(!status?.installed, 'Parakeet model not installed');
+
+    // Write the WAV into the temp recordings dir — an allowed base dir now that
+    // getAllowedBaseDirs() honors getUserDataDir().
+    const recordingsDir = path.join(userDataDir, 'recordings');
+    mkdirSync(recordingsDir, { recursive: true });
+    const wavPath = path.join(recordingsDir, 'pipeline.wav');
+    makeWav(wavPath, { seconds: 5 });
+
+    // Collect HEARTBEAT lines forwarded to the renderer's debug-log channel.
+    // Subscribe BEFORE driving so the first (immediately-forwarded) beat is seen.
+    await page.evaluate(() => {
+      const w = window as StenoWindow;
+      w.__hb = [];
+      w.stenoai.on.debugLog((line: unknown) => {
+        if (typeof line === 'string' && line.includes('HEARTBEAT')) w.__hb!.push(line);
+      });
+    });
+
+    // Drive the real streaming pipeline through the app IPC (enqueues
+    // process-streaming on the WAV).
+    const queued = await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.recording.processSystemAudio(p, 'E2E Pipeline'),
+      wavPath,
+    );
+    expect(queued?.success).toBe(true);
+
+    // Completion: the summary .md lands in the temp output dir. Generous timeout
+    // for model load + transcribe + summarise (mock Ollama answers instantly).
+    const summaryPath = path.join(userDataDir, 'output', 'pipeline_summary.md');
+    await expect
+      .poll(() => existsSync(summaryPath), { timeout: 120_000, intervals: [1000] })
+      .toBe(true);
+
+    // HEARTBEAT markers were observed during the run.
+    const heartbeats = await page.evaluate(() => (window as StenoWindow).__hb ?? []);
+    expect(heartbeats.some((l) => l.includes('HEARTBEAT:transcribe'))).toBe(true);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    // Teardown: the app may have spawned its own `ollama serve` despite the mock
+    // (e.g. a probe race); don't let it outlive the test (PR1 follow-up — the
+    // workflow only pkills BEFORE launch).
+    killOllama();
+  }
+});
+
+function killOllama(): void {
+  try {
+    execSync('pkill -f ollama', { stdio: 'ignore' });
+  } catch {
+    /* nothing matched — fine */
+  }
+}


### PR DESCRIPTION
## What this is

PR2 of the e2e suite (PR1 = #180, merged). Adds a **T2 smoke that drives a synthetic WAV through the real app's streaming transcription→summarization pipeline** and asserts it runs end to end. This is the class of coverage that would have caught the long-meeting OOM / transcription-failure regressions before users hit them.

## What it asserts

Drive `recording.processSystemAudio` (the real `process-streaming` path) on a synthetic WAV, then:
- a `HEARTBEAT:transcribe` marker is observed on the `debug-log` channel,
- a `_summary.md` is written into the temp data dir,
- the real `~/Library/Application Support/stenoai` is byte-for-byte untouched.

**Plumbing + HEARTBEAT only** — a sine WAV is non-speech, so Parakeet returns an empty transcript; the pipeline still completes and writes the summary (verified). No transcript-text assertions. This is the one genuinely Mac-divergent path (parakeet-mlx).

## Enabling production change

`app/main.js getAllowedBaseDirs()` now uses `getUserDataDir()` instead of a hardcoded `~/Library/...` literal — **cross-platform** (the old literal is wrong on Windows/Linux) and it honors `STENOAI_USER_DATA_DIR`. Production behavior is byte-identical (the var is never set in prod); it's what lets a test hand the app a WAV from its temp recordings dir. The path-validation it feeds still rejects out-of-bounds paths.

## Files

- `e2e/specs/transcription-pipeline.t2.spec.ts` (tagged `@pipeline`; skips if the Parakeet model is absent).
- `e2e/fixtures/make-wav.js` (synthetic RIFF WAV), `e2e/fixtures/real-user-data.ts` (shared keystone helpers; org-lock T2 refactored to import — was duplicated).
- `e2e/fixtures/mock-ollama.js` fix: list the model under `model` (ollama-python reads that, not `name`) + a defensive `/api/pull`, so summarization doesn't try to download and crash.
- `.github/workflows/e2e.yml`: new `t2-pipeline-macos` job (HF model `actions/cache` + `download-parakeet-model`); `t2-macos` now `--grep-invert @pipeline` to stay model-free. CI-honesty guards: assert the model is installed (download exits 0 on failure) and that `@pipeline` is actually selected (empty `--grep` exits 0).

## Verification

`/verify` PASS at the real surface: a temp-dir WAV is accepted and the full pipeline writes a coherent summary (frontmatter + mock-Ollama summary + "No speech detected" transcript); an out-of-bounds WAV is rejected (`{"success":false,"error":"Invalid file path"}` — no traversal hole); real dir untouched. Full suite (3 specs) green locally; `node --check`, renderer typecheck clean; no `.py` changed.

## Notes for review

- The `@pipeline` job downloads the Parakeet model (~572 MB) on first run, then `actions/cache` restores it (~30 s). Non-blocking.
- `pkill -f ollama` teardown + `~/.cache/huggingface` cache path are POSIX/mac-only — to be gated when the Windows pipeline job lands in PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a T2 e2e smoke test that streams a synthetic WAV through the real transcription→summarization pipeline and verifies it completes (HEARTBEAT + summary) without touching real user data. CI runs it on macOS with `whisper` (CPU) and caches the model; `parakeet` remains covered locally.

- **New Features**
  - New `@pipeline` spec drives `recording.processSystemAudio` on a synthetic RIFF WAV and asserts `HEARTBEAT:transcribe`, a summary in the temp dir, and the real `stenoai` dir is unchanged. Engine is selected by `STENOAI_E2E_ENGINE` (`parakeet` locally, `whisper` in CI); skips if the active engine’s model isn’t installed.
  - Fixtures: `e2e/fixtures/make-wav.js` (16 kHz PCM WAV), `e2e/fixtures/mock-ollama.js` updated to report the model under `model` and mock `/api/pull` to keep summarization hermetic; shared `realUserDataDir()`/`fileSig()` extracted to `e2e/fixtures/real-user-data.ts`.
  - CI: added `t2-pipeline-macos` job that runs with `STENOAI_E2E_ENGINE=whisper`, caches the whisper `small` model with `actions/cache`, verifies the model is installed, and guards that the `@pipeline` test is selected. `t2-macos` now excludes `@pipeline` to stay model-free.

- **Refactors**
  - `getAllowedBaseDirs()` now uses `getUserDataDir()` and honors `STENOAI_USER_DATA_DIR` (prod behavior unchanged). Enables tests to pass WAVs from the temp recordings dir while preserving path validation.

<sup>Written for commit d1a25f67dd2fb124d1722b21a56136e11c3dfade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

