### PR TITLE
test(e2e): Phase 1 core-loop T2 specs (recording/meetings/folders)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,17 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     out: `--grep @pipeline` runs it (CI's `t2-pipeline-macos` job caches a whisper model),
     `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
     active engine's model **skips** it (loudly) rather than failing.
-  - **Current specs:** `org-lock.t1`, `org-lock-lifecycle.t2`, and `config-corruption.t2`
-    (model-free, run in `t2-macos` / `t2-windows`); `transcription-pipeline.t2` and
-    `honest-failure.t2` (tagged `@pipeline`, run in `t2-pipeline-macos` /
-    `t2-pipeline-windows`). Engine selection for `@pipeline` specs is shared via
-    `e2e/fixtures/engine.ts`.
+  - **Current specs:** `org-lock.t1`, `shared-notes-policy.t1`, `org-lock-lifecycle.t2`,
+    `config-corruption.t2`, and the core-loop trio `recording-lifecycle.t2` /
+    `meetings-crud.t2` / `folders-crud.t2` (all model-free, run in `t2-macos` /
+    `t2-windows`); `transcription-pipeline.t2` and `honest-failure.t2` (tagged
+    `@pipeline`, run in `t2-pipeline-macos` / `t2-pipeline-windows`). Engine selection
+    for `@pipeline` specs is shared via `e2e/fixtures/engine.ts`; model-free T2 setup
+    helpers (deterministic recording config + seeded meeting summaries) live in
+    `e2e/fixtures/user-config.ts`. The core-loop specs drive the preload IPC bridge and
+    assert backend state on disk — `recording-lifecycle` exercises the
+    start/pause/resume/stop state machine via the renderer-driven (no-device, no-model)
+    path and skips loudly where `isSystemAudioSupported()` is false.
   - **Windows T2:** the same specs run on `windows-latest` via explicit per-OS jobs
     (`build-backend-windows` → `t2-windows` / `t2-pipeline-windows`). Differences from the
     macOS jobs: no exec-bit restore (Windows has no exec bit), `taskkill`/`Stop-Process`

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * Shared T2 setup helpers for the core-loop specs. Everything writes into the
+ * per-test STENOAI_USER_DATA_DIR temp dir (the isolation keystone) BEFORE launch,
+ * mirroring how config-corruption.t2 pre-seeds config.json.
+ */
+
+/** Merge a partial config into <userDataDir>/config.json, creating it if absent. */
+export function writeUserConfig(
+  userDataDir: string,
+  partial: Record<string, unknown>,
+): void {
+  const cfgPath = path.join(userDataDir, 'config.json');
+  let cfg: Record<string, unknown> = {};
+  if (existsSync(cfgPath)) {
+    try {
+      cfg = JSON.parse(readFileSync(cfgPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      cfg = {};
+    }
+  }
+  writeFileSync(cfgPath, JSON.stringify({ ...cfg, ...partial }, null, 2));
+}
+
+/**
+ * Configure the app so `start-recording-ui` takes the renderer-driven path
+ * (system audio ON) with the Whisper engine (so no Parakeet live-transcribe
+ * sidecar spawns). That path sets the recording state machine WITHOUT spawning
+ * the Python `record` subprocess, touching a real microphone, or loading any
+ * model — see app/main.js `start-recording-ui` + `loadSystemAudioEnabled` /
+ * `loadTranscriptionEngine`. This is what makes the lifecycle deterministic on a
+ * headless CI runner. It still requires `isSystemAudioSupported()` to be true on
+ * the host (macOS >= 14.4 / Windows >= 10); the spec guards on that and skips
+ * loudly otherwise rather than spawning a real recorder.
+ */
+export function enableDeterministicRecording(userDataDir: string): void {
+  writeUserConfig(userDataDir, {
+    system_audio_enabled: true,
+    transcription_engine: 'whisper',
+  });
+}
+
+export interface FixtureMeeting {
+  name: string;
+  summary?: string;
+  participants?: string[];
+  key_points?: string[];
+  action_items?: string[];
+  transcript?: string;
+  folders?: string[];
+}
+
+/**
+ * Write a deterministic `<stem>_summary.json` into <userDataDir>/output so the
+ * real backend's `list-meetings` (which globs get_data_dirs()['output']) finds
+ * it. Returns the absolute path of the written summary file. Model-free — no
+ * transcription/summarisation involved, just a known-good summary document.
+ */
+export function writeMeetingSummary(
+  userDataDir: string,
+  stem: string,
+  meeting: FixtureMeeting,
+): string {
+  const outputDir = path.join(userDataDir, 'output');
+  mkdirSync(outputDir, { recursive: true });
+  const summaryFile = path.join(outputDir, `${stem}_summary.json`);
+  const now = new Date().toISOString();
+  const data = {
+    session_info: {
+      name: meeting.name,
+      summary_file: summaryFile,
+      processed_at: now,
+      duration_seconds: 0,
+    },
+    summary: meeting.summary ?? `Summary for ${meeting.name}`,
+    participants: meeting.participants ?? [],
+    key_points: meeting.key_points ?? [],
+    action_items: meeting.action_items ?? [],
+    transcript: meeting.transcript ?? '',
+    // Folder membership lives at the TOP level of the summary doc — that's where
+    // src/folders.py add_meeting_to_folder writes it and list-meetings reads it.
+    folders: meeting.folders ?? [],
+  };
+  writeFileSync(summaryFile, JSON.stringify(data, null, 2));
+  return summaryFile;
+}

--- a/e2e/specs/folders-crud.t2.spec.ts
+++ b/e2e/specs/folders-crud.t2.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — folders CRUD + ordering. Drives the real backend's folder IPC through the
+ * preload bridge and asserts both the returned payloads AND the on-disk
+ * folders.json under the temp user-data dir. Model-free (pure state via the
+ * Python folders manager) — runs in the fast t2 jobs.
+ */
+
+type Folder = { id: string; name: string; color?: string; order?: number; icon?: string };
+type ListResult = { success: boolean; folders: Folder[] };
+type CreateResult = { success: boolean; folder?: Folder };
+type Result = { success: boolean; error?: string };
+
+type StenoWindow = Window & {
+  stenoai: {
+    folders: {
+      list: () => Promise<ListResult>;
+      create: (name: string, color?: string) => Promise<CreateResult>;
+      rename: (id: string, name: string) => Promise<Result>;
+      delete: (id: string) => Promise<Result>;
+      reorder: (ids: string[]) => Promise<Result>;
+    };
+  };
+};
+
+const list = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => (window as StenoWindow).stenoai.folders.list());
+
+function readFoldersJson(userDataDir: string): Folder[] {
+  const p = path.join(userDataDir, 'folders.json');
+  if (!existsSync(p)) return [];
+  return (JSON.parse(readFileSync(p, 'utf8')).folders ?? []) as Folder[];
+}
+
+test('folders CRUD + reorder persist to folders.json in the temp dir; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // Starts empty.
+  expect((await list(page)).folders).toEqual([]);
+
+  // Create three folders.
+  const names = ['Engineering', 'Sales', 'Personal'];
+  const ids: string[] = [];
+  for (const name of names) {
+    const res = await page.evaluate(
+      (n) => (window as StenoWindow).stenoai.folders.create(n, '#6366f1'),
+      name,
+    );
+    expect(res.success).toBe(true);
+    expect(res.folder?.id).toBeTruthy();
+    ids.push(res.folder!.id);
+  }
+
+  // All three are listed and persisted to folders.json.
+  await expect.poll(async () => (await list(page)).folders.length).toBe(3);
+  expect((await list(page)).folders.map((f) => f.name).sort()).toEqual(
+    [...names].sort(),
+  );
+  expect(readFoldersJson(userDataDir).map((f) => f.name).sort()).toEqual(
+    [...names].sort(),
+  );
+
+  // Rename one.
+  const rename = await page.evaluate(
+    (id) => (window as StenoWindow).stenoai.folders.rename(id, 'Engineering Team'),
+    ids[0],
+  );
+  expect(rename.success).toBe(true);
+  await expect
+    .poll(() => readFoldersJson(userDataDir).find((f) => f.id === ids[0])?.name)
+    .toBe('Engineering Team');
+
+  // Reorder: reverse the creation order; each folder's `order` field reflects it.
+  const reversed = [...ids].reverse();
+  const reorder = await page.evaluate(
+    (order) => (window as StenoWindow).stenoai.folders.reorder(order),
+    reversed,
+  );
+  expect(reorder.success).toBe(true);
+  await expect
+    .poll(() => {
+      const onDisk = readFoldersJson(userDataDir);
+      return reversed.map((id) => onDisk.find((f) => f.id === id)?.order);
+    })
+    .toEqual([0, 1, 2]);
+
+  // Delete one; it disappears from the list and folders.json, the others remain.
+  const del = await page.evaluate(
+    (id) => (window as StenoWindow).stenoai.folders.delete(id),
+    ids[1],
+  );
+  expect(del.success).toBe(true);
+  await expect.poll(async () => (await list(page)).folders.length).toBe(2);
+  expect(readFoldersJson(userDataDir).some((f) => f.id === ids[1])).toBe(false);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/e2e/specs/meetings-crud.t2.spec.ts
+++ b/e2e/specs/meetings-crud.t2.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { writeMeetingSummary } from '../fixtures/user-config';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, rmSync } from 'fs';
 
 /**
  * T2 — meetings CRUD + folder membership. Pre-seeds known `*_summary.json` docs
@@ -133,13 +133,20 @@ test('save-meeting-notes returns a written path with the note body', async ({
     (n) => (window as StenoWindow).stenoai.meetings.saveNotes('Delta Notes', n),
     note,
   );
-  expect(res.success).toBe(true);
-  // NOTE: save-meeting-notes currently writes to getBackendCwd()/_internal/output
-  // (the bundle dir), NOT the user-data output dir — so we assert via the returned
-  // path rather than the temp dir. That location mismatch (notes saved where the
-  // Python pipeline doesn't read them, into a read-only bundle when packaged) is a
-  // pre-existing bug tracked separately, out of scope for this coverage PR.
-  expect(res.path).toBeTruthy();
-  expect(existsSync(res.path!)).toBe(true);
-  expect(readFileSync(res.path!, 'utf8')).toBe(note);
+  try {
+    expect(res.success).toBe(true);
+    // NOTE: save-meeting-notes currently writes to getBackendCwd()/_internal/output
+    // (the bundle dir), NOT the user-data output dir — so we assert via the returned
+    // path rather than the temp dir. That location mismatch (notes saved where the
+    // Python pipeline doesn't read them, into a read-only bundle when packaged) is a
+    // pre-existing bug tracked separately, out of scope for this coverage PR.
+    expect(res.path).toBeTruthy();
+    expect(existsSync(res.path!)).toBe(true);
+    expect(readFileSync(res.path!, 'utf8')).toBe(note);
+  } finally {
+    // This is the one write in the PR that escapes STENOAI_USER_DATA_DIR (per the
+    // bug above). Clean it up so the suite stays hermetic — otherwise the note
+    // file lingers in the build tree and accumulates across retries/runs.
+    if (res.path) rmSync(res.path, { force: true });
+  }
 });

--- a/e2e/specs/meetings-crud.t2.spec.ts
+++ b/e2e/specs/meetings-crud.t2.spec.ts
@@ -87,6 +87,7 @@ test('folder membership: add/remove a meeting writes the top-level folders array
   launchApp,
   userDataDir,
 }) => {
+  const realDirBefore = fileSig(realUserDataDir());
   const file = writeMeetingSummary(userDataDir, 'gamma', { name: 'Gamma Planning' });
   const { page } = await launchApp();
 
@@ -119,12 +120,16 @@ test('folder membership: add/remove a meeting writes the top-level folders array
   );
   expect(remove.success).toBe(true);
   await expect.poll(() => readSummary(file).folders).not.toContain(folderId);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
 });
 
 test('save-meeting-notes returns a written path with the note body', async ({
   launchApp,
   userDataDir,
 }) => {
+  const realDirBefore = fileSig(realUserDataDir());
   writeMeetingSummary(userDataDir, 'delta', { name: 'Delta Notes' });
   const { page } = await launchApp();
 
@@ -149,4 +154,8 @@ test('save-meeting-notes returns a written path with the note body', async ({
     // file lingers in the build tree and accumulates across retries/runs.
     if (res.path) rmSync(res.path, { force: true });
   }
+
+  // Keystone: save-notes escapes to the bundle dir (the bug above), but the real
+  // user-data dir must still be byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
 });

--- a/e2e/specs/meetings-crud.t2.spec.ts
+++ b/e2e/specs/meetings-crud.t2.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeMeetingSummary } from '../fixtures/user-config';
+import { readFileSync, existsSync } from 'fs';
+
+/**
+ * T2 — meetings CRUD + folder membership. Pre-seeds known `*_summary.json` docs
+ * into the temp user-data `output/` dir, then drives the real backend's meeting
+ * IPC and asserts both the returned payloads and the on-disk summary files.
+ * Model-free: list/update/delete/add/removeMeeting are pure file ops — the
+ * model-bearing reprocess / regen-title handlers are intentionally NOT covered
+ * here (they need Ollama; they belong to a @pipeline/@contract spec).
+ */
+
+type Meeting = {
+  session_info: { name: string; summary_file: string };
+  folders?: string[];
+};
+type ListResult = { success: boolean; meetings: Meeting[] };
+type Result = { success: boolean; error?: string; path?: string };
+type CreateFolderResult = { success: boolean; folder?: { id: string } };
+
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      list: () => Promise<ListResult>;
+      update: (summaryFile: string, patch: Record<string, unknown>) => Promise<Result>;
+      delete: (meeting: Meeting) => Promise<Result>;
+      saveNotes: (name: string, notes: string) => Promise<Result>;
+    };
+    folders: {
+      create: (name: string, color?: string) => Promise<CreateFolderResult>;
+      addMeeting: (summaryFile: string, folderId: string) => Promise<Result>;
+      removeMeeting: (summaryFile: string, folderId: string) => Promise<Result>;
+    };
+  };
+};
+
+const list = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => (window as StenoWindow).stenoai.meetings.list());
+
+const readSummary = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
+
+test('meetings list/update/delete operate on the temp output dir; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Seed two known meetings before launch.
+  const fileA = writeMeetingSummary(userDataDir, 'alpha', { name: 'Alpha Sync' });
+  const fileB = writeMeetingSummary(userDataDir, 'beta', { name: 'Beta Review' });
+
+  const { page } = await launchApp();
+
+  // list-meetings enumerates both.
+  await expect.poll(async () => (await list(page)).meetings.length).toBe(2);
+  const names = (await list(page)).meetings.map((m) => m.session_info.name).sort();
+  expect(names).toEqual(['Alpha Sync', 'Beta Review']);
+
+  // Rename Alpha via update-meeting -> the on-disk JSON reflects the new name
+  // and gets an updated_at stamp.
+  const upd = await page.evaluate(
+    (f) => (window as StenoWindow).stenoai.meetings.update(f, { name: 'Alpha Standup' }),
+    fileA,
+  );
+  expect(upd.success).toBe(true);
+  await expect.poll(() => readSummary(fileA).session_info.name).toBe('Alpha Standup');
+  expect(readSummary(fileA).session_info.updated_at).toBeTruthy();
+
+  // Delete Beta -> its summary file is removed and the list shrinks to one.
+  const beta = (await list(page)).meetings.find((m) => m.session_info.name === 'Beta Review')!;
+  const del = await page.evaluate(
+    (m) => (window as StenoWindow).stenoai.meetings.delete(m),
+    beta,
+  );
+  expect(del.success).toBe(true);
+  await expect.poll(() => existsSync(fileB)).toBe(false);
+  await expect.poll(async () => (await list(page)).meetings.length).toBe(1);
+  expect(existsSync(fileA)).toBe(true);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('folder membership: add/remove a meeting writes the top-level folders array', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const file = writeMeetingSummary(userDataDir, 'gamma', { name: 'Gamma Planning' });
+  const { page } = await launchApp();
+
+  const folder = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.folders.create('Roadmap'),
+  );
+  expect(folder.success).toBe(true);
+  const folderId = folder.folder!.id;
+
+  // Add the meeting to the folder -> top-level `folders` contains the id.
+  const add = await page.evaluate(
+    ({ f, id }) => (window as StenoWindow).stenoai.folders.addMeeting(f, id),
+    { f: file, id: folderId },
+  );
+  expect(add.success).toBe(true);
+  await expect.poll(() => readSummary(file).folders).toContain(folderId);
+
+  // list-meetings surfaces the membership.
+  await expect
+    .poll(async () => {
+      const m = (await list(page)).meetings.find((x) => x.session_info.name === 'Gamma Planning');
+      return m?.folders ?? [];
+    })
+    .toContain(folderId);
+
+  // Remove it -> the id is gone again.
+  const remove = await page.evaluate(
+    ({ f, id }) => (window as StenoWindow).stenoai.folders.removeMeeting(f, id),
+    { f: file, id: folderId },
+  );
+  expect(remove.success).toBe(true);
+  await expect.poll(() => readSummary(file).folders).not.toContain(folderId);
+});
+
+test('save-meeting-notes returns a written path with the note body', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  writeMeetingSummary(userDataDir, 'delta', { name: 'Delta Notes' });
+  const { page } = await launchApp();
+
+  const note = 'Follow up with finance on Q3 budget.';
+  const res = await page.evaluate(
+    (n) => (window as StenoWindow).stenoai.meetings.saveNotes('Delta Notes', n),
+    note,
+  );
+  expect(res.success).toBe(true);
+  // NOTE: save-meeting-notes currently writes to getBackendCwd()/_internal/output
+  // (the bundle dir), NOT the user-data output dir — so we assert via the returned
+  // path rather than the temp dir. That location mismatch (notes saved where the
+  // Python pipeline doesn't read them, into a read-only bundle when packaged) is a
+  // pre-existing bug tracked separately, out of scope for this coverage PR.
+  expect(res.path).toBeTruthy();
+  expect(existsSync(res.path!)).toBe(true);
+  expect(readFileSync(res.path!, 'utf8')).toBe(note);
+});

--- a/e2e/specs/recording-lifecycle.t2.spec.ts
+++ b/e2e/specs/recording-lifecycle.t2.spec.ts
@@ -55,7 +55,9 @@ test('recording state machine: start -> pause -> resume -> stop is reflected in 
   // The renderer-driven (no-subprocess) path needs OS system-audio support
   // (macOS >= 14.4 / Windows >= 10). Without it, start would fall back to the
   // mic subprocess and need a real device — skip LOUDLY rather than emit a
-  // misleading failure or silently spawn a recorder.
+  // misleading failure or silently spawn a recorder. Windows CI (>= 10) always
+  // runs this; macOS only skips on a pre-14.4 runner (hosted images are well
+  // past that), so the loud annotation surfaces any regression to a no-op skip.
   const support = await page.evaluate(() =>
     (window as StenoWindow).stenoai.recording.getSystemAudioSupport(),
   );
@@ -125,9 +127,10 @@ test('recording state machine: start -> pause -> resume -> stop is reflected in 
 
 test('recording guards: stop is idempotent, pause/resume with no recording is rejected', async ({
   launchApp,
-  userDataDir,
 }) => {
-  enableDeterministicRecording(userDataDir);
+  // No enableDeterministicRecording() needed: these edges never call start(), so
+  // they branch purely on the idle currentRecordingProcess / systemAudioRecordingActive
+  // flags and never read the recording-path config.
   const { page } = await launchApp();
 
   // Stop with nothing recording is a no-op success (stale-state race), not an error.

--- a/e2e/specs/recording-lifecycle.t2.spec.ts
+++ b/e2e/specs/recording-lifecycle.t2.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { enableDeterministicRecording } from '../fixtures/user-config';
+
+/**
+ * T2 — recording lifecycle state machine (highest release risk). Drives the real
+ * backend's recording IPC through the preload bridge and asserts the in-memory
+ * state machine via get-queue-status: idle -> recording -> paused -> resumed ->
+ * stopped, plus the idempotent/guard edges.
+ *
+ * Deterministic + model-free: enableDeterministicRecording() puts the app in the
+ * renderer-driven (system-audio) path with the Whisper engine, so start sets the
+ * state machine WITHOUT spawning the Python `record` subprocess, opening a mic,
+ * or loading a model (see fixtures/user-config.ts). No @pipeline tag — runs in
+ * the fast t2-macos / t2-windows jobs.
+ */
+
+type QueueStatus = {
+  success: boolean;
+  isProcessing: boolean;
+  queueSize: number;
+  hasRecording: boolean;
+  isPaused: boolean;
+  elapsedSeconds: number;
+  sessionName: string | null;
+};
+type RecResult = { success: boolean; error?: string; sessionName?: string };
+type SupportResult = { success: boolean; supported?: boolean };
+
+type StenoWindow = Window & {
+  stenoai: {
+    recording: {
+      start: (name?: string) => Promise<RecResult>;
+      stop: () => Promise<RecResult>;
+      pause: () => Promise<RecResult>;
+      resume: () => Promise<RecResult>;
+      getQueue: () => Promise<QueueStatus>;
+      getSystemAudioSupport: () => Promise<SupportResult>;
+    };
+  };
+};
+
+const queue = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => (window as StenoWindow).stenoai.recording.getQueue());
+
+test('recording state machine: start -> pause -> resume -> stop is reflected in queue status', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  enableDeterministicRecording(userDataDir);
+
+  const { page } = await launchApp();
+
+  // The renderer-driven (no-subprocess) path needs OS system-audio support
+  // (macOS >= 14.4 / Windows >= 10). Without it, start would fall back to the
+  // mic subprocess and need a real device — skip LOUDLY rather than emit a
+  // misleading failure or silently spawn a recorder.
+  const support = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.getSystemAudioSupport(),
+  );
+  if (!support?.supported) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[t2] SKIPPED recording lifecycle: system-audio (renderer-driven) path unsupported on this host.',
+    );
+    test.info().annotations.push({
+      type: 'skip-reason',
+      description: 'isSystemAudioSupported() false; deterministic record path unavailable',
+    });
+  }
+  test.skip(!support?.supported, 'system-audio path unsupported on this runner');
+
+  // Idle.
+  const idle = await queue(page);
+  expect(idle.success).toBe(true);
+  expect(idle.hasRecording).toBe(false);
+  expect(idle.isPaused).toBe(false);
+  expect(idle.sessionName).toBeNull();
+
+  // Start -> recording.
+  const started = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.start('E2E Lifecycle'),
+  );
+  expect(started.success).toBe(true);
+  const recording = await queue(page);
+  expect(recording.hasRecording).toBe(true);
+  expect(recording.isPaused).toBe(false);
+  expect(recording.sessionName).toBe('E2E Lifecycle');
+
+  // Starting again while recording is rejected (no double recordings).
+  const dup = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.start('Second'),
+  );
+  expect(dup.success).toBe(false);
+
+  // Pause -> paused.
+  const paused = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.pause(),
+  );
+  expect(paused.success).toBe(true);
+  await expect.poll(async () => (await queue(page)).isPaused).toBe(true);
+  expect((await queue(page)).hasRecording).toBe(true);
+
+  // Resume -> recording.
+  const resumed = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.resume(),
+  );
+  expect(resumed.success).toBe(true);
+  await expect.poll(async () => (await queue(page)).isPaused).toBe(false);
+
+  // Stop -> idle.
+  const stopped = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.stop(),
+  );
+  expect(stopped.success).toBe(true);
+  await expect.poll(async () => (await queue(page)).hasRecording).toBe(false);
+  const finalState = await queue(page);
+  expect(finalState.isPaused).toBe(false);
+  expect(finalState.sessionName).toBeNull();
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('recording guards: stop is idempotent, pause/resume with no recording is rejected', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  enableDeterministicRecording(userDataDir);
+  const { page } = await launchApp();
+
+  // Stop with nothing recording is a no-op success (stale-state race), not an error.
+  const stop = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.stop(),
+  );
+  expect(stop.success).toBe(true);
+  expect((await queue(page)).hasRecording).toBe(false);
+
+  // Pause / resume with no recording are explicit failures.
+  const pause = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.pause(),
+  );
+  expect(pause.success).toBe(false);
+  const resume = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.recording.resume(),
+  );
+  expect(resume.success).toBe(false);
+});


### PR DESCRIPTION
## Description

Phase 1 of the e2e pre-release coverage program (Phase 0 = the release gate, #193). Adds deterministic, **model-free** T2 coverage of the highest-risk core loop, driving the preload IPC bridge (`window.stenoai.<group>.<method>`) against the **real bundled backend** and asserting backend state on disk in the per-test `STENOAI_USER_DATA_DIR` temp dir.

**New specs**
- **`recording-lifecycle.t2`** — the start → pause → resume → stop state machine asserted via `get-queue-status`, plus the idempotent-stop and pause/resume-with-no-recording guard edges. Uses the renderer-driven (system-audio + Whisper) path so the machine runs with **no Python `record` subprocess, no microphone, and no model**; skips *loudly* (warn + annotation, matching `org-lock-lifecycle.t2`) where `isSystemAudioSupported()` is false instead of spawning a real recorder. Windows CI (>=10) always runs it.
- **`meetings-crud.t2`** — `list` / `update` / `delete` over seeded `*_summary.json` docs, plus folder membership add/remove (top-level `folders` array). The model-bearing `reprocess` / `regen-title` handlers are intentionally excluded (they need Ollama).
- **`folders-crud.t2`** — `create` / `list` / `rename` / `reorder` / `delete` asserted against both the returned payloads and `folders.json` on disk.

**Fixture**
- **`e2e/fixtures/user-config.ts`** — reusable helpers (deterministic recording config + seeded meeting summaries) for these and later phases.

All three assert the `STENOAI_USER_DATA_DIR` isolation keystone (real user dir untouched).

## Type of Change

- [x] New feature (e2e test coverage)

## Testing

- [x] All three specs pass locally against the real `dist/stenoai` bundle (`--project=t2`)
- [x] Full model-free T2 suite stays green (8/8) — no regression to existing specs
- [x] Verified the save-notes cleanup leaves no file in the build tree (hermetic)

## Additional Notes

Discovered (out of scope, tracked separately): **`save-meeting-notes` writes to `getBackendCwd()/_internal/output`** (the bundle dir) rather than the user-data `output/` dir — so notes land where the Python pipeline never reads them, and in a signed/packaged app that bundle is read-only. The spec documents this and asserts via the returned path. Worth a follow-up fix PR.

Auto-runs in `t2-macos` / `t2-windows` (untagged, model-free). Part of a stacked series — Phases 2–6 follow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase 1 deterministic, model-free T2 e2e coverage for the core loop (recording, meetings, folders). Tests drive `window.stenoai` against the real bundled backend and assert on-disk state in a per-test `STENOAI_USER_DATA_DIR`; meetings tests now all assert this isolation.

- **New Features**
  - `recording-lifecycle.t2` — start → pause → resume → stop via `get-queue-status`, plus guard edges. Uses renderer-driven system-audio + Whisper path; skips when `isSystemAudioSupported()` is false (Windows CI always runs it). The guards test no longer sets deterministic-recording config.
  - `meetings-crud.t2` — `list`/`update`/`delete` over seeded `*_summary.json`, plus folder add/remove. Cleans up `saveNotes` output; all tests assert the isolation keystone (real dir untouched).
  - `folders-crud.t2` — `create`/`list`/`rename`/`reorder`/`delete`, asserting IPC payloads and `folders.json` on disk.
  - Fixture `e2e/fixtures/user-config.ts` for deterministic recording and seeded summaries; refreshed "Current specs" in `CLAUDE.md`.

<sup>Written for commit da048a8aac2ca22d7e0850554963deeb249a71ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

