### PR TITLE
fix(summarizer): drop 'The transcript discusses' summary preamble

### DIFF
--- a/e2e/specs/summarize-contract.t2.spec.ts
+++ b/e2e/specs/summarize-contract.t2.spec.ts
@@ -93,6 +93,11 @@ test('@contract reprocess builds a transcript-bearing prompt and parses the repl
     expect(prompt).toContain('we ship the release on Friday');
     expect(prompt).toContain('budget is fifty thousand');
 
+    // Summary-style contract: the prompt pins direct phrasing so the summary
+    // doesn't open with a "The transcript discusses…" meta-preamble (a
+    // run-to-run LLM variance we lock down in the prompt itself).
+    expect(prompt).toContain('written directly');
+
     // Exactly one summarise call (regenTitle=false → no separate title call) —
     // pins that reprocess didn't double-summarise.
     expect(ollama.chatCalls()).toBe(1);

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -673,7 +673,7 @@ names, jargon, or context that helps interpret the transcript more accurately.
 
 IMPORTANT: Do not infer or assume information that wasn't directly mentioned.
 
-Include a brief overview so someone can quickly understand what happened in the meeting, what areas/topics were discussed, what were the key points, and what are the next steps if any were mentioned.
+Include a brief overview so someone can quickly understand what happened in the meeting, what areas/topics were discussed, what were the key points, and what are the next steps if any were mentioned. Write the overview directly as a summary of the subject matter — do not refer to "the transcript" or open with phrases like "The transcript discusses".
 
 CRITICAL JSON FORMATTING RULES:
 1. ALL strings must be enclosed in double quotes "like this"
@@ -974,7 +974,7 @@ Return ONLY the response in this exact JSON format:
         return f"""{diarisation_note}{notes_context}Summarise this meeting transcript as markdown. Output ONLY the markdown below with no preamble, commentary, or explanation. Start directly with ## Summary.
 
 ## Summary
-A 1-3 sentence overview of what was discussed.
+A 1-3 sentence overview of the main topics and outcomes, written directly. Do not refer to "the transcript", "the meeting", or "the recording", and do not open with phrases like "The transcript discusses" or "In this meeting".
 
 ## Key Topics
 ### [Topic title]


### PR DESCRIPTION
## Problem
Org-mode (adapter/Claude) summaries intermittently opened with a meta preamble like *"The transcript discusses…"* / *"the transcript says…"*. Root cause is run-to-run LLM variance, not a deterministic regression: the markdown summary prompt is unchanged since March and the adapter model (`claude-sonnet-4-6`) since May. The prompt asked for "an overview of what was discussed" but never forbade referring to the transcript itself.

## Fix
Pin the behaviour in the prompt so the model stops deciding per-run, in **both** live summary paths:
- `_create_markdown_prompt` (streaming — record + reprocess)
- `_create_permissive_prompt` (legacy JSON)

Positive instruction first ("write it directly") plus an explicit ban on "The transcript discusses…" openers — positive phrasing is followed more reliably by the small local models (gemma 2B), and the ban covers the larger ones.

## Verification
Reprocessed a Brazil-trade transcript through the rebuilt backend against a live adapter (Claude):
- before: *"The transcript discusses Brazil's trade relationship with China…"*
- after: *"Brazil's soybean export performance to China was reviewed, showing strong growth…"*

## Tests
`summarize-contract.t2.spec.ts` now asserts the built prompt carries the direct-phrasing rule, so a future edit that drops it fails CI.

Applies to all providers (local/cloud/adapter) since the prompt is shared.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove meta preambles like "The transcript discusses..." by pinning direct-phrasing rules in the summarizer prompts. Applies to both streaming markdown and legacy JSON paths to reduce run-to-run variance across providers.

- **Bug Fixes**
  - Updated `_create_markdown_prompt` and `_create_permissive_prompt` to write the overview directly and forbid references to "the transcript" or similar.
  - Added an e2e contract test to assert the prompt includes the direct-phrasing rule.

<sup>Written for commit af71e9c0e951f0906bbffdf503b5a192b267b81c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

