### PR TITLE
test(e2e): PR4 — Windows T2 + pipeline jobs (cross-platform e2e)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,18 +1,21 @@
 name: e2e
 
-# Tiered Playwright e2e (PR1 of the e2e plan). Drives the REAL Electron app.
+# Tiered Playwright e2e. Drives the REAL Electron app.
 # Intentionally NON-BLOCKING: this workflow is not a required status check yet —
-# it is promoted to required in PR4 once it has a green streak. Keeping it
-# advisory now means a flaky launch can't block unrelated merges while the
-# suite earns trust.
+# it is promoted to required once it has a green streak across the matrix below
+# (a branch-protection change, tracked as a follow-up). Keeping it advisory now
+# means a flaky launch can't block unrelated merges while the suite earns trust.
 #
 #   t1-renderer (Ubuntu) — renderer-only with mock IPC, no Python bundle. Fast.
-#   build-backend-macos -> t2-macos — real bundled backend + mock org adapter;
-#     proves the keystone path-isolation fix with the live backend.
+#   build-backend-macos   -> t2-macos / t2-pipeline-macos   (whisper, CPU)
+#   build-backend-windows -> t2-windows / t2-pipeline-windows (parakeet onnx, CPU)
+#     real bundled backend + mock org adapter; proves the keystone
+#     path-isolation fix on both shipping platforms.
 #
-# Windows T2, the belt-and-suspenders matrix, and dorny/paths-filter backend
-# gating (a latency optimisation) land in PR3. For now both tiers run on every
-# PR so the keystone isolation fix cannot silently regress.
+# Explicit per-OS jobs (not a strategy.matrix) — mirrors the repo's paradigm and
+# keeps the per-OS differences (exec bit, engine, process-kill, model cache)
+# obvious in the CI logs. Both tiers run on every PR so the keystone isolation
+# fix cannot silently regress on either platform.
 
 on:
   workflow_dispatch:
@@ -257,6 +260,196 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: e2e-t2-pipeline-report
+          path: |
+            app/playwright-report
+            app/test-results
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # Windows T2 — same shared-logic + pipeline specs on the other shipping OS.
+  # Self-contained backend build: build-windows.yml doesn't run on PRs and
+  # cross-workflow artifact reuse isn't possible, so we mirror build-backend-macos
+  # here. No exec-bit restore (Windows has no exec bit) and the transcription
+  # engine is onnx-asr (CPU) — which, unlike parakeet-mlx, DOES run on a
+  # GPU-less hosted runner, so the Windows pipeline uses real parakeet-onnx.
+  # ---------------------------------------------------------------------------
+  build-backend-windows:
+    name: Build backend bundle (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Cache PyInstaller work dir
+        uses: actions/cache@v4
+        with:
+          path: build
+          key: pyinstaller-${{ runner.os }}-${{ hashFiles('stenoai.spec', 'requirements.txt') }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      # download-ollama.sh is a bash script; git bash is present on the runner.
+      - name: Download bundled binaries (Ollama + ffmpeg)
+        shell: bash
+        run: |
+          chmod +x scripts/download-ollama.sh
+          ./scripts/download-ollama.sh
+
+      - name: Build backend with PyInstaller
+        run: pyinstaller stenoai.spec --noconfirm
+
+      - name: Upload backend bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-backend-windows
+          path: dist/stenoai
+          retention-days: 3
+          if-no-files-found: error
+
+  t2-windows:
+    name: T2 (real backend + mock adapter, Windows)
+    runs-on: windows-latest
+    needs: build-backend-windows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Download backend bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-backend-windows
+          path: dist/stenoai
+
+      # No exec-bit restore: Windows has no exec bit (the macOS jobs need it
+      # because upload-artifact strips +x). Stop any stray Ollama so the app's
+      # 11434 probe can't answer against a pre-existing server (taskkill is the
+      # Windows analog of the macOS pkill).
+      - name: Ensure no stray Ollama
+        shell: pwsh
+        run: Stop-Process -Name ollama -Force -ErrorAction SilentlyContinue
+
+      - name: Install Electron dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build:renderer
+
+      - name: Run T2 (org-lock, model-free)
+        working-directory: app
+        run: npm run test:e2e -- --project=t2 --grep-invert @pipeline
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-t2-windows-report
+          path: |
+            app/playwright-report
+            app/test-results
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Windows transcription pipeline. Unlike t2-pipeline-macos (whisper, because
+  # hosted Macs have no Metal for parakeet-mlx), Windows transcribes with
+  # onnx-asr on CPU — so this runs the REAL parakeet path (STENOAI_E2E_ENGINE
+  # defaults to parakeet). The onnx weights (~670 MB) aren't bundled; cache them
+  # and pre-download so the spec isn't racing the pull inside its timeout.
+  t2-pipeline-windows:
+    name: T2 pipeline (transcribe + summarize, Windows)
+    runs-on: windows-latest
+    needs: build-backend-windows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Download backend bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-backend-windows
+          path: dist/stenoai
+
+      - name: Ensure no stray Ollama
+        shell: pwsh
+        run: Stop-Process -Name ollama -Force -ErrorAction SilentlyContinue
+
+      # Cache the parakeet-onnx snapshot in the HuggingFace hub cache (HF's
+      # default, used by parakeet_models._hf_cache_dir_for). Only the first run
+      # pays the ~670 MB download; later runs restore in seconds.
+      - name: Cache parakeet ONNX model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub/models--istupakov--parakeet-tdt-0.6b-v3-onnx
+          key: parakeet-tdt-0.6b-v3-onnx
+
+      - name: Install Electron dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build:renderer
+
+      # Pre-download the model (no-op when the cache restored), then verify it's
+      # actually installed. download-parakeet-model exits 0 even on a failed pull
+      # (it reports via JSON), so the parakeet-status guard prevents the spec
+      # from silently skipping green with zero pipeline coverage — mirrors the
+      # whisper guard in t2-pipeline-macos.
+      - name: Ensure parakeet model present
+        shell: pwsh
+        run: |
+          ./dist/stenoai/stenoai.exe download-parakeet-model
+          $status = ./dist/stenoai/stenoai.exe parakeet-status | ConvertFrom-Json
+          if (-not $status.installed) {
+            Write-Error "Parakeet ONNX model not installed after download"
+            exit 1
+          }
+
+      # Assert the tagged spec is actually selected (Playwright exits 0 on a
+      # zero-match --grep). git bash provides grep on the Windows runner.
+      - name: Guard — @pipeline test is selected
+        shell: bash
+        working-directory: app
+        run: npm run test:e2e -- --project=t2 --grep @pipeline --list | grep -q '@pipeline'
+
+      - name: Run T2 pipeline (parakeet onnx)
+        working-directory: app
+        env:
+          STENOAI_E2E_ENGINE: parakeet
+        run: npm run test:e2e -- --project=t2 --grep @pipeline
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-t2-pipeline-windows-report
           path: |
             app/playwright-report
             app/test-results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -355,9 +355,11 @@ jobs:
         working-directory: app
         run: npm run build:renderer
 
+      # Quote '@pipeline': the default Windows shell is pwsh, which treats a bare
+      # @word as splatting ($pipeline) and errors. Single quotes make it literal.
       - name: Run T2 (org-lock, model-free)
         working-directory: app
-        run: npm run test:e2e -- --project=t2 --grep-invert @pipeline
+        run: npm run test:e2e -- --project=t2 --grep-invert '@pipeline'
 
       - name: Upload report on failure
         if: failure()
@@ -433,17 +435,23 @@ jobs:
           }
 
       # Assert the tagged spec is actually selected (Playwright exits 0 on a
-      # zero-match --grep). git bash provides grep on the Windows runner.
+      # zero-match --grep). git bash provides grep on the Windows runner. Capture
+      # --list output first rather than piping into `grep -q`: on Windows the
+      # early pipe-close from `grep -q` makes the node writer crash with EPIPE
+      # (no POSIX SIGPIPE), failing the step even on a match.
       - name: Guard — @pipeline test is selected
         shell: bash
         working-directory: app
-        run: npm run test:e2e -- --project=t2 --grep @pipeline --list | grep -q '@pipeline'
+        run: |
+          out=$(npm run test:e2e -- --project=t2 --grep @pipeline --list)
+          echo "$out" | grep -q '@pipeline'
 
+      # Quote '@pipeline' for the same pwsh-splat reason as the org-lock job.
       - name: Run T2 pipeline (parakeet onnx)
         working-directory: app
         env:
           STENOAI_E2E_ENGINE: parakeet
-        run: npm run test:e2e -- --project=t2 --grep @pipeline
+        run: npm run test:e2e -- --project=t2 --grep '@pipeline'
 
       - name: Upload report on failure
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,7 +149,7 @@ jobs:
       # The app probes 11434 and skips its own `ollama serve` on a 200, so a real
       # Ollama on the runner would answer instead of a test stub. Kill it first
       # (the org-lock spec doesn't use Ollama, but this keeps T2 setup honest for
-      # the summary specs landing in PR2).
+      # the summary/pipeline specs).
       - name: Ensure no stray Ollama
         run: pkill -f ollama || true
 
@@ -372,8 +372,8 @@ jobs:
 
   # Windows transcription pipeline. Unlike t2-pipeline-macos (whisper, because
   # hosted Macs have no Metal for parakeet-mlx), Windows transcribes with
-  # onnx-asr on CPU — so this runs the REAL parakeet path (STENOAI_E2E_ENGINE
-  # defaults to parakeet). The onnx weights (~670 MB) aren't bundled; cache them
+  # onnx-asr on CPU — so this runs the REAL parakeet path (STENOAI_E2E_ENGINE is
+  # set to parakeet below). The onnx weights (~670 MB) aren't bundled; cache them
   # and pre-download so the spec isn't racing the pull inside its timeout.
   t2-pipeline-windows:
     name: T2 pipeline (transcribe + summarize, Windows)
@@ -407,7 +407,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface/hub/models--istupakov--parakeet-tdt-0.6b-v3-onnx
-          key: parakeet-tdt-0.6b-v3-onnx
+          key: parakeet-onnx-${{ runner.os }}-tdt-0.6b-v3
 
       - name: Install Electron dependencies
         working-directory: app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,14 +61,23 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
     active engine's model **skips** it (loudly) rather than failing.
   - **Current specs:** `org-lock.t1`, `org-lock-lifecycle.t2`, and `config-corruption.t2`
-    (model-free, run in `t2-macos`); `transcription-pipeline.t2` and `honest-failure.t2`
-    (tagged `@pipeline`, run in `t2-pipeline-macos`). Engine selection for `@pipeline` specs
-    is shared via `e2e/fixtures/engine.ts`.
+    (model-free, run in `t2-macos` / `t2-windows`); `transcription-pipeline.t2` and
+    `honest-failure.t2` (tagged `@pipeline`, run in `t2-pipeline-macos` /
+    `t2-pipeline-windows`). Engine selection for `@pipeline` specs is shared via
+    `e2e/fixtures/engine.ts`.
+  - **Windows T2:** the same specs run on `windows-latest` via explicit per-OS jobs
+    (`build-backend-windows` → `t2-windows` / `t2-pipeline-windows`). Differences from the
+    macOS jobs: no exec-bit restore (Windows has no exec bit), `taskkill`/`Stop-Process`
+    instead of `pkill`, and the `@pipeline` job uses the REAL parakeet path —
+    `STENOAI_E2E_ENGINE=parakeet` runs onnx-asr on CPU (no Metal needed), caching the
+    `models--istupakov--parakeet-tdt-0.6b-v3-onnx` HF snapshot. org-lock T2 may **skip** on
+    Windows (safeStorage/DPAPI on a headless runner), acceptable while non-blocking.
 - **Isolation keystone:** every test sets `STENOAI_USER_DATA_DIR` to a temp dir, which
   both `getUserDataDir()` (main.js) and `get_user_data_dir()` (`src/config.py`) honor,
   so a test can never read/write the real `~/Library/Application Support/stenoai`. The
   launch fixture (`e2e/fixtures/electron.ts`) waits on `[data-app-ready]` — no fixed
-  timeouts. CI: `.github/workflows/e2e.yml` (T1 on Ubuntu/xvfb, macOS T2; non-blocking).
+  timeouts. CI: `.github/workflows/e2e.yml` (T1 on Ubuntu/xvfb, macOS + Windows T2;
+  non-blocking).
 
 ## Production Readiness
 This app ships as a signed DMG to real users. Before considering any change complete:

--- a/e2e/fixtures/electron.ts
+++ b/e2e/fixtures/electron.ts
@@ -8,6 +8,7 @@ import {
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
+import { execSync } from 'child_process';
 
 // Repo-root/app — the Electron app dir (package.json main: main.js). Resolved
 // from this file so the helper works regardless of the cwd Playwright runs in.
@@ -81,10 +82,33 @@ export const test = base.extend<Fixtures>({
     await use(launch);
 
     for (const app of launched) {
+      // app.close() can hang on Windows: the app spawns children (the backend
+      // pipeline subprocess, a stray `ollama serve`) that keep the Electron main
+      // process alive, so a graceful close never returns and Playwright's worker
+      // teardown times out. Race the close with a grace window, then force-kill
+      // the whole process tree. macOS closes well within the window, so the
+      // fallback never fires there.
+      const proc = app.process();
       try {
-        await app.close();
+        await Promise.race([
+          app.close(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('close-timeout')), 10_000),
+          ),
+        ]);
       } catch {
-        /* already gone */
+        try {
+          const pid = proc?.pid;
+          if (pid) {
+            if (process.platform === 'win32') {
+              execSync(`taskkill /F /T /PID ${pid}`, { stdio: 'ignore' });
+            } else {
+              proc!.kill('SIGKILL');
+            }
+          }
+        } catch {
+          /* already gone */
+        }
       }
     }
   },

--- a/e2e/specs/transcription-pipeline.t2.spec.ts
+++ b/e2e/specs/transcription-pipeline.t2.spec.ts
@@ -108,8 +108,10 @@ test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real 
 });
 
 function killOllama(): void {
-  // Cross-platform: Windows has no pkill. Mirror app/main.js killProcessTree's
-  // taskkill path. Both no-op cleanly when nothing matches.
+  // Cross-platform: Windows has no pkill. Kill by image name (the spec has no
+  // PID; app/main.js killProcessTree kills a known PID + tree instead). Enough
+  // to free 11434 so the probe can't hit a stray server. No-ops when nothing
+  // matches (taskkill exits non-zero → swallowed by the catch).
   const cmd =
     process.platform === 'win32' ? 'taskkill /F /IM ollama.exe' : 'pkill -f ollama';
   try {

--- a/e2e/specs/transcription-pipeline.t2.spec.ts
+++ b/e2e/specs/transcription-pipeline.t2.spec.ts
@@ -108,8 +108,12 @@ test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real 
 });
 
 function killOllama(): void {
+  // Cross-platform: Windows has no pkill. Mirror app/main.js killProcessTree's
+  // taskkill path. Both no-op cleanly when nothing matches.
+  const cmd =
+    process.platform === 'win32' ? 'taskkill /F /IM ollama.exe' : 'pkill -f ollama';
   try {
-    execSync('pkill -f ollama', { stdio: 'ignore' });
+    execSync(cmd, { stdio: 'ignore' });
   } catch {
     /* nothing matched — fine */
   }


### PR DESCRIPTION
## What

Adds **Windows** coverage to the e2e suite so OS-specific breakage is caught pre-merge, mirroring the existing macOS jobs as **explicit per-OS jobs** (the repo's paradigm — no `strategy.matrix`).

New jobs in `.github/workflows/e2e.yml`:
- **`build-backend-windows`** — mirrors `build-backend-macos` on `windows-latest` (PyInstaller bundle, uploads `e2e-backend-windows`). Self-contained because `build-windows.yml` doesn't run on PRs and cross-workflow artifact reuse isn't possible.
- **`t2-windows`** — model-free specs (`org-lock-lifecycle`, `config-corruption`) via `--grep-invert @pipeline`. No exec-bit restore (Windows has no exec bit); `Stop-Process` replaces `pkill`.
- **`t2-pipeline-windows`** — the `@pipeline` specs (`transcription-pipeline`, `honest-failure`) running the **real parakeet path**: `STENOAI_E2E_ENGINE=parakeet` uses onnx-asr on CPU (no Metal needed, unlike hosted Macs). Caches the `models--istupakov--parakeet-tdt-0.6b-v3-onnx` HF snapshot, pre-downloads it, and guards that it's actually installed before running (prevents a silent skip-green).

Also:
- `killOllama()` in `transcription-pipeline.t2.spec.ts` is now cross-platform (`taskkill /F /IM ollama.exe` on win32).
- `CLAUDE.md` documents the Windows jobs + the parakeet-on-CPU rationale.
- Header comment scrubbed of stale PR-number references.

## Notes for reviewers

- **Plan item "gate the macOS chmod step with `if: runner.os == 'macOS'`"** was satisfied by **job separation** rather than a literal conditional: the macOS chmod steps live in dedicated macOS-only jobs and the Windows jobs simply omit them. A `runner.os == 'macOS'` guard inside a `windows-latest`-only job would be dead config.
- **org-lock T2 may skip on Windows** (safeStorage/DPAPI on a headless runner) — acceptable while the suite is non-blocking; `config-corruption` still gives real coverage in `t2-windows`. Documented in CLAUDE.md.
- macOS jobs are **byte-for-byte unchanged** (only the shared `killOllama` helper and comments were touched), per the CLAUDE.md hard rule that a Windows change must never regress the stable macOS build.

## Verification

- macOS suite green locally (5/5: `cd app && npm run test:e2e`).
- YAML validated; specs parse/list.
- **Windows jobs are CI-only verifiable** — watching `build-backend-windows` → `t2-windows` / `t2-pipeline-windows` go green on this PR; expect a round-trip or two for Windows-runner quirks (this suite is non-blocking, so it can iterate safely).

Part of the e2e roadmap (follows #180/#181/#182). PR5 (nightly cadence + long-WAV chunking) follows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows coverage to the e2e CI with explicit per-OS jobs, including pipeline specs that run the real `parakeet` path on CPU. Also fixes Windows-specific quirks so `@pipeline` tests select and teardown reliably.

- **New Features**
  - Added Windows jobs in `.github/workflows/e2e.yml`: `build-backend-windows` → `t2-windows` and `t2-pipeline-windows`.
  - Runs `@pipeline` on Windows with `STENOAI_E2E_ENGINE=parakeet` (ONNX CPU). Caches `models--istupakov--parakeet-tdt-0.6b-v3-onnx` with a per-OS key and verifies install.

- **Bug Fixes**
  - Made `killOllama()` cross-platform: `taskkill /F /IM ollama.exe` on Windows, `pkill -f ollama` elsewhere.
  - Fixed Windows shell quirks: quote `@pipeline` in pwsh and capture `--list` output before `grep` to avoid EPIPE, ensuring the selection guard works on Windows.
  - Prevented teardown timeouts on Windows by force-killing the Electron app process tree if `app.close()` hangs (10s grace; `taskkill /F /T` on Windows, `SIGKILL` elsewhere).

<sup>Written for commit 18faf3db07e64d76e51abd2d7171e4dcae5c3ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

