### PR TITLE
feat(ollama): reuse an already-installed supported model instead of re-pulling the default

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -3985,7 +3985,30 @@ ipcMain.handle('setup-ollama-and-model', async () => {
       }
       sendDebugLog('Warning: Ollama may not be fully ready, attempting pull anyway...');
     }
-    
+
+    // #123: don't re-download the default if the connected Ollama already has a
+    // supported model. The backend matches installed models against the supported
+    // registry (single source of truth in config.py); on a hit we set it active
+    // and skip the pull entirely, so the default Local path needs no network for
+    // anyone with a usable Ollama already set up. Best-effort: any failure here
+    // falls through to the normal download below.
+    try {
+      const resolvedRaw = await runPythonScript('simple_recorder.py', ['resolve-setup-model'], true);
+      const resolved = JSON.parse(resolvedRaw.trim());
+      if (resolved && resolved.installed) {
+        sendDebugLog(`Found already-installed model "${resolved.installed}" — skipping download`);
+        try {
+          await runPythonScript('simple_recorder.py', ['set-model', resolved.installed], true);
+        } catch (e) {
+          // Non-fatal -- config write is best-effort, same as the pull path.
+        }
+        trackEvent('setup_completed', { step: 'ollama_existing_model' });
+        return { success: true, message: `Using already-installed model ${resolved.installed}` };
+      }
+    } catch (e) {
+      sendDebugLog(`Could not check for installed models, proceeding to download: ${e.message}`);
+    }
+
     sendDebugLog('Downloading AI model (this may take several minutes)...');
     sendDebugLog(`POST http://127.0.0.1:11434/api/pull {name: "${DEFAULT_AI_MODEL}"}`);
 

--- a/app/main.js
+++ b/app/main.js
@@ -3997,10 +3997,22 @@ ipcMain.handle('setup-ollama-and-model', async () => {
       const resolved = JSON.parse(resolvedRaw.trim());
       if (resolved && resolved.installed) {
         sendDebugLog(`Found already-installed model "${resolved.installed}" — skipping download`);
+        // Persist it as the active model, and only report success once that
+        // write actually succeeded. set-model now exits non-zero on a
+        // config-write failure (runPythonScript rejects) AND prints
+        // success:false, so we check both: swallowing the failure here would
+        // have setup claim success with no active model saved.
         try {
-          await runPythonScript('simple_recorder.py', ['set-model', resolved.installed], true);
+          const setRaw = await runPythonScript('simple_recorder.py', ['set-model', resolved.installed], true);
+          // set-model prints a human line before the JSON, so grab the last
+          // JSON-looking line rather than parsing the whole stdout.
+          const jsonLine = setRaw.trim().split('\n').reverse().find((l) => l.trim().startsWith('{'));
+          const setRes = jsonLine ? JSON.parse(jsonLine) : null;
+          if (!setRes || setRes.success !== true) {
+            return { success: false, error: (setRes && setRes.error) || 'Failed to save the selected model.' };
+          }
         } catch (e) {
-          // Non-fatal -- config write is best-effort, same as the pull path.
+          return { success: false, error: `Failed to save the selected model: ${e.message}` };
         }
         trackEvent('setup_completed', { step: 'ollama_existing_model' });
         return { success: true, message: `Using already-installed model ${resolved.installed}` };

--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -22,12 +22,13 @@ const OLLAMA_PORT = 11434;
  * Start the mock Ollama on 11434.
  * @param {object} [opts]
  * @param {string} [opts.chatReply='ok'] assistant content returned by /api/chat.
- * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number }>}
+ * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number, pullCalls: () => number }>}
  */
 function startMockOllama(opts = {}) {
   const chatReply = opts.chatReply ?? 'ok';
   let lastChatPrompt = null;
   let chatCalls = 0;
+  let pullCalls = 0;
 
   return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
@@ -66,6 +67,7 @@ function startMockOllama(opts = {}) {
       // /api/pull — defensive: if the model is ever considered missing, answer
       // a success stream rather than 404 so summarisation doesn't crash.
       if (req.method === 'POST' && req.url === '/api/pull') {
+        pullCalls++;
         res.writeHead(200, { 'content-type': 'application/x-ndjson' });
         res.end(JSON.stringify({ status: 'success' }) + '\n');
         return;
@@ -105,6 +107,7 @@ function startMockOllama(opts = {}) {
         close: () => new Promise((r) => server.close(() => r())),
         lastChatPrompt: () => lastChatPrompt,
         chatCalls: () => chatCalls,
+        pullCalls: () => pullCalls,
       });
     });
   });

--- a/e2e/specs/setup-model-reuse.t2.spec.ts
+++ b/e2e/specs/setup-model-reuse.t2.spec.ts
@@ -8,10 +8,14 @@ import path from 'path';
 
 /**
  * T2 — #123: first-run setup must REUSE an already-installed supported model
- * instead of re-pulling the hardcoded default. The mock Ollama lists `llama3.2:3b`
- * under /api/tags, so the `setup-ollama-and-model` flow should detect it, set it
- * as the active model, and issue NO /api/pull (the regression assertion is
- * `pullCalls() === 0`). Model-free: only /api/tags + config I/O, no model loads.
+ * instead of re-pulling the hardcoded default. The mock Ollama lists the default
+ * `gemma4:e2b-it-qat` (plus `llama3.2:3b`) under /api/tags. We seed config with a
+ * supported-but-NOT-installed model (`qwen3.5:9b`), so the `setup-ollama-and-model`
+ * flow must fall through to the installed default, set it as the active model, and
+ * issue NO /api/pull. The regression assertion is `pullCalls() === 0`; the active
+ * model flipping from the seeded `qwen3.5:9b` to the reused `gemma4:e2b-it-qat`
+ * proves the reuse path actually resolved + persisted an installed model rather
+ * than leaving the default untouched. Model-free: only /api/tags + config I/O.
  *
  * The dev-mode handler still locates the bundled Ollama binary (`bin/ollama`)
  * before reusing a running instance, so this skips LOUDLY when that binary is
@@ -52,7 +56,10 @@ test('setup reuses an installed supported model and skips the pull (#123)', asyn
   killOllama();
   const mock = await startMockOllama();
   try {
-    writeUserConfig(userDataDir, { ai_provider: 'local' });
+    // Seed a supported model that the mock does NOT list as installed, so the
+    // picker must fall through to the installed default (gemma4:e2b-it-qat) — and
+    // the post-setup model change proves the reuse path ran.
+    writeUserConfig(userDataDir, { ai_provider: 'local', model: 'qwen3.5:9b' });
     const { page } = await launchApp();
 
     const res = await page.evaluate(() =>
@@ -63,8 +70,9 @@ test('setup reuses an installed supported model and skips the pull (#123)', asyn
 
     // The #123 regression assertion: the installed model was reused, not pulled.
     expect(mock.pullCalls()).toBe(0);
-    // ...and it was persisted as the active model.
-    await expect.poll(() => readUserConfig(userDataDir).model).toBe('llama3.2:3b');
+    // ...and the installed default was resolved + persisted as the active model
+    // (flipped away from the seeded, not-installed qwen3.5:9b).
+    await expect.poll(() => readUserConfig(userDataDir).model).toBe('gemma4:e2b-it-qat');
   } finally {
     await mock.close();
   }

--- a/e2e/specs/setup-model-reuse.t2.spec.ts
+++ b/e2e/specs/setup-model-reuse.t2.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig, readUserConfig } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { killOllama } from '../fixtures/kill-ollama';
+import { existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — #123: first-run setup must REUSE an already-installed supported model
+ * instead of re-pulling the hardcoded default. The mock Ollama lists `llama3.2:3b`
+ * under /api/tags, so the `setup-ollama-and-model` flow should detect it, set it
+ * as the active model, and issue NO /api/pull (the regression assertion is
+ * `pullCalls() === 0`). Model-free: only /api/tags + config I/O, no model loads.
+ *
+ * The dev-mode handler still locates the bundled Ollama binary (`bin/ollama`)
+ * before reusing a running instance, so this skips LOUDLY when that binary is
+ * absent (CI downloads it via scripts/download-ollama.sh; a bare local checkout
+ * may not have it) rather than emitting a misleading "Bundled Ollama not found".
+ */
+
+type SetupResult = { success: boolean; message?: string; error?: string; skipped?: boolean };
+type StenoWindow = Window & {
+  stenoai: { setup: { ollamaAndModel: () => Promise<SetupResult> } };
+};
+
+const ollamaBinaryExists = (): boolean => {
+  const exe = process.platform === 'win32' ? 'ollama.exe' : 'ollama';
+  // app/main.js dev path: path.join(__dirname /* app */, '..', 'bin', exe).
+  // This spec lives at e2e/specs, so the repo-root bin/ is two levels up.
+  return existsSync(path.resolve(__dirname, '../../bin', exe));
+};
+
+test('setup reuses an installed supported model and skips the pull (#123)', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  if (!ollamaBinaryExists()) {
+    // eslint-disable-next-line no-console
+    console.warn('[t2] SKIPPED setup-model-reuse: bundled bin/ollama absent on this host.');
+    test.info().annotations.push({
+      type: 'skip-reason',
+      description: 'bin/ollama not present; setup-ollama-and-model refuses to proceed',
+    });
+  }
+  test.skip(!ollamaBinaryExists(), 'bundled bin/ollama unavailable on this runner');
+
+  const realDirBefore = fileSig(realUserDataDir());
+  // Own port 11434 with the mock so the handler reuses it (and never spawns the
+  // real bundled Ollama). Local provider so setup takes the local path, not the
+  // remote/cloud early-return.
+  killOllama();
+  const mock = await startMockOllama();
+  try {
+    writeUserConfig(userDataDir, { ai_provider: 'local' });
+    const { page } = await launchApp();
+
+    const res = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.setup.ollamaAndModel(),
+    );
+    expect(res.success).toBe(true);
+    expect(res.skipped).toBeFalsy();
+
+    // The #123 regression assertion: the installed model was reused, not pulled.
+    expect(mock.pullCalls()).toBe(0);
+    // ...and it was persisted as the active model.
+    await expect.poll(() => readUserConfig(userDataDir).model).toBe('llama3.2:3b');
+  } finally {
+    await mock.close();
+  }
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2828,6 +2828,10 @@ def set_model(model_name):
     else:
         print(f"ERROR: Failed to save model configuration")
         print(json.dumps({"success": False, "error": "Failed to save config"}))
+        # Exit non-zero so callers (e.g. the setup-ollama-and-model reuse path in
+        # main.js) can't read a config-write failure as success — the model was
+        # NOT persisted as active. sys.exit (not bare exit) for the PyInstaller bundle.
+        sys.exit(1)
 
 
 @cli.command()

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3538,6 +3538,75 @@ def pull_model(model_name):
         print(json.dumps({"success": False, "error": str(e)}))
 
 
+def pick_installed_supported_model(installed_names, preferred, supported_order, deprecated=()):
+    """Pick the best already-installed supported Ollama model id, or None (#123).
+
+    Args:
+        installed_names: model ids the connected Ollama reports via /api/tags.
+        preferred: ids to try first, in order — the configured model, then the
+            packaged default. Honours "prefer the configured default if present".
+        supported_order: the supported registry keys, ascending by capability
+            (config.SUPPORTED_MODELS order); the fall-through when no preferred
+            id is installed.
+        deprecated: supported ids flagged deprecated — chosen only as a last
+            resort so a live model always wins over a retired one.
+
+    Returns the id to reuse, or None when nothing supported is installed (the
+    caller then pulls the default).
+    """
+    installed = set(installed_names)
+    supported = set(supported_order)
+    dep = set(deprecated)
+    for cand in preferred:
+        if cand and cand in supported and cand in installed:
+            return cand
+    for cand in supported_order:
+        if cand in installed and cand not in dep:
+            return cand
+    for cand in supported_order:
+        if cand in installed and cand in dep:
+            return cand
+    return None
+
+
+@cli.command(name='resolve-setup-model')
+def resolve_setup_model():
+    """Report an already-installed supported model so first-run setup can skip a
+    redundant download (#123).
+
+    Prints {"installed": "<model-id>"} when the connected Ollama already has a
+    supported model, else {"installed": null}. Never pulls — the caller decides
+    whether to download. Uses the HTTP API (ollama package), not the binary.
+    """
+    from src.config import get_config, Config
+    from src.ollama_manager import start_ollama_server
+
+    result = {"installed": None}
+    try:
+        start_ollama_server()
+        import ollama
+        resp = ollama.list()
+        installed = {
+            getattr(m, 'model', '') or ''
+            for m in (getattr(resp, 'models', None) or [])
+        }
+        installed.discard('')
+        config = get_config()
+        deprecated = [
+            mid for mid, meta in Config.SUPPORTED_MODELS.items()
+            if meta.get('deprecated')
+        ]
+        result["installed"] = pick_installed_supported_model(
+            installed_names=installed,
+            preferred=[config.get_model(), Config.DEFAULT_MODEL],
+            supported_order=list(Config.SUPPORTED_MODELS.keys()),
+            deprecated=deprecated,
+        )
+    except Exception as e:
+        result["error"] = str(e)
+    print(json.dumps(result))
+
+
 @cli.command(name='check-adapter')
 @click.argument('url')
 def check_adapter_cmd(url: str):

--- a/tests/test_setup_model_reuse.py
+++ b/tests/test_setup_model_reuse.py
@@ -6,8 +6,13 @@ is the decision (which installed model to reuse, in what preference order);
 these tests pin that behaviour without touching Ollama or the network.
 """
 
+import json
 import unittest
+from unittest import mock
 
+from click.testing import CliRunner
+
+import simple_recorder
 from simple_recorder import pick_installed_supported_model
 
 # A representative slice of config.SUPPORTED_MODELS order (ascending capability,
@@ -119,6 +124,42 @@ class PickInstalledSupportedModelTests(unittest.TestCase):
                 deprecated=DEPRECATED,
             ),
             "llama3.2:3b",
+        )
+
+
+class SetModelExitCodeTests(unittest.TestCase):
+    """`set-model` must signal a config-write failure through its EXIT CODE, not
+    just a JSON body. The reuse flow (setup-ollama-and-model) shells out to it to
+    persist the reused model as active; if the write fails but the process exits
+    0, setup reports success while the active model was never saved (#123)."""
+
+    def _invoke(self, *, save_succeeds):
+        # Installed fallback model differs from the configured + default model;
+        # persisting it as active is what may fail.
+        fake_config = mock.Mock()
+        fake_config.SUPPORTED_MODELS = {"llama3.2:3b": {}, "qwen3.5:9b": {}}
+        fake_config.set_model.return_value = save_succeeds
+        with mock.patch("src.config.get_config", return_value=fake_config):
+            return CliRunner().invoke(simple_recorder.set_model, ["qwen3.5:9b"])
+
+    def _last_json(self, output):
+        line = [ln for ln in output.splitlines() if ln.strip().startswith("{")][-1]
+        return json.loads(line)
+
+    def test_config_write_failure_exits_nonzero(self):
+        result = self._invoke(save_succeeds=False)
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertEqual(
+            self._last_json(result.output),
+            {"success": False, "error": "Failed to save config"},
+        )
+
+    def test_success_exits_zero(self):
+        result = self._invoke(save_succeeds=True)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            self._last_json(result.output),
+            {"success": True, "model": "qwen3.5:9b"},
         )
 
 

--- a/tests/test_setup_model_reuse.py
+++ b/tests/test_setup_model_reuse.py
@@ -1,0 +1,126 @@
+"""Tests for the installed-model picker used by `resolve-setup-model` (#123).
+
+First-run setup should reuse a supported Ollama model that's already installed
+instead of re-pulling the hardcoded default. `pick_installed_supported_model`
+is the decision (which installed model to reuse, in what preference order);
+these tests pin that behaviour without touching Ollama or the network.
+"""
+
+import unittest
+
+from simple_recorder import pick_installed_supported_model
+
+# A representative slice of config.SUPPORTED_MODELS order (ascending capability,
+# default first) with the two deprecated entries at the tail.
+SUPPORTED = [
+    "llama3.2:3b",
+    "gemma4:e2b-it-qat",
+    "qwen3.5:9b",
+    "gemma4:12b",
+    "gpt-oss:20b",
+    "gemma3:4b",        # deprecated
+    "deepseek-r1:14b",  # deprecated
+]
+DEPRECATED = ["gemma3:4b", "deepseek-r1:14b"]
+DEFAULT = "llama3.2:3b"
+
+
+class PickInstalledSupportedModelTests(unittest.TestCase):
+    def test_returns_none_when_nothing_supported_is_installed(self):
+        # Only unsupported models present -> caller must pull the default.
+        self.assertIsNone(
+            pick_installed_supported_model(
+                installed_names={"mistral:7b", "phi3:mini"},
+                preferred=[DEFAULT, DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            )
+        )
+
+    def test_returns_none_when_no_models_installed(self):
+        self.assertIsNone(
+            pick_installed_supported_model(
+                installed_names=set(),
+                preferred=[DEFAULT, DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            )
+        )
+
+    def test_prefers_the_configured_model_when_installed(self):
+        # Configured model differs from the default and both are installed:
+        # the configured one wins.
+        self.assertEqual(
+            pick_installed_supported_model(
+                installed_names={"llama3.2:3b", "qwen3.5:9b"},
+                preferred=["qwen3.5:9b", DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            ),
+            "qwen3.5:9b",
+        )
+
+    def test_falls_back_to_default_when_configured_absent(self):
+        # Configured model not installed, default is -> default wins (the #123
+        # headline: existing llama3.2:3b means no pull).
+        self.assertEqual(
+            pick_installed_supported_model(
+                installed_names={"llama3.2:3b", "gemma4:12b"},
+                preferred=["gpt-oss:20b", DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            ),
+            "llama3.2:3b",
+        )
+
+    def test_falls_through_registry_when_no_preferred_installed(self):
+        # Neither configured nor default installed: take the first supported,
+        # non-deprecated id in registry order.
+        self.assertEqual(
+            pick_installed_supported_model(
+                installed_names={"gemma4:12b", "qwen3.5:9b"},
+                preferred=["gpt-oss:20b", DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            ),
+            "qwen3.5:9b",
+        )
+
+    def test_deprecated_only_as_last_resort(self):
+        # A deprecated-but-installed model is used only when nothing live is
+        # installed -- a live model always beats a retired one.
+        self.assertEqual(
+            pick_installed_supported_model(
+                installed_names={"gemma3:4b", "gemma4:12b"},
+                preferred=["gpt-oss:20b", DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            ),
+            "gemma4:12b",
+        )
+        # ...but a deprecated model is still better than pulling fresh.
+        self.assertEqual(
+            pick_installed_supported_model(
+                installed_names={"deepseek-r1:14b"},
+                preferred=["gpt-oss:20b", DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            ),
+            "deepseek-r1:14b",
+        )
+
+    def test_ignores_blank_preferred_entries(self):
+        # A falsy configured model (unset) must not match a blank installed id.
+        self.assertEqual(
+            pick_installed_supported_model(
+                installed_names={"llama3.2:3b"},
+                preferred=["", DEFAULT],
+                supported_order=SUPPORTED,
+                deprecated=DEPRECATED,
+            ),
+            "llama3.2:3b",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

First-run setup unconditionally issued `POST /api/pull {name: "llama3.2:3b"}` even when the connected Ollama already had a usable supported model. That re-downloads a multi-GB model that's already on disk, and — as reported in #123 — leaves the app broken when the pull is restricted (e.g. locked-down network) despite a perfectly usable model sitting right there.

This makes the default **Local** path no-network-needed for anyone who already has a supported Ollama model installed.

## How

Before pulling, the backend lists installed models (`GET /api/tags` via the `ollama` HTTP API — no shelling to the binary) and matches them against the supported registry, which stays the single source of truth in `config.SUPPORTED_MODELS`. On a hit it sets that model active and **skips the pull entirely**; it only downloads when nothing supported is installed.

Preference order: the configured model → the packaged default (`llama3.2:3b`) → registry order, with deprecated entries chosen only as a last resort (a live model always beats a retired one).

- **`simple_recorder.py`** — `pick_installed_supported_model()` (pure, testable picker) + a `resolve-setup-model` CLI command that reports the already-installed model as JSON.
- **`app/main.js`** — `setup-ollama-and-model` calls it before the pull. Best-effort: any failure (Ollama not ready, parse error) falls through to the existing download, so the worst case is today's behaviour.

## Acceptance criteria (from #123)

- ✅ Existing Ollama with `llama3.2:3b` (or any supported tag) → no `/api/pull`.
- ✅ Existing Ollama with no supported model → falls back to the current pull.
- ✅ Pull-restricted network + a supported model already installed → uses the installed one.
- ✅ No regression for users with no Ollama installed — the bundled-Ollama startup + default pull path is unchanged.

## Testing

- **Unit** (`tests/test_setup_model_reuse.py`, 7 cases): default preference, configured-model preference, registry fall-through, deprecated-as-last-resort, empty → `None`, blank-id handling.
- **e2e T2** (`setup-model-reuse.t2.spec.ts`, model-free): drives `setup.ollamaAndModel()` against the mock Ollama (which lists `llama3.2:3b`) and asserts `pullCalls() === 0` and `config.model === 'llama3.2:3b'`. Verified as a true regression test — it fails when the `main.js` change is reverted. Skips loudly where the bundled `bin/ollama` is absent (CI downloads it), mirroring the existing `@pipeline` skip convention.
- Full backend suite (154 tests) green.

Closes #123

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
First-run setup now reuses an already-installed supported `ollama` model and skips pulling the default. It also fails fast if saving the reused model as active fails, preventing a false success (covers #123).

- **New Features**
  - `app/main.js`: `setup-ollama-and-model` uses `resolve-setup-model` to detect an installed supported model, set it active, and skip `/api/pull` (falls back to pull on any error).
  - `simple_recorder.py`: added `pick_installed_supported_model()` and a `resolve-setup-model` CLI using the `ollama` HTTP API (`/api/tags`), not the binary.
  - Selection order: configured model → packaged default (`gemma4:e2b-it-qat`) → supported registry; deprecated only as a last resort.
  - Tests: unit coverage for the picker; T2 e2e asserts no `/api/pull`; `mock-ollama` now exposes `pullCalls()` and the spec reflects the new default.

- **Bug Fixes**
  - Setup now reports failure if persisting the reused model fails: `set-model` exits non-zero on config-write failure, and the handler checks exit code plus structured output before reporting success.
  - Tests: regression for `set-model` exit codes (non-zero on failure, zero on success).

<sup>Written for commit 96a71a18a9c4b6ad163607acd890a0596cfac6a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

