### PR TITLE
fix(cloud): show current OpenAI chat models in the picker

### DIFF
--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3890,9 +3890,12 @@ def test_remote_ollama(url):
 # Model families OpenAI's /models endpoint mixes in alongside chat models —
 # embeddings, speech, image and moderation. Excluded so the Settings model
 # picker only offers models that actually answer chat completions (#198).
+# NB: no "search" marker — the *-search-preview models are chat-completion
+# models (web-search-grounded), and "search" is also a substring of
+# "deep-research", so excluding it would drop real chat/reasoning models.
 _OPENAI_NON_CHAT_MARKERS = (
     "embedding", "whisper", "tts", "audio", "realtime",
-    "moderation", "dall-e", "image", "transcribe", "search", "codex",
+    "moderation", "dall-e", "image", "transcribe", "codex",
 )
 
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3887,6 +3887,32 @@ def test_remote_ollama(url):
         print(json.dumps({"success": False, "error": str(e)}))
 
 
+# Model families OpenAI's /models endpoint mixes in alongside chat models —
+# embeddings, speech, image and moderation. Excluded so the Settings model
+# picker only offers models that actually answer chat completions (#198).
+_OPENAI_NON_CHAT_MARKERS = (
+    "embedding", "whisper", "tts", "audio", "realtime",
+    "moderation", "dall-e", "image", "transcribe", "search", "codex",
+)
+
+
+def _is_openai_chat_model(model_id: str) -> bool:
+    """True for OpenAI chat/reasoning models (``gpt-*``, the ``o<n>`` reasoning
+    series, ``chatgpt-*``), excluding the non-chat families above. ``gpt-`` and
+    ``o\\d`` are prefix/pattern matches so newer releases (gpt-4.1, o4, …) keep
+    showing up without a code change. Applied to the openai provider only —
+    custom OpenAI-compatible endpoints use their own naming, so their lists are
+    left unfiltered."""
+    mid = model_id.lower()
+    if not (
+        mid.startswith("gpt-")
+        or mid.startswith("chatgpt-")
+        or re.match(r"o\d", mid)
+    ):
+        return False
+    return not any(marker in mid for marker in _OPENAI_NON_CHAT_MARKERS)
+
+
 @cli.command()
 def test_cloud_api():
     """Test connection to the cloud API"""
@@ -3956,7 +3982,20 @@ def test_cloud_api():
             base_url = cloud_api_url if cloud_provider == "custom" and cloud_api_url else None
             client = OpenAI(api_key=cloud_api_key, base_url=base_url)
             models = client.models.list()
-            model_ids = [m.id for m in models.data[:10]]
+            # Newest first so current chat models lead the Settings dropdown.
+            # OpenAI returns ~50+ models in arbitrary order, mixing in
+            # embeddings/audio/image/moderation; the old unfiltered [:10] slice
+            # crowded those in and pushed newer chat models off the end (#198).
+            # Keep only chat/reasoning models for the openai provider; custom
+            # OpenAI-compatible endpoints keep every model (unknown naming).
+            entries = sorted(
+                models.data,
+                key=lambda m: getattr(m, "created", 0) or 0,
+                reverse=True,
+            )
+            if cloud_provider == "openai":
+                entries = [m for m in entries if _is_openai_chat_model(m.id)]
+            model_ids = [m.id for m in entries[:25]]
             print(json.dumps({"success": True, "models": model_ids}))
     except Exception as e:
         print(json.dumps({"success": False, "error": str(e)}))

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3891,17 +3891,28 @@ def test_remote_ollama(url):
 # embeddings, speech, image and moderation. Excluded so the Settings model
 # picker only offers models that actually answer chat completions (#198).
 # NB: no "search" marker — the *-search-preview models are chat-completion
-# models (web-search-grounded), and "search" is also a substring of
-# "deep-research", so excluding it would drop real chat/reasoning models.
+# models (web-search-grounded). "search" is a substring of "deep-research", but
+# those are excluded by their own marker below, so the two don't interfere.
 _OPENAI_NON_CHAT_MARKERS = (
     "embedding", "whisper", "tts", "audio", "realtime",
     "moderation", "dall-e", "image", "transcribe", "codex",
 )
 
+# Reasoning tiers OpenAI serves ONLY through the Responses API, never
+# chat.completions. Steno talks to client.chat.completions.create, so offering
+# one of these would 400 at request time — they must be dropped from the picker
+# even though they pass the gpt-/o\d gate. ``deep-research`` is a substring match
+# (covers o3-deep-research, o4-mini-deep-research and their dated snapshots); the
+# ``-pro`` tier (gpt-5-pro, …-pro-YYYY-MM-DD) is matched as a ``-pro`` segment so
+# dated snapshots drop too without snagging unrelated names.
+_OPENAI_RESPONSES_ONLY_MARKERS = ("deep-research",)
+_OPENAI_RESPONSES_ONLY_RE = re.compile(r"-pro(?:-|$)")
+
 
 def _is_openai_chat_model(model_id: str) -> bool:
     """True for OpenAI chat/reasoning models (``gpt-*``, the ``o<n>`` reasoning
-    series, ``chatgpt-*``), excluding the non-chat families above. ``gpt-`` and
+    series, ``chatgpt-*``), excluding the non-chat families above and the
+    Responses-only reasoning tiers (``*-pro``, ``*-deep-research``). ``gpt-`` and
     ``o\\d`` are prefix/pattern matches so newer releases (gpt-4.1, o4, …) keep
     showing up without a code change. Applied to the openai provider only —
     custom OpenAI-compatible endpoints use their own naming, so their lists are
@@ -3913,7 +3924,13 @@ def _is_openai_chat_model(model_id: str) -> bool:
         or re.match(r"o\d", mid)
     ):
         return False
-    return not any(marker in mid for marker in _OPENAI_NON_CHAT_MARKERS)
+    if any(marker in mid for marker in _OPENAI_NON_CHAT_MARKERS):
+        return False
+    if any(marker in mid for marker in _OPENAI_RESPONSES_ONLY_MARKERS):
+        return False
+    if _OPENAI_RESPONSES_ONLY_RE.search(mid):
+        return False
+    return True
 
 
 @cli.command()

--- a/tests/test_cloud_model_filter.py
+++ b/tests/test_cloud_model_filter.py
@@ -27,15 +27,29 @@ class OpenAIChatModelFilterTests(unittest.TestCase):
             "o3-mini",
             "o4-mini",
             # web-search-grounded chat models — served via chat completions, so
-            # the "search" substring must NOT exclude them (#198 follow-up).
+            # the "search" substring must NOT exclude them (#198 follow-up). They
+            # don't contain "deep-research", so the Responses-only filter below
+            # leaves them alone.
             "gpt-4o-search-preview",
             "gpt-4o-mini-search-preview",
-            # deep-research reasoning models pass the o\\d gate; "research"
-            # contains "search", so they must not be excluded either.
-            "o3-deep-research",
-            "o4-mini-deep-research",
         ]:
             self.assertTrue(_is_openai_chat_model(model_id), msg=model_id)
+
+    def test_drops_responses_only_models(self):
+        # gpt-5-pro and the *-deep-research reasoning models are served ONLY via
+        # the Responses API, not chat.completions. Steno calls
+        # client.chat.completions.create, so offering these in the picker yields
+        # a runtime 400 — they must be dropped even though they pass the gpt-/o\\d
+        # gate. Dated snapshots (…-pro-YYYY-MM-DD, …-deep-research-YYYY-MM-DD)
+        # must drop too.
+        for model_id in [
+            "gpt-5-pro",
+            "gpt-5-pro-2025-10-06",
+            "o3-deep-research",
+            "o3-deep-research-2025-06-26",
+            "o4-mini-deep-research",
+        ]:
+            self.assertFalse(_is_openai_chat_model(model_id), msg=model_id)
 
     def test_drops_non_chat_families(self):
         for model_id in [
@@ -56,8 +70,10 @@ class OpenAIChatModelFilterTests(unittest.TestCase):
 
     def test_future_gpt_and_o_series_pass_without_a_code_change(self):
         # `gpt-` is a prefix match and the reasoning series is `o\d`, so models
-        # that don't exist yet still surface — the whole point of #198.
-        for model_id in ["gpt-5", "gpt-6-mini", "o5", "o9-pro"]:
+        # that don't exist yet still surface — the whole point of #198. (A future
+        # `-pro` tier stays Responses-only, so it's covered by the drop test, not
+        # here.)
+        for model_id in ["gpt-5", "gpt-6-mini", "o5", "o9"]:
             self.assertTrue(_is_openai_chat_model(model_id), msg=model_id)
 
     def test_case_insensitive(self):

--- a/tests/test_cloud_model_filter.py
+++ b/tests/test_cloud_model_filter.py
@@ -1,0 +1,61 @@
+"""Tests for the OpenAI chat-model filter used by `test-cloud-api` (#198).
+
+OpenAI's /models endpoint returns ~50+ models in arbitrary order, mixing chat
+models in with embeddings, speech, image and moderation models. The Settings
+model picker should only offer models that actually answer chat completions, so
+`_is_openai_chat_model` gates the list. These tests pin the keep/drop decisions
+(the substance of the fix) without making a network call.
+"""
+
+import unittest
+
+from simple_recorder import _is_openai_chat_model
+
+
+class OpenAIChatModelFilterTests(unittest.TestCase):
+    def test_keeps_chat_and_reasoning_families(self):
+        for model_id in [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-4-turbo",
+            "gpt-3.5-turbo",
+            "chatgpt-4o-latest",
+            "o1",
+            "o1-mini",
+            "o3",
+            "o3-mini",
+            "o4-mini",
+        ]:
+            self.assertTrue(_is_openai_chat_model(model_id), msg=model_id)
+
+    def test_drops_non_chat_families(self):
+        for model_id in [
+            "text-embedding-3-large",
+            "whisper-1",
+            "tts-1",
+            "tts-1-hd",
+            "dall-e-3",
+            "gpt-image-1",
+            "gpt-4o-audio-preview",
+            "gpt-4o-realtime-preview",
+            "gpt-4o-transcribe",
+            "omni-moderation-latest",
+            "babbage-002",
+            "davinci-002",
+        ]:
+            self.assertFalse(_is_openai_chat_model(model_id), msg=model_id)
+
+    def test_future_gpt_and_o_series_pass_without_a_code_change(self):
+        # `gpt-` is a prefix match and the reasoning series is `o\d`, so models
+        # that don't exist yet still surface — the whole point of #198.
+        for model_id in ["gpt-5", "gpt-6-mini", "o5", "o9-pro"]:
+            self.assertTrue(_is_openai_chat_model(model_id), msg=model_id)
+
+    def test_case_insensitive(self):
+        self.assertTrue(_is_openai_chat_model("GPT-4O"))
+        self.assertFalse(_is_openai_chat_model("Whisper-1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cloud_model_filter.py
+++ b/tests/test_cloud_model_filter.py
@@ -26,6 +26,14 @@ class OpenAIChatModelFilterTests(unittest.TestCase):
             "o3",
             "o3-mini",
             "o4-mini",
+            # web-search-grounded chat models — served via chat completions, so
+            # the "search" substring must NOT exclude them (#198 follow-up).
+            "gpt-4o-search-preview",
+            "gpt-4o-mini-search-preview",
+            # deep-research reasoning models pass the o\\d gate; "research"
+            # contains "search", so they must not be excluded either.
+            "o3-deep-research",
+            "o4-mini-deep-research",
         ]:
             self.assertTrue(_is_openai_chat_model(model_id), msg=model_id)
 


### PR DESCRIPTION
Closes #198.

## Problem
The "Test connection" path (`test-cloud-api`) returned `models.data[:10]` straight from OpenAI's `/models` endpoint. That list comes back in an arbitrary order and mixes chat models in with embeddings, speech (whisper/tts), image (dall-e/gpt-image), realtime/audio and moderation models. The hard 10-cap then crowded those non-chat entries into the dropdown and pushed newer chat models (gpt-4.1, the `o` reasoning series, dated gpt-4o variants) off the end — so the Settings model picker often offered little beyond `gpt-4o`.

## Change (backend only)
In the OpenAI/custom branch of `test_cloud_api`:
- **Sort newest-first** (`created` desc) so current models lead the dropdown.
- **For the `openai` provider, keep only chat/reasoning models** — `gpt-*`, the `o<n>` reasoning series, `chatgpt-*`, minus the embeddings/audio/image/moderation/legacy families. `gpt-` and `o\d` are prefix/pattern matches, so future releases (gpt-5, o5, …) surface without another code change.
- **Custom OpenAI-compatible endpoints keep every model** (their naming is unknown) and just get the sort + a wider cap (25 vs 10).

Anthropic (already recent-first) and Bedrock (curated list) are untouched.

## Note
The dropdown already has a "Custom…" free-text escape hatch, so a determined user could always type any model id — but it wasn't discoverable, and the default list is what most people see. This fixes the default list.

## Tests
`tests/test_cloud_model_filter.py` pins the keep/drop decisions and the future-model behaviour of the filter (pure function, no network). Green locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings model picker to show current OpenAI chat models instead of 10 arbitrary models. Sorts `/models` newest-first, filters to chat/reasoning families, keeps `*-search-preview`, and drops Responses-only tiers (`*-pro`, `*-deep-research`) so only models that work with `chat.completions` appear. Closes #198.

- **Bug Fixes**
  - Sort by `created` (newest first) and raise the cap from 10 to 25.
  - For `openai`, keep only chat/reasoning models; exclude embeddings/whisper/tts/audio/realtime/moderation/dall-e/image/transcribe/codex; keep `*-search-preview`; drop `*-pro` and `*-deep-research`.
  - For custom OpenAI-compatible endpoints, no filter; apply sort + 25 cap.
  - Add unit tests pinning kept/dropped models, including `*-search-preview` and dated `*-pro`/`*-deep-research` snapshots; Anthropic and Bedrock unchanged.

<sup>Written for commit 9343f32f86a870f26f144d9677f4b2492627b80c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

