### PR TITLE
test(e2e): Phase 2 config/settings/AI-provider/model T2 specs (+ cloud-key isolation fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,9 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
     active engine's model **skips** it (loudly) rather than failing.
   - **Current specs:** `org-lock.t1`, `shared-notes-policy.t1`, `org-lock-lifecycle.t2`,
-    `config-corruption.t2`, and the core-loop trio `recording-lifecycle.t2` /
-    `meetings-crud.t2` / `folders-crud.t2` (all model-free, run in `t2-macos` /
+    `config-corruption.t2`, the core-loop trio `recording-lifecycle.t2` /
+    `meetings-crud.t2` / `folders-crud.t2`, and the config trio `settings-roundtrip.t2` /
+    `ai-provider.t2` / `model-management.t2` (all model-free, run in `t2-macos` /
     `t2-windows`); `transcription-pipeline.t2` and `honest-failure.t2` (tagged
     `@pipeline`, run in `t2-pipeline-macos` / `t2-pipeline-windows`). Engine selection
     for `@pipeline` specs is shared via `e2e/fixtures/engine.ts`; model-free T2 setup
@@ -70,7 +71,10 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     `e2e/fixtures/user-config.ts`. The core-loop specs drive the preload IPC bridge and
     assert backend state on disk — `recording-lifecycle` exercises the
     start/pause/resume/stop state machine via the renderer-driven (no-device, no-model)
-    path and skips loudly where `isSystemAudioSupported()` is false.
+    path and skips loudly where `isSystemAudioSupported()` is false. The config trio
+    asserts get/set round-trips persist to the right `config.json` keys (settings),
+    the provider matrix + encrypted cloud key (ai-provider), and the deterministic
+    model list/status/set surface (model-management) — pulls stay in `@pipeline`.
   - **Windows T2:** the same specs run on `windows-latest` via explicit per-OS jobs
     (`build-backend-windows` → `t2-windows` / `t2-pipeline-windows`). Differences from the
     macOS jobs: no exec-bit restore (Windows has no exec bit), `taskkill`/`Stop-Process`

--- a/app/main.js
+++ b/app/main.js
@@ -5683,7 +5683,13 @@ ipcMain.handle('set-user-name', async (event, name) => {
 // AI Provider IPC handlers
 
 function getCloudKeyPath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.cloud-api-key');
+  // Use getUserDataDir() like every other app-managed file (.org-session,
+  // .pre-adapter-provider, config.json). The old hardcoded
+  // ~/Library/Application Support literal was macOS-only (wrong dir on Windows)
+  // and ignored the STENOAI_USER_DATA_DIR e2e override, so the encrypted cloud
+  // key escaped test isolation into the real user dir. On real macOS this
+  // resolves to the identical path, so existing keys are unaffected.
+  return path.join(getUserDataDir(), '.cloud-api-key');
 }
 
 function saveCloudApiKey(key) {

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -7,6 +7,17 @@ import path from 'path';
  * mirroring how config-corruption.t2 pre-seeds config.json.
  */
 
+/** Read <userDataDir>/config.json (returns {} if absent/unreadable). */
+export function readUserConfig(userDataDir: string): Record<string, unknown> {
+  const cfgPath = path.join(userDataDir, 'config.json');
+  if (!existsSync(cfgPath)) return {};
+  try {
+    return JSON.parse(readFileSync(cfgPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
 /** Merge a partial config into <userDataDir>/config.json, creating it if absent. */
 export function writeUserConfig(
   userDataDir: string,

--- a/e2e/specs/ai-provider.t2.spec.ts
+++ b/e2e/specs/ai-provider.t2.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { readFileSync, existsSync } from 'fs';
+import { readUserConfig } from '../fixtures/user-config';
+import { existsSync } from 'fs';
 import path from 'path';
 
 /**
@@ -45,11 +46,6 @@ type StenoWindow = Window & {
 const getProvider = (page: import('@playwright/test').Page) =>
   page.evaluate(() => (window as StenoWindow).stenoai.ai.getProvider());
 
-function readConfig(userDataDir: string): Record<string, unknown> {
-  const p = path.join(userDataDir, 'config.json');
-  if (!existsSync(p)) return {};
-  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
-}
 
 test('provider switch + cloud/bedrock config persist and round-trip through get-ai-provider', async ({
   launchApp,
@@ -69,7 +65,7 @@ test('provider switch + cloud/bedrock config persist and round-trip through get-
       (p) => (window as StenoWindow).stenoai.ai.setProvider(p),
       provider,
     );
-    await expect.poll(() => readConfig(userDataDir).ai_provider).toBe(provider);
+    await expect.poll(() => readUserConfig(userDataDir).ai_provider).toBe(provider);
     expect((await getProvider(page)).ai_provider).toBe(provider);
   }
 
@@ -151,5 +147,5 @@ test('cloud API key is stored encrypted (safeStorage) in the temp dir, not confi
   // ...the snapshot reports it set...
   await expect.poll(async () => (await getProvider(page)).cloud_api_key_set).toBe(true);
   // ...and the plaintext key never appears in config.json.
-  expect(JSON.stringify(readConfig(userDataDir))).not.toContain('sk-e2e-secret-123');
+  expect(JSON.stringify(readUserConfig(userDataDir))).not.toContain('sk-e2e-secret-123');
 });

--- a/e2e/specs/ai-provider.t2.spec.ts
+++ b/e2e/specs/ai-provider.t2.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — AI provider configuration matrix. Drives the real backend's `ai` IPC and
+ * asserts both the get-ai-provider snapshot and the persisted config.json keys.
+ * Model-free + deterministic: every call here is a local config write or local
+ * encryption — the network calls (test-cloud-api / test-remote-ollama) and the
+ * org-adapter path (covered by the org specs) are intentionally excluded.
+ *
+ * No org is signed in, so set-ai-provider is not org-locked here.
+ */
+
+type ProviderSnapshot = {
+  success: boolean;
+  ai_provider?: string;
+  cloud_provider?: string;
+  cloud_api_url?: string;
+  cloud_model?: string;
+  cloud_api_key_set?: boolean;
+  bedrock_region?: string;
+  bedrock_inference_profile?: string;
+  remote_ollama_url?: string;
+};
+type Result = { success?: boolean; error?: string };
+
+type StenoWindow = Window & {
+  stenoai: {
+    ai: {
+      getProvider: () => Promise<ProviderSnapshot>;
+      setProvider: (p: string) => Promise<Result>;
+      setRemoteOllamaUrl: (url: string) => Promise<Result>;
+      setCloudApiUrl: (url: string) => Promise<Result>;
+      setCloudApiKey: (key: string) => Promise<Result>;
+      setCloudProvider: (p: string) => Promise<Result>;
+      setCloudModel: (m: string) => Promise<Result>;
+      setBedrockRegion: (r: string) => Promise<Result>;
+      setBedrockInferenceProfile: (p: string) => Promise<Result>;
+    };
+  };
+};
+
+const getProvider = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => (window as StenoWindow).stenoai.ai.getProvider());
+
+function readConfig(userDataDir: string): Record<string, unknown> {
+  const p = path.join(userDataDir, 'config.json');
+  if (!existsSync(p)) return {};
+  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
+}
+
+test('provider switch + cloud/bedrock config persist and round-trip through get-ai-provider', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // Default snapshot is a coherent local config.
+  const initial = await getProvider(page);
+  expect(initial.success).toBe(true);
+  expect(initial.ai_provider).toBe('local');
+
+  // Provider switches persist to config.ai_provider and reflect in the snapshot.
+  for (const provider of ['remote', 'cloud', 'local']) {
+    await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.ai.setProvider(p),
+      provider,
+    );
+    await expect.poll(() => readConfig(userDataDir).ai_provider).toBe(provider);
+    expect((await getProvider(page)).ai_provider).toBe(provider);
+  }
+
+  // Cloud config: provider, url, model.
+  await page.evaluate(() => (window as StenoWindow).stenoai.ai.setCloudProvider('anthropic'));
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setCloudApiUrl('https://api.example.test/v1'),
+  );
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setCloudModel('claude-haiku-4-5-20251001'),
+  );
+
+  // Bedrock config.
+  await page.evaluate(() => (window as StenoWindow).stenoai.ai.setBedrockRegion('us-west-2'));
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setBedrockInferenceProfile('my-profile'),
+  );
+
+  // Remote Ollama URL (no connectivity check — set only).
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setRemoteOllamaUrl('http://ollama.example.test:11434'),
+  );
+
+  await expect
+    .poll(async () => {
+      const s = await getProvider(page);
+      return {
+        cloud_provider: s.cloud_provider,
+        cloud_api_url: s.cloud_api_url,
+        cloud_model: s.cloud_model,
+        bedrock_region: s.bedrock_region,
+        bedrock_inference_profile: s.bedrock_inference_profile,
+        remote_ollama_url: s.remote_ollama_url,
+      };
+    })
+    .toEqual({
+      cloud_provider: 'anthropic',
+      cloud_api_url: 'https://api.example.test/v1',
+      cloud_model: 'claude-haiku-4-5-20251001',
+      bedrock_region: 'us-west-2',
+      bedrock_inference_profile: 'my-profile',
+      remote_ollama_url: 'http://ollama.example.test:11434',
+    });
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('cloud API key is stored encrypted (safeStorage) in the temp dir, not config.json', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const { app, page } = await launchApp();
+
+  // The key is persisted via safeStorage; on a headless runner with no usable
+  // keyring it is unavailable — skip LOUDLY rather than emit a misleading red
+  // (mirrors org-lock-lifecycle.t2's keystone guard).
+  const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
+    safeStorage.isEncryptionAvailable(),
+  );
+  if (!encryptionAvailable) {
+    // eslint-disable-next-line no-console
+    console.warn('[t2] SKIPPED cloud-api-key: safeStorage unavailable on this runner.');
+    test.info().annotations.push({
+      type: 'skip-reason',
+      description: 'safeStorage unavailable; cloud key cannot persist on this runner',
+    });
+  }
+  test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
+
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setCloudApiKey('sk-e2e-secret-123'),
+  );
+
+  // Encrypted blob lands in the temp dir...
+  await expect
+    .poll(() => existsSync(path.join(userDataDir, '.cloud-api-key')), { timeout: 10_000 })
+    .toBe(true);
+  // ...the snapshot reports it set...
+  await expect.poll(async () => (await getProvider(page)).cloud_api_key_set).toBe(true);
+  // ...and the plaintext key never appears in config.json.
+  expect(JSON.stringify(readConfig(userDataDir))).not.toContain('sk-e2e-secret-123');
+});

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — model management (the deterministic, model-free subset). Covers the
+ * summary-model and whisper-model config round-trips plus the whisper / parakeet
+ * list + status SHAPE. Model PULLS (pull-model / pull-whisper-model /
+ * pull-parakeet-model) download hundreds of MB and are NOT covered here — they
+ * belong to the model-bearing @pipeline jobs. "installed" reflects the host's
+ * real model cache (not the temp dir), so we assert the SHAPE of those flags,
+ * never a specific install state.
+ */
+
+type ModelInfo = { installed?: boolean };
+type ListResult = {
+  success: boolean;
+  current_model?: string;
+  supported_models?: Record<string, ModelInfo>;
+  provider?: string;
+};
+type CurrentModel = { success: boolean; model?: string };
+type StatusResult = { success: boolean; model?: string; installed?: boolean };
+type Result = { success?: boolean };
+
+type StenoWindow = Window & {
+  stenoai: {
+    models: {
+      getCurrent: () => Promise<CurrentModel>;
+      set: (name: string) => Promise<Result>;
+    };
+    whisperModels: {
+      list: () => Promise<ListResult>;
+      set: (name: string) => Promise<Result>;
+    };
+    parakeetModels: {
+      list: () => Promise<ListResult>;
+      status: () => Promise<StatusResult>;
+    };
+  };
+};
+
+function readConfig(userDataDir: string): Record<string, unknown> {
+  const p = path.join(userDataDir, 'config.json');
+  if (!existsSync(p)) return {};
+  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
+}
+
+/** Every entry in a supported-models map must carry a boolean `installed` flag. */
+function assertInstalledShape(models: Record<string, ModelInfo> | undefined) {
+  expect(models && typeof models === 'object').toBeTruthy();
+  const entries = Object.values(models!);
+  expect(entries.length).toBeGreaterThan(0);
+  for (const m of entries) {
+    expect(typeof m.installed).toBe('boolean');
+  }
+}
+
+test('summary model set persists to config.model and round-trips through get-current-model', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // There's always a current model (config default).
+  const before = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.models.getCurrent(),
+  );
+  expect(before.success).toBe(true);
+  expect(before.model).toBeTruthy();
+
+  await page.evaluate(() => (window as StenoWindow).stenoai.models.set('llama3.2:1b'));
+  await expect.poll(() => readConfig(userDataDir).model).toBe('llama3.2:1b');
+  await expect
+    .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.models.getCurrent())).model)
+    .toBe('llama3.2:1b');
+
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('whisper models: list reports installed flags; set persists to config.whisper_model', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const { page } = await launchApp();
+
+  const listed = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.whisperModels.list(),
+  );
+  expect(listed.success).toBe(true);
+  expect(listed.provider).toBe('local');
+  assertInstalledShape(listed.supported_models);
+
+  // Pick a known supported key (SUPPORTED_WHISPER_MODELS = small | large-v3-turbo;
+  // set-whisper-model validates against those) and set it; it persists + the
+  // list's current model follows.
+  await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.set('large-v3-turbo'));
+  await expect.poll(() => readConfig(userDataDir).whisper_model).toBe('large-v3-turbo');
+  await expect
+    .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.list())).current_model)
+    .toBe('large-v3-turbo');
+});
+
+test('parakeet models: list + status return a coherent installed shape', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp();
+
+  const listed = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.parakeetModels.list(),
+  );
+  expect(listed.success).toBe(true);
+  expect(listed.current_model).toBeTruthy();
+  assertInstalledShape(listed.supported_models);
+
+  const status = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.parakeetModels.status(),
+  );
+  expect(status.success).toBe(true);
+  expect(status.model).toBeTruthy();
+  expect(typeof status.installed).toBe('boolean');
+  // status + list agree on the default model id.
+  expect(status.model).toBe(listed.current_model);
+});

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { readFileSync, existsSync } from 'fs';
-import path from 'path';
+import { readUserConfig } from '../fixtures/user-config';
 
 /**
  * T2 — model management (the deterministic, model-free subset). Covers the
@@ -41,11 +40,6 @@ type StenoWindow = Window & {
   };
 };
 
-function readConfig(userDataDir: string): Record<string, unknown> {
-  const p = path.join(userDataDir, 'config.json');
-  if (!existsSync(p)) return {};
-  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
-}
 
 /** Every entry in a supported-models map must carry a boolean `installed` flag. */
 function assertInstalledShape(models: Record<string, ModelInfo> | undefined) {
@@ -72,7 +66,7 @@ test('summary model set persists to config.model and round-trips through get-cur
   expect(before.model).toBeTruthy();
 
   await page.evaluate(() => (window as StenoWindow).stenoai.models.set('llama3.2:1b'));
-  await expect.poll(() => readConfig(userDataDir).model).toBe('llama3.2:1b');
+  await expect.poll(() => readUserConfig(userDataDir).model).toBe('llama3.2:1b');
   await expect
     .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.models.getCurrent())).model)
     .toBe('llama3.2:1b');
@@ -97,7 +91,7 @@ test('whisper models: list reports installed flags; set persists to config.whisp
   // set-whisper-model validates against those) and set it; it persists + the
   // list's current model follows.
   await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.set('large-v3-turbo'));
-  await expect.poll(() => readConfig(userDataDir).whisper_model).toBe('large-v3-turbo');
+  await expect.poll(() => readUserConfig(userDataDir).whisper_model).toBe('large-v3-turbo');
   await expect
     .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.list())).current_model)
     .toBe('large-v3-turbo');

--- a/e2e/specs/settings-roundtrip.t2.spec.ts
+++ b/e2e/specs/settings-roundtrip.t2.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — settings get/set round-trip. Drives the real backend's settings IPC and
+ * asserts each value persists to the right config.json key in the temp user-data
+ * dir. Model-free + deterministic (pure config writes via the Python CLI). The
+ * side-effecting settings (storage-path, which creates dirs) get their own test;
+ * the network/model ones (model pulls, test-cloud-api) are out of scope here.
+ */
+
+type SettingKind =
+  | 'language'
+  | 'userName'
+  | 'keepRecordings'
+  | 'silenceEnabled'
+  | 'silenceMinutes'
+  | 'systemAudio'
+  | 'telemetry'
+  | 'transcriptionEngine'
+  | 'dockIcon';
+
+type SettingsBridge = {
+  settings: {
+    setLanguage: (v: string) => Promise<unknown>;
+    setUserName: (v: string) => Promise<unknown>;
+    setKeepRecordings: (v: boolean) => Promise<unknown>;
+    setSilenceAutoStopEnabled: (v: boolean) => Promise<unknown>;
+    setSilenceAutoStopMinutes: (v: number) => Promise<unknown>;
+    setSystemAudio: (v: boolean) => Promise<unknown>;
+    setTelemetry: (v: boolean) => Promise<unknown>;
+    setDockIcon: (v: boolean) => Promise<unknown>;
+    setStoragePath: (p: string) => Promise<{ success?: boolean; error?: string }>;
+  };
+  transcriptionEngine: { set: (v: string) => Promise<unknown> };
+};
+type StenoWindow = Window & { stenoai: SettingsBridge };
+
+type Case = { kind: SettingKind; value: string | boolean | number; configKey: string };
+
+// Each case: drive the setter, then assert the persisted config.json key. The
+// expected value IS what we set, so this catches a setter writing the wrong key,
+// dropping the value, or coercing it.
+const CASES: Case[] = [
+  { kind: 'language', value: 'fr', configKey: 'language' },
+  { kind: 'userName', value: 'E2E Tester', configKey: 'user_name' },
+  { kind: 'keepRecordings', value: true, configKey: 'keep_recordings' },
+  { kind: 'silenceEnabled', value: false, configKey: 'silence_auto_stop_enabled' },
+  { kind: 'silenceMinutes', value: 15, configKey: 'silence_auto_stop_minutes' },
+  { kind: 'systemAudio', value: true, configKey: 'system_audio_enabled' },
+  { kind: 'telemetry', value: false, configKey: 'telemetry_enabled' },
+  { kind: 'transcriptionEngine', value: 'whisper', configKey: 'transcription_engine' },
+  { kind: 'dockIcon', value: true, configKey: 'hide_dock_icon' },
+];
+
+function readConfig(userDataDir: string): Record<string, unknown> {
+  const p = path.join(userDataDir, 'config.json');
+  if (!existsSync(p)) return {};
+  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
+}
+
+function applySetting(
+  page: import('@playwright/test').Page,
+  kind: SettingKind,
+  value: string | boolean | number,
+) {
+  return page.evaluate(
+    ({ kind, value }) => {
+      const s = (window as StenoWindow).stenoai;
+      switch (kind) {
+        case 'language':
+          return s.settings.setLanguage(value as string);
+        case 'userName':
+          return s.settings.setUserName(value as string);
+        case 'keepRecordings':
+          return s.settings.setKeepRecordings(value as boolean);
+        case 'silenceEnabled':
+          return s.settings.setSilenceAutoStopEnabled(value as boolean);
+        case 'silenceMinutes':
+          return s.settings.setSilenceAutoStopMinutes(value as number);
+        case 'systemAudio':
+          return s.settings.setSystemAudio(value as boolean);
+        case 'telemetry':
+          return s.settings.setTelemetry(value as boolean);
+        case 'dockIcon':
+          return s.settings.setDockIcon(value as boolean);
+        case 'transcriptionEngine':
+          return s.transcriptionEngine.set(value as string);
+        default:
+          throw new Error(`unknown setting kind: ${kind}`);
+      }
+    },
+    { kind, value },
+  );
+}
+
+test('settings setters persist each value to the right config.json key; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  for (const { kind, value, configKey } of CASES) {
+    await applySetting(page, kind, value);
+    await expect
+      .poll(() => readConfig(userDataDir)[configKey], {
+        message: `${kind} -> config.${configKey}`,
+      })
+      .toBe(value);
+  }
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('set-storage-path persists the path and provisions its data subdirs', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // A fresh absolute path inside the temp dir (set-storage-path requires an
+  // absolute, writable location and provisions recordings/transcripts/output).
+  const target = path.join(userDataDir, 'custom-storage');
+  const res = await page.evaluate(
+    (p) => (window as StenoWindow).stenoai.settings.setStoragePath(p),
+    target,
+  );
+  expect(res.success).toBe(true);
+
+  await expect.poll(() => readConfig(userDataDir).storage_path).toBe(target);
+  for (const sub of ['recordings', 'transcripts', 'output']) {
+    expect(existsSync(path.join(target, sub))).toBe(true);
+  }
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/e2e/specs/settings-roundtrip.t2.spec.ts
+++ b/e2e/specs/settings-roundtrip.t2.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { readFileSync, existsSync } from 'fs';
+import { readUserConfig } from '../fixtures/user-config';
+import { existsSync } from 'fs';
 import path from 'path';
 
 /**
@@ -49,17 +50,13 @@ const CASES: Case[] = [
   { kind: 'keepRecordings', value: true, configKey: 'keep_recordings' },
   { kind: 'silenceEnabled', value: false, configKey: 'silence_auto_stop_enabled' },
   { kind: 'silenceMinutes', value: 15, configKey: 'silence_auto_stop_minutes' },
-  { kind: 'systemAudio', value: true, configKey: 'system_audio_enabled' },
+  // false flips the macOS default (true) so this has teeth on the primary signed
+  // platform — asserting `true` there would pass even if the setter no-oped.
+  { kind: 'systemAudio', value: false, configKey: 'system_audio_enabled' },
   { kind: 'telemetry', value: false, configKey: 'telemetry_enabled' },
   { kind: 'transcriptionEngine', value: 'whisper', configKey: 'transcription_engine' },
   { kind: 'dockIcon', value: true, configKey: 'hide_dock_icon' },
 ];
-
-function readConfig(userDataDir: string): Record<string, unknown> {
-  const p = path.join(userDataDir, 'config.json');
-  if (!existsSync(p)) return {};
-  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
-}
 
 function applySetting(
   page: import('@playwright/test').Page,
@@ -106,7 +103,7 @@ test('settings setters persist each value to the right config.json key; real dir
   for (const { kind, value, configKey } of CASES) {
     await applySetting(page, kind, value);
     await expect
-      .poll(() => readConfig(userDataDir)[configKey], {
+      .poll(() => readUserConfig(userDataDir)[configKey], {
         message: `${kind} -> config.${configKey}`,
       })
       .toBe(value);
@@ -132,7 +129,7 @@ test('set-storage-path persists the path and provisions its data subdirs', async
   );
   expect(res.success).toBe(true);
 
-  await expect.poll(() => readConfig(userDataDir).storage_path).toBe(target);
+  await expect.poll(() => readUserConfig(userDataDir).storage_path).toBe(target);
   for (const sub of ['recordings', 'transcripts', 'output']) {
     expect(existsSync(path.join(target, sub))).toBe(true);
   }


### PR DESCRIPTION
## Description

Phase 2 of the e2e pre-release coverage program. **Stacked on #194 (Phase 1)** — base is `e2e/phase1-core-loop`, so this diff shows only Phase 2; it auto-retargets to `main` once #194 merges. Review/merge #194 first.

Adds deterministic, **model-free** T2 coverage of the config surface, driving the preload IPC bridge against the real bundled backend and asserting `config.json` + state on disk in the temp `STENOAI_USER_DATA_DIR`.

**New specs**
- **`settings-roundtrip.t2`** — a param-table get/set over language, user-name, keep-recordings, silence-auto-stop (enabled + minutes), system-audio, telemetry, transcription-engine, dock-icon — each asserted against its `config.json` key; plus `set-storage-path` (persists + provisions `recordings`/`transcripts`/`output`).
- **`ai-provider.t2`** — provider matrix (local/remote/cloud) + cloud/bedrock config round-trip through `get-ai-provider`; the cloud API key is stored **encrypted via safeStorage** in the temp dir (skips loudly if safeStorage is unavailable) and never appears in plaintext `config.json`.
- **`model-management.t2`** — summary-model + whisper-model config round-trips and the whisper/parakeet `list`+`status` shape (installed flags asserted by type, not value, so they're host-independent). Model **pulls** are excluded (they download — they stay in `@pipeline`).

**Fixture:** `readUserConfig()` added to `e2e/fixtures/user-config.ts` (shared config reader).

## ⚠️ Production fix included (please review)

The `ai-provider` spec **caught a real isolation bug**: `getCloudKeyPath()` (app/main.js) hardcoded the macOS `~/Library/Application Support/stenoai/.cloud-api-key` literal, so the encrypted cloud key **ignored `STENOAI_USER_DATA_DIR`** (escaping test isolation into the real user dir) and wrote to the **wrong path on Windows** (where cloud summarization was effectively broken — the key landed in a dir the rest of the app never reads). Fixed to route through `getUserDataDir()` like every sibling (`​.org-session`, `.pre-adapter-provider`, `config.json`).

**Safety:** on real macOS with no override, `getUserDataDir()` resolves to the *identical* path → existing users' keys are unaffected, no migration. On Windows it corrects a previously-broken location (alpha; the old path was orphaned, so nothing working to migrate). Key remains safeStorage-encrypted either way.

## Type of Change

- [x] New feature (e2e coverage)
- [x] Bug fix (cloud-key path isolation / Windows correctness)

## Testing

- [x] All 7 Phase 2 specs pass locally against the real `dist/stenoai`
- [x] Full stacked model-free T2 suite green (15/15) — no regression
- [x] Reviewed by QA+security and senior-engineer lenses: cloud-key change confirmed safe to ship; `systemAudio` case hardened to flip the macOS default

## Additional Notes

Part of the stacked series — Phases 3–6 follow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model-free T2 e2e coverage for config (settings, AI provider, models) and fixes the cloud API key path to use the app user-data dir on all OSes. This improves test isolation and restores correct cloud-key behavior on Windows.

- **New Features**
  - `settings-roundtrip.t2`: verifies get/set for language, user name, keep recordings, silence auto-stop (enabled + minutes), system audio, telemetry, transcription engine, dock icon; asserts persisted `config.json`; `setStoragePath` provisions `recordings`/`transcripts`/`output`.
  - `ai-provider.t2`: exercises local/remote/cloud provider matrix plus cloud/bedrock fields; key is stored encrypted via `safeStorage` in the temp dir and never in plaintext `config.json` (skips if encryption unavailable).
  - `model-management.t2`: summary-model and whisper-model set/persist round-trips; validates whisper/parakeet list+status shape (installed flags); model pulls remain in `@pipeline`. Adds shared `readUserConfig()` and updates `CLAUDE.md`.

- **Bug Fixes**
  - Cloud API key path now resolves via `getUserDataDir()` instead of a macOS-specific literal, respecting `STENOAI_USER_DATA_DIR` and fixing the Windows path; existing macOS paths remain unchanged, and the key stays `safeStorage`-encrypted.

<sup>Written for commit e623b2b0d763bb3edf1ddc2944e82aba56eb0597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

