### PR TITLE
feat: re-add local audio file import (picker + drag & drop)

### DIFF
--- a/app/docs/ipc-contract.md
+++ b/app/docs/ipc-contract.md
@@ -85,7 +85,7 @@ progress events back.
 | `resume-recording-ui` | R→M invoke | yes | `stenoai.recording.resume()` |
 | `system-audio-recording-state` | R→M send | yes | `stenoai.recording.reportSystemAudioState(active)` |
 | `process-system-audio-recording` | R→M invoke | yes | `stenoai.recording.processSystemAudio(filePath, name)` |
-| `process-recording` | R→M invoke | yes | `stenoai.recording.processFile(path, name)` |
+| `process-recording` | R→M invoke | yes | `stenoai.recording.processFile(path, name)` — imports a local file: copies it into `recordings/` then **queues** it (fire-and-forget, resolves before transcription; progress shows as a processing row) |
 | `select-audio-file` | R→M invoke | yes | `stenoai.recording.pickAudioFile()` |
 | — | R-direct (webUtils) | yes | `stenoai.recording.getPathForFile(file)` — sync; resolves a dropped File's absolute path (Electron 32+ removed `File.path`) |
 | `get-queue-status` | R→M invoke | yes | `stenoai.recording.getQueue()` |
@@ -389,7 +389,7 @@ are string-cased (`"True"`/`"False"`) — that translation lives in main.js.
 | `set-silence-auto-stop-enabled` | R→M invoke | yes | `stenoai.settings.setSilenceAutoStopEnabled(b)` |
 | `set-silence-auto-stop-minutes` | R→M invoke | yes | `stenoai.settings.setSilenceAutoStopMinutes(n)` |
 | `show-silence-auto-stop-notification` | R→M invoke | yes | `stenoai.settings.showSilenceAutoStopNotification({ minutes, sessionName })` |
-| `show-note-ready-notification` | R→M invoke | yes | `stenoai.settings.showNoteReadyNotification({ title })` |
+| `show-note-ready-notification` | R→M invoke | yes | `stenoai.settings.showNoteReadyNotification({ title, failed?, hardFailure? })` — `failed`: graceful transcription failure (marked note written); `hardFailure`: processing crash / import that never enqueued (no note) |
 | `get-telemetry` / `set-telemetry` | R→M invoke | yes | `stenoai.settings.getTelemetry()` / `setTelemetry(b)` |
 | `get-dock-icon` / `set-dock-icon` | R→M invoke | yes | `stenoai.settings.getDockIcon()` / `setDockIcon(b)` |
 | `get-system-audio` / `set-system-audio` | R→M invoke | yes | `stenoai.settings.getSystemAudio()` / `setSystemAudio(b)` |

--- a/app/docs/ipc-contract.md
+++ b/app/docs/ipc-contract.md
@@ -16,6 +16,7 @@ will implement exactly what is listed here, exposed through
   - `R→M (invoke)` — `ipcRenderer.invoke(...)` → `ipcMain.handle(...)` request/response
   - `R→M (send)` — `ipcRenderer.send(...)` → `ipcMain.on(...)` fire-and-forget
   - `M→R` — `webContents.send(...)` → `ipcRenderer.on(...)` main-driven event
+  - `R-direct` — synchronous renderer-side call with no IPC hop (an Electron renderer API such as `webUtils` exposed through the bridge). Not every bridge method is an IPC channel.
 - **Needed** — whether the new (React) renderer needs the channel.
   - `yes` — keep and port
   - `drop` — remove (dead listener, unused in renderer, or main-only concern)
@@ -86,6 +87,7 @@ progress events back.
 | `process-system-audio-recording` | R→M invoke | yes | `stenoai.recording.processSystemAudio(filePath, name)` |
 | `process-recording` | R→M invoke | yes | `stenoai.recording.processFile(path, name)` |
 | `select-audio-file` | R→M invoke | yes | `stenoai.recording.pickAudioFile()` |
+| — | R-direct (webUtils) | yes | `stenoai.recording.getPathForFile(file)` — sync; resolves a dropped File's absolute path (Electron 32+ removed `File.path`) |
 | `get-queue-status` | R→M invoke | yes | `stenoai.recording.getQueue()` |
 | `get-recordings-dir` | R→M invoke | yes | `stenoai.recording.getDir()` |
 | `get-live-transcript-state` | R→M invoke | yes | `stenoai.liveTranscript.getState()` |

--- a/app/main.js
+++ b/app/main.js
@@ -649,6 +649,29 @@ function resolveRecordingsDir() {
   return dir;
 }
 
+// Copy an externally-imported audio file into Steno's own recordings/ dir
+// before it enters the processing pipeline. process-streaming deletes the
+// source after a successful transcribe whenever keep_recordings is off (the
+// default), so transcribing an import in place would silently delete the
+// user's original (e.g. ~/Desktop/interview.m4a). Copying first means the
+// unlink only ever touches our own copy. The collision-safe filename also
+// stops two imports that share a basename from overwriting each other's
+// {stem}_summary.md. The displayed title comes from the caller's sessionName,
+// not this (possibly de-duplicated) filename, so the user still sees "interview".
+async function copyImportIntoRecordings(srcPath) {
+  const dir = resolveRecordingsDir();
+  const ext = path.extname(srcPath);
+  const stem = path.basename(srcPath, ext);
+  let dest = path.join(dir, `${stem}${ext}`);
+  let n = 1;
+  while (fs.existsSync(dest)) {
+    dest = path.join(dir, `${stem}-${n}${ext}`);
+    n += 1;
+  }
+  await fs.promises.copyFile(srcPath, dest);
+  return dest;
+}
+
 /**
  * Validate that a file path is within allowed directories (security)
  * Prevents path traversal attacks by ensuring files are only accessed
@@ -1454,7 +1477,12 @@ ipcMain.handle('process-recording', async (event, audioFile, sessionName) => {
     // process-streaming (already captured by the #224 processing-log via its
     // 'process-streaming' label), serialises behind any in-flight job, and
     // emits 'processing-complete' when done.
-    addToProcessingQueue(audioFile, sessionName, null);
+    //
+    // Copy the import into our recordings/ dir first: process-streaming
+    // unlinks the source after a successful transcribe (keep_recordings
+    // defaults off), so queueing the user's original path would delete it.
+    const queuedFile = await copyImportIntoRecordings(audioFile);
+    addToProcessingQueue(queuedFile, sessionName, null);
     return { success: true };
   } catch (error) {
     trackEvent('error_occurred', { error_type: 'process_recording' });
@@ -1471,11 +1499,21 @@ ipcMain.handle('test-system', async () => {
   }
 });
 
+// Audio/video container formats the backend (librosa/ffmpeg) can decode.
+// MUST stay in sync with AUDIO_EXTENSIONS in
+// app/renderer/src/hooks/useImportAudio.ts — the picker (here) and drag-drop
+// (there) live in different processes, so the list is mirrored rather than
+// shared. Keep both edits together.
+const IMPORT_AUDIO_EXTENSIONS = [
+  'wav', 'mp3', 'm4a', 'aac', 'webm', 'aiff', 'aif', 'flac', 'ogg', 'caf',
+  'mp4', 'mov',
+];
+
 ipcMain.handle('select-audio-file', async () => {
   const result = await dialog.showOpenDialog(mainWindow, {
     properties: ['openFile'],
     filters: [
-      { name: 'Audio Files', extensions: ['wav', 'mp3', 'm4a', 'aac', 'webm'] }
+      { name: 'Audio Files', extensions: IMPORT_AUDIO_EXTENSIONS }
     ]
   });
   
@@ -5067,15 +5105,27 @@ ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
   try {
     // `shown` = passed the notifications_enabled gate (see show-silence-auto-stop).
     if (!(await notificationsEnabled())) return { success: true, shown: false };
-    const { title, failed } = payload || {};
-    // Be honest when transcription crashed: don't tell the user their note
-    // is "ready". The recording was preserved (not deleted) and the note
-    // explains the failure on open.
+    const { title, failed, hardFailure } = payload || {};
+    // Three honest states:
+    //  - hardFailure: processing crashed (or an import never enqueued) so no
+    //    note was written — there's nothing to "open". Keep the message
+    //    neutral: it's shared by recording crashes, import crashes and import
+    //    enqueue failures, and over-promising ("audio kept") is either hollow
+    //    (no UI surfaces the orphaned audio) or wrong (enqueue failure).
+    //  - failed: a graceful transcription failure DID write a marked note —
+    //    the recording was preserved and the note explains it on open.
+    //  - otherwise: the note is genuinely ready.
     const notif = new Notification({
-      title: failed ? 'Transcription failed' : 'Note ready',
-      body: failed
-        ? 'Your recording was preserved — open the note for details.'
-        : (title || 'Your note has finished processing'),
+      title: hardFailure
+        ? 'Processing failed'
+        : failed
+          ? 'Transcription failed'
+          : 'Note ready',
+      body: hardFailure
+        ? `Steno couldn't process ${title ? `"${title}"` : 'your note'}.`
+        : failed
+          ? 'Your recording was preserved — open the note for details.'
+          : (title || 'Your note has finished processing'),
     });
     notif.on('click', () => {
       if (mainWindow && !mainWindow.isDestroyed()) {

--- a/app/main.js
+++ b/app/main.js
@@ -1446,11 +1446,16 @@ ipcMain.handle('get-status', handleGetStatus);
 
 ipcMain.handle('process-recording', async (event, audioFile, sessionName) => {
   try {
-    const env = getAiEnv();
-    const result = await runPythonScript('simple_recorder.py', ['process', audioFile, '--name', sessionName], false, env, 'process-recording');
-    trackEvent('transcription_completed', { success: true });
-    trackEvent('summarization_completed', { success: true });
-    return { success: true, result: result };
+    // Route imported files through the same processing queue a stopped
+    // recording uses, instead of a blocking synchronous run. The import then
+    // surfaces as a processing row (badge + auto-refresh on completion) in
+    // the meeting list and survives the trigger popover closing, rather than
+    // showing no progress until it finishes. addToProcessingQueue spawns
+    // process-streaming (already captured by the #224 processing-log via its
+    // 'process-streaming' label), serialises behind any in-flight job, and
+    // emits 'processing-complete' when done.
+    addToProcessingQueue(audioFile, sessionName, null);
+    return { success: true };
   } catch (error) {
     trackEvent('error_occurred', { error_type: 'process_recording' });
     return { success: false, error: error.message };
@@ -2232,7 +2237,11 @@ ipcMain.handle('get-queue-status', async () => {
     currentReprocesses: Array.from(activeReprocessJobs.values()),
     hasRecording: currentRecordingProcess !== null || systemAudioRecordingActive,
     isPaused: recordingRuntimeState.isPaused,
-    elapsedSeconds: (currentRecordingProcess !== null || systemAudioRecordingActive) ? getRecordingElapsedSeconds() : 0,
+    elapsedSeconds: (currentRecordingProcess !== null || systemAudioRecordingActive)
+      ? getRecordingElapsedSeconds()
+      : (isProcessing && currentProcessingStartedAtMs
+          ? Math.floor((Date.now() - currentProcessingStartedAtMs) / 1000)
+          : 0),
     sessionName: currentRecordingSessionName
   };
 });
@@ -2516,6 +2525,10 @@ let liveTranscribeSessionName = null;
 let liveTranscribeStdoutBuf = '';
 let isProcessing = false;
 let currentProcessingJob = null;
+// Wall-clock start of the in-flight queue job, so the processing timer advances
+// for jobs with no recording elapsed (e.g. an imported file). Recordings keep
+// using their draft start time on the renderer side.
+let currentProcessingStartedAtMs = null;
 // Reprocess runs as a side-channel from the main processing queue (different
 // Python command, started directly from the reprocess-meeting IPC). Tracked
 // here so the renderer can show "this note is being regenerated" on Home
@@ -2679,7 +2692,8 @@ async function processNextInQueue() {
   
   isProcessing = true;
   currentProcessingJob = processingQueue.shift();
-  
+  currentProcessingStartedAtMs = Date.now();
+
   console.log(`🔄 Processing queued job: ${currentProcessingJob.sessionName}`);
   
   try {
@@ -2874,6 +2888,7 @@ async function processNextInQueue() {
   } finally {
     isProcessing = false;
     currentProcessingJob = null;
+    currentProcessingStartedAtMs = null;
     // Process next job in queue
     setTimeout(processNextInQueue, 1000);
   }

--- a/app/main.js
+++ b/app/main.js
@@ -1131,10 +1131,6 @@ if (!gotSingleInstanceLock) {
       console.warn('processing-log init failed (non-fatal):', e?.message);
     }
 
-    // Clear any .import reservation markers orphaned by a crash mid-import; no
-    // import is in flight at startup, so a leftover marker is always stale and
-    // would otherwise force every future import of that stem to bump to -N.
-    sweepStaleImportMarkers();
     // Application menu. macOS uses the global menu bar with mac-only roles
     // (services/hide/unhide). Windows/Linux get a slimmer, platform-correct
     // menu — kept (editing accelerators, Settings, Help) but hidden by default
@@ -1301,6 +1297,14 @@ if (!gotSingleInstanceLock) {
         // Non-fatal - custom path just won't be cached
       }
     }
+
+    // Clear any .import reservation markers orphaned by a crash mid-import. No
+    // import is in flight at startup, so a leftover marker is always stale and
+    // would otherwise force every future import of that stem to bump to -N.
+    // MUST run after the custom storage path is loaded above: resolveRecordingsDir()
+    // keys off _cachedCustomStoragePath, so sweeping earlier would scan the
+    // default dir and miss a custom-storage user's recordings/ entirely.
+    await sweepStaleImportMarkers();
 
     // Register global hotkey for toggle recording (Cmd+Shift+R on macOS, Ctrl+Shift+R on Windows/Linux)
     const hotkeyModifier = process.platform === 'darwin' ? 'Command+Shift+R' : 'Ctrl+Shift+R';

--- a/app/main.js
+++ b/app/main.js
@@ -660,8 +660,21 @@ function resolveRecordingsDir() {
 // not this (possibly de-duplicated) filename, so the user still sees "interview".
 async function copyImportIntoRecordings(srcPath) {
   const dir = resolveRecordingsDir();
+  // The durable note lives in output/<stem>_summary.{md,json}, named from the
+  // audio stem — and it OUTLIVES the audio: process-streaming unlinks the
+  // recording after a successful transcribe (keep_recordings off, the default).
+  // So a stem that's free in recordings/ can still collide with a note from an
+  // earlier same-basename import whose audio was already removed. Skip any stem
+  // whose note already exists so re-importing e.g. interview.m4a becomes
+  // interview-1 rather than silently overwriting the first interview's summary.
+  // output/ is the sibling of recordings/ under the same data root (matching
+  // the Python pipeline's get_data_dirs layout).
+  const outputDir = path.join(path.dirname(dir), 'output');
   const ext = path.extname(srcPath);
   const stem = path.basename(srcPath, ext);
+  const noteExists = (name) =>
+    fs.existsSync(path.join(outputDir, `${name}_summary.md`)) ||
+    fs.existsSync(path.join(outputDir, `${name}_summary.json`));
   // COPYFILE_EXCL makes each attempt atomic: the copy fails with EEXIST rather
   // than overwriting an existing file, so two concurrent imports that share a
   // basename can't clobber each other. (An existsSync-then-copyFile check would
@@ -669,7 +682,11 @@ async function copyImportIntoRecordings(srcPath) {
   // it.) On EEXIST we bump the suffix and retry. On APFS the copy is a
   // near-instant copy-on-write clone.
   for (let n = 0; ; n += 1) {
-    const dest = path.join(dir, n === 0 ? `${stem}${ext}` : `${stem}-${n}${ext}`);
+    const name = n === 0 ? stem : `${stem}-${n}`;
+    // A pre-existing note with this stem means an earlier import already owns
+    // it; skip ahead so the pipeline writes <name>-N_summary.* beside it.
+    if (noteExists(name)) continue;
+    const dest = path.join(dir, `${name}${ext}`);
     try {
       await fs.promises.copyFile(srcPath, dest, fs.constants.COPYFILE_EXCL);
       return dest;

--- a/app/main.js
+++ b/app/main.js
@@ -731,6 +731,28 @@ async function copyImportIntoRecordings(srcPath) {
   }
 }
 
+// Sweep orphaned .<stem>.import reservation markers. copyImportIntoRecordings
+// removes its marker in a finally, but a crash (or hard kill) between the 'wx'
+// open and that finally leaves the marker on disk. Because audioStemTaken skips
+// dotfiles, the orphan never trips the early skip — it silently forces every
+// later import of that stem to bump to <stem>-1 via EEXIST, even with no real
+// collision. No import is ever in flight at app startup, so any marker present
+// then is unambiguously stale and safe to delete. Best-effort: a failure here
+// must never block launch.
+async function sweepStaleImportMarkers() {
+  try {
+    const dir = resolveRecordingsDir();
+    const entries = await fs.promises.readdir(dir);
+    await Promise.all(
+      entries
+        .filter((f) => f.startsWith('.') && f.endsWith('.import'))
+        .map((f) => fs.promises.rm(path.join(dir, f), { force: true })),
+    );
+  } catch (err) {
+    console.warn('Failed to sweep stale import markers:', err?.message ?? err);
+  }
+}
+
 /**
  * Validate that a file path is within allowed directories (security)
  * Prevents path traversal attacks by ensuring files are only accessed
@@ -1109,6 +1131,10 @@ if (!gotSingleInstanceLock) {
       console.warn('processing-log init failed (non-fatal):', e?.message);
     }
 
+    // Clear any .import reservation markers orphaned by a crash mid-import; no
+    // import is in flight at startup, so a leftover marker is always stale and
+    // would otherwise force every future import of that stem to bump to -N.
+    sweepStaleImportMarkers();
     // Application menu. macOS uses the global menu bar with mac-only roles
     // (services/hide/unhide). Windows/Linux get a slimmer, platform-correct
     // menu — kept (editing accelerators, Settings, Help) but hidden by default

--- a/app/main.js
+++ b/app/main.js
@@ -662,14 +662,22 @@ async function copyImportIntoRecordings(srcPath) {
   const dir = resolveRecordingsDir();
   const ext = path.extname(srcPath);
   const stem = path.basename(srcPath, ext);
-  let dest = path.join(dir, `${stem}${ext}`);
-  let n = 1;
-  while (fs.existsSync(dest)) {
-    dest = path.join(dir, `${stem}-${n}${ext}`);
-    n += 1;
+  // COPYFILE_EXCL makes each attempt atomic: the copy fails with EEXIST rather
+  // than overwriting an existing file, so two concurrent imports that share a
+  // basename can't clobber each other. (An existsSync-then-copyFile check would
+  // have a TOCTOU window where both pick the same dest before either creates
+  // it.) On EEXIST we bump the suffix and retry. On APFS the copy is a
+  // near-instant copy-on-write clone.
+  for (let n = 0; ; n += 1) {
+    const dest = path.join(dir, n === 0 ? `${stem}${ext}` : `${stem}-${n}${ext}`);
+    try {
+      await fs.promises.copyFile(srcPath, dest, fs.constants.COPYFILE_EXCL);
+      return dest;
+    } catch (err) {
+      if (err.code === 'EEXIST') continue;
+      throw err;
+    }
   }
-  await fs.promises.copyFile(srcPath, dest);
-  return dest;
 }
 
 /**

--- a/app/main.js
+++ b/app/main.js
@@ -675,24 +675,58 @@ async function copyImportIntoRecordings(srcPath) {
   const noteExists = (name) =>
     fs.existsSync(path.join(outputDir, `${name}_summary.md`)) ||
     fs.existsSync(path.join(outputDir, `${name}_summary.json`));
-  // COPYFILE_EXCL makes each attempt atomic: the copy fails with EEXIST rather
-  // than overwriting an existing file, so two concurrent imports that share a
-  // basename can't clobber each other. (An existsSync-then-copyFile check would
-  // have a TOCTOU window where both pick the same dest before either creates
-  // it.) On EEXIST we bump the suffix and retry. On APFS the copy is a
+  // Is the STEM already taken in recordings/, regardless of extension? The note
+  // is keyed on the stem alone (output/<stem>_summary.md), so meeting.wav and
+  // meeting.m4a collide on it even though their filenames differ. A bare
+  // COPYFILE_EXCL on <stem><ext> wouldn't catch that — the two dest names don't
+  // clash — so we must also reject a stem any sibling file already uses. Dotfiles
+  // (our .stem.import reservation markers below) are skipped.
+  const audioStemTaken = (name) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return false;
+    }
+    return entries.some(
+      (f) => !f.startsWith('.') && path.basename(f, path.extname(f)) === name,
+    );
+  };
+  // Reserve the OUTPUT STEM atomically and independently of the extension. The
+  // noteExists / audioStemTaken checks are non-atomic on their own: two
+  // concurrent imports of the same stem but different extensions (meeting.wav +
+  // meeting.m4a) could both pass them, both copy successfully (different dest
+  // filenames → no EEXIST), and both later write meeting_summary.md, one
+  // clobbering the other. A per-stem marker created with 'wx' (O_EXCL) is the
+  // atomic claim that closes that window: only one import wins .<name>.import,
+  // the other gets EEXIST and bumps to <stem>-1. Once a copy lands, the audio
+  // file itself holds the stem (audioStemTaken sees it), so the marker is
+  // transient and removed in finally; the durable post-deletion record stays the
+  // note. COPYFILE_EXCL is kept as belt-and-suspenders. On APFS the copy is a
   // near-instant copy-on-write clone.
   for (let n = 0; ; n += 1) {
     const name = n === 0 ? stem : `${stem}-${n}`;
-    // A pre-existing note with this stem means an earlier import already owns
-    // it; skip ahead so the pipeline writes <name>-N_summary.* beside it.
-    if (noteExists(name)) continue;
-    const dest = path.join(dir, `${name}${ext}`);
+    // A pre-existing note or sibling audio with this stem means it's already
+    // owned; skip ahead so the pipeline writes <stem>-N_summary.* beside it.
+    if (noteExists(name) || audioStemTaken(name)) continue;
+    const reservation = path.join(dir, `.${name}.import`);
+    let handle;
     try {
+      handle = await fs.promises.open(reservation, 'wx');
+    } catch (err) {
+      if (err.code === 'EEXIST') continue;
+      throw err;
+    }
+    try {
+      const dest = path.join(dir, `${name}${ext}`);
       await fs.promises.copyFile(srcPath, dest, fs.constants.COPYFILE_EXCL);
       return dest;
     } catch (err) {
       if (err.code === 'EEXIST') continue;
       throw err;
+    } finally {
+      await handle.close();
+      await fs.promises.rm(reservation, { force: true });
     }
   }
 }

--- a/app/preload.js
+++ b/app/preload.js
@@ -7,7 +7,7 @@
  * doc is a contract break — update both in the same commit.
  */
 
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer, webUtils } = require('electron');
 
 const VERSION = 1;
 
@@ -108,6 +108,10 @@ const stenoai = {
     processSystemAudio: (filePath, name) => invoke('process-system-audio-recording', filePath, name),
     processFile: (filePath, name) => invoke('process-recording', filePath, name),
     pickAudioFile: () => invoke('select-audio-file'),
+    // Electron 32+ removed File.path; webUtils.getPathForFile resolves the
+    // absolute path of a dropped File so drag-and-drop import can reuse the
+    // same processFile pipeline as the picker.
+    getPathForFile: (file) => webUtils.getPathForFile(file),
     getQueue: () => invoke('get-queue-status'),
     getDir: () => invoke('get-recordings-dir'),
     // Hint that a recording may be imminent (e.g. user landed on Home) so

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -19,6 +19,7 @@ import { LiveTranscriptBar } from '@/components/LiveTranscriptBar';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { useTranscriptionEngine } from '@/hooks/useModels';
 import { QuitDialog } from '@/components/QuitDialog';
+import { ImportDropZone } from '@/components/ImportDropZone';
 import { AskBarProvider } from '@/lib/askBarContext';
 import {
   useRecording,
@@ -189,6 +190,7 @@ export function App() {
       <AskBarProvider>
         <RouteView route={route} />
         <QuitDialog />
+        <ImportDropZone />
 
         {/* Bottom dock — shared anchor across recording → processing → meeting.
             During recording the slot swaps between the compact LiveDock pill

--- a/app/renderer/src/components/ImportDropZone.tsx
+++ b/app/renderer/src/components/ImportDropZone.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
-import { FileAudio } from 'lucide-react';
+import { Ban, FileAudio } from 'lucide-react';
 import { ipc } from '@/lib/ipc';
-import { importAudioFile, isAudioFile } from '@/hooks/useImportAudio';
+import {
+  basenameStem,
+  importAudioFile,
+  isAudioFile,
+  notifyImportFailed,
+} from '@/hooks/useImportAudio';
+import { useRecording } from '@/hooks/useRecording';
 
 /**
  * Full-window drag-and-drop target for importing audio files. Mounted once at
@@ -12,10 +18,22 @@ import { importAudioFile, isAudioFile } from '@/hooks/useImportAudio';
  * Electron 32+ removed `File.path`, so the absolute path is resolved via
  * `webUtils.getPathForFile` through the preload bridge. Imports are
  * fire-and-forget — each file lands as a processing row in the meeting list
- * (the queue serialises them); failures are logged.
+ * (the queue serialises them); enqueue failures fire a notification.
+ *
+ * Disabled while a recording is in progress: processNextInQueue only gates on
+ * isProcessing, so dropping mid-recording would start a transcription
+ * concurrent with the live session (OOM/contention risk on Apple Silicon).
+ * This mirrors the picker button's `disabled={isRecording}` guard.
  */
 export function ImportDropZone() {
   const [dragging, setDragging] = React.useState(false);
+
+  // The window-level listeners are bound once, so read the live recording
+  // status through a ref rather than re-binding on every status change.
+  const { status } = useRecording();
+  const isRecording = status === 'recording' || status === 'paused';
+  const isRecordingRef = React.useRef(isRecording);
+  isRecordingRef.current = isRecording;
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !window.stenoai) return;
@@ -47,6 +65,10 @@ export function ImportDropZone() {
       e.preventDefault();
       depth = 0;
       setDragging(false);
+      // Mirror the picker's guard: never start an import concurrent with a
+      // live recording. The overlay already shows the "stop recording" state,
+      // so silently ignoring the drop here is the right call.
+      if (isRecordingRef.current) return;
       const files = Array.from(e.dataTransfer!.files);
       for (const file of files) {
         if (!isAudioFile(file.name)) continue;
@@ -55,6 +77,7 @@ export function ImportDropZone() {
         void importAudioFile(path).catch((err) => {
           // eslint-disable-next-line no-console
           console.error('[importDropZone] import failed', err);
+          notifyImportFailed(basenameStem(file.name));
         });
       }
     };
@@ -76,20 +99,36 @@ export function ImportDropZone() {
   return (
     <div
       // pointer-events:none so the overlay never intercepts the drop — the
-      // window-level listeners handle it.
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: 'rgba(0, 0, 0, 0.35)', pointerEvents: 'none' }}
+      // window-level listeners handle it. Ink-based scrim + ~120ms fade match
+      // the design system (mirrors DialogOverlay) rather than a hard pop.
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink-900/40 backdrop-blur-sm animate-in fade-in-0 duration-fast ease-steno"
+      style={{ pointerEvents: 'none' }}
     >
+      {/* Two visually distinct states so the blocked overlay never reads as a
+          live drop target. Active: dashed border + audio icon = "drop here".
+          Blocked (recording): solid border + ban icon + muted text = "not a
+          target". Neutral palette only (paper+ink), so "blocked" is signalled
+          by the ban glyph + muting, not a warning colour. */}
       <div
-        className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed px-12 py-10"
+        className={
+          isRecording
+            ? 'flex flex-col items-center gap-3 rounded-xl border-2 px-12 py-10 opacity-90'
+            : 'flex flex-col items-center gap-3 rounded-xl border-2 border-dashed px-12 py-10'
+        }
         style={{
           borderColor: 'var(--border-subtle)',
           background: 'var(--surface-raised)',
-          color: 'var(--fg-1)',
+          color: isRecording ? 'var(--fg-2)' : 'var(--fg-1)',
         }}
       >
-        <FileAudio className="size-8 text-muted-foreground" />
-        <p className="text-sm font-medium">Drop audio to import</p>
+        {isRecording ? (
+          <Ban className="size-8 text-muted-foreground" />
+        ) : (
+          <FileAudio className="size-8 text-muted-foreground" />
+        )}
+        <p className="text-sm font-medium">
+          {isRecording ? 'Stop recording to import' : 'Drop audio to import'}
+        </p>
       </div>
     </div>
   );

--- a/app/renderer/src/components/ImportDropZone.tsx
+++ b/app/renderer/src/components/ImportDropZone.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { FileAudio } from 'lucide-react';
+import { ipc } from '@/lib/ipc';
+import { importAudioFile, isAudioFile } from '@/hooks/useImportAudio';
+
+/**
+ * Full-window drag-and-drop target for importing audio files. Mounted once at
+ * the App level. Shows an overlay while a file is dragged over the window and,
+ * on drop, runs each audio file through the same import pipeline as the
+ * "Import audio file…" picker.
+ *
+ * Electron 32+ removed `File.path`, so the absolute path is resolved via
+ * `webUtils.getPathForFile` through the preload bridge. Imports are
+ * fire-and-forget — each file lands as a processing row in the meeting list
+ * (the queue serialises them); failures are logged.
+ */
+export function ImportDropZone() {
+  const [dragging, setDragging] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.stenoai) return;
+
+    // Drag events fire for any drag (incl. internal note→folder drags); only
+    // react to OS file drags, which carry the 'Files' type.
+    const hasFiles = (e: DragEvent) =>
+      !!e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files');
+
+    // enter/leave fire per child element crossed; a depth counter avoids the
+    // overlay flickering as the cursor moves over nested elements.
+    let depth = 0;
+
+    const onEnter = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      depth += 1;
+      setDragging(true);
+    };
+    const onLeave = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      depth = Math.max(0, depth - 1);
+      if (depth === 0) setDragging(false);
+    };
+    const onOver = (e: DragEvent) => {
+      if (hasFiles(e)) e.preventDefault(); // required to allow the drop
+    };
+    const onDrop = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      depth = 0;
+      setDragging(false);
+      const files = Array.from(e.dataTransfer!.files);
+      for (const file of files) {
+        if (!isAudioFile(file.name)) continue;
+        const path = ipc().recording.getPathForFile(file);
+        if (!path) continue;
+        void importAudioFile(path).catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('[importDropZone] import failed', err);
+        });
+      }
+    };
+
+    window.addEventListener('dragenter', onEnter);
+    window.addEventListener('dragleave', onLeave);
+    window.addEventListener('dragover', onOver);
+    window.addEventListener('drop', onDrop);
+    return () => {
+      window.removeEventListener('dragenter', onEnter);
+      window.removeEventListener('dragleave', onLeave);
+      window.removeEventListener('dragover', onOver);
+      window.removeEventListener('drop', onDrop);
+    };
+  }, []);
+
+  if (!dragging) return null;
+
+  return (
+    <div
+      // pointer-events:none so the overlay never intercepts the drop — the
+      // window-level listeners handle it.
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'rgba(0, 0, 0, 0.35)', pointerEvents: 'none' }}
+    >
+      <div
+        className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed px-12 py-10"
+        style={{
+          borderColor: 'var(--border-subtle)',
+          background: 'var(--surface-raised)',
+          color: 'var(--fg-1)',
+        }}
+      >
+        <FileAudio className="size-8 text-muted-foreground" />
+        <p className="text-sm font-medium">Drop audio to import</p>
+      </div>
+    </div>
+  );
+}

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FileAudio, Loader2, MessageSquare, Moon, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, PencilLine, Sun } from 'lucide-react';
+import { FileAudio, MessageSquare, Moon, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, PencilLine, Sun } from 'lucide-react';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -181,9 +181,13 @@ function RecordingOptionsPopover({
   // renderer forces loopback on there). Also hidden while support is loading
   // or on a Mac without loopback support (pre-14.4).
   const showSystemAudio = isMac && systemAudioSupport.data?.supported === true;
+  // Controlled so the import action can close the popover when it fires — the
+  // import's progress then shows as a processing row in the meeting list,
+  // not in this (now closed) popover.
+  const [open, setOpen] = React.useState(false);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
           variant="ghost"
@@ -234,30 +238,22 @@ function RecordingOptionsPopover({
 
           <button
             type="button"
-            disabled={disabled || importAudio.isPending}
-            onClick={() => importAudio.mutate()}
+            disabled={disabled}
+            onClick={() => {
+              setOpen(false);
+              importAudio.mutate();
+            }}
             className="flex w-full items-start gap-3 rounded-md border p-3 text-left transition-colors hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
             style={{ borderColor: 'var(--border-subtle)' }}
           >
-            {importAudio.isPending ? (
-              <Loader2 className="mt-0.5 size-4 flex-shrink-0 animate-spin text-muted-foreground" />
-            ) : (
-              <FileAudio className="mt-0.5 size-4 flex-shrink-0 text-muted-foreground" />
-            )}
+            <FileAudio className="mt-0.5 size-4 flex-shrink-0 text-muted-foreground" />
             <div className="flex-1 space-y-0.5">
-              <p className="text-sm font-medium">
-                {importAudio.isPending ? 'Importing…' : 'Import audio file…'}
-              </p>
+              <p className="text-sm font-medium">Import audio file…</p>
               <p className="text-xs text-muted-foreground">
                 {disabled
                   ? 'Stop the current recording to import a file.'
-                  : 'Transcribe and summarise an existing recording.'}
+                  : 'Transcribe and summarise an existing recording. It will appear in the list while it processes.'}
               </p>
-              {importAudio.isError && (
-                <p className="text-xs text-muted-foreground">
-                  Couldn’t import that file — see logs for details.
-                </p>
-              )}
             </div>
           </button>
         </div>

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { MessageSquare, Moon, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, PencilLine, Sun } from 'lucide-react';
+import { FileAudio, Loader2, MessageSquare, Moon, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, PencilLine, Sun } from 'lucide-react';
+import type { UseMutationResult } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { AudioWave } from '@/components/AudioWave';
@@ -15,6 +16,7 @@ import {
 } from '@/hooks/useSettings';
 import type { RecordingStatus } from '@/hooks/useRecording';
 import { useTheme } from '@/hooks/useTheme';
+import { useImportAudio } from '@/hooks/useImportAudio';
 import { useRoute, navigate } from '@/lib/router';
 import { cn, isMac } from '@/lib/utils';
 
@@ -51,6 +53,10 @@ export function MainToolbar({
   // Windows/Linux there are none, so align to the sidebar's left edge.
   const toggleLeft = isMac ? 82 : 16;
 
+  // Hoisted here (always mounted) so a long import's onSuccess refresh
+  // still fires even if the user closes the options popover mid-import.
+  const importAudio = useImportAudio();
+
   return (
     <div
       className="flex h-10 items-center justify-between gap-2 px-5 pt-2.5"
@@ -84,7 +90,7 @@ export function MainToolbar({
             <PanelLeftClose className="size-[15px]" />
           )}
         </button>
-        <RecordingOptionsPopover />
+        <RecordingOptionsPopover importAudio={importAudio} disabled={isRecording} />
         <button
           type="button"
           onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
@@ -158,7 +164,13 @@ export function MainToolbar({
   );
 }
 
-function RecordingOptionsPopover() {
+function RecordingOptionsPopover({
+  importAudio,
+  disabled,
+}: {
+  importAudio: UseMutationResult<boolean, Error, void>;
+  disabled: boolean;
+}) {
   const systemAudio = useSystemAudioSetting();
   const setSystemAudio = useSetSystemAudio();
   const systemAudioSupport = useSystemAudioSupport();
@@ -219,6 +231,35 @@ function RecordingOptionsPopover() {
               </div>
             </div>
           )}
+
+          <button
+            type="button"
+            disabled={disabled || importAudio.isPending}
+            onClick={() => importAudio.mutate()}
+            className="flex w-full items-start gap-3 rounded-md border p-3 text-left transition-colors hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ borderColor: 'var(--border-subtle)' }}
+          >
+            {importAudio.isPending ? (
+              <Loader2 className="mt-0.5 size-4 flex-shrink-0 animate-spin text-muted-foreground" />
+            ) : (
+              <FileAudio className="mt-0.5 size-4 flex-shrink-0 text-muted-foreground" />
+            )}
+            <div className="flex-1 space-y-0.5">
+              <p className="text-sm font-medium">
+                {importAudio.isPending ? 'Importing…' : 'Import audio file…'}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {disabled
+                  ? 'Stop the current recording to import a file.'
+                  : 'Transcribe and summarise an existing recording.'}
+              </p>
+              {importAudio.isError && (
+                <p className="text-xs text-muted-foreground">
+                  Couldn’t import that file — see logs for details.
+                </p>
+              )}
+            </div>
+          </button>
         </div>
       </PopoverContent>
     </Popover>

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -243,7 +243,7 @@ function RecordingOptionsPopover({
               setOpen(false);
               importAudio.mutate();
             }}
-            className="flex w-full items-start gap-3 rounded-md border p-3 text-left transition-colors hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex w-full items-start gap-3 rounded-md border p-3 text-left transition-colors hover:bg-[color:var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
             style={{ borderColor: 'var(--border-subtle)' }}
           >
             <FileAudio className="mt-0.5 size-4 flex-shrink-0 text-muted-foreground" />

--- a/app/renderer/src/hooks/index.ts
+++ b/app/renderer/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useSettings';
 export * from './useAi';
 export * from './useSetup';
 export * from './useChatSessions';
+export * from './useImportAudio';

--- a/app/renderer/src/hooks/useImportAudio.ts
+++ b/app/renderer/src/hooks/useImportAudio.ts
@@ -2,23 +2,34 @@ import { useMutation } from '@tanstack/react-query';
 import { ipc } from '@/lib/ipc';
 
 /**
- * Import an existing local audio file into stenoai.
+ * Hand a local audio file (by absolute path) to the backend import pipeline.
  *
- * Opens the native file picker (`pickAudioFile`), then hands the chosen
- * file to the backend (`processFile`), which enqueues it on the same
- * processing queue a stopped recording uses. The import then shows up as a
- * processing row in the meeting list (with a badge) and becomes a finished
- * note when summarisation completes. The meeting title defaults to the
- * file's basename (sans extension); the user can rename it afterwards.
+ * `processFile` enqueues it on the same processing queue a stopped recording
+ * uses, so it shows up as a processing row in the meeting list (with a badge)
+ * and becomes a finished note when summarisation completes. The meeting title
+ * defaults to the file's basename (sans extension); the user can rename it.
  *
- * Fire-and-forget: `processFile` returns as soon as the file is queued, not
- * when processing finishes. The processing row appears via the queue poll
- * and the App-level `processing-complete` listener refreshes the list when
- * the note is ready, so this hook does no cache invalidation itself.
+ * Fire-and-forget: resolves as soon as the file is queued, not when processing
+ * finishes. The processing row appears via the queue poll and the App-level
+ * `processing-complete` listener refreshes the list when the note is ready.
+ * Rejects on a backend failure so the caller can surface it.
+ *
+ * Shared by the file-picker import (`useImportAudio`) and drag-and-drop
+ * (`ImportDropZone`).
+ */
+export async function importAudioFile(filePath: string): Promise<void> {
+  const title = basenameStem(filePath);
+  const result = await ipc().recording.processFile(filePath, title);
+  if (!result.success) {
+    throw new Error(result.error ?? 'Import failed');
+  }
+}
+
+/**
+ * Import an existing local audio file via the native file picker.
  *
  * `mutateAsync()` resolves to `true` when a file was enqueued and `false`
- * when the user cancelled the picker. A backend failure rejects so the
- * caller can surface an error state.
+ * when the user cancelled the picker.
  */
 export function useImportAudio() {
   return useMutation<boolean, Error, void>({
@@ -28,14 +39,24 @@ export function useImportAudio() {
         // User cancelled the dialog (or selected nothing) — not an error.
         return false;
       }
-      const title = basenameStem(picked.filePath);
-      const result = await ipc().recording.processFile(picked.filePath, title);
-      if (!result.success) {
-        throw new Error(result.error ?? 'Import failed');
-      }
+      await importAudioFile(picked.filePath);
       return true;
     },
   });
+}
+
+// Formats the backend (librosa/ffmpeg) can decode. Used to filter dropped files
+// so non-audio drops are ignored.
+const AUDIO_EXTENSIONS = [
+  'wav', 'mp3', 'm4a', 'aac', 'webm', 'aiff', 'aif', 'flac', 'ogg', 'caf',
+  'mp4', 'mov',
+];
+
+/** True when `name`'s extension is an audio/video format we can import. */
+export function isAudioFile(name: string): boolean {
+  const dot = name.lastIndexOf('.');
+  if (dot < 0) return false;
+  return AUDIO_EXTENSIONS.includes(name.slice(dot + 1).toLowerCase());
 }
 
 /** Filename without directory or extension: `/a/b/Talk.m4a` -> `Talk`. */

--- a/app/renderer/src/hooks/useImportAudio.ts
+++ b/app/renderer/src/hooks/useImportAudio.ts
@@ -26,6 +26,23 @@ export async function importAudioFile(filePath: string): Promise<void> {
 }
 
 /**
+ * Surface an import that failed to even enqueue (e.g. the copy-into-recordings
+ * step threw, or the backend rejected the file). Shared by the picker and
+ * drag-drop so a foreground import failure isn't swallowed by a bare
+ * `console.error`. In-flight processing crashes are surfaced separately by the
+ * App-level `processing-complete` handler; this covers the enqueue failure that
+ * never produces a processing row. Reuses the note-ready notification channel
+ * (`hardFailure`) since there's no in-app toast surface.
+ */
+export function notifyImportFailed(title: string): void {
+  void ipc()
+    .settings.showNoteReadyNotification({ title, failed: true, hardFailure: true })
+    .catch(() => {
+      // Notification failure isn't fatal and there's nothing to fall back to.
+    });
+}
+
+/**
  * Import an existing local audio file via the native file picker.
  *
  * `mutateAsync()` resolves to `true` when a file was enqueued and `false`
@@ -39,14 +56,23 @@ export function useImportAudio() {
         // User cancelled the dialog (or selected nothing) — not an error.
         return false;
       }
-      await importAudioFile(picked.filePath);
+      try {
+        await importAudioFile(picked.filePath);
+      } catch (err) {
+        // The popover has already closed, so there's no inline slot — fire the
+        // failure notification with the title we still have in scope.
+        notifyImportFailed(basenameStem(picked.filePath));
+        throw err;
+      }
       return true;
     },
   });
 }
 
 // Formats the backend (librosa/ffmpeg) can decode. Used to filter dropped files
-// so non-audio drops are ignored.
+// so non-audio drops are ignored. MUST stay in sync with
+// IMPORT_AUDIO_EXTENSIONS in app/main.js (the file-picker dialog filter) — the
+// two live in different processes, so the list is mirrored rather than shared.
 const AUDIO_EXTENSIONS = [
   'wav', 'mp3', 'm4a', 'aac', 'webm', 'aiff', 'aif', 'flac', 'ogg', 'caf',
   'mp4', 'mov',
@@ -60,7 +86,7 @@ export function isAudioFile(name: string): boolean {
 }
 
 /** Filename without directory or extension: `/a/b/Talk.m4a` -> `Talk`. */
-function basenameStem(filePath: string): string {
+export function basenameStem(filePath: string): string {
   const base = filePath.split(/[\\/]/).pop() ?? filePath;
   const dot = base.lastIndexOf('.');
   return dot > 0 ? base.slice(0, dot) : base;

--- a/app/renderer/src/hooks/useImportAudio.ts
+++ b/app/renderer/src/hooks/useImportAudio.ts
@@ -1,27 +1,26 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { ipc } from '@/lib/ipc';
-import { meetingsKeys } from '@/hooks/meetingKeys';
 
 /**
  * Import an existing local audio file into stenoai.
  *
- * Opens the native file picker (`pickAudioFile`), then runs the chosen
- * file through the same `process-recording` backend pipeline a stopped
- * recording uses (`processFile`). The result lands in the meeting list
- * with the user's configured transcription + summary settings. The
- * meeting title defaults to the file's basename (sans extension); the
- * user can rename it afterwards.
+ * Opens the native file picker (`pickAudioFile`), then hands the chosen
+ * file to the backend (`processFile`), which enqueues it on the same
+ * processing queue a stopped recording uses. The import then shows up as a
+ * processing row in the meeting list (with a badge) and becomes a finished
+ * note when summarisation completes. The meeting title defaults to the
+ * file's basename (sans extension); the user can rename it afterwards.
  *
- * `mutateAsync()` resolves to `true` when a file was imported and `false`
+ * Fire-and-forget: `processFile` returns as soon as the file is queued, not
+ * when processing finishes. The processing row appears via the queue poll
+ * and the App-level `processing-complete` listener refreshes the list when
+ * the note is ready, so this hook does no cache invalidation itself.
+ *
+ * `mutateAsync()` resolves to `true` when a file was enqueued and `false`
  * when the user cancelled the picker. A backend failure rejects so the
  * caller can surface an error state.
- *
- * Hoist this hook into an always-mounted component (e.g. MainToolbar) so
- * the `onSuccess` meeting-list invalidation still fires if the UI that
- * triggered it (the options popover) unmounts mid-import.
  */
 export function useImportAudio() {
-  const qc = useQueryClient();
   return useMutation<boolean, Error, void>({
     mutationFn: async (): Promise<boolean> => {
       const picked = await ipc().recording.pickAudioFile();
@@ -35,11 +34,6 @@ export function useImportAudio() {
         throw new Error(result.error ?? 'Import failed');
       }
       return true;
-    },
-    onSuccess: (imported) => {
-      if (imported) {
-        void qc.invalidateQueries({ queryKey: meetingsKeys.all });
-      }
     },
   });
 }

--- a/app/renderer/src/hooks/useImportAudio.ts
+++ b/app/renderer/src/hooks/useImportAudio.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ipc } from '@/lib/ipc';
+import { meetingsKeys } from '@/hooks/meetingKeys';
+
+/**
+ * Import an existing local audio file into stenoai.
+ *
+ * Opens the native file picker (`pickAudioFile`), then runs the chosen
+ * file through the same `process-recording` backend pipeline a stopped
+ * recording uses (`processFile`). The result lands in the meeting list
+ * with the user's configured transcription + summary settings. The
+ * meeting title defaults to the file's basename (sans extension); the
+ * user can rename it afterwards.
+ *
+ * `mutateAsync()` resolves to `true` when a file was imported and `false`
+ * when the user cancelled the picker. A backend failure rejects so the
+ * caller can surface an error state.
+ *
+ * Hoist this hook into an always-mounted component (e.g. MainToolbar) so
+ * the `onSuccess` meeting-list invalidation still fires if the UI that
+ * triggered it (the options popover) unmounts mid-import.
+ */
+export function useImportAudio() {
+  const qc = useQueryClient();
+  return useMutation<boolean, Error, void>({
+    mutationFn: async (): Promise<boolean> => {
+      const picked = await ipc().recording.pickAudioFile();
+      if (!picked.success) {
+        // User cancelled the dialog (or selected nothing) — not an error.
+        return false;
+      }
+      const title = basenameStem(picked.filePath);
+      const result = await ipc().recording.processFile(picked.filePath, title);
+      if (!result.success) {
+        throw new Error(result.error ?? 'Import failed');
+      }
+      return true;
+    },
+    onSuccess: (imported) => {
+      if (imported) {
+        void qc.invalidateQueries({ queryKey: meetingsKeys.all });
+      }
+    },
+  });
+}
+
+/** Filename without directory or extension: `/a/b/Talk.m4a` -> `Talk`. */
+function basenameStem(filePath: string): string {
+  const base = filePath.split(/[\\/]/).pop() ?? filePath;
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -369,6 +369,24 @@ export function useRecordingProcessingEffects() {
             });
         }
       }
+      // Hard processing crash (process-streaming non-zero exit): no note was
+      // written, so the synthetic processing row is about to vanish on the
+      // queue invalidation below with nothing to show for it. Surface a
+      // failure notification keyed on the session so an import/recording that
+      // dies in the background doesn't just silently disappear. The graceful
+      // transcription-failure path takes the success:true branch above (it
+      // writes a marked note), so this only fires for true crashes.
+      if (!data.success) {
+        void ipc()
+          .settings.showNoteReadyNotification({
+            title: data.sessionName?.trim() || 'your note',
+            failed: true,
+            hardFailure: true,
+          })
+          .catch(() => {
+            // Notification failure isn't fatal — nothing else to fall back to.
+          });
+      }
       qc.invalidateQueries({ queryKey: meetingsKeys.all });
       qc.invalidateQueries({ queryKey: queueKey });
       // Clear any streamCache entry for the finished session. MeetingDetail

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -617,7 +617,10 @@ export interface StenoaiBridge {
      *  notification (a failed start would otherwise be silent). Fire-and-forget. */
     reportCaptureError: SendFn<[message: string]>;
     processSystemAudio: RequestFn<[filePath: string, name: string], Result<{ message: string }>>;
-    processFile: RequestFn<[filePath: string, name: string], Result<{ message: string }>>;
+    // Fire-and-forget: the handler copies the file into recordings/ and queues
+    // it (addToProcessingQueue), then resolves immediately with no payload —
+    // it does NOT wait for transcription. Progress shows as a processing row.
+    processFile: RequestFn<[filePath: string, name: string], Result<Record<string, never>>>;
     pickAudioFile: RequestFn<[], PickAudioFileResponse>;
     /** Resolve a dropped File's absolute path (Electron 32+ removed File.path). Synchronous. */
     getPathForFile: (file: File) => string;
@@ -722,7 +725,7 @@ export interface StenoaiBridge {
       Result<Record<string, never>>
     >;
     showNoteReadyNotification: RequestFn<
-      [payload: { title: string; failed?: boolean }],
+      [payload: { title: string; failed?: boolean; hardFailure?: boolean }],
       Result<Record<string, never>>
     >;
     /** Design-for-test seam for the pre-meeting notification (production fire

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -619,6 +619,8 @@ export interface StenoaiBridge {
     processSystemAudio: RequestFn<[filePath: string, name: string], Result<{ message: string }>>;
     processFile: RequestFn<[filePath: string, name: string], Result<{ message: string }>>;
     pickAudioFile: RequestFn<[], PickAudioFileResponse>;
+    /** Resolve a dropped File's absolute path (Electron 32+ removed File.path). Synchronous. */
+    getPathForFile: (file: File) => string;
     getQueue: RequestFn<[], QueueStatus | { success: false; error: string }>;
     getDir: RequestFn<[], RecordingsDirResponse>;
   };

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -44,9 +44,12 @@ export function Processing() {
     activeSession ? s.drafts[activeSession] : undefined,
   );
   const startedAt = draft ? new Date(draft.startedAtMs) : null;
+  // Recordings have a live draft to time from. Imported files don't — fall back
+  // to the queue's processing elapsed (get-queue-status), which advances on the
+  // poll, so the timer counts up instead of sticking at 0s.
   const totalElapsedSeconds = startedAt
     ? Math.max(0, Math.floor((Date.now() - startedAt.getTime()) / 1000))
-    : 0;
+    : recording.elapsed;
 
   const [stage, setStage] = React.useState<ProcessingStage>('transcribing');
   const [streamText, setStreamText] = React.useState('');
@@ -370,9 +373,12 @@ export function ProcessingDock() {
     sessionName ? s.drafts[sessionName] : undefined,
   );
   const startedAt = draft ? new Date(draft.startedAtMs) : null;
+  // Recordings have a live draft to time from. Imported files don't — fall back
+  // to the queue's processing elapsed (get-queue-status), which advances on the
+  // poll, so the timer counts up instead of sticking at 0s.
   const totalElapsedSeconds = startedAt
     ? Math.max(0, Math.floor((Date.now() - startedAt.getTime()) / 1000))
-    : 0;
+    : recording.elapsed;
 
   return (
     <div className="flex justify-center pointer-events-none">

--- a/e2e/specs/audio-import-collision.t2.spec.ts
+++ b/e2e/specs/audio-import-collision.t2.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { makeWav } from '../fixtures/make-wav';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { killOllama } from '../fixtures/kill-ollama';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 (model-free) — import collision de-duplication against the durable note.
+ *
+ * The note lives in output/<stem>_summary.{md,json}, named from the audio stem,
+ * and OUTLIVES the audio (process-streaming unlinks the recording after a
+ * successful transcribe, keep_recordings off). So a stem that's free in
+ * recordings/ can still collide with an EARLIER same-basename import whose audio
+ * was already removed — and the old collision check, which looked only at
+ * recordings/, would let the second import reuse the stem and silently overwrite
+ * the first import's summary. This pins that copyImportIntoRecordings now also
+ * skips a stem whose note already exists.
+ *
+ * Model-free on purpose: the stem is chosen at copy/enqueue time, BEFORE any
+ * transcription, so the deduped recordings/ filename is observable without a
+ * model. processFile is fire-and-forget; we assert the copy it just made, not
+ * the (model-bearing) pipeline result. The end-to-end "original survives the
+ * unlink" case stays in audio-import.t2 (@pipeline).
+ *
+ * The seeded note goes in the output dir that copyImportIntoRecordings actually
+ * checks — the sibling of the app's recordings dir (from getDir()). In an
+ * unpackaged run that's the repo-root output/ (resolveRecordingsDir doesn't
+ * honor STENOAI_USER_DATA_DIR in dev — a pre-existing quirk; the dirs coincide
+ * with the user-data root once packaged), so the finally cleans up that scratch.
+ */
+
+type StenoWindow = Window & {
+  stenoai: {
+    recording: {
+      processFile: (filePath: string, name: string) => Promise<{ success?: boolean; error?: string }>;
+      getDir: () => Promise<{ success?: boolean; path?: string }>;
+    };
+  };
+};
+
+test('a re-import of a same-basename file does not overwrite the first import\'s note', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // Defensive: own 11434 so the queued (modelless) job can't reach a real LLM.
+  killOllama();
+  const ollama = await startMockOllama();
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  let firstNote: string | undefined;
+  let recordingsDir: string | undefined;
+
+  try {
+    const { page } = await launchApp();
+
+    // The dir copyImportIntoRecordings copies into, and its sibling output/ —
+    // the same pair the collision check consults.
+    const dir = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.recording.getDir(),
+    );
+    recordingsDir = dir?.path;
+    expect(recordingsDir).toBeTruthy();
+    const outputDir = path.join(path.dirname(recordingsDir!), 'output');
+
+    // Stand in for "an earlier import of imported.wav already produced a note":
+    // seed output/imported_summary.md, as if its audio was since unlinked.
+    mkdirSync(outputDir, { recursive: true });
+    firstNote = path.join(outputDir, 'imported_summary.md');
+    const firstNoteBody = '# First import\n\nThis note must survive a re-import.\n';
+    writeFileSync(firstNote, firstNoteBody);
+
+    // A fresh, DIFFERENT file that happens to share the basename.
+    const srcDir = path.join(userDataDir, 'import-src');
+    mkdirSync(srcDir, { recursive: true });
+    const srcPath = path.join(srcDir, 'imported.wav');
+    makeWav(srcPath, { seconds: 2 });
+
+    // processFile resolves once the file is copied + queued (before transcribe).
+    const queued = await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.recording.processFile(p, 'Imported Note'),
+      srcPath,
+    );
+    expect(queued?.success).toBe(true);
+
+    // The copy must have side-stepped the existing note's stem: imported-1.wav,
+    // NOT imported.wav. (imported.wav being free in recordings/ is exactly the
+    // trap the old code fell into.)
+    await expect
+      .poll(() => existsSync(path.join(recordingsDir!, 'imported-1.wav')), {
+        timeout: 10_000,
+        intervals: [200],
+      })
+      .toBe(true);
+
+    // The first import's note is byte-for-byte intact — nothing overwrote it.
+    expect(readFileSync(firstNote, 'utf8')).toBe(firstNoteBody);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    killOllama();
+    // Tidy the (non-isolated in dev) scratch this test wrote.
+    if (firstNote) rmSync(firstNote, { force: true });
+    if (recordingsDir) {
+      rmSync(path.join(recordingsDir, 'imported.wav'), { force: true });
+      rmSync(path.join(recordingsDir, 'imported-1.wav'), { force: true });
+    }
+  }
+});

--- a/e2e/specs/audio-import-collision.t2.spec.ts
+++ b/e2e/specs/audio-import-collision.t2.spec.ts
@@ -200,3 +200,81 @@ test('two parallel imports of the same stem with different extensions get distin
     }
   }
 });
+
+test('a stale .import marker left by a crash does not permanently force a suffix', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // The reservation marker (.<stem>.import) is created with 'wx' and removed in
+  // a finally. A crash BETWEEN the open and that finally orphans the marker on
+  // disk. audioStemTaken skips dotfiles, so the orphan never trips the early
+  // skip — instead the next import of that stem hits EEXIST on the open and is
+  // bumped to <stem>-1 forever, even though no real file/note collision exists.
+  // The fix sweeps orphaned markers at startup (no import is ever in flight at
+  // app launch, so a leftover marker is unambiguously stale). This pins that a
+  // marker present at launch does not block a later import from claiming the
+  // bare stem.
+  killOllama();
+  const ollama = await startMockOllama();
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // The dir resolveRecordingsDir() uses in an unpackaged (dev) run — repo-root/
+  // recordings, independent of STENOAI_USER_DATA_DIR (the same pre-existing dev
+  // quirk the other tests in this file rely on). Seeded BEFORE launch so the
+  // marker is present when the startup sweep runs.
+  const recordingsDir = path.resolve(__dirname, '..', '..', 'recordings');
+  mkdirSync(recordingsDir, { recursive: true });
+  const stem = 'crashedimport';
+  const staleMarker = path.join(recordingsDir, `.${stem}.import`);
+  const outputDir = path.join(path.dirname(recordingsDir), 'output');
+
+  // Stand in for the orphan a crash mid-import leaves behind.
+  writeFileSync(staleMarker, '');
+
+  try {
+    const { page } = await launchApp();
+
+    // Sanity: the app copies into exactly the dir we seeded the orphan in.
+    const dir = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.recording.getDir(),
+    );
+    expect(dir?.path).toBe(recordingsDir);
+
+    const srcDir = path.join(userDataDir, 'stale-import-src');
+    mkdirSync(srcDir, { recursive: true });
+    const srcPath = path.join(srcDir, `${stem}.wav`);
+    makeWav(srcPath, { seconds: 2 });
+
+    const queued = await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.recording.processFile(p, 'Crashed Import'),
+      srcPath,
+    );
+    expect(queued?.success).toBe(true);
+
+    // With the orphan swept at startup, the import claims the bare stem.
+    await expect
+      .poll(() => existsSync(path.join(recordingsDir, `${stem}.wav`)), {
+        timeout: 10_000,
+        intervals: [200],
+      })
+      .toBe(true);
+    // Not bumped to <stem>-1 by a leftover marker.
+    expect(existsSync(path.join(recordingsDir, `${stem}-1.wav`))).toBe(false);
+    // And the orphan itself is gone.
+    expect(existsSync(staleMarker)).toBe(false);
+
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    killOllama();
+    rmSync(staleMarker, { force: true });
+    rmSync(path.join(recordingsDir, `${stem}.wav`), { force: true });
+    rmSync(path.join(recordingsDir, `${stem}-1.wav`), { force: true });
+    rmSync(path.join(recordingsDir, `.${stem}-1.import`), { force: true });
+    rmSync(path.join(outputDir, `${stem}_summary.md`), { force: true });
+    rmSync(path.join(outputDir, `${stem}_summary.json`), { force: true });
+    rmSync(path.join(outputDir, `${stem}-1_summary.md`), { force: true });
+    rmSync(path.join(outputDir, `${stem}-1_summary.json`), { force: true });
+  }
+});

--- a/e2e/specs/audio-import-collision.t2.spec.ts
+++ b/e2e/specs/audio-import-collision.t2.spec.ts
@@ -3,7 +3,7 @@ import { startMockOllama } from '../fixtures/mock-ollama';
 import { makeWav } from '../fixtures/make-wav';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { killOllama } from '../fixtures/kill-ollama';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, rmSync } from 'fs';
 import path from 'path';
 
 /**
@@ -39,6 +39,11 @@ type StenoWindow = Window & {
     };
   };
 };
+
+// The stem (filename without extension) a recordings/ entry will write its
+// note under: output/<stem>_summary.md. Two imports that resolve to the same
+// stem collide on that note.
+const stemOf = (file: string) => path.basename(file, path.extname(file));
 
 test('a re-import of a same-basename file does not overwrite the first import\'s note', async ({
   launchApp,
@@ -108,6 +113,90 @@ test('a re-import of a same-basename file does not overwrite the first import\'s
     if (recordingsDir) {
       rmSync(path.join(recordingsDir, 'imported.wav'), { force: true });
       rmSync(path.join(recordingsDir, 'imported-1.wav'), { force: true });
+    }
+  }
+});
+
+test('two parallel imports of the same stem with different extensions get distinct stems', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // Regression for the COPYFILE_EXCL-only reservation: it reserved the full
+  // filename (<stem><ext>), so dup.wav and dup.m4a produced different dest names
+  // (dup.wav, dup.m4a), neither raising EEXIST — both kept the stem "dup" and
+  // would later write the SAME output/dup_summary.md, one clobbering the other.
+  // The reservation must be on the stem, independent of extension, so the second
+  // import bumps to dup-1.
+  killOllama();
+  const ollama = await startMockOllama();
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  let recordingsDir: string | undefined;
+  let outputDir: string | undefined;
+  const stems = ['dup', 'dup-1'];
+  const exts = ['wav', 'm4a'];
+
+  try {
+    const { page } = await launchApp();
+
+    const dir = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.recording.getDir(),
+    );
+    recordingsDir = dir?.path;
+    expect(recordingsDir).toBeTruthy();
+    outputDir = path.join(path.dirname(recordingsDir!), 'output');
+
+    // Same stem, different extensions — the exact pair the old check let through.
+    const srcDir = path.join(userDataDir, 'parallel-import-src');
+    mkdirSync(srcDir, { recursive: true });
+    const wavSrc = path.join(srcDir, 'dup.wav');
+    const m4aSrc = path.join(srcDir, 'dup.m4a');
+    makeWav(wavSrc, { seconds: 2 });
+    makeWav(m4aSrc, { seconds: 2 }); // WAV bytes in a .m4a — only the stem/ext matter here
+
+    // Fire both through the bridge in the same tick so their copies interleave
+    // (each copyImportIntoRecordings yields at its first await before either
+    // finishes), reproducing the concurrent reservation race.
+    const results = await page.evaluate(
+      ([a, b]) => {
+        const api = (window as StenoWindow).stenoai.recording;
+        return Promise.all([
+          api.processFile(a, 'Dup A'),
+          api.processFile(b, 'Dup B'),
+        ]);
+      },
+      [wavSrc, m4aSrc],
+    );
+    expect(results.every((r) => r?.success === true)).toBe(true);
+
+    // processFile resolves only after copyImportIntoRecordings has copied the
+    // file, so both copies exist now. Snapshot synchronously — the async
+    // pipeline unlinks them seconds later, so a poll would race the cleanup.
+    // Both imports must live under DISTINCT stems: collect the dup* copies'
+    // stems and assert exactly {dup, dup-1} — never a second "dup" under a
+    // different extension, which is what would later overwrite dup_summary.md.
+    const dupStems = readdirSync(recordingsDir!)
+      .filter((f) => !f.startsWith('.') && /^dup(-\d+)?\.(wav|m4a)$/.test(f))
+      .map(stemOf);
+    expect([...new Set(dupStems)].sort()).toEqual(['dup', 'dup-1']);
+
+    // The two summaries the pipeline will write therefore differ — no clobber.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    killOllama();
+    if (recordingsDir) {
+      for (const s of stems) for (const e of exts) {
+        rmSync(path.join(recordingsDir, `${s}.${e}`), { force: true });
+        rmSync(path.join(recordingsDir, `.${s}.import`), { force: true });
+      }
+    }
+    if (outputDir) {
+      for (const s of stems) {
+        rmSync(path.join(outputDir, `${s}_summary.md`), { force: true });
+        rmSync(path.join(outputDir, `${s}_summary.json`), { force: true });
+      }
     }
   }
 });

--- a/e2e/specs/audio-import.t2.spec.ts
+++ b/e2e/specs/audio-import.t2.spec.ts
@@ -21,10 +21,11 @@ import path from 'path';
  * transcription succeeds, the unlink fires, and "the original still exists"
  * is a genuine regression assertion that fails on the pre-fix code.
  *
- * Collision de-duplication (two same-basename imports -> distinct summaries)
- * is covered at the unit level; this spec keeps to one import to stay within
- * the pipeline lane's budget. Tagged @pipeline so it runs in the model-bearing
- * job and stays out of the fast model-free T2 lane.
+ * Collision de-duplication (a re-import of a same-basename file must not
+ * overwrite the first import's note) is covered model-free in
+ * audio-import-collision.t2; this spec keeps to one import to stay within the
+ * pipeline lane's budget. Tagged @pipeline so it runs in the model-bearing job
+ * and stays out of the fast model-free T2 lane.
  */
 
 type StenoWindow = Window & {

--- a/e2e/specs/audio-import.t2.spec.ts
+++ b/e2e/specs/audio-import.t2.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { makeWav } from '../fixtures/make-wav';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { selectEngine, isEngineModelReady, E2E_ENGINE } from '../fixtures/engine';
+import { killOllama } from '../fixtures/kill-ollama';
+import { mkdirSync, existsSync, rmSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — local audio-file import (@pipeline). Drives `process-recording`
+ * (the picker / drag-drop entry point) with a file that lives OUTSIDE the
+ * recordings dir and asserts the import is non-destructive end to end.
+ *
+ * This needs the model-bearing lane precisely because the bug it guards is
+ * post-transcription: `process-streaming` unlinks the processed audio after a
+ * successful transcribe when keep_recordings is off (the default). Before the
+ * copy-on-import fix the *original* was passed straight through and deleted;
+ * now the handler copies the file into recordings/ first, so the unlink only
+ * touches our copy and the user's source survives. With a real model the
+ * transcription succeeds, the unlink fires, and "the original still exists"
+ * is a genuine regression assertion that fails on the pre-fix code.
+ *
+ * Collision de-duplication (two same-basename imports -> distinct summaries)
+ * is covered at the unit level; this spec keeps to one import to stay within
+ * the pipeline lane's budget. Tagged @pipeline so it runs in the model-bearing
+ * job and stays out of the fast model-free T2 lane.
+ */
+
+type StenoWindow = Window & {
+  stenoai: {
+    recording: {
+      processFile: (filePath: string, name: string) => Promise<{ success?: boolean; error?: string }>;
+      getDir: () => Promise<{ success?: boolean; path?: string }>;
+    };
+  };
+};
+
+test('@pipeline importing a file creates a note and leaves the original on disk', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // Model load + transcribe + summarise can outlast Playwright's 30 s default
+  // on a cold CI runner; give the file-poll below room.
+  test.setTimeout(180_000);
+
+  // Mock Ollama on 11434 so summarisation never reaches a real LLM (kill any
+  // stray real one first so the successful bind proves the port is ours).
+  killOllama();
+  const ollama = await startMockOllama();
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Captured after launch so the finally block can tidy the copy without
+  // re-launching the app.
+  let recordingsDir: string | undefined;
+
+  try {
+    const { page } = await launchApp();
+    await selectEngine(page);
+
+    // Skip loudly if the active engine's model isn't installed (transcribe would
+    // otherwise auto-download ~0.5 GB). CI installs it before this spec.
+    const modelReady = await isEngineModelReady(page);
+    if (!modelReady) {
+      // eslint-disable-next-line no-console
+      console.warn(`[t2:@pipeline] SKIPPED: ${E2E_ENGINE} model not installed on this runner.`);
+      test.info().annotations.push({ type: 'skip-reason', description: `${E2E_ENGINE} model not installed` });
+    }
+    test.skip(!modelReady, `${E2E_ENGINE} model not installed`);
+
+    // The source lives OUTSIDE the recordings dir — this is the "import a file
+    // from elsewhere on disk" case (e.g. ~/Desktop/interview.m4a). It sits in
+    // the per-test temp dir so it's still hermetic.
+    const srcDir = path.join(userDataDir, 'import-src');
+    mkdirSync(srcDir, { recursive: true });
+    const srcPath = path.join(srcDir, 'imported.wav');
+    makeWav(srcPath, { seconds: 5 });
+
+    // Where the handler copies imports to (so the finally can tidy it).
+    const dir = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.recording.getDir(),
+    );
+    recordingsDir = dir?.path;
+
+    // Drive the real import pipeline through the app IPC (same path as the
+    // picker and drag-drop). Fire-and-forget: resolves once the file is copied
+    // and queued, not when transcription finishes.
+    const queued = await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.recording.processFile(p, 'Imported Note'),
+      srcPath,
+    );
+    expect(queued?.success).toBe(true);
+
+    // Completion: the summary lands in the temp output dir. The file name comes
+    // from the copy's stem (`imported`), proving the file flowed through the
+    // pipeline and a note was created.
+    const summaryPath = path.join(userDataDir, 'output', 'imported_summary.md');
+    await expect
+      .poll(() => existsSync(summaryPath), { timeout: 120_000, intervals: [1000] })
+      .toBe(true);
+
+    // The regression guard: the summary exists, so transcription succeeded and
+    // process-streaming has run its post-success cleanup (the unlink). The
+    // user's ORIGINAL file must still be on disk — it would be gone here on the
+    // pre-fix code, which fed the original straight to the pipeline.
+    expect(existsSync(srcPath)).toBe(true);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    // Teardown: the app may have spawned its own `ollama serve` despite the
+    // mock (probe race); don't let it outlive the test.
+    killOllama();
+    // Best-effort: the copy lands in the app's recordings dir. keep_recordings
+    // defaults off so a successful transcribe already unlinked it, but if the
+    // run skipped or failed mid-way, clean up so the dev recordings/ dir (which
+    // isn't STENOAI_USER_DATA_DIR-isolated in an unpackaged run) stays tidy.
+    if (recordingsDir) {
+      rmSync(path.join(recordingsDir, 'imported.wav'), { force: true });
+    }
+  }
+});


### PR DESCRIPTION
## Description

Re-adds the ability to import an existing local audio file into Steno, via **two entry points**: an **"Import audio file…"** menu action (native file picker) and **drag-and-drop** onto the window. Both existed through v0.2.13 but were lost in the React/Vite renderer migration (#95) — the backend `process` command, the `select-audio-file`/`process-recording` IPC handlers, and the `pickAudioFile`/`processFile` preload bridge all survived, but no UI calls them anymore. Addresses #179.

**Problem.** You can only capture audio by recording live — there's no way to bring in a file you already have. The plumbing for it is still present but dead.

**Change.**
- Adds an **"Import audio file…"** action to the toolbar's recording-options (⋯) popover, and a **full-window drag-and-drop** target (overlay on drag, drops anywhere). Both share one `importAudioFile()` path; the meeting title defaults to the filename.
- Routes the import through the **same processing queue a stopped recording uses** (`addToProcessingQueue` → `process-streaming`), so it shows up as a processing row with a badge in the meeting list, serialises behind any in-flight job, and becomes a finished note on completion — instead of a blocking call with no visible progress. The trigger popover closes so the list row is visible; the import is fire-and-forget (the existing `processing-complete` listener refreshes the list).
- The processing timer also advances for queued jobs that have no recording elapsed (imported files): the queue records the job's start time and reports it as `elapsedSeconds`, and the Processing view falls back to it when there's no live draft, so the badge/dock count up instead of sticking at 0s.
- Drag-and-drop resolves the dropped file's path via `webUtils.getPathForFile` (Electron 32+ removed `File.path`), exposed through the preload bridge.

**Verified at runtime.** On macOS via `npm start`, both paths: picked and dropped a recording — the row appears immediately with a counting-up "Processing" badge, the import respects the user's configured transcription + summary settings, and the finished note lands with a correct, structured summary. Long files transcribe fine via the chunking already in `main` (#175).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

## Additional Notes

macOS-only verification (no Windows machine here). The change is platform-agnostic — renderer/preload plus the existing cross-platform `process-recording` handler — and touches no platform-gated code. `webUtils.getPathForFile` is cross-platform.
