### PR TITLE
docs(claude): standing rule — ship an e2e spec with each new feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,15 @@ The e2e suite drives the **real Electron app** (real window, real clicks) to cat
 full-app regressions like the org-provider reset before they reach users. It lives
 at repo-root `e2e/` (config, fixtures, specs); run it from `app/`.
 
+**Standing rule — keep coverage current:** when you add or materially change a
+user-facing feature, add or update its e2e spec in the **same** change. Prefer a
+model-free T2 spec that drives the `window.stenoai.<group>` preload bridge and
+asserts backend state on disk (config/files/JSON), using the existing specs +
+`e2e/fixtures/` helpers as templates — only reach for a UI/T1 spec when the
+interaction itself is the risk, and keep model/network-bearing assertions in the
+`@pipeline`/nightly lanes. This applies to luffy-built work too (CLAUDE.md
+overrides luffy's test-level defaults); the QA review lens checks for it.
+
 - Run the whole suite: `cd app && npm run test:e2e` (needs the renderer built and,
   for T2, the backend bundle at `dist/stenoai/`).
 - Run one tier: `cd app && npm run test:e2e -- --project=t1` (or `t2`).


### PR DESCRIPTION
## Description

Codifies the standing rule the e2e coverage program intended but never wrote down: **when you add or materially change a user-facing feature, add/update its e2e spec in the same change** (prefer a model-free T2 spec driving the `window.stenoai.<group>` preload bridge).

One-line addition to the **End-to-end tests** section of CLAUDE.md. It also explicitly steers **luffy** toward picking an e2e spec (CLAUDE.md overrides luffy's test-level defaults), and notes the QA review lens checks for it — so coverage doesn't rot as new features land.

## Type of Change

- [x] Documentation update

## Testing

- [x] Docs-only; no code change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-line rule to `CLAUDE.md`: every new or materially changed user-facing feature must ship an e2e spec in the same PR. Prefer model-free T2 specs via `window.stenoai.<group>` asserting on-disk backend state; use UI/T1 only when interaction is the risk, keep model/network assertions in nightly lanes, and QA checks this for `luffy` work.

<sup>Written for commit 83b5e01d4ab600003c9cf0525003966b3acfe270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

