### PR TITLE
feat: honor enterprise sharing policy from the org adapter

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -107,6 +107,13 @@ function install({ ipcMain }) {
   // permissive { success: true } — enough to keep invoke() from rejecting.
   const DEFAULTS = {
     'get-app-version': '0.0.0-e2e',
+    // Fires on first paint once signed in (Sidebar + RouteView gate the
+    // Shared notes feature on it). Default to feature-enabled to match the
+    // adapter's default and keep the org-lock spec's UI unchanged.
+    'org-get-policy': {
+      success: true,
+      policy: { auto_share_default: true, shared_notes_enabled: true },
+    },
     'list-meetings': { success: true, meetings: [] },
     'list-folders': { success: true, folders: [] },
     'get-calendar-events': { success: true, events: [] },

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -109,10 +109,14 @@ function install({ ipcMain }) {
     'get-app-version': '0.0.0-e2e',
     // Fires on first paint once signed in (Sidebar + RouteView gate the
     // Shared notes feature on it). Default to feature-enabled to match the
-    // adapter's default and keep the org-lock spec's UI unchanged.
+    // adapter's default and keep the org-lock spec's UI unchanged. A spec can
+    // drive the hidden path by launching with STENOAI_E2E_SHARED_NOTES=0.
     'org-get-policy': {
       success: true,
-      policy: { auto_share_default: true, shared_notes_enabled: true },
+      policy: {
+        auto_share_default: true,
+        shared_notes_enabled: process.env.STENOAI_E2E_SHARED_NOTES !== '0',
+      },
     },
     'list-meetings': { success: true, meetings: [] },
     'list-folders': { success: true, folders: [] },

--- a/app/main.js
+++ b/app/main.js
@@ -8583,6 +8583,19 @@ ipcMain.handle('org-try-auto-backup', async (_event, payload) => {
     const session = loadOrgSession();
     if (!session) return { attempted: false, reason: 'not-signed-in' };
 
+    // Close the sign-in seeding race (cubic P1): the sign-in handler seeds
+    // the auto-backup default fire-and-forget, so a recording that finishes
+    // right after sign-in could reach this gate before the org's
+    // auto_share_default has been written — and the read below treats an
+    // unset pref as enabled (!== false), which would auto-share against an
+    // org policy of auto_share_default=false. seedOrgAutoBackupDefault is
+    // idempotent (writes only when no pref exists, swallows its own errors),
+    // so awaiting it here deterministically materialises the policy default
+    // before we decide. The adapter is necessarily reachable on the path
+    // that actually uploads, so this fetch is the same reachability the
+    // share itself needs.
+    await seedOrgAutoBackupDefault();
+
     // Fail closed: any error / unparseable output treats the toggle as
     // disabled. A privacy + sharing setting should never default ON via a
     // transient read failure — if the user enabled it, they can do so

--- a/app/main.js
+++ b/app/main.js
@@ -8092,6 +8092,9 @@ ipcMain.handle('org-login', async (_event, payload) => {
     markOrgKnown();
     // Fire-and-forget — sign-in shouldn't wait on a config write.
     autoSwitchToAdapterOnSignIn().catch(() => {});
+    // Seed the auto-backup toggle from the org's auto_share_default (only
+    // if the user hasn't set it). Fire-and-forget for the same reason.
+    seedOrgAutoBackupDefault().catch(() => {});
     return {
       success: true,
       signedIn: true,
@@ -8286,6 +8289,9 @@ ipcMain.handle('org-sso-google-start', async (_event, payload) => {
     markOrgKnown();
     // Fire-and-forget — sign-in shouldn't wait on a config write.
     autoSwitchToAdapterOnSignIn().catch(() => {});
+    // Seed the auto-backup toggle from the org's auto_share_default (only
+    // if the user hasn't set it). Fire-and-forget for the same reason.
+    seedOrgAutoBackupDefault().catch(() => {});
     return {
       success: true,
       signedIn: true,
@@ -8526,6 +8532,38 @@ ipcMain.handle('org-set-auto-backup', async (_event, enabled) => {
     return { success: false, error: e.message };
   }
 });
+
+// Enterprise policy published by the adapter (GET /policy, authenticated).
+// Shape: { auto_share_default, shared_notes_enabled }. The desktop honors
+// these in the UI; the adapter also enforces the security-relevant half
+// (shared_notes_enabled) server-side.
+async function fetchOrgPolicy() {
+  return adapterFetch('/policy');
+}
+
+ipcMain.handle('org-get-policy', async () => {
+  try {
+    const policy = await fetchOrgPolicy();
+    return { success: true, policy };
+  } catch (e) {
+    return { success: false, error: e.message };
+  }
+});
+
+// Seed the local auto-backup toggle from the adapter's auto_share_default
+// on sign-in. "Default only" contract: Python only writes the value when
+// the user has no stored preference, so an explicit user choice is never
+// clobbered on a later sign-in. Fire-and-forget — on any failure the
+// historical default (true) stays in place.
+async function seedOrgAutoBackupDefault() {
+  try {
+    const policy = await fetchOrgPolicy();
+    const def = policy?.auto_share_default !== false; // default true
+    await runPythonScript('simple_recorder.py', ['seed-org-auto-backup', def ? 'True' : 'False']);
+  } catch (e) {
+    sendDebugLog('seed-org-auto-backup-default: ' + (e?.message || e));
+  }
+}
 
 // Single-shot auto-backup gateway. The renderer fires this once per
 // processing-complete event; main does all the gating (signed in + toggle

--- a/app/preload.js
+++ b/app/preload.js
@@ -271,6 +271,7 @@ const stenoai = {
     unshareBySummary: (summaryFile) => invoke('org-unshare-by-summary', summaryFile),
     getAutoBackup: () => invoke('org-get-auto-backup'),
     setAutoBackup: (enabled) => invoke('org-set-auto-backup', enabled),
+    getPolicy: () => invoke('org-get-policy'),
     tryAutoBackup: (payload) => invoke('org-try-auto-backup', payload),
     aiChat: (payload) => invoke('org-ai-chat', payload),
     /** Fire-and-forget streaming start. Chunks arrive via query-chunk +

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -9,7 +9,7 @@ import { Home } from '@/routes/Home';
 import { MeetingDetail } from '@/routes/MeetingDetail';
 import { FolderDetail } from '@/routes/FolderDetail';
 import { OrgShared, OrgSharedDetail } from '@/routes/OrgShared';
-import { useOrgSession, useSharedNotesEnabled } from '@/hooks/useOrg';
+import { useOrgSession, useSharedNotesGate } from '@/hooks/useOrg';
 import { Recording } from '@/routes/Recording';
 import { Processing, ProcessingDock } from '@/routes/Processing';
 import { AskBar, TranscriptBar } from '@/components/AskBar';
@@ -234,7 +234,19 @@ function RouteView({ route }: { route: string }) {
   // routes on it so a stale nav or deep-link can't reach the browse view
   // or its detail (the detail is what wires the cross-folder AskBar chat).
   const orgSession = useOrgSession();
-  const sharedNotesEnabled = useSharedNotesEnabled(orgSession.data?.signedIn ?? false);
+  const sharedNotes = useSharedNotesGate(orgSession.data?.signedIn ?? false);
+
+  // If we're sitting on a Shared notes route that policy has now resolved as
+  // disabled, redirect to Home rather than rendering Home in place — keeps
+  // the URL and content in agreement (and the sidebar active-state correct).
+  // Gated on `resolved` so this only fires once we *know* it's disabled, not
+  // during the initial load. Effect, never navigate() during render.
+  const onOrgSharedRoute = route === '/org/shared' || route.startsWith('/org/shared/');
+  React.useEffect(() => {
+    if (onOrgSharedRoute && sharedNotes.resolved && !sharedNotes.enabled) {
+      navigate('/');
+    }
+  }, [onOrgSharedRoute, sharedNotes.resolved, sharedNotes.enabled]);
 
   if (route === '/dev' || route.startsWith('/dev/')) return <Sandbox />;
   // Match deep-links like /settings?tab=organisation too — the Settings
@@ -257,7 +269,9 @@ function RouteView({ route }: { route: string }) {
     return <FolderDetail folderId={folderId} />;
   }
   if (route === '/org/shared' || route.startsWith('/org/shared/')) {
-    if (!sharedNotesEnabled) return <Home mode="home" />;
+    // Not yet known-enabled (still loading, or disabled): show Home. The
+    // effect above redirects to '/' once the policy resolves to disabled.
+    if (!sharedNotes.enabled) return <Home mode="home" />;
     if (route === '/org/shared') return <OrgShared />;
     const id = safeDecode(route.slice('/org/shared/'.length));
     return <OrgSharedDetail id={id} />;

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import { Home } from '@/routes/Home';
 import { MeetingDetail } from '@/routes/MeetingDetail';
 import { FolderDetail } from '@/routes/FolderDetail';
 import { OrgShared, OrgSharedDetail } from '@/routes/OrgShared';
+import { useOrgSession, useSharedNotesEnabled } from '@/hooks/useOrg';
 import { Recording } from '@/routes/Recording';
 import { Processing, ProcessingDock } from '@/routes/Processing';
 import { AskBar, TranscriptBar } from '@/components/AskBar';
@@ -229,6 +230,12 @@ function LiveRecordingDock() {
 }
 
 function RouteView({ route }: { route: string }) {
+  // Enterprise can hide the Shared notes feature. Gate the /org/shared
+  // routes on it so a stale nav or deep-link can't reach the browse view
+  // or its detail (the detail is what wires the cross-folder AskBar chat).
+  const orgSession = useOrgSession();
+  const sharedNotesEnabled = useSharedNotesEnabled(orgSession.data?.signedIn ?? false);
+
   if (route === '/dev' || route.startsWith('/dev/')) return <Sandbox />;
   // Match deep-links like /settings?tab=organisation too — the Settings
   // component reads the tab param off the route on mount.
@@ -249,8 +256,9 @@ function RouteView({ route }: { route: string }) {
     const folderId = safeDecode(route.slice('/folders/'.length));
     return <FolderDetail folderId={folderId} />;
   }
-  if (route === '/org/shared') return <OrgShared />;
-  if (route.startsWith('/org/shared/')) {
+  if (route === '/org/shared' || route.startsWith('/org/shared/')) {
+    if (!sharedNotesEnabled) return <Home mode="home" />;
+    if (route === '/org/shared') return <OrgShared />;
     const id = safeDecode(route.slice('/org/shared/'.length));
     return <OrgSharedDetail id={id} />;
   }

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -15,7 +15,7 @@ import { navigate, rememberNonSettingsRoute, toggleSettings } from '@/lib/router
 import { cn, shortcut } from '@/lib/utils';
 import { LucideIcon, IconPicker } from '@/components/IconPicker';
 import { useUpdateFolderIcon } from '@/hooks/useFolders';
-import { useOrgLogout, useOrgSession, useSharedNotesEnabled } from '@/hooks/useOrg';
+import { useOrgLogout, useOrgSession, useSharedNotesGate } from '@/hooks/useOrg';
 
 export interface SidebarMeeting {
   summaryFile: string;
@@ -179,7 +179,9 @@ export function Sidebar({
   const orgLogout = useOrgLogout();
   const orgSignedIn = orgSession.data?.signedIn ?? false;
   // Enterprise can hide the Shared notes feature (tab + cross-folder chat).
-  const sharedNotesEnabled = useSharedNotesEnabled(orgSignedIn);
+  // `enabled` stays false until policy resolves, so the tab doesn't flash in
+  // then vanish for an org that has the feature turned off.
+  const sharedNotes = useSharedNotesGate(orgSignedIn);
   // Malformed % escapes throw URIError. Guard so a bad route can't crash
   // the entire sidebar render.
   const activeFolderId = React.useMemo<string | null>(() => {
@@ -403,7 +405,7 @@ export function Sidebar({
             <span className="flex-1 truncate">Chat</span>
           </button>
 
-          {orgSignedIn && sharedNotesEnabled && (
+          {sharedNotes.enabled && (
             <button
               type="button"
               className={cn('sb-row', isOrgSharedActive && 'active')}

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -15,7 +15,7 @@ import { navigate, rememberNonSettingsRoute, toggleSettings } from '@/lib/router
 import { cn, shortcut } from '@/lib/utils';
 import { LucideIcon, IconPicker } from '@/components/IconPicker';
 import { useUpdateFolderIcon } from '@/hooks/useFolders';
-import { useOrgLogout, useOrgSession } from '@/hooks/useOrg';
+import { useOrgLogout, useOrgSession, useSharedNotesEnabled } from '@/hooks/useOrg';
 
 export interface SidebarMeeting {
   summaryFile: string;
@@ -178,6 +178,8 @@ export function Sidebar({
   const orgSession = useOrgSession();
   const orgLogout = useOrgLogout();
   const orgSignedIn = orgSession.data?.signedIn ?? false;
+  // Enterprise can hide the Shared notes feature (tab + cross-folder chat).
+  const sharedNotesEnabled = useSharedNotesEnabled(orgSignedIn);
   // Malformed % escapes throw URIError. Guard so a bad route can't crash
   // the entire sidebar render.
   const activeFolderId = React.useMemo<string | null>(() => {
@@ -401,7 +403,7 @@ export function Sidebar({
             <span className="flex-1 truncate">Chat</span>
           </button>
 
-          {orgSignedIn && (
+          {orgSignedIn && sharedNotesEnabled && (
             <button
               type="button"
               className={cn('sb-row', isOrgSharedActive && 'active')}

--- a/app/renderer/src/hooks/useOrg.ts
+++ b/app/renderer/src/hooks/useOrg.ts
@@ -90,12 +90,21 @@ export function useOrgPolicy(enabled = true) {
  *
  *  Failing closed while loading (rather than the old default-true) trades a
  *  one-frame delay before the tab appears for an enabled org against never
- *  flashing it for a disabled one — the latter is the case that matters. */
+ *  flashing it for a disabled one — the latter is the case that matters.
+ *
+ *  Keyed on `isFetchedAfterMount`, not `isSuccess`: the policy query cache is
+ *  shared and survives sign-out (invalidate keeps stale data until refetch),
+ *  so a *previous* org's cached "enabled" could otherwise satisfy the gate
+ *  before this session's fetch lands — flashing the tab for an org that
+ *  disabled it. isFetchedAfterMount is only true once a fetch has completed
+ *  since this observer mounted, so stale cross-session cache can't leak in. */
 export function useSharedNotesGate(signedIn: boolean): { enabled: boolean; resolved: boolean } {
   const policy = useOrgPolicy(signedIn);
-  const resolved = !signedIn || policy.isSuccess || policy.isError;
+  const resolved = !signedIn || policy.isError || policy.isFetchedAfterMount;
   const enabled =
-    signedIn && resolved && policy.data?.shared_notes_enabled !== false;
+    signedIn &&
+    (policy.isError ||
+      (policy.isFetchedAfterMount && policy.data?.shared_notes_enabled !== false));
   return { enabled, resolved };
 }
 

--- a/app/renderer/src/hooks/useOrg.ts
+++ b/app/renderer/src/hooks/useOrg.ts
@@ -77,13 +77,26 @@ export function useOrgPolicy(enabled = true) {
   });
 }
 
-/** Convenience boolean for the most common gate: is the cross-user Shared
- *  notes feature available? Defaults to true while the policy loads or when
- *  signed out, matching the adapter's default and avoiding a hide flicker
- *  for the common (enabled) case. */
-export function useSharedNotesEnabled(signedIn: boolean): boolean {
+/** Gate for the cross-user Shared notes feature (tab + browse routes).
+ *
+ *  - `enabled` — render the feature. Held `false` while the policy is still
+ *    loading so a disabled org never flashes the tab/route on before the
+ *    one-shot fetch resolves; flips true only once we positively know the
+ *    feature is on (or the fetch errored — fail-open for the UI, since the
+ *    adapter still enforces owner-only server-side either way).
+ *  - `resolved` — the policy has produced a verdict (success or error).
+ *    Callers use this to tell "still loading" apart from "known disabled"
+ *    so a redirect only fires once the answer is in, not mid-load.
+ *
+ *  Failing closed while loading (rather than the old default-true) trades a
+ *  one-frame delay before the tab appears for an enabled org against never
+ *  flashing it for a disabled one — the latter is the case that matters. */
+export function useSharedNotesGate(signedIn: boolean): { enabled: boolean; resolved: boolean } {
   const policy = useOrgPolicy(signedIn);
-  return policy.data?.shared_notes_enabled !== false;
+  const resolved = !signedIn || policy.isSuccess || policy.isError;
+  const enabled =
+    signedIn && resolved && policy.data?.shared_notes_enabled !== false;
+  return { enabled, resolved };
 }
 
 // Sign-in / sign-out auto-switches the Python-side ai_provider (between

--- a/app/renderer/src/hooks/useOrg.ts
+++ b/app/renderer/src/hooks/useOrg.ts
@@ -12,6 +12,7 @@ import type {
 export const orgKeys = {
   all: ['org'] as const,
   status: () => [...orgKeys.all, 'status'] as const,
+  policy: () => [...orgKeys.all, 'policy'] as const,
   meetings: () => [...orgKeys.all, 'meetings'] as const,
   meeting: (id: string) => [...orgKeys.all, 'meeting', id] as const,
   autoBackup: () => [...orgKeys.all, 'auto-backup'] as const,
@@ -57,6 +58,32 @@ export function useOrgSession() {
   }, [exp, qc]);
 
   return query;
+}
+
+/** Enterprise policy from the adapter (GET /policy). Fetched once the user
+ *  is signed in and used to shape the UI: whether to show the Shared notes
+ *  tab + cross-folder chat (`shared_notes_enabled`) and the seed value for
+ *  the auto-backup toggle (`auto_share_default`, applied on sign-in in main).
+ *  The adapter also enforces shared_notes_enabled server-side, so the UI
+ *  gate is defense-in-depth, not the only line. Consumers should treat a
+ *  not-yet-loaded policy as feature-enabled (`!== false`) to preserve the
+ *  historical default while the one-shot fetch is in flight. */
+export function useOrgPolicy(enabled = true) {
+  return useQuery({
+    queryKey: orgKeys.policy(),
+    queryFn: async () => unwrap(await ipc().org.getPolicy()).policy,
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+/** Convenience boolean for the most common gate: is the cross-user Shared
+ *  notes feature available? Defaults to true while the policy loads or when
+ *  signed out, matching the adapter's default and avoiding a hide flicker
+ *  for the common (enabled) case. */
+export function useSharedNotesEnabled(signedIn: boolean): boolean {
+  const policy = useOrgPolicy(signedIn);
+  return policy.data?.shared_notes_enabled !== false;
 }
 
 // Sign-in / sign-out auto-switches the Python-side ai_provider (between

--- a/app/renderer/src/hooks/useOrg.ts
+++ b/app/renderer/src/hooks/useOrg.ts
@@ -12,7 +12,7 @@ import type {
 export const orgKeys = {
   all: ['org'] as const,
   status: () => [...orgKeys.all, 'status'] as const,
-  policy: () => [...orgKeys.all, 'policy'] as const,
+  policy: (orgId?: string) => [...orgKeys.all, 'policy', orgId ?? 'none'] as const,
   meetings: () => [...orgKeys.all, 'meetings'] as const,
   meeting: (id: string) => [...orgKeys.all, 'meeting', id] as const,
   autoBackup: () => [...orgKeys.all, 'auto-backup'] as const,
@@ -60,51 +60,50 @@ export function useOrgSession() {
   return query;
 }
 
-/** Enterprise policy from the adapter (GET /policy). Fetched once the user
- *  is signed in and used to shape the UI: whether to show the Shared notes
- *  tab + cross-folder chat (`shared_notes_enabled`) and the seed value for
- *  the auto-backup toggle (`auto_share_default`, applied on sign-in in main).
- *  The adapter also enforces shared_notes_enabled server-side, so the UI
- *  gate is defense-in-depth, not the only line. Consumers should treat a
- *  not-yet-loaded policy as feature-enabled (`!== false`) to preserve the
- *  historical default while the one-shot fetch is in flight. */
-export function useOrgPolicy(enabled = true) {
+/** Enterprise policy from the adapter (GET /policy). Fetched once the user is
+ *  signed in and used to shape the UI: whether to show the Shared notes tab +
+ *  cross-folder chat (`shared_notes_enabled`) and the seed value for the
+ *  auto-backup toggle (`auto_share_default`, applied on sign-in in main). The
+ *  adapter also enforces shared_notes_enabled server-side, so the UI gate is
+ *  defense-in-depth, not the only line.
+ *
+ *  The query is keyed by `org_id`: a different org is a different cache entry,
+ *  so a *previous* org's cached policy can never satisfy the gate before the
+ *  current org's fetch lands (the stale-cross-org-cache concern). Within one
+ *  org, the cache is reused — reconnecting the same org shows its (correct)
+ *  policy immediately with no refetch flash. */
+export function useOrgPolicy() {
+  const session = useOrgSession();
+  const orgId = session.data?.signedIn ? session.data.orgId : undefined;
   return useQuery({
-    queryKey: orgKeys.policy(),
+    queryKey: orgKeys.policy(orgId),
     queryFn: async () => unwrap(await ipc().org.getPolicy()).policy,
-    enabled,
+    enabled: Boolean(orgId),
     staleTime: 60_000,
   });
 }
 
 /** Gate for the cross-user Shared notes feature (tab + browse routes).
  *
- *  - `enabled` — render the feature. Held `false` while the policy is still
- *    loading so a disabled org never flashes the tab/route on before the
- *    one-shot fetch resolves; flips true only once we positively know the
- *    feature is on (or the fetch errored — fail-open for the UI, since the
- *    adapter still enforces owner-only server-side either way).
- *  - `resolved` — the policy has produced a verdict (success or error).
- *    Callers use this to tell "still loading" apart from "known disabled"
- *    so a redirect only fires once the answer is in, not mid-load.
+ *  - `enabled` — render the feature. Held `false` until the current org's
+ *    policy fetch resolves, so a disabled org never flashes the tab/route on
+ *    before we know; flips true only once we positively know the feature is on
+ *    (or the fetch errored — fail-open for the UI, since the adapter still
+ *    enforces owner-only server-side either way).
+ *  - `resolved` — the policy produced a verdict (success or error) for the
+ *    current org. Callers use this to tell "still loading" apart from "known
+ *    disabled" so a redirect only fires once the answer is in, not mid-load.
  *
- *  Failing closed while loading (rather than the old default-true) trades a
- *  one-frame delay before the tab appears for an enabled org against never
- *  flashing it for a disabled one — the latter is the case that matters.
- *
- *  Keyed on `isFetchedAfterMount`, not `isSuccess`: the policy query cache is
- *  shared and survives sign-out (invalidate keeps stale data until refetch),
- *  so a *previous* org's cached "enabled" could otherwise satisfy the gate
- *  before this session's fetch lands — flashing the tab for an org that
- *  disabled it. isFetchedAfterMount is only true once a fetch has completed
- *  since this observer mounted, so stale cross-session cache can't leak in. */
+ *  Because the query is keyed per-org (see useOrgPolicy), `isSuccess` here can
+ *  only mean *this* org's policy resolved — there's no cross-org cache to leak
+ *  a stale "enabled" through, so the simple success check is both correct and
+ *  reliable (an over-strict isFetchedAfterMount check hid the tab even for
+ *  enabled orgs whose policy was already cache-fresh). */
 export function useSharedNotesGate(signedIn: boolean): { enabled: boolean; resolved: boolean } {
-  const policy = useOrgPolicy(signedIn);
-  const resolved = !signedIn || policy.isError || policy.isFetchedAfterMount;
+  const policy = useOrgPolicy();
+  const resolved = !signedIn || policy.isSuccess || policy.isError;
   const enabled =
-    signedIn &&
-    (policy.isError ||
-      (policy.isFetchedAfterMount && policy.data?.shared_notes_enabled !== false));
+    signedIn && resolved && policy.data?.shared_notes_enabled !== false;
   return { enabled, resolved };
 }
 

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -228,6 +228,18 @@ export type OrgTryAutoBackupResponse =
 export type GetOrgAutoBackupResponse = Result<{ org_auto_backup_enabled: boolean }>;
 export type SetOrgAutoBackupResponse = Result<{ org_auto_backup_enabled: boolean }>;
 
+/** Enterprise policy published by the adapter (GET /policy). The desktop
+ *  honors these in the UI; the adapter also enforces shared_notes_enabled
+ *  server-side (a disabled feature collapses /meetings to owner-only). */
+export interface OrgPolicy {
+  /** Initial on-state for the auto-backup toggle, seeded on first sign-in. */
+  auto_share_default: boolean;
+  /** When false, hide the Shared notes tab + cross-folder chat. */
+  shared_notes_enabled: boolean;
+}
+
+export type GetOrgPolicyResponse = Result<{ policy: OrgPolicy }>;
+
 export type OrgGetBackupStateResponse = Result<{
   shared: boolean;
   meeting_id: string | null;
@@ -820,6 +832,7 @@ export interface StenoaiBridge {
     unshareBySummary: RequestFn<[summaryFile: string], OrgUnshareBySummaryResponse>;
     getAutoBackup: RequestFn<[], GetOrgAutoBackupResponse>;
     setAutoBackup: RequestFn<[enabled: boolean], SetOrgAutoBackupResponse>;
+    getPolicy: RequestFn<[], GetOrgPolicyResponse>;
     tryAutoBackup: RequestFn<[payload: OrgTryAutoBackupPayload], OrgTryAutoBackupResponse>;
     aiChat: RequestFn<[payload: OrgChatPayload], OrgChatResponse>;
     chatStream: SendFn<[streamId: string, payload: OrgChatPayload]>;

--- a/e2e/fixtures/mock-adapter.js
+++ b/e2e/fixtures/mock-adapter.js
@@ -43,6 +43,13 @@ function startMockAdapter() {
               org_id: 'org-e2e',
             }),
           );
+        } else if (req.method === 'GET' && req.url === '/policy') {
+          // Enterprise policy the desktop fetches on sign-in (auto-share
+          // seed) and to gate the Shared notes feature. Defaults here.
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(
+            JSON.stringify({ auto_share_default: true, shared_notes_enabled: true }),
+          );
         } else {
           res.writeHead(404, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ detail: 'mock: not found' }));

--- a/e2e/specs/shared-notes-policy.t1.spec.ts
+++ b/e2e/specs/shared-notes-policy.t1.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '../fixtures/electron';
+import type { Page } from '@playwright/test';
+
+/**
+ * T1 — renderer-only, mock IPC, no backend. Drives the enterprise "Shared
+ * notes" policy gating through the real Electron renderer:
+ *  - default (org enables the feature): the sidebar "Shared notes" tab shows
+ *    and navigates to the browse view.
+ *  - STENOAI_E2E_SHARED_NOTES=0 (org disables it): the tab is hidden and a
+ *    deep-link to /org/shared is redirected back to Home.
+ *
+ * The policy wire shape is stubbed in app/e2e-mock-ipc.js (org-get-policy);
+ * T2 is the real-adapter cross-check. Gate logic: useSharedNotesGate in
+ * app/renderer/src/hooks/useOrg.ts.
+ */
+
+// Mirrors the org-lock.t1 sign-in flow, then returns to Home so the sidebar
+// is in view.
+async function signIn(page: Page) {
+  await page.evaluate(() => {
+    window.location.hash = '#/settings?tab=organisation';
+  });
+  await expect(page.getByTestId('org-sign-in-card')).toBeVisible();
+  await page.getByPlaceholder('https://steno-adapter.yourcompany.com').fill('https://e2e.example.com');
+  await page.getByPlaceholder('you@yourcompany.com').fill('e2e@example.com');
+  await page.getByPlaceholder('••••••').fill('hunter2');
+  await page.getByRole('button', { name: /sign in with password/i }).click();
+  await expect(page.getByTestId('org-signed-in-card')).toBeVisible();
+  await page.evaluate(() => {
+    window.location.hash = '#/';
+  });
+}
+
+test('enabled: Shared notes tab shows and opens the browse view', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+  await signIn(page);
+
+  const tab = page.getByRole('button', { name: 'Shared notes' });
+  await expect(tab).toBeVisible();
+
+  await tab.click();
+  // The browse view renders its own <h1>Shared notes</h1> (heading role,
+  // distinct from the sidebar button) once the route is allowed.
+  await expect(page.getByRole('heading', { name: 'Shared notes' })).toBeVisible();
+});
+
+test('disabled: Shared notes tab is hidden and /org/shared redirects to Home', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({ mockIpc: true, env: { STENOAI_E2E_SHARED_NOTES: '0' } });
+  await signIn(page);
+
+  // Deep-link straight to the browse route; the gate must redirect to Home
+  // once the policy resolves to disabled (navigate('/') -> hash '#/').
+  await page.evaluate(() => {
+    window.location.hash = '#/org/shared';
+  });
+  await expect
+    .poll(() => page.evaluate(() => window.location.hash), { timeout: 10_000 })
+    .toBe('#/');
+
+  // Did not land on the OrgShared browse view, and the sidebar tab is absent
+  // now that policy has positively resolved to disabled.
+  await expect(page.getByRole('heading', { name: 'Shared notes' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Shared notes' })).toHaveCount(0);
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3463,6 +3463,18 @@ def set_org_auto_backup(enabled):
 
 
 @cli.command()
+@click.argument('default', type=bool)
+def seed_org_auto_backup(default):
+    """Seed org auto-backup from the adapter's auto_share_default policy,
+    only when the user has no stored preference yet (set-the-default-only)."""
+    from src.config import get_config
+
+    config = get_config()
+    effective = config.seed_org_auto_backup_default(default)
+    print(json.dumps({"success": True, "org_auto_backup_enabled": effective}))
+
+
+@cli.command()
 @click.argument('enabled', type=bool)
 def set_dock_icon(enabled):
     """Set hide-dock-icon preference (True/False)"""

--- a/src/config.py
+++ b/src/config.py
@@ -554,6 +554,18 @@ class Config:
         self._config["org_auto_backup_enabled"] = enabled
         return self._save()
 
+    def seed_org_auto_backup_default(self, default: bool) -> bool:
+        """Seed the auto-backup preference from the enterprise adapter's
+        `auto_share_default` policy, but ONLY if the user has no stored
+        preference yet. This is the "set the default only" contract: the
+        org decides the initial on/off state for a brand-new user, after
+        which any explicit toggle by the user wins and is never clobbered
+        by a later sign-in. Returns the effective value."""
+        if "org_auto_backup_enabled" not in self._config:
+            self._config["org_auto_backup_enabled"] = bool(default)
+            self._save()
+        return self._config["org_auto_backup_enabled"]
+
 
     def get_keep_recordings(self) -> bool:
         """Get whether audio recordings should be kept after processing."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,6 +134,33 @@ class ConfigAutoDetectMeetingsTests(unittest.TestCase):
             self.assertTrue(reloaded.get_auto_detect_meetings_enabled())
 
 
+class ConfigOrgAutoBackupTests(unittest.TestCase):
+    def test_default_auto_backup_is_true(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertTrue(config.get_org_auto_backup_enabled())
+
+    def test_seed_applies_default_when_no_preference(self):
+        """First sign-in seeds the org's auto_share_default into config."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertFalse(config.seed_org_auto_backup_default(False))
+            self.assertFalse(config.get_org_auto_backup_enabled())
+            reloaded = Config(config_path=path)
+            self.assertFalse(reloaded.get_org_auto_backup_enabled())
+
+    def test_seed_does_not_clobber_explicit_user_choice(self):
+        """Once the user sets the toggle, a later seed must not overwrite it —
+        the enterprise sets the default only, the user's choice wins."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertTrue(config.set_org_auto_backup_enabled(True))
+            # Org default is False, but the user already chose True.
+            self.assertTrue(config.seed_org_auto_backup_default(False))
+            self.assertTrue(config.get_org_auto_backup_enabled())
+
+
 class ConfigKeepRecordingsTests(unittest.TestCase):
     def test_default_keep_recordings_is_false(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## What & why

Companion to the adapter's policy PR (ruzin/stenoai-enterprise#7). The adapter now publishes `GET /policy`; this wires the desktop to read it and honor two IT-lead-controlled settings.

### Auto-share default (set-the-default-only)
On sign-in, seed the local "auto-back up new notes" toggle from the adapter's `auto_share_default` — but **only when the user has no stored preference**. An explicit user choice always wins and is never clobbered on a later sign-in.
- New `seed-org-auto-backup` CLI command + `Config.seed_org_auto_backup_default`.

### Shared notes visibility
When the adapter sets `shared_notes_enabled=false`:
- Hide the **Shared notes** sidebar tab.
- Gate the `/org/shared` routes (the detail route is what wires the cross-folder AskBar chat), so a stale nav / deep-link can't reach it.

The adapter also enforces this server-side (collapses `/meetings` to owner-only), so the UI gate is defense-in-depth, not the only line.

## Wiring
`org-get-policy` IPC (`adapterFetch('/policy')`) → preload `org.getPolicy` → `ipc.ts` `OrgPolicy` type → `useOrgPolicy` / `useSharedNotesEnabled` hooks. Gated in `Sidebar.tsx` and `App.tsx` `RouteView`.

## Fixtures / tests
- T1 `app/e2e-mock-ipc.js` and T2 `e2e/fixtures/mock-adapter.js` updated to serve the new `/policy` shape (keeps the org-lock specs faithful).
- `tests/test_config.py` — 3 new tests for the seed default-only semantics (applies default when unset; never clobbers an explicit choice). Full config suite: **27 passed**.
- Renderer `typecheck:renderer` clean.

## Notes
- Defaults preserve current behaviour (`auto_share_default=true`, `shared_notes_enabled=true`) — no change for orgs that don't set the env vars.
- Scoped strictly to the policy feature; unrelated working-tree edits were intentionally left out of this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the enterprise org policy from the adapter to set the auto‑backup default and hide/gate Shared notes when disabled. Defaults keep current behavior for orgs without a policy.

- **New Features**
  - Read `GET /policy` via `org-get-policy`; expose `org.getPolicy`, `OrgPolicy`, and hooks `useOrgPolicy` / `useSharedNotesGate`.
  - Auto‑backup default: on sign‑in, run `seed-org-auto-backup` to apply `auto_share_default` only if unset; `Config.seed_org_auto_backup_default` preserves user choices.
  - Shared notes: when `shared_notes_enabled=false`, hide the sidebar tab and gate `/org/shared*` with a redirect; T1 e2e `shared-notes-policy.t1.spec.ts`; mocks support env `STENOAI_E2E_SHARED_NOTES=0`; mock adapter implements `/policy`.

- **Bug Fixes**
  - Close the sign‑in seeding race by awaiting the idempotent seed in `org-try-auto-backup`, preventing unintended auto‑share.
  - Gate polish: no reveal‑then‑hide tab flash; redirect off `/org/shared*` when disabled; key the policy query per‑org to avoid cross‑org stale cache. UI fails open on fetch error; server still enforces owner‑only.

<sup>Written for commit 61aa070946642cd0ba0ca0ea2ee257048838dec7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

