### PR TITLE
test(e2e): Phase 3 chat-sessions + org CRUD/share T2 specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,10 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     active engine's model **skips** it (loudly) rather than failing.
   - **Current specs:** `org-lock.t1`, `shared-notes-policy.t1`, `org-lock-lifecycle.t2`,
     `config-corruption.t2`, the core-loop trio `recording-lifecycle.t2` /
-    `meetings-crud.t2` / `folders-crud.t2`, and the config trio `settings-roundtrip.t2` /
-    `ai-provider.t2` / `model-management.t2` (all model-free, run in `t2-macos` /
+    `meetings-crud.t2` / `folders-crud.t2`, the config trio `settings-roundtrip.t2` /
+    `ai-provider.t2` / `model-management.t2`, and the chat/org pair `chat-sessions.t2`
+    (local session persistence) / `org-crud.t2` (meeting CRUD + share/unshare + ai-chat
+    against the stateful `mock-adapter.js`) (all model-free, run in `t2-macos` /
     `t2-windows`); `transcription-pipeline.t2` and `honest-failure.t2` (tagged
     `@pipeline`, run in `t2-pipeline-macos` / `t2-pipeline-windows`). Engine selection
     for `@pipeline` specs is shared via `e2e/fixtures/engine.ts`; model-free T2 setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,9 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
     active engine's model **skips** it (loudly) rather than failing.
   - **Current specs:** `org-lock.t1`, `shared-notes-policy.t1`, `org-lock-lifecycle.t2`,
-    `config-corruption.t2`, and the core-loop trio `recording-lifecycle.t2` /
-    `meetings-crud.t2` / `folders-crud.t2` (all model-free, run in `t2-macos` /
+    `config-corruption.t2`, the core-loop trio `recording-lifecycle.t2` /
+    `meetings-crud.t2` / `folders-crud.t2`, and the config trio `settings-roundtrip.t2` /
+    `ai-provider.t2` / `model-management.t2` (all model-free, run in `t2-macos` /
     `t2-windows`); `transcription-pipeline.t2` and `honest-failure.t2` (tagged
     `@pipeline`, run in `t2-pipeline-macos` / `t2-pipeline-windows`). Engine selection
     for `@pipeline` specs is shared via `e2e/fixtures/engine.ts`; model-free T2 setup
@@ -70,7 +71,10 @@ at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
     `e2e/fixtures/user-config.ts`. The core-loop specs drive the preload IPC bridge and
     assert backend state on disk — `recording-lifecycle` exercises the
     start/pause/resume/stop state machine via the renderer-driven (no-device, no-model)
-    path and skips loudly where `isSystemAudioSupported()` is false.
+    path and skips loudly where `isSystemAudioSupported()` is false. The config trio
+    asserts get/set round-trips persist to the right `config.json` keys (settings),
+    the provider matrix + encrypted cloud key (ai-provider), and the deterministic
+    model list/status/set surface (model-management) — pulls stay in `@pipeline`.
   - **Windows T2:** the same specs run on `windows-latest` via explicit per-OS jobs
     (`build-backend-windows` → `t2-windows` / `t2-pipeline-windows`). Differences from the
     macOS jobs: no exec-bit restore (Windows has no exec bit), `taskkill`/`Stop-Process`

--- a/app/main.js
+++ b/app/main.js
@@ -5683,7 +5683,13 @@ ipcMain.handle('set-user-name', async (event, name) => {
 // AI Provider IPC handlers
 
 function getCloudKeyPath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.cloud-api-key');
+  // Use getUserDataDir() like every other app-managed file (.org-session,
+  // .pre-adapter-provider, config.json). The old hardcoded
+  // ~/Library/Application Support literal was macOS-only (wrong dir on Windows)
+  // and ignored the STENOAI_USER_DATA_DIR e2e override, so the encrypted cloud
+  // key escaped test isolation into the real user dir. On real macOS this
+  // resolves to the identical path, so existing keys are unaffected.
+  return path.join(getUserDataDir(), '.cloud-api-key');
 }
 
 function saveCloudApiKey(key) {

--- a/e2e/fixtures/mock-adapter.js
+++ b/e2e/fixtures/mock-adapter.js
@@ -2,10 +2,11 @@
 // handlers call against a signed-in adapter, with just enough state to drive the
 // CRUD + share/unshare lifecycle deterministically — no real backend, no AWS/S3.
 //
-// Backwards compatible with the original sign-in-only mock (org-lock-lifecycle.t2,
-// shared-notes-policy): POST /auth/login still returns a structurally valid HS256
-// JWT in the { token, email, name, org_id } envelope (app/main.js ~8071) and
-// GET /policy still returns the enterprise policy. It NEVER returns 401 (that
+// Backwards compatible with the original sign-in-only mock (org-lock-lifecycle.t2
+// is the only other real-adapter consumer; shared-notes-policy is a T1 mock-IPC
+// spec that doesn't touch this): POST /auth/login still returns a structurally
+// valid HS256 JWT in the { token, email, name, org_id } envelope (app/main.js
+// ~8071) and GET /policy still returns the enterprise policy. It NEVER returns 401 (that
 // would trip the app's real sign-out path mid-test). Listens on an ephemeral
 // loopback port; the caller passes the returned url as the adapter URL.
 //
@@ -46,7 +47,7 @@ const json = (res, status, body) => {
  * Start the mock adapter on an ephemeral loopback port.
  * @param {object} [opts]
  * @param {object} [opts.policy] override the /policy response.
- * @returns {Promise<{ url: string, close: () => Promise<void>, meetingCount: () => number, s3Puts: () => number }>}
+ * @returns {Promise<{ url: string, close: () => Promise<void>, s3Puts: () => number }>}
  */
 function startMockAdapter(opts = {}) {
   const policy = opts.policy || { auto_share_default: true, shared_notes_enabled: true };
@@ -142,7 +143,6 @@ function startMockAdapter(opts = {}) {
       resolve({
         url: baseUrl,
         close: () => new Promise((r) => server.close(() => r())),
-        meetingCount: () => meetings.size,
         s3Puts: () => s3PutCount,
       });
     });

--- a/e2e/fixtures/mock-adapter.js
+++ b/e2e/fixtures/mock-adapter.js
@@ -1,9 +1,24 @@
-// Mock org adapter for the T2 tier. Serves POST /auth/login with a
-// structurally valid HS256 JWT (exp +1h) in the { token, email, name, org_id }
-// envelope the real org-login handler expects (app/main.js ~8042). Everything
-// else 404s, and it NEVER returns 401 — a 401 would trip the app's real
-// sign-out path mid-test. Listens on an ephemeral port; the caller passes the
-// returned url as the adapter URL in the sign-in form.
+// Mock org adapter for the T2 tier. Serves the endpoints the desktop's org
+// handlers call against a signed-in adapter, with just enough state to drive the
+// CRUD + share/unshare lifecycle deterministically — no real backend, no AWS/S3.
+//
+// Backwards compatible with the original sign-in-only mock (org-lock-lifecycle.t2,
+// shared-notes-policy): POST /auth/login still returns a structurally valid HS256
+// JWT in the { token, email, name, org_id } envelope (app/main.js ~8071) and
+// GET /policy still returns the enterprise policy. It NEVER returns 401 (that
+// would trip the app's real sign-out path mid-test). Listens on an ephemeral
+// loopback port; the caller passes the returned url as the adapter URL.
+//
+// Statefulness (per server instance, so each test starts clean):
+//   POST   /auth/login           -> { token, email, name, org_id }
+//   GET    /policy               -> { auto_share_default, shared_notes_enabled }
+//   POST   /meetings             -> create; returns { id, ...payload }
+//   GET    /meetings             -> { meetings: [...] }
+//   GET    /meetings/:id         -> the meeting (404 if gone)
+//   DELETE /meetings/:id         -> { id } (404 if gone)
+//   POST   /uploads/presign      -> { upload_url: <self>/s3/<key>, s3_key }
+//   PUT    /s3/:key              -> 200 (accepts the uploaded bytes)
+//   POST   /ai/chat              -> { answer } (echoes the question deterministically)
 const http = require('http');
 
 const b64url = (obj) =>
@@ -22,46 +37,113 @@ function makeToken() {
   ].join('.');
 }
 
+const json = (res, status, body) => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
 /**
  * Start the mock adapter on an ephemeral loopback port.
- * @returns {Promise<{ url: string, close: () => Promise<void> }>}
+ * @param {object} [opts]
+ * @param {object} [opts.policy] override the /policy response.
+ * @returns {Promise<{ url: string, close: () => Promise<void>, meetingCount: () => number, s3Puts: () => number }>}
  */
-function startMockAdapter() {
+function startMockAdapter(opts = {}) {
+  const policy = opts.policy || { auto_share_default: true, shared_notes_enabled: true };
+  const meetings = new Map(); // id -> meeting object
+  let idSeq = 0;
+  let keySeq = 0;
+  let s3PutCount = 0;
+  let baseUrl = '';
+
   return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
-      // Drain the request body (we don't inspect credentials) so 'end' fires;
-      // the mock authenticates structurally, not by content.
-      req.resume();
+      const chunks = [];
+      req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
-        if (req.method === 'POST' && req.url === '/auth/login') {
-          res.writeHead(200, { 'content-type': 'application/json' });
-          res.end(
-            JSON.stringify({
-              token: makeToken(),
-              email: 'e2e@example.com',
-              name: 'E2E Bot',
-              org_id: 'org-e2e',
-            }),
-          );
-        } else if (req.method === 'GET' && req.url === '/policy') {
-          // Enterprise policy the desktop fetches on sign-in (auto-share
-          // seed) and to gate the Shared notes feature. Defaults here.
-          res.writeHead(200, { 'content-type': 'application/json' });
-          res.end(
-            JSON.stringify({ auto_share_default: true, shared_notes_enabled: true }),
-          );
-        } else {
-          res.writeHead(404, { 'content-type': 'application/json' });
-          res.end(JSON.stringify({ detail: 'mock: not found' }));
+        const raw = Buffer.concat(chunks).toString('utf8');
+        const parse = () => {
+          try {
+            return raw ? JSON.parse(raw) : {};
+          } catch {
+            return {};
+          }
+        };
+        const { method, url } = req;
+
+        // --- auth + policy (unchanged contract) ---
+        if (method === 'POST' && url === '/auth/login') {
+          return json(res, 200, {
+            token: makeToken(),
+            email: 'e2e@example.com',
+            name: 'E2E Bot',
+            org_id: 'org-e2e',
+          });
         }
+        if (method === 'GET' && url === '/policy') {
+          return json(res, 200, policy);
+        }
+
+        // --- meetings CRUD ---
+        if (method === 'POST' && url === '/meetings') {
+          const payload = parse();
+          const id = `m${++idSeq}`;
+          const meeting = { id, ...payload };
+          meetings.set(id, meeting);
+          return json(res, 200, meeting);
+        }
+        if (method === 'GET' && url === '/meetings') {
+          return json(res, 200, { meetings: [...meetings.values()] });
+        }
+        const meetingMatch = url.match(/^\/meetings\/([^/?]+)$/);
+        if (meetingMatch) {
+          const id = decodeURIComponent(meetingMatch[1]);
+          if (method === 'GET') {
+            return meetings.has(id)
+              ? json(res, 200, meetings.get(id))
+              : json(res, 404, { detail: 'mock: meeting not found' });
+          }
+          if (method === 'DELETE') {
+            if (!meetings.has(id)) return json(res, 404, { detail: 'mock: meeting not found' });
+            meetings.delete(id);
+            return json(res, 200, { id });
+          }
+        }
+
+        // --- share upload: presign + (self-hosted) S3 PUT ---
+        if (method === 'POST' && url === '/uploads/presign') {
+          const { filename = 'note.md' } = parse();
+          const s3_key = `notes/${++keySeq}-${filename}`;
+          return json(res, 200, {
+            upload_url: `${baseUrl}/s3/${encodeURIComponent(s3_key)}`,
+            s3_key,
+          });
+        }
+        if (method === 'PUT' && url.startsWith('/s3/')) {
+          s3PutCount++;
+          res.writeHead(200);
+          return res.end();
+        }
+
+        // --- org AI chat (deterministic echo) ---
+        if (method === 'POST' && url === '/ai/chat') {
+          const { question = '' } = parse();
+          return json(res, 200, { answer: `mock-org-answer: ${question}` });
+        }
+
+        // Default: 404 (never 401 — see header comment).
+        return json(res, 404, { detail: 'mock: not found' });
       });
     });
     server.on('error', reject);
     server.listen(0, '127.0.0.1', () => {
       const { port } = server.address();
+      baseUrl = `http://127.0.0.1:${port}`;
       resolve({
-        url: `http://127.0.0.1:${port}`,
+        url: baseUrl,
         close: () => new Promise((r) => server.close(() => r())),
+        meetingCount: () => meetings.size,
+        s3Puts: () => s3PutCount,
       });
     });
   });

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -7,6 +7,17 @@ import path from 'path';
  * mirroring how config-corruption.t2 pre-seeds config.json.
  */
 
+/** Read <userDataDir>/config.json (returns {} if absent/unreadable). */
+export function readUserConfig(userDataDir: string): Record<string, unknown> {
+  const cfgPath = path.join(userDataDir, 'config.json');
+  if (!existsSync(cfgPath)) return {};
+  try {
+    return JSON.parse(readFileSync(cfgPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
 /** Merge a partial config into <userDataDir>/config.json, creating it if absent. */
 export function writeUserConfig(
   userDataDir: string,

--- a/e2e/specs/ai-provider.t2.spec.ts
+++ b/e2e/specs/ai-provider.t2.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { readFileSync, existsSync } from 'fs';
+import { readUserConfig } from '../fixtures/user-config';
+import { existsSync } from 'fs';
 import path from 'path';
 
 /**
@@ -45,11 +46,6 @@ type StenoWindow = Window & {
 const getProvider = (page: import('@playwright/test').Page) =>
   page.evaluate(() => (window as StenoWindow).stenoai.ai.getProvider());
 
-function readConfig(userDataDir: string): Record<string, unknown> {
-  const p = path.join(userDataDir, 'config.json');
-  if (!existsSync(p)) return {};
-  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
-}
 
 test('provider switch + cloud/bedrock config persist and round-trip through get-ai-provider', async ({
   launchApp,
@@ -69,7 +65,7 @@ test('provider switch + cloud/bedrock config persist and round-trip through get-
       (p) => (window as StenoWindow).stenoai.ai.setProvider(p),
       provider,
     );
-    await expect.poll(() => readConfig(userDataDir).ai_provider).toBe(provider);
+    await expect.poll(() => readUserConfig(userDataDir).ai_provider).toBe(provider);
     expect((await getProvider(page)).ai_provider).toBe(provider);
   }
 
@@ -151,5 +147,5 @@ test('cloud API key is stored encrypted (safeStorage) in the temp dir, not confi
   // ...the snapshot reports it set...
   await expect.poll(async () => (await getProvider(page)).cloud_api_key_set).toBe(true);
   // ...and the plaintext key never appears in config.json.
-  expect(JSON.stringify(readConfig(userDataDir))).not.toContain('sk-e2e-secret-123');
+  expect(JSON.stringify(readUserConfig(userDataDir))).not.toContain('sk-e2e-secret-123');
 });

--- a/e2e/specs/ai-provider.t2.spec.ts
+++ b/e2e/specs/ai-provider.t2.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — AI provider configuration matrix. Drives the real backend's `ai` IPC and
+ * asserts both the get-ai-provider snapshot and the persisted config.json keys.
+ * Model-free + deterministic: every call here is a local config write or local
+ * encryption — the network calls (test-cloud-api / test-remote-ollama) and the
+ * org-adapter path (covered by the org specs) are intentionally excluded.
+ *
+ * No org is signed in, so set-ai-provider is not org-locked here.
+ */
+
+type ProviderSnapshot = {
+  success: boolean;
+  ai_provider?: string;
+  cloud_provider?: string;
+  cloud_api_url?: string;
+  cloud_model?: string;
+  cloud_api_key_set?: boolean;
+  bedrock_region?: string;
+  bedrock_inference_profile?: string;
+  remote_ollama_url?: string;
+};
+type Result = { success?: boolean; error?: string };
+
+type StenoWindow = Window & {
+  stenoai: {
+    ai: {
+      getProvider: () => Promise<ProviderSnapshot>;
+      setProvider: (p: string) => Promise<Result>;
+      setRemoteOllamaUrl: (url: string) => Promise<Result>;
+      setCloudApiUrl: (url: string) => Promise<Result>;
+      setCloudApiKey: (key: string) => Promise<Result>;
+      setCloudProvider: (p: string) => Promise<Result>;
+      setCloudModel: (m: string) => Promise<Result>;
+      setBedrockRegion: (r: string) => Promise<Result>;
+      setBedrockInferenceProfile: (p: string) => Promise<Result>;
+    };
+  };
+};
+
+const getProvider = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => (window as StenoWindow).stenoai.ai.getProvider());
+
+function readConfig(userDataDir: string): Record<string, unknown> {
+  const p = path.join(userDataDir, 'config.json');
+  if (!existsSync(p)) return {};
+  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
+}
+
+test('provider switch + cloud/bedrock config persist and round-trip through get-ai-provider', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // Default snapshot is a coherent local config.
+  const initial = await getProvider(page);
+  expect(initial.success).toBe(true);
+  expect(initial.ai_provider).toBe('local');
+
+  // Provider switches persist to config.ai_provider and reflect in the snapshot.
+  for (const provider of ['remote', 'cloud', 'local']) {
+    await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.ai.setProvider(p),
+      provider,
+    );
+    await expect.poll(() => readConfig(userDataDir).ai_provider).toBe(provider);
+    expect((await getProvider(page)).ai_provider).toBe(provider);
+  }
+
+  // Cloud config: provider, url, model.
+  await page.evaluate(() => (window as StenoWindow).stenoai.ai.setCloudProvider('anthropic'));
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setCloudApiUrl('https://api.example.test/v1'),
+  );
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setCloudModel('claude-haiku-4-5-20251001'),
+  );
+
+  // Bedrock config.
+  await page.evaluate(() => (window as StenoWindow).stenoai.ai.setBedrockRegion('us-west-2'));
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setBedrockInferenceProfile('my-profile'),
+  );
+
+  // Remote Ollama URL (no connectivity check — set only).
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setRemoteOllamaUrl('http://ollama.example.test:11434'),
+  );
+
+  await expect
+    .poll(async () => {
+      const s = await getProvider(page);
+      return {
+        cloud_provider: s.cloud_provider,
+        cloud_api_url: s.cloud_api_url,
+        cloud_model: s.cloud_model,
+        bedrock_region: s.bedrock_region,
+        bedrock_inference_profile: s.bedrock_inference_profile,
+        remote_ollama_url: s.remote_ollama_url,
+      };
+    })
+    .toEqual({
+      cloud_provider: 'anthropic',
+      cloud_api_url: 'https://api.example.test/v1',
+      cloud_model: 'claude-haiku-4-5-20251001',
+      bedrock_region: 'us-west-2',
+      bedrock_inference_profile: 'my-profile',
+      remote_ollama_url: 'http://ollama.example.test:11434',
+    });
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('cloud API key is stored encrypted (safeStorage) in the temp dir, not config.json', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const { app, page } = await launchApp();
+
+  // The key is persisted via safeStorage; on a headless runner with no usable
+  // keyring it is unavailable — skip LOUDLY rather than emit a misleading red
+  // (mirrors org-lock-lifecycle.t2's keystone guard).
+  const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
+    safeStorage.isEncryptionAvailable(),
+  );
+  if (!encryptionAvailable) {
+    // eslint-disable-next-line no-console
+    console.warn('[t2] SKIPPED cloud-api-key: safeStorage unavailable on this runner.');
+    test.info().annotations.push({
+      type: 'skip-reason',
+      description: 'safeStorage unavailable; cloud key cannot persist on this runner',
+    });
+  }
+  test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
+
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.setCloudApiKey('sk-e2e-secret-123'),
+  );
+
+  // Encrypted blob lands in the temp dir...
+  await expect
+    .poll(() => existsSync(path.join(userDataDir, '.cloud-api-key')), { timeout: 10_000 })
+    .toBe(true);
+  // ...the snapshot reports it set...
+  await expect.poll(async () => (await getProvider(page)).cloud_api_key_set).toBe(true);
+  // ...and the plaintext key never appears in config.json.
+  expect(JSON.stringify(readConfig(userDataDir))).not.toContain('sk-e2e-secret-123');
+});

--- a/e2e/specs/chat-sessions.t2.spec.ts
+++ b/e2e/specs/chat-sessions.t2.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — chat session persistence. The Chat tab persists its sessions through
+ * save-chat-sessions / load-chat-sessions, an atomic local write with no LLM and
+ * no network. Drives the real backend IPC and asserts the round-trip plus the
+ * on-disk chat_sessions_v2.json in the temp user-data dir. Deterministic +
+ * model-free.
+ */
+
+type SaveResult = { success: boolean; error?: string };
+type LoadResult = { success: boolean; data: unknown; migratedFromLegacy?: boolean };
+
+type StenoWindow = Window & {
+  stenoai: {
+    chat: {
+      save: (data: unknown) => Promise<SaveResult>;
+      load: () => Promise<LoadResult>;
+    };
+  };
+};
+
+const V2_FILE = 'chat_sessions_v2.json';
+
+test('chat sessions save+load round-trip persists to chat_sessions_v2.json; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // First load on a clean profile returns empty (data: null), not an error.
+  const empty = await page.evaluate(() => (window as StenoWindow).stenoai.chat.load());
+  expect(empty.success).toBe(true);
+  expect(empty.data).toBeNull();
+
+  // Save a known session graph.
+  const sessions = {
+    version: 2,
+    sessions: [
+      { id: 's1', title: 'Roadmap chat', messages: [{ role: 'user', content: 'hi' }] },
+      { id: 's2', title: 'Bug triage', messages: [] },
+    ],
+  };
+  const saved = await page.evaluate(
+    (data) => (window as StenoWindow).stenoai.chat.save(data),
+    sessions,
+  );
+  expect(saved.success).toBe(true);
+
+  // It landed in the temp dir as chat_sessions_v2.json with the exact payload.
+  const v2Path = path.join(userDataDir, V2_FILE);
+  await expect.poll(() => existsSync(v2Path)).toBe(true);
+  expect(JSON.parse(readFileSync(v2Path, 'utf8'))).toEqual(sessions);
+
+  // load() returns the saved graph (not the legacy-migration path).
+  const loaded = await page.evaluate(() => (window as StenoWindow).stenoai.chat.load());
+  expect(loaded.success).toBe(true);
+  expect(loaded.data).toEqual(sessions);
+  expect(loaded.migratedFromLegacy).toBeFalsy();
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — model management (the deterministic, model-free subset). Covers the
+ * summary-model and whisper-model config round-trips plus the whisper / parakeet
+ * list + status SHAPE. Model PULLS (pull-model / pull-whisper-model /
+ * pull-parakeet-model) download hundreds of MB and are NOT covered here — they
+ * belong to the model-bearing @pipeline jobs. "installed" reflects the host's
+ * real model cache (not the temp dir), so we assert the SHAPE of those flags,
+ * never a specific install state.
+ */
+
+type ModelInfo = { installed?: boolean };
+type ListResult = {
+  success: boolean;
+  current_model?: string;
+  supported_models?: Record<string, ModelInfo>;
+  provider?: string;
+};
+type CurrentModel = { success: boolean; model?: string };
+type StatusResult = { success: boolean; model?: string; installed?: boolean };
+type Result = { success?: boolean };
+
+type StenoWindow = Window & {
+  stenoai: {
+    models: {
+      getCurrent: () => Promise<CurrentModel>;
+      set: (name: string) => Promise<Result>;
+    };
+    whisperModels: {
+      list: () => Promise<ListResult>;
+      set: (name: string) => Promise<Result>;
+    };
+    parakeetModels: {
+      list: () => Promise<ListResult>;
+      status: () => Promise<StatusResult>;
+    };
+  };
+};
+
+function readConfig(userDataDir: string): Record<string, unknown> {
+  const p = path.join(userDataDir, 'config.json');
+  if (!existsSync(p)) return {};
+  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
+}
+
+/** Every entry in a supported-models map must carry a boolean `installed` flag. */
+function assertInstalledShape(models: Record<string, ModelInfo> | undefined) {
+  expect(models && typeof models === 'object').toBeTruthy();
+  const entries = Object.values(models!);
+  expect(entries.length).toBeGreaterThan(0);
+  for (const m of entries) {
+    expect(typeof m.installed).toBe('boolean');
+  }
+}
+
+test('summary model set persists to config.model and round-trips through get-current-model', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // There's always a current model (config default).
+  const before = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.models.getCurrent(),
+  );
+  expect(before.success).toBe(true);
+  expect(before.model).toBeTruthy();
+
+  await page.evaluate(() => (window as StenoWindow).stenoai.models.set('llama3.2:1b'));
+  await expect.poll(() => readConfig(userDataDir).model).toBe('llama3.2:1b');
+  await expect
+    .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.models.getCurrent())).model)
+    .toBe('llama3.2:1b');
+
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('whisper models: list reports installed flags; set persists to config.whisper_model', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const { page } = await launchApp();
+
+  const listed = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.whisperModels.list(),
+  );
+  expect(listed.success).toBe(true);
+  expect(listed.provider).toBe('local');
+  assertInstalledShape(listed.supported_models);
+
+  // Pick a known supported key (SUPPORTED_WHISPER_MODELS = small | large-v3-turbo;
+  // set-whisper-model validates against those) and set it; it persists + the
+  // list's current model follows.
+  await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.set('large-v3-turbo'));
+  await expect.poll(() => readConfig(userDataDir).whisper_model).toBe('large-v3-turbo');
+  await expect
+    .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.list())).current_model)
+    .toBe('large-v3-turbo');
+});
+
+test('parakeet models: list + status return a coherent installed shape', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp();
+
+  const listed = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.parakeetModels.list(),
+  );
+  expect(listed.success).toBe(true);
+  expect(listed.current_model).toBeTruthy();
+  assertInstalledShape(listed.supported_models);
+
+  const status = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.parakeetModels.status(),
+  );
+  expect(status.success).toBe(true);
+  expect(status.model).toBeTruthy();
+  expect(typeof status.installed).toBe('boolean');
+  // status + list agree on the default model id.
+  expect(status.model).toBe(listed.current_model);
+});

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { readFileSync, existsSync } from 'fs';
-import path from 'path';
+import { readUserConfig } from '../fixtures/user-config';
 
 /**
  * T2 — model management (the deterministic, model-free subset). Covers the
@@ -41,11 +40,6 @@ type StenoWindow = Window & {
   };
 };
 
-function readConfig(userDataDir: string): Record<string, unknown> {
-  const p = path.join(userDataDir, 'config.json');
-  if (!existsSync(p)) return {};
-  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
-}
 
 /** Every entry in a supported-models map must carry a boolean `installed` flag. */
 function assertInstalledShape(models: Record<string, ModelInfo> | undefined) {
@@ -72,7 +66,7 @@ test('summary model set persists to config.model and round-trips through get-cur
   expect(before.model).toBeTruthy();
 
   await page.evaluate(() => (window as StenoWindow).stenoai.models.set('llama3.2:1b'));
-  await expect.poll(() => readConfig(userDataDir).model).toBe('llama3.2:1b');
+  await expect.poll(() => readUserConfig(userDataDir).model).toBe('llama3.2:1b');
   await expect
     .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.models.getCurrent())).model)
     .toBe('llama3.2:1b');
@@ -97,7 +91,7 @@ test('whisper models: list reports installed flags; set persists to config.whisp
   // set-whisper-model validates against those) and set it; it persists + the
   // list's current model follows.
   await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.set('large-v3-turbo'));
-  await expect.poll(() => readConfig(userDataDir).whisper_model).toBe('large-v3-turbo');
+  await expect.poll(() => readUserConfig(userDataDir).whisper_model).toBe('large-v3-turbo');
   await expect
     .poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.whisperModels.list())).current_model)
     .toBe('large-v3-turbo');

--- a/e2e/specs/org-crud.t2.spec.ts
+++ b/e2e/specs/org-crud.t2.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockAdapter } from '../fixtures/mock-adapter';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import path from 'path';
+
+/**
+ * T2 — org meeting CRUD + share/unshare + AI chat, all against the stateful mock
+ * adapter (no real backend, no AWS/S3). Signs in through the real org-login IPC,
+ * then exercises the adapter-backed operations and the local backup-state file
+ * that makes share/unshare stick. Builds on org-lock-lifecycle.t2 (sign-in) and
+ * shared-notes-policy (policy). Deterministic — the adapter echoes/stores in
+ * memory and the share upload PUTs back to the mock itself.
+ */
+
+type Result = { success: boolean; error?: string };
+type Meeting = { id: string; title?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    org: {
+      login: (url: string, email: string, password: string) => Promise<Result & { signedIn?: boolean }>;
+      status: () => Promise<{ signedIn: boolean }>;
+      createMeeting: (payload: unknown) => Promise<Result & { meeting?: Meeting }>;
+      listMeetings: () => Promise<Result & { meetings: Meeting[] }>;
+      getMeeting: (id: string) => Promise<Result & { meeting?: Meeting }>;
+      deleteMeeting: (id: string) => Promise<Result & { id?: string }>;
+      shareMeeting: (payload: unknown) => Promise<Result & { meeting?: Meeting }>;
+      getBackupState: (
+        summaryFile: string,
+      ) => Promise<Result & { shared: boolean; meeting_id: string | null }>;
+      unshareBySummary: (summaryFile: string) => Promise<Result & { adapter_status?: string }>;
+      aiChat: (payload: unknown) => Promise<Result & { answer?: string }>;
+    };
+  };
+};
+
+test('org CRUD + share/unshare + ai-chat round-trip through the adapter; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const adapter = await startMockAdapter();
+  try {
+    const { app, page } = await launchApp();
+
+    // .org-session is persisted via safeStorage; skip LOUDLY on a headless runner
+    // with no usable keyring rather than emit a misleading red (mirrors
+    // org-lock-lifecycle.t2).
+    const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
+      safeStorage.isEncryptionAvailable(),
+    );
+    if (!encryptionAvailable) {
+      // eslint-disable-next-line no-console
+      console.warn('[t2] SKIPPED org-crud: safeStorage unavailable on this runner.');
+      test.info().annotations.push({
+        type: 'skip-reason',
+        description: 'safeStorage unavailable; org session cannot persist',
+      });
+    }
+    test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
+
+    // Sign in through the real org-login IPC (HTTP round-trip to the mock).
+    const login = await page.evaluate(
+      (url) => (window as StenoWindow).stenoai.org.login(url, 'e2e@example.com', 'hunter2'),
+      adapter.url,
+    );
+    expect(login.success).toBe(true);
+    await expect.poll(async () => (await page.evaluate(() => (window as StenoWindow).stenoai.org.status())).signedIn).toBe(true);
+
+    // Create -> list -> get.
+    const created = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.org.createMeeting({ title: 'Alpha Sync' }),
+    );
+    expect(created.success).toBe(true);
+    const id = created.meeting!.id;
+    expect(id).toBeTruthy();
+
+    const listed = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.org.listMeetings(),
+    );
+    expect(listed.success).toBe(true);
+    expect(listed.meetings.map((m) => m.id)).toContain(id);
+
+    const got = await page.evaluate(
+      (mid) => (window as StenoWindow).stenoai.org.getMeeting(mid),
+      id,
+    );
+    expect(got.success).toBe(true);
+    expect(got.meeting?.title).toBe('Alpha Sync');
+
+    // Delete -> gone from the list.
+    const del = await page.evaluate(
+      (mid) => (window as StenoWindow).stenoai.org.deleteMeeting(mid),
+      id,
+    );
+    expect(del.success).toBe(true);
+    const afterDelete = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.org.listMeetings(),
+    );
+    expect(afterDelete.meetings.map((m) => m.id)).not.toContain(id);
+
+    // AI chat through the adapter (deterministic echo).
+    const chat = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.org.aiChat({ question: 'ping' }),
+    );
+    expect(chat.success).toBe(true);
+    expect(chat.answer).toBe('mock-org-answer: ping');
+
+    // Share -> backup-state records it -> unshare clears it. summaryFile is just
+    // the local key the backup-state file is indexed by.
+    const summaryFile = path.join(userDataDir, 'output', 'shared-note_summary.json');
+    const share = await page.evaluate(
+      (sf) =>
+        (window as StenoWindow).stenoai.org.shareMeeting({
+          title: 'Shared Note',
+          body: '# Shared Note\n\nbody',
+          summaryFile: sf,
+        }),
+      summaryFile,
+    );
+    expect(share.success).toBe(true);
+    expect(adapter.s3Puts()).toBeGreaterThan(0); // the markdown PUT landed
+
+    const stateAfterShare = await page.evaluate(
+      (sf) => (window as StenoWindow).stenoai.org.getBackupState(sf),
+      summaryFile,
+    );
+    expect(stateAfterShare.shared).toBe(true);
+    expect(stateAfterShare.meeting_id).toBe(share.meeting!.id);
+
+    const unshare = await page.evaluate(
+      (sf) => (window as StenoWindow).stenoai.org.unshareBySummary(sf),
+      summaryFile,
+    );
+    expect(unshare.success).toBe(true);
+
+    const stateAfterUnshare = await page.evaluate(
+      (sf) => (window as StenoWindow).stenoai.org.getBackupState(sf),
+      summaryFile,
+    );
+    expect(stateAfterUnshare.shared).toBe(false);
+
+    // Keystone: org session + backup-state landed in the temp dir; the real
+    // user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await adapter.close();
+  }
+});

--- a/e2e/specs/settings-roundtrip.t2.spec.ts
+++ b/e2e/specs/settings-roundtrip.t2.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — settings get/set round-trip. Drives the real backend's settings IPC and
+ * asserts each value persists to the right config.json key in the temp user-data
+ * dir. Model-free + deterministic (pure config writes via the Python CLI). The
+ * side-effecting settings (storage-path, which creates dirs) get their own test;
+ * the network/model ones (model pulls, test-cloud-api) are out of scope here.
+ */
+
+type SettingKind =
+  | 'language'
+  | 'userName'
+  | 'keepRecordings'
+  | 'silenceEnabled'
+  | 'silenceMinutes'
+  | 'systemAudio'
+  | 'telemetry'
+  | 'transcriptionEngine'
+  | 'dockIcon';
+
+type SettingsBridge = {
+  settings: {
+    setLanguage: (v: string) => Promise<unknown>;
+    setUserName: (v: string) => Promise<unknown>;
+    setKeepRecordings: (v: boolean) => Promise<unknown>;
+    setSilenceAutoStopEnabled: (v: boolean) => Promise<unknown>;
+    setSilenceAutoStopMinutes: (v: number) => Promise<unknown>;
+    setSystemAudio: (v: boolean) => Promise<unknown>;
+    setTelemetry: (v: boolean) => Promise<unknown>;
+    setDockIcon: (v: boolean) => Promise<unknown>;
+    setStoragePath: (p: string) => Promise<{ success?: boolean; error?: string }>;
+  };
+  transcriptionEngine: { set: (v: string) => Promise<unknown> };
+};
+type StenoWindow = Window & { stenoai: SettingsBridge };
+
+type Case = { kind: SettingKind; value: string | boolean | number; configKey: string };
+
+// Each case: drive the setter, then assert the persisted config.json key. The
+// expected value IS what we set, so this catches a setter writing the wrong key,
+// dropping the value, or coercing it.
+const CASES: Case[] = [
+  { kind: 'language', value: 'fr', configKey: 'language' },
+  { kind: 'userName', value: 'E2E Tester', configKey: 'user_name' },
+  { kind: 'keepRecordings', value: true, configKey: 'keep_recordings' },
+  { kind: 'silenceEnabled', value: false, configKey: 'silence_auto_stop_enabled' },
+  { kind: 'silenceMinutes', value: 15, configKey: 'silence_auto_stop_minutes' },
+  { kind: 'systemAudio', value: true, configKey: 'system_audio_enabled' },
+  { kind: 'telemetry', value: false, configKey: 'telemetry_enabled' },
+  { kind: 'transcriptionEngine', value: 'whisper', configKey: 'transcription_engine' },
+  { kind: 'dockIcon', value: true, configKey: 'hide_dock_icon' },
+];
+
+function readConfig(userDataDir: string): Record<string, unknown> {
+  const p = path.join(userDataDir, 'config.json');
+  if (!existsSync(p)) return {};
+  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
+}
+
+function applySetting(
+  page: import('@playwright/test').Page,
+  kind: SettingKind,
+  value: string | boolean | number,
+) {
+  return page.evaluate(
+    ({ kind, value }) => {
+      const s = (window as StenoWindow).stenoai;
+      switch (kind) {
+        case 'language':
+          return s.settings.setLanguage(value as string);
+        case 'userName':
+          return s.settings.setUserName(value as string);
+        case 'keepRecordings':
+          return s.settings.setKeepRecordings(value as boolean);
+        case 'silenceEnabled':
+          return s.settings.setSilenceAutoStopEnabled(value as boolean);
+        case 'silenceMinutes':
+          return s.settings.setSilenceAutoStopMinutes(value as number);
+        case 'systemAudio':
+          return s.settings.setSystemAudio(value as boolean);
+        case 'telemetry':
+          return s.settings.setTelemetry(value as boolean);
+        case 'dockIcon':
+          return s.settings.setDockIcon(value as boolean);
+        case 'transcriptionEngine':
+          return s.transcriptionEngine.set(value as string);
+        default:
+          throw new Error(`unknown setting kind: ${kind}`);
+      }
+    },
+    { kind, value },
+  );
+}
+
+test('settings setters persist each value to the right config.json key; real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  for (const { kind, value, configKey } of CASES) {
+    await applySetting(page, kind, value);
+    await expect
+      .poll(() => readConfig(userDataDir)[configKey], {
+        message: `${kind} -> config.${configKey}`,
+      })
+      .toBe(value);
+  }
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('set-storage-path persists the path and provisions its data subdirs', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // A fresh absolute path inside the temp dir (set-storage-path requires an
+  // absolute, writable location and provisions recordings/transcripts/output).
+  const target = path.join(userDataDir, 'custom-storage');
+  const res = await page.evaluate(
+    (p) => (window as StenoWindow).stenoai.settings.setStoragePath(p),
+    target,
+  );
+  expect(res.success).toBe(true);
+
+  await expect.poll(() => readConfig(userDataDir).storage_path).toBe(target);
+  for (const sub of ['recordings', 'transcripts', 'output']) {
+    expect(existsSync(path.join(target, sub))).toBe(true);
+  }
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/e2e/specs/settings-roundtrip.t2.spec.ts
+++ b/e2e/specs/settings-roundtrip.t2.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { readFileSync, existsSync } from 'fs';
+import { readUserConfig } from '../fixtures/user-config';
+import { existsSync } from 'fs';
 import path from 'path';
 
 /**
@@ -49,17 +50,13 @@ const CASES: Case[] = [
   { kind: 'keepRecordings', value: true, configKey: 'keep_recordings' },
   { kind: 'silenceEnabled', value: false, configKey: 'silence_auto_stop_enabled' },
   { kind: 'silenceMinutes', value: 15, configKey: 'silence_auto_stop_minutes' },
-  { kind: 'systemAudio', value: true, configKey: 'system_audio_enabled' },
+  // false flips the macOS default (true) so this has teeth on the primary signed
+  // platform — asserting `true` there would pass even if the setter no-oped.
+  { kind: 'systemAudio', value: false, configKey: 'system_audio_enabled' },
   { kind: 'telemetry', value: false, configKey: 'telemetry_enabled' },
   { kind: 'transcriptionEngine', value: 'whisper', configKey: 'transcription_engine' },
   { kind: 'dockIcon', value: true, configKey: 'hide_dock_icon' },
 ];
-
-function readConfig(userDataDir: string): Record<string, unknown> {
-  const p = path.join(userDataDir, 'config.json');
-  if (!existsSync(p)) return {};
-  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
-}
 
 function applySetting(
   page: import('@playwright/test').Page,
@@ -106,7 +103,7 @@ test('settings setters persist each value to the right config.json key; real dir
   for (const { kind, value, configKey } of CASES) {
     await applySetting(page, kind, value);
     await expect
-      .poll(() => readConfig(userDataDir)[configKey], {
+      .poll(() => readUserConfig(userDataDir)[configKey], {
         message: `${kind} -> config.${configKey}`,
       })
       .toBe(value);
@@ -132,7 +129,7 @@ test('set-storage-path persists the path and provisions its data subdirs', async
   );
   expect(res.success).toBe(true);
 
-  await expect.poll(() => readConfig(userDataDir).storage_path).toBe(target);
+  await expect.poll(() => readUserConfig(userDataDir).storage_path).toBe(target);
   for (const sub of ['recordings', 'transcripts', 'output']) {
     expect(existsSync(path.join(target, sub))).toBe(true);
   }


### PR DESCRIPTION
## Description

Phase 3 of the e2e pre-release coverage program. **Stacked on #195 (Phase 2)** — base is `e2e/phase2-settings`; auto-retargets to `main` once #194 → #195 merge. Review/merge the earlier PRs first.

Model-free T2 coverage of the chat-persistence and org-adapter surfaces.

**New specs**
- **`chat-sessions.t2`** — `save-chat-sessions` / `load-chat-sessions` round-trip: empty on a clean profile (`data: null`), persists to `chat_sessions_v2.json` in the temp dir, loads back the exact graph (not the legacy-migration path). No LLM, no network.
- **`org-crud.t2`** — signs in through the real `org-login` IPC, then exercises meeting **CRUD** (create/list/get/delete), the **share → backup-state → unshare** cycle (asserts the markdown PUT lands + `.org-backup-state.json` flips `shared`), and adapter **AI chat** — all against the mock adapter. Skips loudly without safeStorage (like `org-lock-lifecycle.t2`).

**Fixture**
- `e2e/fixtures/mock-adapter.js` made **stateful** (in-memory meetings + presign / self-hosted S3 PUT + `/ai/chat`) while keeping `/auth/login` + `/policy` byte-identical — the existing `org-lock-lifecycle.t2` is unaffected (verified green).

All assert the `STENOAI_USER_DATA_DIR` keystone (real dir untouched).

## Type of Change

- [x] New feature (e2e coverage)

## Testing

- [x] Phase 3 specs pass locally against the real `dist/stenoai`
- [x] `org-lock-lifecycle.t2` still green (mock-adapter rewrite is backward compatible)
- [x] Reviewed by QA + senior-engineer lenses — nothing critical/high; the `req.resume()`→chunk-collection rewrite confirmed safe for bodyless requests

## Additional Notes

Deferred to a follow-up (documented in the commit): the **local-Ollama `query-transcript` streaming `@contract`** (prompt-build + chunk framing). `org.aiChat` here already covers chat-with-LLM deterministically through the adapter; the local streaming path needs a mock-Ollama with request capture. Part of the stacked series — Phases 4–6 follow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add T2 e2e coverage for chat-session persistence and org adapter flows, powered by a stateful mock adapter. No LLM or network required; the real user-data dir stays untouched.

- **New Features**
  - `chat-sessions.t2`: verifies save/load round-trip, persists `chat_sessions_v2.json`, and avoids the legacy migration path.
  - `org-crud.t2`: signs in via real org-login IPC; tests meeting create/list/get/delete, share → backup-state → unshare, and adapter AI chat; skips when `safeStorage` is unavailable.
  - Stateful `e2e/fixtures/mock-adapter.js`: adds meetings CRUD, `/uploads/presign` + self-hosted S3 PUT, and `/ai/chat`; keeps `/auth/login` and `/policy` unchanged (never returns 401). Updated spec list in `CLAUDE.md`.

<sup>Written for commit 7a8c28bb8d18f4a4cf464c6290cb48f0ba802796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

