### PR TITLE
test(e2e): PR3 — config-corruption + honest-failure specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     out: `--grep @pipeline` runs it (CI's `t2-pipeline-macos` job caches a whisper model),
     `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
     active engine's model **skips** it (loudly) rather than failing.
+  - **Current specs:** `org-lock.t1`, `org-lock-lifecycle.t2`, and `config-corruption.t2`
+    (model-free, run in `t2-macos`); `transcription-pipeline.t2` and `honest-failure.t2`
+    (tagged `@pipeline`, run in `t2-pipeline-macos`). Engine selection for `@pipeline` specs
+    is shared via `e2e/fixtures/engine.ts`.
 - **Isolation keystone:** every test sets `STENOAI_USER_DATA_DIR` to a temp dir, which
   both `getUserDataDir()` (main.js) and `get_user_data_dir()` (`src/config.py`) honor,
   so a test can never read/write the real `~/Library/Application Support/stenoai`. The

--- a/e2e/fixtures/engine.ts
+++ b/e2e/fixtures/engine.ts
@@ -1,0 +1,52 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Transcription-engine selection for T2 specs that run the real pipeline.
+ *
+ * parakeet locally (the Mac-divergent path), whisper.cpp in CI — GitHub-hosted
+ * macOS runners have no Metal GPU, so parakeet-mlx can't load there. Set via
+ * STENOAI_E2E_ENGINE so the specs are unchanged either way.
+ *
+ * The model must already be installed: the transcriber AUTO-DOWNLOADS a missing
+ * model (~0.5 GB) on first use, so a spec that runs without the model present
+ * would silently pull weights mid-test. isEngineModelReady() lets specs skip
+ * instead; CI installs the model before the model-bearing job.
+ */
+export const E2E_ENGINE: 'parakeet' | 'whisper' =
+  process.env.STENOAI_E2E_ENGINE === 'whisper' ? 'whisper' : 'parakeet';
+export const WHISPER_MODEL = 'small'; // smallest registered model (466 MB)
+
+type EngineWindow = Window & {
+  stenoai: {
+    parakeetModels: { status: () => Promise<{ installed?: boolean }> };
+    whisperModels: {
+      list: () => Promise<{ supported_models?: Record<string, { installed?: boolean }> }>;
+      set: (name: string) => Promise<unknown>;
+    };
+    transcriptionEngine: { set: (engine: string) => Promise<unknown> };
+  };
+};
+
+/** Select the engine in the per-test config (the backend reads it at process
+ *  time). For whisper, pin the small model so the larger default isn't needed. */
+export async function selectEngine(page: Page): Promise<void> {
+  await page.evaluate((e) => (window as EngineWindow).stenoai.transcriptionEngine.set(e), E2E_ENGINE);
+  if (E2E_ENGINE === 'whisper') {
+    await page.evaluate((m) => (window as EngineWindow).stenoai.whisperModels.set(m), WHISPER_MODEL);
+  }
+}
+
+/** Whether the active engine's model is installed (no auto-download). */
+export async function isEngineModelReady(page: Page): Promise<boolean> {
+  if (E2E_ENGINE === 'whisper') {
+    return page.evaluate(
+      async (m) =>
+        !!(await (window as EngineWindow).stenoai.whisperModels.list())?.supported_models?.[m]
+          ?.installed,
+      WHISPER_MODEL,
+    );
+  }
+  return page.evaluate(
+    async () => (await (window as EngineWindow).stenoai.parakeetModels.status())?.installed === true,
+  );
+}

--- a/e2e/specs/config-corruption.t2.spec.ts
+++ b/e2e/specs/config-corruption.t2.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeFileSync, readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — config-corruption recovery. A corrupt config.json must NOT wipe data: the
+ * backend backs the bad file up to config.json.corrupt, runs on in-memory
+ * defaults, and writes a fresh valid config on the next save (the org-reset /
+ * config-wipe regression that reached users). Model-free, so it runs in the
+ * org-lock T2 job (--grep-invert @pipeline).
+ *
+ * Drives the real app: pre-write a corrupt config into the temp dir before
+ * launch, then assert recovery + that the real user dir is untouched.
+ */
+
+type StenoWindow = Window & {
+  stenoai: {
+    ai: {
+      getProvider: () => Promise<{ success?: boolean; ai_provider?: string }>;
+      setProvider: (p: string) => Promise<{ success?: boolean }>;
+    };
+  };
+};
+
+test('corrupt config is backed up and recovered, not wiped; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Corrupt the per-test config BEFORE launch (the fixture has already created
+  // userDataDir). A torn/invalid JSON body is the realistic corruption.
+  const configPath = path.join(userDataDir, 'config.json');
+  writeFileSync(configPath, '{ "ai_provider": "local"  <<< torn write');
+
+  // App must start despite the corrupt config (the launch fixture waits on
+  // [data-app-ready]).
+  const { page } = await launchApp();
+
+  // A config read backs the bad file up and serves in-memory defaults — the app
+  // stays functional rather than erroring.
+  const provider = await page.evaluate(() => (window as StenoWindow).stenoai.ai.getProvider());
+  expect(provider?.success).toBe(true);
+  expect(provider?.ai_provider).toBeTruthy();
+
+  // The corrupt file was preserved for debugging (anti-wipe guarantee), not
+  // silently discarded.
+  await expect
+    .poll(() => existsSync(path.join(userDataDir, 'config.json.corrupt')), { timeout: 10_000 })
+    .toBe(true);
+
+  // A save (provider write) recovers to a fresh, valid config.json — proving the
+  // recover→persist cycle doesn't leave the file corrupt.
+  await page.evaluate(() => (window as StenoWindow).stenoai.ai.setProvider('local'));
+  await expect
+    .poll(
+      () => {
+        try {
+          const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+          return cfg !== null && typeof cfg === 'object' && !Array.isArray(cfg);
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/e2e/specs/honest-failure.t2.spec.ts
+++ b/e2e/specs/honest-failure.t2.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { selectEngine, isEngineModelReady, E2E_ENGINE } from '../fixtures/engine';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — honest transcription failure (@pipeline). Undecodable audio must fail
+ * HONESTLY: emit transcription_failed (never fake silence) AND preserve the
+ * source recording so the user can reprocess (the dishonest-failure regression).
+ *
+ * Feeds a >1 KB non-audio file through the real pipeline and asserts the
+ * TRANSCRIPTION_FAILED signal + a transcription_failed summary + the source
+ * preserved. Tagged @pipeline: the transcriber AUTO-DOWNLOADS a missing model,
+ * so this must run with a model present (the model-bearing job) — otherwise it
+ * would fail on model-absence (and pull ~0.5 GB) instead of on the bad audio.
+ * No mock Ollama needed — summarisation is skipped on transcription failure.
+ */
+
+type StenoWindow = Window & {
+  stenoai: {
+    recording: { processSystemAudio: (p: string, name: string) => Promise<{ success?: boolean }> };
+    on: { debugLog: (cb: (line: unknown) => void) => void };
+  };
+  __dl?: string[];
+};
+
+test('@pipeline garbage audio fails honestly and preserves the source; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  test.setTimeout(180_000);
+  const realDirBefore = fileSig(realUserDataDir());
+
+  const { page } = await launchApp();
+  await selectEngine(page);
+
+  const modelReady = await isEngineModelReady(page);
+  if (!modelReady) {
+    // eslint-disable-next-line no-console
+    console.warn(`[t2:@pipeline] SKIPPED: ${E2E_ENGINE} model not installed on this runner.`);
+    test.info().annotations.push({ type: 'skip-reason', description: `${E2E_ENGINE} model not installed` });
+  }
+  test.skip(!modelReady, `${E2E_ENGINE} model not installed`);
+
+  // Garbage: above the transcriber's 1 KB stub floor but not valid audio, so the
+  // decode fails (it won't reach a real transcript).
+  const recordingsDir = path.join(userDataDir, 'recordings');
+  mkdirSync(recordingsDir, { recursive: true });
+  const badPath = path.join(recordingsDir, 'garbage.wav');
+  writeFileSync(badPath, Buffer.alloc(4096, 0xff));
+  const sizeBefore = statSync(badPath).size;
+
+  await page.evaluate(() => {
+    const w = window as StenoWindow;
+    w.__dl = [];
+    w.stenoai.on.debugLog((line: unknown) => {
+      if (typeof line === 'string') w.__dl!.push(line);
+    });
+  });
+
+  const queued = await page.evaluate(
+    (p) => (window as StenoWindow).stenoai.recording.processSystemAudio(p, 'E2E Bad Audio'),
+    badPath,
+  );
+  expect(queued?.success).toBe(true);
+
+  // The honest-failure path completes and writes a marked summary.
+  const summaryPath = path.join(userDataDir, 'output', 'garbage_summary.md');
+  await expect
+    .poll(() => existsSync(summaryPath), { timeout: 120_000, intervals: [1000] })
+    .toBe(true);
+
+  // Failure surfaced honestly on the debug-log channel. main.js forwards the
+  // raw TRANSCRIPTION_FAILED: protocol line as a humanized message
+  // ("Transcription failed (audio preserved): …"), so match on that.
+  const lines = await page.evaluate(() => (window as StenoWindow).__dl ?? []);
+  expect(lines.some((l) => /transcription failed/i.test(l))).toBe(true);
+
+  // Summary marks the failure (not faked silence). Case-insensitive: the YAML
+  // bool may render as true/True.
+  expect(readFileSync(summaryPath, 'utf8')).toMatch(/transcription_failed:\s*true/i);
+
+  // Source audio preserved (not deleted), byte-for-byte — the user can reprocess.
+  expect(existsSync(badPath)).toBe(true);
+  expect(statSync(badPath).size).toBe(sizeBefore);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/e2e/specs/honest-failure.t2.spec.ts
+++ b/e2e/specs/honest-failure.t2.spec.ts
@@ -77,8 +77,7 @@ test('@pipeline garbage audio fails honestly and preserves the source; real dir 
   const lines = await page.evaluate(() => (window as StenoWindow).__dl ?? []);
   expect(lines.some((l) => /transcription failed/i.test(l))).toBe(true);
 
-  // Summary marks the failure (not faked silence). Case-insensitive: the YAML
-  // bool may render as true/True.
+  // Summary marks the failure (not faked silence).
   expect(readFileSync(summaryPath, 'utf8')).toMatch(/transcription_failed:\s*true/i);
 
   // Source audio preserved (not deleted), byte-for-byte — the user can reprocess.

--- a/e2e/specs/transcription-pipeline.t2.spec.ts
+++ b/e2e/specs/transcription-pipeline.t2.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures/electron';
 import { startMockOllama } from '../fixtures/mock-ollama';
 import { makeWav } from '../fixtures/make-wav';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { selectEngine, isEngineModelReady, E2E_ENGINE } from '../fixtures/engine';
 import { mkdirSync, existsSync } from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
@@ -13,32 +14,17 @@ import { execSync } from 'child_process';
  * summary written into the temp dir, and the real user-data dir untouched.
  *
  * Plumbing + HEARTBEAT only — never asserts transcript text (a sine WAV is
- * non-speech, so Parakeet returns an empty transcript; the pipeline still
- * completes and writes the summary). This is the one genuinely Mac-divergent
- * path (parakeet-mlx), so it needs the Parakeet model present — CI installs it
- * (cached); a dev machine without it skips. Tagged @pipeline so CI can run it in
- * its own model-bearing job and keep the org-lock T2 model-free.
+ * non-speech, so the engine returns an empty transcript; the pipeline still
+ * completes and writes the summary). Engine + model handling lives in
+ * fixtures/engine.ts (parakeet local / whisper CI). Tagged @pipeline so CI runs
+ * it in the model-bearing job and keeps the org-lock T2 model-free.
  */
 
-// Engine: parakeet locally (the Mac-divergent path), whisper in CI. GitHub-hosted
-// macOS runners have no Metal GPU, so parakeet-mlx can't load there — whisper.cpp
-// (CPU) exercises the same process-streaming plumbing + HEARTBEAT. Set via env so
-// the spec is unchanged either way.
-const ENGINE: 'parakeet' | 'whisper' =
-  process.env.STENOAI_E2E_ENGINE === 'whisper' ? 'whisper' : 'parakeet';
-const WHISPER_MODEL = 'small'; // smallest registered model (466 MB)
-
-// The preload surface the renderer sees (app/preload.js), narrowed to what this
-// spec drives. e2e/ lives outside renderer/, so window.stenoai isn't ambiently
-// typed here — declare just the slice we use rather than reaching for `any`.
+// Narrowed preload surface this spec drives directly (engine bits live in
+// fixtures/engine.ts). e2e/ is outside renderer/, so window.stenoai isn't
+// ambiently typed here.
 type StenoWindow = Window & {
   stenoai: {
-    parakeetModels: { status: () => Promise<{ installed?: boolean }> };
-    whisperModels: {
-      list: () => Promise<{ supported_models?: Record<string, { installed?: boolean }> }>;
-      set: (name: string) => Promise<unknown>;
-    };
-    transcriptionEngine: { set: (engine: string) => Promise<unknown> };
     recording: { processSystemAudio: (p: string, name: string) => Promise<{ success?: boolean }> };
     on: { debugLog: (cb: (line: unknown) => void) => void };
   };
@@ -65,37 +51,17 @@ test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real 
 
   try {
     const { page } = await launchApp();
+    await selectEngine(page);
 
-    // Select the engine in the per-test config (the backend reads it at process
-    // time). For whisper, also pin the small model so we don't need the larger
-    // default.
-    await page.evaluate((e) => (window as StenoWindow).stenoai.transcriptionEngine.set(e), ENGINE);
-    if (ENGINE === 'whisper') {
-      await page.evaluate((m) => (window as StenoWindow).stenoai.whisperModels.set(m), WHISPER_MODEL);
-    }
-
-    // Models aren't bundled — they download on use. Without the active engine's
-    // model transcription can't run, and this is a pipeline smoke, not a
-    // model-download test — skip loudly rather than hang/fail. CI installs the
-    // model before this spec.
-    const modelReady =
-      ENGINE === 'whisper'
-        ? await page.evaluate(
-            async (m) =>
-              !!(await (window as StenoWindow).stenoai.whisperModels.list())?.supported_models?.[m]
-                ?.installed,
-            WHISPER_MODEL,
-          )
-        : await page.evaluate(
-            async () =>
-              (await (window as StenoWindow).stenoai.parakeetModels.status())?.installed === true,
-          );
+    // Skip loudly if the active engine's model isn't installed (transcribe would
+    // otherwise auto-download ~0.5 GB). CI installs it before this spec.
+    const modelReady = await isEngineModelReady(page);
     if (!modelReady) {
       // eslint-disable-next-line no-console
-      console.warn(`[t2:@pipeline] SKIPPED: ${ENGINE} model not installed on this runner.`);
-      test.info().annotations.push({ type: 'skip-reason', description: `${ENGINE} model not installed` });
+      console.warn(`[t2:@pipeline] SKIPPED: ${E2E_ENGINE} model not installed on this runner.`);
+      test.info().annotations.push({ type: 'skip-reason', description: `${E2E_ENGINE} model not installed` });
     }
-    test.skip(!modelReady, `${ENGINE} model not installed`);
+    test.skip(!modelReady, `${E2E_ENGINE} model not installed`);
 
     // Write the WAV into the temp recordings dir — an allowed base dir now that
     // getAllowedBaseDirs() honors getUserDataDir().
@@ -114,16 +80,14 @@ test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real 
       });
     });
 
-    // Drive the real streaming pipeline through the app IPC (enqueues
-    // process-streaming on the WAV).
+    // Drive the real streaming pipeline through the app IPC.
     const queued = await page.evaluate(
       (p) => (window as StenoWindow).stenoai.recording.processSystemAudio(p, 'E2E Pipeline'),
       wavPath,
     );
     expect(queued?.success).toBe(true);
 
-    // Completion: the summary .md lands in the temp output dir. Generous timeout
-    // for model load + transcribe + summarise (mock Ollama answers instantly).
+    // Completion: the summary .md lands in the temp output dir.
     const summaryPath = path.join(userDataDir, 'output', 'pipeline_summary.md');
     await expect
       .poll(() => existsSync(summaryPath), { timeout: 120_000, intervals: [1000] })
@@ -138,8 +102,7 @@ test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real 
   } finally {
     await ollama.close();
     // Teardown: the app may have spawned its own `ollama serve` despite the mock
-    // (e.g. a probe race); don't let it outlive the test (PR1 follow-up — the
-    // workflow only pkills BEFORE launch).
+    // (e.g. a probe race); don't let it outlive the test.
     killOllama();
   }
 });


### PR DESCRIPTION
## What this is

PR3 of the e2e suite (PR1 #180, PR2 #181 merged). Two shared-logic T2 specs covering regressions that reached users. **Scoped down** (by decision): the Windows T2 job + belt-and-suspenders matrix are split to PR4 — this PR is the two macOS-verifiable specs.

## Specs

- **`config-corruption.t2`** (model-free → `t2-macos`): pre-writes a torn `config.json`, then asserts the app still starts, the bad file is backed up to `config.json.corrupt` (not wiped), a save recovers a fresh valid config, and the real user dir is untouched. Guards the config-wipe / org-reset regression — and proves *recovery*, not just "starts".
- **`honest-failure.t2`** (`@pipeline` → `t2-pipeline-macos`): feeds undecodable audio and asserts it fails **honestly** (`TRANSCRIPTION_FAILED` on the debug-log + a `transcription_failed: true` summary) **and preserves the source recording** (not deleted). Tagged `@pipeline` because the transcriber auto-downloads a missing model (~0.5 GB) — it must run with a model present.

## Engine helper

`e2e/fixtures/engine.ts` extracts `E2E_ENGINE` / `selectEngine` / `isEngineModelReady` (parakeet local, whisper CI) shared by the pipeline + honest-failure specs; the pipeline spec is refactored to consume it (net deletion). No CI/main.js change — both specs route through the existing `@pipeline` grep split.

## Verification

`/verify` is a **SKIP** here (tests-only diff — no production code changed). The behaviors the specs lock in were independently confirmed at the backend CLI during implementation: corrupt config → `.corrupt` backup + recovery; garbage audio → `TRANSCRIPTION_FAILED` + source preserved + `transcription_failed` summary. All 5 specs green locally (honest-failure on both parakeet and whisper).

## Next (PR4, in SESSION_LOG)

Windows T2 job + matrix: `build-windows.yml` must upload the `dist/stenoai` bundle; gate `killOllama`'s `pkill`→`taskkill`; `safeStorage` org-lock T2 will skip on headless Windows; Windows uses onnx-asr (CPU) so `STENOAI_E2E_ENGINE=parakeet` works there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two T2 e2e tests to lock in config corruption recovery and honest transcription failure. Introduces a shared engine helper and refactors the pipeline spec; `CLAUDE.md` updated.

- **New Features**
  - `config-corruption.t2`: starts with a torn `config.json`, backs it up to `config.json.corrupt`, saves a fresh valid config, and keeps the real user dir untouched; runs model-free in `t2-macos`.
  - `honest-failure.t2` (`@pipeline`): feeds undecodable audio, expects `TRANSCRIPTION_FAILED` in debug logs and `transcription_failed: true` in the summary, and preserves the source recording; requires a model and runs in `t2-pipeline-macos`.

- **Refactors**
  - Added `e2e/fixtures/engine.ts` with `E2E_ENGINE`, `selectEngine`, and `isEngineModelReady` (parakeet local, whisper in CI) to prevent silent model auto-downloads.
  - Updated `transcription-pipeline.t2` to use the helper (net deletion). Also refreshed `CLAUDE.md` to list current specs and their jobs.

<sup>Written for commit 51b3857a108ce48bbfbc1c5248fffba44b5af59e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

