### PR TITLE
ci(e2e): pre-tag release gate + T1 backstop smoke

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,45 @@ permissions:
   contents: write
 
 jobs:
+  # Backstop gate. The real release gate is e2e-release-gate.yml on the release/*
+  # branch (full matrix, run BEFORE the tag). This is defense-in-depth for the
+  # case where a tag is pushed without going through that branch gate: a fast,
+  # hermetic T1 smoke (renderer + mock IPC, no Python backend, no models, no
+  # network) that build-macos depends on, so we can't sign + ship on a broken
+  # renderer / IPC contract. Deliberately T1-only — the heavy backend/model/ML
+  # coverage belongs to the branch gate + nightly, not the critical release path.
+  gate-smoke:
+    name: Release gate smoke (T1)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install Electron dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Install Linux system deps (+ xvfb)
+        working-directory: app
+        run: npx playwright install-deps
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build:renderer
+
+      - name: Run T1 under xvfb
+        working-directory: app
+        run: xvfb-run -a npm run test:e2e -- --project=t1
+
   build-macos:
+    needs: gate-smoke
     # Apple-Silicon only as of v0.4.0. macOS 26 (Tahoe) drops Intel and
     # our headline transcription engine (Parakeet TDT v3 via MLX) is
     # Apple-Silicon only, so the Intel build was shipping a degraded

--- a/.github/workflows/e2e-release-gate.yml
+++ b/.github/workflows/e2e-release-gate.yml
@@ -1,0 +1,122 @@
+name: e2e-release-gate
+
+# Pre-tag release gate. The full e2e suite, run BEFORE the immutable version tag
+# exists, so a regression in any covered area blocks the release instead of
+# reaching users.
+#
+# Why a release/* branch and not build-release.yml: build-release.yml triggers on
+# `git push tag vX.Y.Z` — by then the tag is already created, so a failing gate
+# there would leave a "tag exists but release failed" mess to unwind. Gating on
+# the release branch puts the green/red signal in front of the human BEFORE they
+# cut the tag. Release flow (see CLAUDE.md "Release Process"):
+#   1. branch  release/vX.Y.Z  off main
+#   2. this workflow runs the full matrix
+#   3. tag ONLY once it is green  ->  build-release.yml builds + ships
+#
+# Unlike e2e.yml (advisory/non-blocking per-PR), the human treats THIS run as a
+# hard prerequisite for the tag. The jobs themselves fail on any spec failure, so
+# the workflow conclusion is the gate.
+#
+# Manually triggerable (workflow_dispatch) to dry-run the gate without a branch.
+
+on:
+  push:
+    branches:
+      - 'release/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Full per-PR suite: T1 (Ubuntu) + macOS/Windows T2 (model-free) + macOS/Windows
+  # @pipeline (transcribe + summarize). Reused verbatim via `uses:` so there's no
+  # job duplication and the gate can never drift from what PRs run.
+  suite:
+    name: Full suite (release gate)
+    uses: ./.github/workflows/e2e.yml
+
+  # Heavy long-meeting chunking smoke (T3) — too slow for per-PR, but a release
+  # must not ship a broken long-file path. Mirrors e2e-nightly.yml's job: reuses
+  # the Windows backend bundle + parakeet-onnx model the suite just built/cached
+  # (download-artifact across the reusable-workflow boundary), so it adds no extra
+  # build/download. `needs: suite` couples it to the whole suite passing — correct
+  # for a gate (you don't tag on a partial pass anyway).
+  long-meeting-windows:
+    name: T3 long-meeting (parakeet onnx, Windows)
+    runs-on: windows-latest
+    needs: suite
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Download backend bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-backend-windows
+          path: dist/stenoai
+
+      - name: Ensure no stray Ollama
+        shell: pwsh
+        run: Stop-Process -Name ollama -Force -ErrorAction SilentlyContinue
+
+      # Same key as e2e.yml's t2-pipeline-windows, so the model the suite
+      # downloaded this run restores here instead of pulling the ~670 MB snapshot.
+      - name: Cache parakeet ONNX model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub/models--istupakov--parakeet-tdt-0.6b-v3-onnx
+          key: parakeet-onnx-${{ runner.os }}-tdt-0.6b-v3
+
+      - name: Install Electron dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build:renderer
+
+      - name: Ensure parakeet model present
+        shell: pwsh
+        run: |
+          ./dist/stenoai/stenoai.exe download-parakeet-model
+          $status = ./dist/stenoai/stenoai.exe parakeet-status | ConvertFrom-Json
+          if (-not $status.installed) {
+            Write-Error "Parakeet ONNX model not installed after download"
+            exit 1
+          }
+
+      # Assert the tagged spec is selected (Playwright exits 0 on a zero-match
+      # --grep). Capture first, then grep — `grep -q`'s early pipe-close crashes
+      # the node writer with EPIPE on Windows. A dropped @long-meeting tag must
+      # fail the gate, not silently run zero tests and pass green.
+      - name: Guard — @long-meeting test is selected
+        shell: bash
+        working-directory: app
+        run: |
+          out=$(npm run test:e2e -- --project=t3 --grep @long-meeting --list)
+          echo "$out" | grep -q '@long-meeting'
+
+      - name: Run T3 long-meeting (parakeet onnx)
+        working-directory: app
+        env:
+          STENOAI_E2E_ENGINE: parakeet
+        run: npm run test:e2e -- --project=t3 --grep '@long-meeting'
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-release-t3-long-meeting-report
+          path: |
+            app/playwright-report
+            app/test-results
+          retention-days: 7
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,17 +159,18 @@ Releases are automated via `.github/workflows/build-release.yml`. Never create r
    - One-line summary at the top.
    - Headline features grouped under `### Section` headers (e.g., "System audio", "UX polish", "Under the hood", "Fixes").
    - Migration/upgrade notes if anything changed paths, identifiers, defaults, or requires user action.
-6. **Create an annotated tag** on `main` with the release notes as the tag message. **Always pass `--cleanup=whitespace`** — without it, `git tag -F` strips every line starting with `#`, which silently deletes Markdown `### Section` headers from the release body:
+6. **Run the release gate (blocks the tag).** Push a `release/v<version>` branch — `git push origin main:refs/heads/release/v0.3.0` — to trigger `.github/workflows/e2e-release-gate.yml`, which runs the full e2e matrix (T1 + macOS/Windows T2 + `@pipeline` + the `@long-meeting` T3 smoke). **Do not create the tag until this run is green.** The gate runs on the branch, before the immutable tag exists, so a failure is fixed-and-re-pushed rather than leaving a half-released tag. (You can also dry-run it via `workflow_dispatch`.) `build-release.yml` additionally runs a fast T1 backstop smoke (`gate-smoke`) before signing, but that is defense-in-depth — the branch gate is the real signal.
+7. **Create an annotated tag** on `main` with the release notes as the tag message. **Always pass `--cleanup=whitespace`** — without it, `git tag -F` strips every line starting with `#`, which silently deletes Markdown `### Section` headers from the release body:
    ```
    git tag -a v0.3.0 --cleanup=whitespace -F /path/to/notes.md
    git push origin v0.3.0
    ```
    (If using `-m` instead of `-F`, pass `--cleanup=whitespace` anyway — the comment-stripping default applies to both.)
-7. The tag push triggers the workflow which:
+8. The tag push triggers the workflow which:
    - Builds signed + notarized DMGs for both arm64 and x64
    - Creates a GitHub Release with the tag message as the body
    - Uploads both DMGs as release assets
-8. Do NOT build DMGs locally for releases, do NOT use `gh release create` manually.
+9. Do NOT build DMGs locally for releases, do NOT use `gh release create` manually.
 
 ## Session Logging
 When the user says "log session" or similar (e.g., "update session log", "document this session"):


### PR DESCRIPTION
## Description

Phase 0 of the comprehensive pre-release e2e coverage program. Adds the missing **release gate**: today `build-release.yml` triggers purely on `git push tag vX.Y.Z` with **zero** e2e dependency, so "don't tag until e2e is green" is only a checklist line — nothing enforces it.

**What this adds**

- **`.github/workflows/e2e-release-gate.yml`** — runs the **full** e2e matrix (T1 + macOS/Windows T2 + `@pipeline` + the `@long-meeting` T3 smoke) on `release/**` branches and via `workflow_dispatch`. Reuses `e2e.yml` via `uses:` so the gate can never drift from the per-PR suite. The jobs fail on any spec failure — the workflow conclusion **is** the gate, and it runs **before** the immutable tag exists (so a failure is fixed-and-re-pushed, never a half-released tag).
- **`build-release.yml`** — a fast, hermetic **T1 `gate-smoke`** job that `build-macos` now `needs:`, so a tag pushed *without* going through the branch gate still can't sign/ship on a broken renderer / IPC contract. Deliberately T1-only — heavy backend/model coverage belongs to the branch gate + nightly, not the critical release path.
- **`CLAUDE.md`** — Release Process step 6 requires the branch gate green before the tag.

**Gating policy (deliberate):** PRs are **not** gated on the heavy suite. The release gate (this workflow) carries the full matrix; per-PR stays on the fast deterministic subset, with new domain specs promoted to required only after a green streak. This matches `e2e.yml`'s "earns trust first" design.

## Type of Change

- [x] New feature (CI/release infrastructure)

## Testing

- [x] Both workflow YAMLs validated (parse + job graph: `gate-smoke → build-macos → release`; `suite → long-meeting-windows`)
- [x] `e2e-release-gate.yml` is `workflow_dispatch`-able for a dry run before any real release
- [ ] First real exercise lands when the next `release/*` branch is cut

## Additional Notes

No app/spec code changed — only workflow YAML + the release checklist. Phases 1–6 (the actual coverage burn-down across recording/notes/folders/settings/chat/ML/calendar/onboarding) follow as separate PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pre-tag release gate that runs the full e2e matrix on `release/*` branches, plus a fast T1 smoke backstop in `build-release.yml`. This enforces “e2e green before tagging” and prevents shipping if core UI/IPC is broken.

- **New Features**
  - New `e2e-release-gate.yml`: runs the full suite via reusable `e2e.yml` on `release/*` and `workflow_dispatch`, including Windows T3 `@long-meeting`; fails on any spec to gate the tag.
  - Added `gate-smoke` (T1) to `build-release.yml`; `build-macos` now depends on it for a quick hermetic check.
  - Updated release docs to require a green gate before creating the tag.

- **Migration**
  - Cut `release/vX.Y.Z` from `main` and tag only after the gate is green (or dry-run via `workflow_dispatch`).
  - Tag-triggered builds still work, but now block on the T1 smoke; no other changes required.

<sup>Written for commit 30d2fb8a5587945f36aec6467bc3bc38ac38855f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

