### PR TITLE
fix(ci): bundle arm64 ffmpeg in the arm64 mac build (fixes #209)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -100,6 +100,11 @@ jobs:
       run: |
         chmod +x scripts/download-ollama.sh
         ./scripts/download-ollama.sh
+        # Fail loudly if the bundled ffmpeg isn't arm64 — an x86_64 ffmpeg in the
+        # arm64 build crashes on Apple Silicon without Rosetta (#209). Mirrors the
+        # mic-monitor arch guard below.
+        file bin/ffmpeg
+        file bin/ffmpeg | grep -q "arm64"
 
     - name: Build mic-monitor helper (Swift)
       run: |

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -11,14 +11,25 @@ BIN_DIR="$(cd "$(dirname "$0")/.." && pwd)/bin"
 echo "=== Downloading ffmpeg ==="
 case "$(uname -s)" in
     Darwin)
-        FFMPEG_URL="https://evermeet.cx/ffmpeg/ffmpeg-7.1.1.zip"
+        # ffmpeg must match the BUILD architecture, not just the OS. evermeet.cx
+        # (the old URL) ships x86_64-only mac builds, so it bundled an Intel ffmpeg
+        # into the arm64 release — which crashes on Apple Silicon without Rosetta
+        # (#209). The mac build is Apple-Silicon only (arm64) since v0.4.0, so use
+        # osxexperts' arm64 static build (same 7.1.1 as before) and refuse any
+        # other arch rather than silently shipping a mismatch.
+        if [ "$(uname -m)" != "arm64" ]; then
+            echo "macOS build is arm64-only; unsupported arch: $(uname -m)" >&2
+            exit 1
+        fi
+        FFMPEG_URL="https://www.osxexperts.net/ffmpeg711arm.zip"
         mkdir -p "$BIN_DIR"
         curl -L "$FFMPEG_URL" -o "$BIN_DIR/ffmpeg.zip"
         cd "$BIN_DIR"
-        unzip -o ffmpeg.zip
+        # Extract only the binary; skip the __MACOSX resource-fork junk in the zip.
+        unzip -o ffmpeg.zip ffmpeg
         rm ffmpeg.zip
         chmod +x ffmpeg
-        echo "ffmpeg downloaded"
+        echo "ffmpeg 7.1.1 (arm64) downloaded"
         cd - > /dev/null
         ;;
     Linux)

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -29,11 +29,21 @@ case "$(uname -s)" in
         unzip -o ffmpeg.zip ffmpeg
         rm ffmpeg.zip
         chmod +x ffmpeg
-        # Validate the binary actually runs and is the expected major version —
-        # catches a truncated/corrupt download or a wrong-format extract before it
-        # gets bundled (complements the `file ... arm64` arch guard in CI). set -e
-        # makes a non-zero exit here fail the build loudly.
-        if ! ./ffmpeg -version | grep -q "ffmpeg version 7.1"; then
+        # Validate the binary before bundling it. Two distinct failure modes:
+        #  1. Wrong architecture. An x86_64 ffmpeg runs fine HERE under Rosetta and
+        #     would sail through the -version check, then crash on a Rosetta-less
+        #     user machine (#209). Assert the Mach-O is arm64 so the script
+        #     self-enforces the arch rather than leaning only on the external CI
+        #     `file ... arm64` guard.
+        #  2. Truncated/corrupt download or wrong-format extract. Run -version and
+        #     pin the major; pipefail (scoped to a subshell) makes a non-zero
+        #     ffmpeg exit fail loudly instead of being masked by grep's exit.
+        # set -e turns either non-zero exit into a loud build failure.
+        if ! file ./ffmpeg | grep -q "arm64"; then
+            echo "Downloaded ffmpeg is not an arm64 binary: $(file ./ffmpeg)" >&2
+            exit 1
+        fi
+        if ! ( set -o pipefail; ./ffmpeg -version | grep -q "ffmpeg version 7.1" ); then
             echo "Downloaded ffmpeg failed -version or is not 7.1.x" >&2
             exit 1
         fi

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -29,6 +29,14 @@ case "$(uname -s)" in
         unzip -o ffmpeg.zip ffmpeg
         rm ffmpeg.zip
         chmod +x ffmpeg
+        # Validate the binary actually runs and is the expected major version —
+        # catches a truncated/corrupt download or a wrong-format extract before it
+        # gets bundled (complements the `file ... arm64` arch guard in CI). set -e
+        # makes a non-zero exit here fail the build loudly.
+        if ! ./ffmpeg -version | grep -q "ffmpeg version 7.1"; then
+            echo "Downloaded ffmpeg failed -version or is not 7.1.x" >&2
+            exit 1
+        fi
         echo "ffmpeg 7.1.1 (arm64) downloaded"
         cd - > /dev/null
         ;;


### PR DESCRIPTION
## What

The arm64 macOS build bundles an **x86_64** `ffmpeg`. On Apple Silicon **without Rosetta 2**, the transcription backend crashes the moment it execs ffmpeg:

```
OSError: [Errno 86] Bad CPU type in executable:
'/Applications/Steno.app/Contents/Resources/stenoai/_internal/ffmpeg'
```

So every recording fails before transcription starts ("Processing" forever → "Couldn't process this recording"). Fixes #209.

## Root cause

`scripts/download-ollama.sh` selected the ffmpeg download by **OS (`uname -s`), not architecture**, and the Darwin branch pulled `evermeet.cx`, which publishes **x86_64-only** mac builds. The release job runs on the `macos-14` arm64 runner and PyInstaller builds an arm64 backend, but this step dropped an Intel ffmpeg into `bin/`, and `stenoai.spec` placed it into the bundle with no arch check.

It slipped through because **Rosetta 2 masks it** — present on GitHub's macOS runners and basically every dev machine, so the x86_64 ffmpeg runs there. It only hard-fails on Apple Silicon without Rosetta. (The `@pipeline` e2e also uses whisper in CI, not the arch-sensitive path.)

Confirmed by pulling `_internal/ffmpeg` straight out of the official `Steno-0.5.4-arm64-mac.zip`: `Mach-O 64-bit executable x86_64`, while the Electron main binary and the whisper `.so` in the same bundle are arm64.

## Change

- **`scripts/download-ollama.sh`**: the mac build is Apple-Silicon-only (arm64) since v0.4.0, so fetch the **arm64** static ffmpeg (same version, 7.1.1) from osxexperts and refuse any other arch, instead of the Intel-only evermeet build.
- **`.github/workflows/build-release.yml`**: assert `file bin/ffmpeg` is arm64 after download, mirroring the existing mic-monitor arch guard — an arch mismatch now fails the build instead of shipping.

## Verification

Locally ran the patched Darwin branch on arm64: downloads → `Mach-O 64-bit executable arm64`, `ffmpeg version 7.1.1`, the CI assertion passes. The previously-bundled x86_64 binary reproduced `Errno 86` on an M2 without Rosetta; this arm64 binary runs natively (no Rosetta needed).

Workaround for users on an affected build until this ships: `softwareupdate --install-rosetta --agree-to-license`. Preserved recordings can then be reprocessed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundles the correct arm64 `ffmpeg` in the macOS arm64 build to prevent crashes on Apple Silicon without Rosetta. Adds CI and build-time validation to prevent shipping a mismatched or corrupt binary. Fixes #209.

- **Bug Fixes**
  - macOS: enforce arm64 builds and download the arm64 static `ffmpeg` 7.1.1 from osxexperts; refuse non-arm64.
  - macOS: after extraction, assert the binary is Mach-O arm64 and run `ffmpeg -version` with pipefail; require 7.1.x to catch corrupt/wrong downloads.
  - CI: verify `bin/ffmpeg` is arm64 in `build-release.yml` to fail fast on arch mismatches.

<sup>Written for commit e737b30e266011d469927ab6b3ed9d4d362abd89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

