### PR TITLE
chore: bump bundled Ollama to v0.30.8 (enables Gemma 4 models)

### DIFF
--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-OLLAMA_VERSION="v0.17.5"
+OLLAMA_VERSION="v0.30.8"
 BIN_DIR="$(cd "$(dirname "$0")/.." && pwd)/bin"
 
 # --- Download ffmpeg ---

--- a/stenoai.spec
+++ b/stenoai.spec
@@ -197,15 +197,18 @@ for pkg in _DYLIB_PKGS:
 # lib/ollama/ that must be preserved relative to ollama.exe.
 import os
 
-# Ollama's Windows bundle ships GPU runner libs under lib/ollama/{cuda_v12,
-# cuda_v13,vulkan,rocm}. They're NVIDIA-/discrete-GPU-only and add ~2.7 GB
-# (cuda_v12/ggml-cuda.dll alone is 1.6 GB) — dead weight on the CPU-only path:
+# Ollama's Windows bundle ships GPU runner libs under lib/ollama/. As of
+# v0.30.8 that's lib/ollama/{cuda_v12,cuda_v13,vulkan} (rocm is no longer
+# shipped). They're NVIDIA-/discrete-GPU-only and add multiple GB
+# (each cuda_v*/ggml-cuda.dll is ~1.6 GB) — dead weight on the CPU-only path:
 # transcription is ONNX-CPU, and the bundled Ollama summarises on the CPU
-# runner (ggml-cpu-*.dll / ggml-base.dll, which we keep). Skipping them takes
-# the Windows download from ~3.1 GB to ~0.6 GB and lets the NSIS installer
-# build (makensis can't mmap a multi-GB app .7z). GPU acceleration for NVIDIA
-# users is a tracked follow-up (separate build/pack). No-op on macOS — these
-# dirs don't exist there.
+# runner (ggml-cpu-*.dll / ggml-base.dll, which we keep). Skipping them keeps
+# the Windows bundle small enough for the NSIS installer to build (makensis
+# can't mmap a multi-GB app .7z). GPU acceleration for NVIDIA users is a
+# tracked follow-up (separate build/pack). The substring markers match any
+# cuda_vNN dir; rocm is kept as a defensive marker in case a future Ollama
+# re-adds it. No-op on macOS — these dirs don't exist there (Metal is built
+# into the darwin binary + its mlx_metal_v3/ runner, which we keep).
 _OLLAMA_GPU_MARKERS = ('lib/ollama/cuda', 'lib/ollama/rocm', 'lib/ollama/vulkan')
 ollama_bin_dir = os.path.join(SPECPATH, 'bin')
 if os.path.exists(ollama_bin_dir):


### PR DESCRIPTION
## Why

The Gemma 4 models added in #186 — `gemma4:12b` and `gemma4:e2b-it-qat` — **cannot run on the bundled Ollama 0.17.5**. Per Ollama's release notes, `gemma4:12b` support landed in **v0.30.3** and the QAT variants in **v0.30.6**. On the packaged app, selecting either Gemma 4 option in Settings → AI fails to pull/load the model. (#186's "tested end-to-end" passed only in dev, where the app talks to whatever Ollama is already on :11434 — a newer local one — not the bundled 0.17.5 users ship with.)

This bumps the bundled version to the latest **v0.30.8**.

## Change

- `scripts/download-ollama.sh`: `OLLAMA_VERSION` `v0.17.5` → `v0.30.8` (asset names are stable across releases, so this is the only functional change).
- `stenoai.spec`: comment refresh only — the GPU-lib prune logic is unchanged and still correct (verified below).

## Verification (both shipping platforms)

Inspected the actual v0.30.8 release assets:

- **Windows** (`ollama-windows-amd64.zip`, 1.46 GB): GPU runner libs are still under `lib/ollama/{cuda_v12, cuda_v13, vulkan}`, so the existing `_OLLAMA_GPU_MARKERS` substring prune in `stenoai.spec` still strips them (each `cuda_v*/ggml-cuda.dll` is ~1.6 GB). `rocm` is **no longer shipped** in 0.30.8 — its marker is now a harmless defensive no-op. The CPU runners we keep (`ggml-cpu-*.dll`, `ggml-base.dll`, `ggml.dll`, `libllama*.dll`, `llama-server.exe`) remain directly under `lib/ollama/`, and `ollama.exe` at root. So the bundle stays lean and the NSIS installer remains buildable.
- **macOS** (`ollama-darwin.tgz`, 142 MB): flat layout — `ollama` binary + runner dylibs + an `mlx_metal_v3/` Metal backend. No cuda/rocm/vulkan, so the prune is a no-op and libs stay co-located with the binary. Minimum macOS is still **14 (Sonoma)**, matching the existing gate in `app/main.js:4383`.
- No other references to the old version remain in the repo.

## Testing required before release (bundled-binary change)

Per the production-readiness rules, this changes shipped binaries, so confirm before tagging a release:
- [ ] **Windows NSIS build is green** (`build-windows.yml`, incl. `onnx-selftest`) — this is where the prune actually executes and the installer is assembled; confirm it still fits.
- [ ] **macOS packaged DMG cold-start** — `ollama serve` starts and a Gemma 4 model (`gemma4:e2b-it-qat`) pulls + summarizes on the installed app.
- [ ] Spot-check that `gemma4:12b` / `gemma4:e2b-it-qat` now pull on the packaged app (the whole point of the bump).

## Notes
- This effectively **gates the next release**: shipping `main` as-is gives users two broken Gemma 4 options. If a release is imminent and this can't be verified in time, the interim alternative is to hide/deprecate those two registry entries until the bundle is bumped.
- gemma4 on Windows runs **CPU-only** (the GPU libs above are exactly what's pruned), so `gemma4:12b` will be slow there; `e2b-it-qat` is the realistic Windows pick.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps bundled `ollama` to v0.30.8 so Gemma 4 models run on the packaged app. Windows GPU libs remain pruned to keep the installer small; macOS layout is unchanged.

- **Dependencies**
  - Update `scripts/download-ollama.sh` to `OLLAMA_VERSION="v0.30.8"`.
  - Refresh comments in `stenoai.spec`; `_OLLAMA_GPU_MARKERS` stay the same and still match v0.30.8.

- **Migration**
  - Verify Windows NSIS build is green.
  - On macOS, cold-start and pull a Gemma 4 model to confirm it runs.

<sup>Written for commit 091e7d413dafbbaa6ed41ca11ac7cbdf61a7c16f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

