### PR TITLE
fix: make note deletion feel instant (optimistic cache removal)

### DIFF
--- a/app/renderer/src/hooks/useMeetings.ts
+++ b/app/renderer/src/hooks/useMeetings.ts
@@ -146,7 +146,36 @@ export function useDeleteMeeting() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (meeting: Meeting) => unwrap(await ipc().meetings.delete(meeting)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: meetingsKeys.all }),
+    // Remove the row from the list immediately. The file deletion itself is
+    // fast (a direct fs unlink in the main process), but the follow-up list
+    // refresh shells out to the bundled backend — a multi-second cold start —
+    // so without this the deleted note lingers on screen, looking like
+    // nothing happened, until the refetch lands. Optimistic removal also
+    // prevents a second delete on the same note (which fails as "already
+    // deleted").
+    onMutate: async (meeting) => {
+      await qc.cancelQueries({ queryKey: meetingsKeys.list() });
+      qc.setQueryData<Meeting[] | undefined>(meetingsKeys.list(), (old) =>
+        old?.filter(
+          (m) => m.session_info.summary_file !== meeting.session_info.summary_file,
+        ),
+      );
+    },
+    onError: (_err, meeting) => {
+      // Re-insert only the meeting that failed to delete, rather than restoring
+      // a whole pre-delete snapshot — a snapshot would clobber a concurrent
+      // in-flight delete's optimistic removal. Order is reconciled by the
+      // onSettled refetch.
+      qc.setQueryData<Meeting[] | undefined>(meetingsKeys.list(), (old) =>
+        !old ||
+        old.some(
+          (m) => m.session_info.summary_file === meeting.session_info.summary_file,
+        )
+          ? old
+          : [...old, meeting],
+      );
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: meetingsKeys.all }),
   });
 }
 


### PR DESCRIPTION
## Description

**Problem.** Deleting a note felt broken: you'd click Delete, nothing visibly happened for ~20–30 s, then the note disappeared — and clicking Delete again in the meantime hit the backend with an already-deleted note. The deletion itself is fast (a direct `fs` unlink in the main process), but `useDeleteMeeting` then invalidates the list, which re-runs `list-meetings` — a multi-second cold start of the bundled backend. The deleted note lingered on screen until that refetch landed, looking like nothing happened.

**Change.** Remove the row from the react-query cache optimistically in `onMutate` (with a snapshot for rollback), roll back in `onError`, and reconcile via the background refetch in `onSettled`. The note now disappears immediately on click, and because it's already gone from the list there's no second (failing) delete.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tested locally with `npm start`
- [ ] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

## Additional Notes

Single-file change to `useDeleteMeeting`. The same cold-start-subprocess pattern affects other mutations (reprocess, rename) — those could get the same optimistic treatment in a follow-up if useful.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make note deletion feel instant by removing the note from the `@tanstack/react-query` cache immediately and reconciling via a background refetch. This stops the lingering item and avoids a second (failing) delete during backend cold starts.

- **Bug Fixes**
  - Optimistic removal in `useDeleteMeeting` with `onMutate` + `setQueryData` (no snapshot); cancel in-flight list queries to prevent races.
  - Roll back by re-inserting only the failed meeting in `onError`; reconcile via `onSettled` invalidation.

<sup>Written for commit dca1f392ce46ed39a5f615b533c38f825941615c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

