### PR TITLE
test(e2e): PR5 — nightly cadence + long-meeting chunking smoke (T3)

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,110 @@
+name: e2e-nightly
+
+# Scheduled e2e run (the repo's first cron). Two purposes:
+#   1. Re-run the full PR suite on a schedule to catch flakes and external drift
+#      (model-download changes, runner-image updates) that a single PR can't see.
+#      Done by reusing .github/workflows/e2e.yml verbatim via `uses:` — no job
+#      duplication.
+#   2. Run the heavy long-meeting chunking smoke (T3), which is too slow for the
+#      per-PR suite. It drives a multi-minute WAV through the REAL parakeet-onnx
+#      windowing path (PARAKEET_CHUNK_DURATION_S) on Windows CPU and asserts the
+#      pipeline completes — exercising the long-file CHUNKING PLUMBING, NOT the
+#      MLX/Metal OOM (that needs a GPU runner; tracked follow-up).
+#
+# Non-blocking, like e2e.yml. Manually triggerable (workflow_dispatch) so the
+# long-meeting job can be validated without waiting for the cron.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # 07:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Flake/drift re-run of the exact per-PR suite (T1 + macOS/Windows T2).
+  suite:
+    name: Full suite (nightly re-run)
+    uses: ./.github/workflows/e2e.yml
+
+  # Long-meeting chunking smoke. Reuses the Windows backend bundle the suite just
+  # built (download-artifact across the reusable-workflow boundary) and the
+  # parakeet-onnx model the suite cached, so this adds no extra build/download.
+  long-meeting-windows:
+    name: T3 long-meeting (parakeet onnx, Windows)
+    runs-on: windows-latest
+    needs: suite
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Download backend bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-backend-windows
+          path: dist/stenoai
+
+      - name: Ensure no stray Ollama
+        shell: pwsh
+        run: Stop-Process -Name ollama -Force -ErrorAction SilentlyContinue
+
+      # Same key as t2-pipeline-windows, so the model the suite downloaded this
+      # run restores here instead of pulling the ~670 MB snapshot again.
+      - name: Cache parakeet ONNX model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub/models--istupakov--parakeet-tdt-0.6b-v3-onnx
+          key: parakeet-onnx-${{ runner.os }}-tdt-0.6b-v3
+
+      - name: Install Electron dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build:renderer
+
+      - name: Ensure parakeet model present
+        shell: pwsh
+        run: |
+          ./dist/stenoai/stenoai.exe download-parakeet-model
+          $status = ./dist/stenoai/stenoai.exe parakeet-status | ConvertFrom-Json
+          if (-not $status.installed) {
+            Write-Error "Parakeet ONNX model not installed after download"
+            exit 1
+          }
+
+      # Assert the tagged spec is selected (Playwright exits 0 on a zero-match
+      # --grep). Capture first, then grep — `grep -q`'s early pipe-close crashes
+      # the node writer with EPIPE on Windows.
+      - name: Guard — @long-meeting test is selected
+        shell: bash
+        working-directory: app
+        run: |
+          out=$(npm run test:e2e -- --project=t3 --grep @long-meeting --list)
+          echo "$out" | grep -q '@long-meeting'
+
+      - name: Run T3 long-meeting (parakeet onnx)
+        working-directory: app
+        env:
+          STENOAI_E2E_ENGINE: parakeet
+        run: npm run test:e2e -- --project=t3 --grep '@long-meeting'
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-t3-long-meeting-report
+          path: |
+            app/playwright-report
+            app/test-results
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -31,6 +31,10 @@ jobs:
   # Long-meeting chunking smoke. Reuses the Windows backend bundle the suite just
   # built (download-artifact across the reusable-workflow boundary) and the
   # parakeet-onnx model the suite cached, so this adds no extra build/download.
+  # Tradeoff: `needs: suite` couples this to the WHOLE suite passing (you can't
+  # depend on a single job inside a called workflow), so an unrelated flake skips
+  # it. If the suite's flake rate ever makes this un-runnable, inline a
+  # self-contained Windows build like e2e.yml's build-backend-windows does.
   long-meeting-windows:
     name: T3 long-meeting (parakeet onnx, Windows)
     runs-on: windows-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,9 @@ name: e2e
 
 on:
   workflow_dispatch:
+  # Callable so the scheduled e2e-nightly workflow can re-run this exact suite
+  # for flake/drift detection without duplicating the job definitions.
+  workflow_call:
   push:
     branches:
       - main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,22 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     `STENOAI_E2E_ENGINE=parakeet` runs onnx-asr on CPU (no Metal needed), caching the
     `models--istupakov--parakeet-tdt-0.6b-v3-onnx` HF snapshot. org-lock T2 may **skip** on
     Windows (safeStorage/DPAPI on a headless runner), acceptable while non-blocking.
+  - **T3 — `*.t3.spec.ts` (nightly only):** the heavy `@long-meeting` chunking smoke. Drives a
+    multi-minute WAV (`STENOAI_E2E_LONG_WAV_SECONDS`, default 1200) through the real
+    **parakeet** windowing path (`PARAKEET_CHUNK_DURATION_S` = 60 s, a hard constant) and
+    asserts the pipeline completes. parakeet-only — whisper.cpp doesn't use that path; it
+    `skip`s on whisper. Exercises the long-file chunking **plumbing**, NOT the MLX/Metal OOM
+    (that needs a GPU runner — tracked follow-up). Too slow for per-PR, so it lives in the
+    nightly workflow, not `e2e.yml`.
 - **Isolation keystone:** every test sets `STENOAI_USER_DATA_DIR` to a temp dir, which
   both `getUserDataDir()` (main.js) and `get_user_data_dir()` (`src/config.py`) honor,
   so a test can never read/write the real `~/Library/Application Support/stenoai`. The
-  launch fixture (`e2e/fixtures/electron.ts`) waits on `[data-app-ready]` — no fixed
-  timeouts. CI: `.github/workflows/e2e.yml` (T1 on Ubuntu/xvfb, macOS + Windows T2;
-  non-blocking).
+  launch fixture (`e2e/fixtures/electron.ts`) waits on `[data-app-ready]` (no fixed timeouts)
+  and force-kills the app process tree if a graceful close hangs on teardown (Windows).
+- **CI:** `.github/workflows/e2e.yml` (T1 on Ubuntu/xvfb, macOS + Windows T2; non-blocking,
+  runs per-PR). `.github/workflows/e2e-nightly.yml` (scheduled) reuses that suite via
+  `workflow_call` for flake/drift detection and adds the T3 long-meeting job. A CI-only
+  Playwright `globalSetup` kills a stray Ollama + waits for a clean 11434 before the run.
 
 ## Production Readiness
 This app ships as a signed DMG to real users. Before considering any change complete:

--- a/e2e/fixtures/global-setup.ts
+++ b/e2e/fixtures/global-setup.ts
@@ -1,0 +1,27 @@
+import { createConnection } from 'net';
+import { killOllama } from './kill-ollama';
+
+/**
+ * Run-wide hardening: before any spec, kill a stray Ollama and wait for the
+ * hardcoded port 11434 to be free, so the first T2/T3 mock-Ollama bind can't
+ * lose a race with a server left over from a previous run (CI runners are
+ * reused). CI-only: locally a dev may be running their own Ollama on purpose,
+ * and the per-test killOllama already handles isolation there.
+ */
+export default async function globalSetup(): Promise<void> {
+  if (!process.env.CI) return;
+  killOllama();
+  // Poll until a connect to 11434 is refused (nothing listening), up to ~5 s.
+  for (let i = 0; i < 25; i++) {
+    const free = await new Promise<boolean>((resolve) => {
+      const sock = createConnection({ port: 11434, host: '127.0.0.1' });
+      sock.once('connect', () => {
+        sock.destroy();
+        resolve(false); // something is still listening
+      });
+      sock.once('error', () => resolve(true)); // connection refused → port free
+    });
+    if (free) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}

--- a/e2e/fixtures/global-setup.ts
+++ b/e2e/fixtures/global-setup.ts
@@ -15,6 +15,11 @@ export default async function globalSetup(): Promise<void> {
   for (let i = 0; i < 25; i++) {
     const free = await new Promise<boolean>((resolve) => {
       const sock = createConnection({ port: 11434, host: '127.0.0.1' });
+      // Guard against a DROP'd (non-RST) port so a probe can't hang the run.
+      sock.setTimeout(200, () => {
+        sock.destroy();
+        resolve(true);
+      });
       sock.once('connect', () => {
         sock.destroy();
         resolve(false); // something is still listening
@@ -24,4 +29,8 @@ export default async function globalSetup(): Promise<void> {
     if (free) return;
     await new Promise((r) => setTimeout(r, 200));
   }
+  // Surface the failure mode: a server we couldn't kill would let the run
+  // proceed into the same port race this setup exists to prevent.
+  // eslint-disable-next-line no-console
+  console.warn('[e2e:global-setup] port 11434 still busy after ~5s; mock-Ollama bind may race');
 }

--- a/e2e/fixtures/kill-ollama.ts
+++ b/e2e/fixtures/kill-ollama.ts
@@ -1,0 +1,18 @@
+import { execSync } from 'child_process';
+
+/**
+ * Kill any stray Ollama so a test's mock can own the hardcoded port 11434 (the
+ * app probes /api/tags and skips its own `ollama serve` on a 200). Cross-platform:
+ * Windows has no pkill, so kill by image name (the spec has no PID; app/main.js
+ * killProcessTree kills a known PID + tree instead). No-ops when nothing matches
+ * (the kill command exits non-zero → swallowed by the catch).
+ */
+export function killOllama(): void {
+  const cmd =
+    process.platform === 'win32' ? 'taskkill /F /IM ollama.exe' : 'pkill -f ollama';
+  try {
+    execSync(cmd, { stdio: 'ignore' });
+  } catch {
+    /* nothing matched — fine */
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,14 +6,20 @@ import { defineConfig } from '@playwright/test';
  *  - T1 (`*.t1.spec.ts`): renderer-only, mock IPC, no Python bundle. Runs on
  *    Ubuntu in CI under xvfb.
  *  - T2 (`*.t2.spec.ts`): real bundled backend + mock adapter / Ollama. Needs
- *    `dist/stenoai/` built; runs on macOS (Windows added in PR3).
+ *    `dist/stenoai/` built; runs on macOS + Windows.
+ *  - T3 (`*.t3.spec.ts`): heavy, nightly-only (the long-meeting chunking smoke).
+ *    Real backend like T2 but minutes-long, so it's split into its own project
+ *    and run by the scheduled e2e-nightly workflow, never per-PR.
  *
  * Tiers are selected by spec filename so CI can fan them into separate jobs.
- * `workers: 1` because every test launches a real Electron app and T2 binds the
+ * `workers: 1` because every test launches a real Electron app and T2/T3 bind the
  * fixed Ollama port 11434 — serialising avoids port and resource collisions.
  */
 export default defineConfig({
   testDir: './specs',
+  // CI-only: kill a stray Ollama + wait for a clean 11434 before the run (no-op
+  // locally so a dev's own Ollama is left alone).
+  globalSetup: './fixtures/global-setup.ts',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -27,5 +33,6 @@ export default defineConfig({
   projects: [
     { name: 't1', testMatch: /.*\.t1\.spec\.ts$/ },
     { name: 't2', testMatch: /.*\.t2\.spec\.ts$/ },
+    { name: 't3', testMatch: /.*\.t3\.spec\.ts$/ },
   ],
 });

--- a/e2e/specs/long-meeting.t3.spec.ts
+++ b/e2e/specs/long-meeting.t3.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { makeWav } from '../fixtures/make-wav';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { selectEngine, isEngineModelReady, E2E_ENGINE } from '../fixtures/engine';
+import { killOllama } from '../fixtures/kill-ollama';
+import { mkdirSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T3 — long-meeting chunking smoke (nightly only). Drives a multi-minute
+ * synthetic WAV through the real pipeline and asserts it COMPLETES (summary
+ * written, HEARTBEAT observed) rather than failing or returning empty.
+ *
+ * What this covers: the parakeet long-file CHUNKING PLUMBING. The onnx and MLX
+ * backends window audio into PARAKEET_CHUNK_DURATION_S (60 s) slices and merge
+ * the per-window results (src/_parakeet_onnx.py transcribe_file). Any file
+ * longer than one chunk exercises that multi-window path end to end through the
+ * app IPC. The engine is parakeet (onnx CPU on the Windows nightly runner; MLX
+ * locally on a Mac) — whisper.cpp does NOT use this code path, so this spec is
+ * parakeet-only.
+ *
+ * What this does NOT cover: the original long-meeting OOM was MLX/Metal-specific
+ * (a 33-min file allocating ~40 GB on Metal). GitHub-hosted runners have no
+ * Metal, so this exercises the chunking plumbing on CPU, not the GPU OOM — that
+ * needs a Metal-capable runner (tracked follow-up). T3 is nightly because it's
+ * minutes-long, not seconds.
+ *
+ * Duration is env-tunable (STENOAI_E2E_LONG_WAV_SECONDS) so the nightly job can
+ * trade realism against CPU time; the default comfortably spans several chunks.
+ */
+
+const LONG_WAV_SECONDS = Number(process.env.STENOAI_E2E_LONG_WAV_SECONDS) || 1200;
+
+type StenoWindow = Window & {
+  stenoai: {
+    recording: { processSystemAudio: (p: string, name: string) => Promise<{ success?: boolean }> };
+    on: { debugLog: (cb: (line: unknown) => void) => void };
+  };
+  __hb?: string[];
+};
+
+test('@long-meeting long WAV runs the chunking path to completion; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  if (E2E_ENGINE !== 'parakeet') {
+    test.skip(true, 'long-meeting chunking is parakeet-only (whisper.cpp does not window via PARAKEET_CHUNK_DURATION_S)');
+  }
+
+  // A multi-minute CPU transcription far outlasts any per-test default; size the
+  // budget off the audio length with generous headroom for model load.
+  test.setTimeout(LONG_WAV_SECONDS * 1000 + 600_000);
+
+  // Mock Ollama on 11434 so summarisation never reaches a real LLM (same setup
+  // as the short pipeline smoke). Kill any stray real Ollama first.
+  killOllama();
+  const ollama = await startMockOllama();
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  try {
+    const { page } = await launchApp();
+    await selectEngine(page);
+
+    const modelReady = await isEngineModelReady(page);
+    if (!modelReady) {
+      // eslint-disable-next-line no-console
+      console.warn(`[t3:@long-meeting] SKIPPED: ${E2E_ENGINE} model not installed on this runner.`);
+      test.info().annotations.push({ type: 'skip-reason', description: `${E2E_ENGINE} model not installed` });
+    }
+    test.skip(!modelReady, `${E2E_ENGINE} model not installed`);
+
+    // A long sine WAV: non-speech (empty transcript per window) but it still
+    // flows through every chunk, which is what the plumbing test wants.
+    const recordingsDir = path.join(userDataDir, 'recordings');
+    mkdirSync(recordingsDir, { recursive: true });
+    const wavPath = path.join(recordingsDir, 'long_meeting.wav');
+    makeWav(wavPath, { seconds: LONG_WAV_SECONDS });
+
+    await page.evaluate(() => {
+      const w = window as StenoWindow;
+      w.__hb = [];
+      w.stenoai.on.debugLog((line: unknown) => {
+        if (typeof line === 'string' && line.includes('HEARTBEAT')) w.__hb!.push(line);
+      });
+    });
+
+    const queued = await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.recording.processSystemAudio(p, 'E2E Long Meeting'),
+      wavPath,
+    );
+    expect(queued?.success).toBe(true);
+
+    // Completion is the assertion: the summary lands, proving the long file
+    // chunked + merged through the pipeline rather than failing or going empty.
+    const summaryPath = path.join(userDataDir, 'output', 'long_meeting_summary.md');
+    await expect
+      .poll(() => existsSync(summaryPath), {
+        timeout: LONG_WAV_SECONDS * 1000 + 300_000,
+        intervals: [2000],
+      })
+      .toBe(true);
+
+    // Transcription actually ran (not a short-circuit to empty).
+    const heartbeats = await page.evaluate(() => (window as StenoWindow).__hb ?? []);
+    expect(heartbeats.some((l) => l.includes('HEARTBEAT:transcribe'))).toBe(true);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    killOllama();
+  }
+});

--- a/e2e/specs/long-meeting.t3.spec.ts
+++ b/e2e/specs/long-meeting.t3.spec.ts
@@ -27,7 +27,9 @@ import path from 'path';
  * minutes-long, not seconds.
  *
  * Duration is env-tunable (STENOAI_E2E_LONG_WAV_SECONDS) so the nightly job can
- * trade realism against CPU time; the default comfortably spans several chunks.
+ * trade realism against CPU time. The default 1200 s against the 60 s chunk size
+ * (45 s step after the 15 s overlap) windows into ~26 chunks — the multi-window
+ * merge path is exercised many times over, not just twice.
  */
 
 const LONG_WAV_SECONDS = Number(process.env.STENOAI_E2E_LONG_WAV_SECONDS) || 1200;
@@ -102,9 +104,27 @@ test('@long-meeting long WAV runs the chunking path to completion; real dir unto
       })
       .toBe(true);
 
-    // Transcription actually ran (not a short-circuit to empty).
+    // Liveness: transcription actually ran (both backends emit at least the
+    // `HEARTBEAT:transcribe:start` beat before decoding).
     const heartbeats = await page.evaluate(() => (window as StenoWindow).__hb ?? []);
     expect(heartbeats.some((l) => l.includes('HEARTBEAT:transcribe'))).toBe(true);
+
+    // Witness the multi-WINDOW chunking path specifically on the onnx backend —
+    // the path that runs in the nightly (Windows/Linux CPU). Its chunked loop
+    // emits `HEARTBEAT:transcribe:<done>/<total>` per window where <total> is the
+    // window count, so a real <total> >= 2 proves the long file split into
+    // multiple windows (the bare :start beat above would pass even without
+    // chunking — exactly the weak-assertion gap this guards). The pinned
+    // parakeet-mlx build (local macOS) doesn't surface per-window beats, so the
+    // strong check is gated to the backend that emits them; local is dev-only and
+    // still asserts completion + liveness above.
+    if (process.platform !== 'darwin') {
+      const windowTotals = heartbeats
+        .map((l) => /HEARTBEAT:transcribe:\d+\/(\d+)/.exec(l)?.[1])
+        .filter((n): n is string => Boolean(n))
+        .map(Number);
+      expect(Math.max(0, ...windowTotals)).toBeGreaterThanOrEqual(2);
+    }
 
     // Keystone: the real user-data dir is byte-for-byte untouched.
     expect(fileSig(realUserDataDir())).toBe(realDirBefore);

--- a/e2e/specs/transcription-pipeline.t2.spec.ts
+++ b/e2e/specs/transcription-pipeline.t2.spec.ts
@@ -3,9 +3,9 @@ import { startMockOllama } from '../fixtures/mock-ollama';
 import { makeWav } from '../fixtures/make-wav';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { selectEngine, isEngineModelReady, E2E_ENGINE } from '../fixtures/engine';
+import { killOllama } from '../fixtures/kill-ollama';
 import { mkdirSync, existsSync } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
 
 /**
  * T2 — real-backend transcription pipeline smoke (@pipeline). Drives a synthetic
@@ -106,17 +106,3 @@ test('@pipeline synthetic WAV runs the full pipeline: HEARTBEAT + summary, real 
     killOllama();
   }
 });
-
-function killOllama(): void {
-  // Cross-platform: Windows has no pkill. Kill by image name (the spec has no
-  // PID; app/main.js killProcessTree kills a known PID + tree instead). Enough
-  // to free 11434 so the probe can't hit a stray server. No-ops when nothing
-  // matches (taskkill exits non-zero → swallowed by the catch).
-  const cmd =
-    process.platform === 'win32' ? 'taskkill /F /IM ollama.exe' : 'pkill -f ollama';
-  try {
-    execSync(cmd, { stdio: 'ignore' });
-  } catch {
-    /* nothing matched — fine */
-  }
-}


### PR DESCRIPTION
## What

Adds the e2e roadmap's nightly cadence + hardening (follows PR4 #183).

- **`.github/workflows/e2e-nightly.yml`** (new) — the repo's first `schedule:` cron (07:00 UTC daily) + `workflow_dispatch`:
  - `suite`: re-runs the **exact** per-PR suite via `uses: ./.github/workflows/e2e.yml` (a new `workflow_call` trigger on e2e.yml) — flake/drift detection, zero job duplication.
  - `long-meeting-windows`: the heavy **T3** chunking smoke. Reuses the suite's Windows backend artifact + cached parakeet-onnx model (no extra build/download), runs the long-WAV spec on the **real parakeet-onnx windowing path** (Windows CPU).
- **`e2e/specs/long-meeting.t3.spec.ts`** (new) — drives a multi-minute WAV (`STENOAI_E2E_LONG_WAV_SECONDS`, default 1200s ≈ 26 windows) through the pipeline and asserts it **completes** (summary written) and that transcription **actually split into ≥2 windows** (`HEARTBEAT:transcribe:<n>/<total>`, total ≥ 2 on onnx). Exercises the chunking **plumbing**, *not* the MLX/Metal OOM (that needs a GPU runner — tracked follow-up). parakeet-only (whisper.cpp doesn't use this path).
- **`e2e/fixtures/kill-ollama.ts`** (new) — cross-platform `killOllama` extracted from the pipeline spec (now shared by pipeline + T3 + globalSetup).
- **`e2e/fixtures/global-setup.ts`** (new) — CI-only Playwright `globalSetup`: kills stray Ollama + waits for a clean 11434 before the run (no-op locally so a dev's Ollama is left alone).
- `playwright.config.ts`: adds the `t3` project + globalSetup. `CLAUDE.md`: documents the nightly tier + T3.

## Deviations from the plan (justified)

- **Engine/duration:** the plan assumed `PARAKEET_CHUNK_DURATION_S` was env-tunable and suggested whisper at ~35-40 min. It's actually a hard-coded 60s constant, and the windowing code lives **only** in the parakeet backends — whisper.cpp doesn't use it. So T3 runs **parakeet-onnx** (the engine that owns the windowing) at a default 1200s, which windows ~26× — genuinely exercising the multi-window merge path. The MLX OOM remains untestable without Metal (documented).
- **Deferred (plan-sanctioned):** packaged cold-start smoke ("only if stable"). "Promote to required" is a branch-protection change handled separately after a green streak.

## Verification

- Local: full per-PR suite green (5/5); T3 green on local MLX (`STENOAI_E2E_LONG_WAV_SECONDS=120`).
- Three senior reviews (QA/Eng/Product) — fixed the one HIGH (T3 assertion now witnesses real multi-window chunking) + cheap nits.
- The nightly long-meeting job (onnx) is **CI-verifiable** — I'll trigger it via `workflow_dispatch` on this branch to confirm green before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nightly e2e workflow and a T3 long‑meeting smoke test that exercises real `parakeet-onnx` chunking. Improves test reliability by cleaning up stray Ollama and reusing artifacts to keep nightly runs fast.

- **New Features**
  - Scheduled `e2e-nightly` (07:00 UTC daily + manual) reuses the per‑PR suite via `workflow_call`.
  - T3 long‑meeting smoke: drives a multi‑minute WAV through real `parakeet-onnx` windowing on Windows and asserts completion and `HEARTBEAT:transcribe:<n>/<total>` with total ≥ 2 (parakeet‑only).
  - Reuses the suite’s Windows backend artifact and cached model to avoid extra build/download.

- **Refactors**
  - Extracted cross‑platform `killOllama` and added a CI‑only global setup to kill it and ensure port 11434 is free.
  - `playwright.config.ts`: adds `t3` and `globalSetup`; `e2e.yml` is now callable; pipeline spec uses the shared helper.
  - `CLAUDE.md`: documents the nightly tier, T3, and teardown behavior.

<sup>Written for commit 134e49b15e5c2111ea78f6aa0c47ddbc04dc344d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

