### PR TITLE
fix(paths): route all app-managed paths through getUserDataDir() (Windows pilot)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -5693,6 +5693,31 @@ ipcMain.handle('set-user-name', async (event, name) => {
 
 // AI Provider IPC handlers
 
+// One-time forward-migration of an app-managed credential from its pre-fix
+// hardcoded location. Before the getUserDataDir() path fix, the cloud key and
+// calendar tokens were written to a hardcoded ~/Library/Application Support
+// literal — correct on macOS (so this is a NO-OP there: legacy === current), but
+// a bogus dir on Windows. If a user configured cloud/calendar on an older Windows
+// build, copy that file forward to the current path so they don't have to
+// re-enter. safeStorage/DPAPI is user-scoped (not path-scoped), so the copied
+// ciphertext still decrypts. Best-effort + non-destructive (copy, leave legacy).
+//
+// HARD GUARD: never run under the STENOAI_USER_DATA_DIR e2e override — otherwise
+// a test would pull the dev's REAL ~/Library credential into the temp dir.
+function migrateLegacyCredentialFile(currentPath, filename) {
+  if (process.env.STENOAI_USER_DATA_DIR) return;
+  if (fs.existsSync(currentPath)) return;
+  const legacy = path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', filename);
+  if (legacy === currentPath || !fs.existsSync(legacy)) return;
+  try {
+    fs.mkdirSync(path.dirname(currentPath), { recursive: true });
+    fs.copyFileSync(legacy, currentPath);
+    console.log(`Migrated ${filename} forward from the legacy path`);
+  } catch (e) {
+    console.error(`Legacy ${filename} migration failed (best-effort):`, e.message);
+  }
+}
+
 function getCloudKeyPath() {
   // Use getUserDataDir() like every other app-managed file (.org-session,
   // .pre-adapter-provider, config.json). The old hardcoded
@@ -5721,6 +5746,7 @@ function saveCloudApiKey(key) {
 function loadCloudApiKey() {
   try {
     const keyPath = getCloudKeyPath();
+    migrateLegacyCredentialFile(keyPath, '.cloud-api-key');
     if (!fs.existsSync(keyPath)) return null;
     const encrypted = fs.readFileSync(keyPath);
     return safeStorage.decryptString(encrypted);
@@ -6671,6 +6697,7 @@ function saveGoogleTokens(tokens) {
 function loadGoogleTokens() {
   try {
     const tokenPath = getTokenFilePath();
+    migrateLegacyCredentialFile(tokenPath, '.google-tokens');
     if (!fs.existsSync(tokenPath)) return null;
     const encrypted = fs.readFileSync(tokenPath);
     const decrypted = safeStorage.decryptString(encrypted);
@@ -6718,6 +6745,7 @@ function saveOutlookTokens(tokens) {
 function loadOutlookTokens() {
   try {
     const tokenPath = getOutlookTokenFilePath();
+    migrateLegacyCredentialFile(tokenPath, '.outlook-tokens');
     if (!fs.existsSync(tokenPath)) return null;
     const encrypted = fs.readFileSync(tokenPath);
     const decrypted = safeStorage.decryptString(encrypted);

--- a/app/main.js
+++ b/app/main.js
@@ -633,7 +633,9 @@ function resolveRecordingsDir() {
   if (_cachedCustomStoragePath) {
     dir = path.join(_cachedCustomStoragePath, 'recordings');
   } else if (app.isPackaged) {
-    dir = path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', 'recordings');
+    // getUserDataDir() (not a macOS literal) so the packaged path is correct on
+    // Windows (%APPDATA%/stenoai) too; identical on macOS.
+    dir = path.join(getUserDataDir(), 'recordings');
   } else {
     dir = path.join(__dirname, '..', 'recordings');
   }
@@ -1986,7 +1988,13 @@ ipcMain.handle('load-chat-sessions', async () => {
 
 ipcMain.handle('save-meeting-notes', async (event, sessionName, notes) => {
   try {
-    const outputDir = path.join(getBackendCwd(), '_internal', 'output');
+    // Write into the user-data output dir — the SAME dir Python's get_data_dirs()
+    // uses (custom storage if set, else getUserDataDir(), which honors
+    // STENOAI_USER_DATA_DIR). The old getBackendCwd()/_internal/output target was
+    // INSIDE the app bundle: read-only in a packaged/signed app (so saving notes
+    // failed for real users on macOS + Windows), and a dir the Python pipeline
+    // never reads notes from, so reprocess's _load_user_notes couldn't find them.
+    const outputDir = path.join(_cachedCustomStoragePath || getUserDataDir(), 'output');
     if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
     const safeName = sessionName.replace(/[^a-zA-Z0-9_-]/g, '_');
     const notesFile = path.join(outputDir, `${safeName}_notes.txt`);
@@ -4788,7 +4796,10 @@ ipcMain.handle('get-storage-path', async () => {
     const customPath = jsonData.storage_path && jsonData.storage_path.trim()
       ? jsonData.storage_path
       : null;
-    const defaultPath = path.join(os.homedir(), 'Library', 'Application Support', 'stenoai');
+    // getUserDataDir() so the "where your data lives" path shown in Settings is
+    // correct on Windows (%APPDATA%/stenoai), not a macOS literal. It already
+    // resolves to the per-OS .../stenoai dir.
+    const defaultPath = getUserDataDir();
     return {
       success: true,
       storage_path: customPath || defaultPath,
@@ -5683,7 +5694,13 @@ ipcMain.handle('set-user-name', async (event, name) => {
 // AI Provider IPC handlers
 
 function getCloudKeyPath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.cloud-api-key');
+  // Use getUserDataDir() like every other app-managed file (.org-session,
+  // .pre-adapter-provider, config.json). The old hardcoded
+  // ~/Library/Application Support literal was macOS-only (wrong dir on Windows)
+  // and ignored the STENOAI_USER_DATA_DIR e2e override, so the encrypted cloud
+  // key escaped test isolation into the real user dir. On real macOS this
+  // resolves to the identical path, so existing keys are unaffected.
+  return path.join(getUserDataDir(), '.cloud-api-key');
 }
 
 function saveCloudApiKey(key) {
@@ -6184,7 +6201,8 @@ ipcMain.handle('get-recordings-dir', async () => {
     if (jsonData.storage_path) {
       recordingsDir = path.join(jsonData.storage_path, 'recordings');
     } else if (app.isPackaged) {
-      recordingsDir = path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', 'recordings');
+      // getUserDataDir() for the correct Windows path (%APPDATA%); identical on macOS.
+      recordingsDir = path.join(getUserDataDir(), 'recordings');
     } else {
       recordingsDir = path.join(__dirname, '..', 'recordings');
     }
@@ -6629,7 +6647,11 @@ ipcMain.handle('open-external', async (event, url) => {
 // ── Google Calendar: Token Storage ──────────────────────────────────────
 
 function getTokenFilePath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.google-tokens');
+  // getUserDataDir() like every other app-managed file — the old hardcoded
+  // ~/Library/Application Support literal was macOS-only (wrong dir on Windows)
+  // and ignored the STENOAI_USER_DATA_DIR e2e override. Resolves identically on
+  // real macOS, so existing tokens are unaffected.
+  return path.join(getUserDataDir(), '.google-tokens');
 }
 
 function saveGoogleTokens(tokens) {
@@ -6674,7 +6696,9 @@ function deleteGoogleTokens() {
 // ── Outlook Calendar: Token Storage ─────────────────────────────────────
 
 function getOutlookTokenFilePath() {
-  return path.join(os.homedir(), 'Library', 'Application Support', 'stenoai', '.outlook-tokens');
+  // See getTokenFilePath — route through getUserDataDir() for cross-platform +
+  // e2e isolation; identical path on real macOS.
+  return path.join(getUserDataDir(), '.outlook-tokens');
 }
 
 function saveOutlookTokens(tokens) {

--- a/e2e/specs/save-notes-location.t2.spec.ts
+++ b/e2e/specs/save-notes-location.t2.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — save-meeting-notes must write into the user-data output dir, NOT the app
+ * bundle. The old getBackendCwd()/_internal/output target was read-only in a
+ * packaged/signed app (notes-saving failed for real users on macOS + Windows)
+ * and was a dir the Python pipeline never reads notes from. This pins the fix:
+ * the note lands under <STENOAI_USER_DATA_DIR>/output (where Python's
+ * get_data_dirs() looks) and the real user-data dir is untouched.
+ */
+
+type SaveResult = { success: boolean; path?: string; error?: string };
+type StenoWindow = Window & {
+  stenoai: { meetings: { saveNotes: (name: string, notes: string) => Promise<SaveResult> } };
+};
+
+test('save-meeting-notes writes into the user-data output dir (not the bundle); real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  const note = 'Ship the Windows alpha to the enterprise pilot.';
+  const res = await page.evaluate(
+    (n) => (window as StenoWindow).stenoai.meetings.saveNotes('Pilot Meeting', n),
+    note,
+  );
+
+  expect(res.success).toBe(true);
+  expect(res.path).toBeTruthy();
+
+  // The returned path is inside the temp user-data output dir — proving it no
+  // longer escapes to the bundle (getBackendCwd()/_internal/output).
+  const expectedDir = path.join(userDataDir, 'output');
+  expect(path.dirname(res.path!)).toBe(expectedDir);
+  expect(path.basename(res.path!)).toBe('Pilot_Meeting_notes.txt');
+  expect(existsSync(res.path!)).toBe(true);
+  expect(readFileSync(res.path!, 'utf8')).toBe(note);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});


### PR DESCRIPTION
## Description

Cross-platform path-correctness fix, **prioritized for the fresh Windows enterprise pilot build this week**. Every app-managed path that hardcoded the macOS `~/Library/Application Support/stenoai/...` literal resolved to the **wrong directory on Windows** (and ignored the e2e-isolation override). All routed through `getUserDataDir()` — which is a byte-identical mirror of Python's `get_user_data_dir()`, so JS and the backend agree on **both** platforms.

**Zero behavior change on the signed macOS build** — `getUserDataDir()` resolves to exactly the old literal there.

### Fixes (all the same root cause)
- **`save-meeting-notes`** *(the genuinely user-impacting one — fails on macOS too)*: was writing into `getBackendCwd()/_internal/output`, **inside the app bundle** — read-only in a packaged/signed app, so saving notes **failed for real users on macOS + Windows**, and the Python pipeline never reads notes from there (`reprocess`'s `_load_user_notes` couldn't find them). Now writes to the user-data `output/` dir (`_cachedCustomStoragePath || getUserDataDir()`), matching `get_data_dirs()`. **Covered by the new `save-notes-location.t2` spec.**
- **`resolveRecordingsDir` + the `get-recordings-dir` resolver**: packaged branch → wrong recordings dir on Windows (reveal-folder / path validation). → `getUserDataDir()`.
- **`get-storage-path` default display path**: showed a macOS literal on Windows. → `getUserDataDir()`.
- **`getCloudKeyPath` / `getTokenFilePath` / `getOutlookTokenFilePath`**: cloud key + Google/Outlook calendar tokens wrote to the wrong dir on Windows (broke cloud summarization + calendar auth there). **These lines are character-identical to the edits already in #195 / #199**, so they 3-way-merge with no conflict. Pulled in here so a **single production PR carries the complete set** for the Windows build.

## Type of Change

- [x] Bug fix (cross-platform path correctness + read-only-bundle write failure)

## Testing

- [x] `save-meeting-notes` fix verified by the new `save-notes-location.t2` spec (note lands in `<userDataDir>/output`, not the bundle)
- [x] Model-free T2 suite green on this branch (config-corruption, org-lock-lifecycle, save-notes-location)
- [x] Reviewed by QA+security and engineer lenses: **safe to ship to the Windows pilot**; macOS byte-identical (no regression); no security downgrade
- [ ] ⚠️ The three `app.isPackaged`-gated resolvers (recordings dirs, display path) **cannot be e2e-verified** (the suite runs unpackaged) — they need a manual packaged-Windows smoke or the pilot's feedback. The fix is a minimal, low-risk one-liner per site.

## Notes

- **Merge this before #195 / #199** — eliminates any merge-order fragility (those PRs then 3-way-merge cleanly against an already-fixed `main`).
- Follow-ups (pre-existing, out of scope): `setup-system-check` uses `app.getPath('appData')` and skips the `STENOAI_USER_DATA_DIR` override (minor e2e-isolation gap); the `_cachedCustomStoragePath` startup-probe could leave a custom-storage user on the default dir if the probe throws.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all app-managed paths through getUserDataDir() so Windows uses the correct, writable user data dir. Fixes notes saving, recordings dir, Settings default path, and key/token storage, and migrates existing Windows credentials; no behavior change on macOS.

- **Bug Fixes**
  - Notes now save to the user-data `output/` dir (custom storage or getUserDataDir()); added `save-notes-location.t2` test.
  - Recordings dir resolvers use getUserDataDir() when packaged.
  - Default storage path in Settings shows the correct Windows path.
  - Cloud API key and Google/Outlook token files now live under getUserDataDir() for cross‑platform consistency and test isolation.
  - Windows upgrade: automatically copies existing cloud key and calendar tokens from the old macOS‑literal path to the new path (non‑destructive, idempotent; disabled when `STENOAI_USER_DATA_DIR` is set).

<sup>Written for commit 204014e7a80192609d984e4565cf18f823d1ca3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

