### PR TITLE
feat(models): default to gemma4:e2b-it-qat + explicit Ollama num_ctx (WS1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Thank you for your interest in contributing to StenoAI! This guide will help you
    # Install Ollama
    brew install ollama
    ollama serve &
-   ollama pull llama3.2:3b
+   ollama pull gemma4:e2b-it-qat
    
    # Install ffmpeg
    brew install ffmpeg

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu)
 - `Whisper Small` (466 MB): Balanced speed and accuracy. Same 99-language coverage. **(legacy — kept available for existing users; Large V3 Turbo recommended)**
 
 **Summarization Models** (Ollama):
-- `llama3.2:3b` (2GB): Fast and lightweight for quick meetings **(default)**
-- `gemma4:e2b-it-qat` (4.3GB): Lightest Gemma 4, quantization-aware — good for memory-constrained machines (128K context)
+- `gemma4:e2b-it-qat` (4.3GB): Lightest Gemma 4, quantization-aware, with a real 128K context **(default)**
+- `llama3.2:3b` (2GB): Fast and lightweight for quick meetings
 - `qwen3.5:9b` (6.6GB): Excellent at structured output and action items
 - `gemma4:12b` (7.6GB): Gemma 4 with a 256K context — best for long meetings
 - `gpt-oss:20b` (14GB): OpenAI open-weight model with reasoning capabilities

--- a/app/main.js
+++ b/app/main.js
@@ -402,6 +402,11 @@ async function showShortcutNotification(body) {
 const BACKEND_STATUS_RETRY_ATTEMPTS = 3;
 const BACKEND_STATUS_RETRY_DELAY_MS = 250;
 
+// Default local AI (summarisation) model the first-run setup pulls. The setup
+// pull here is NOT backend-driven, so this must be kept in sync with
+// src.config.Config.DEFAULT_MODEL (the Python single source of truth).
+const DEFAULT_AI_MODEL = 'gemma4:e2b-it-qat';
+
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -4493,11 +4498,11 @@ ipcMain.handle('setup-ollama-and-model', async () => {
     }
     
     sendDebugLog('Downloading AI model (this may take several minutes)...');
-    sendDebugLog('POST http://127.0.0.1:11434/api/pull {name: "llama3.2:3b"}');
+    sendDebugLog(`POST http://127.0.0.1:11434/api/pull {name: "${DEFAULT_AI_MODEL}"}`);
 
     const http = require('http');
     return new Promise((resolve) => {
-      const postData = JSON.stringify({ name: 'llama3.2:3b' });
+      const postData = JSON.stringify({ name: DEFAULT_AI_MODEL });
       const req = http.request({
         hostname: '127.0.0.1',
         port: 11434,
@@ -4541,7 +4546,7 @@ ipcMain.handle('setup-ollama-and-model', async () => {
           if (res.statusCode === 200) {
             sendDebugLog('AI model download completed successfully');
             try {
-              await runPythonScript('simple_recorder.py', ['set-model', 'llama3.2:3b'], true);
+              await runPythonScript('simple_recorder.py', ['set-model', DEFAULT_AI_MODEL], true);
             } catch (e) {
               // Non-fatal -- config reset is best-effort
             }

--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -40,6 +40,17 @@ function startMockOllama(opts = {}) {
         res.end(
           JSON.stringify({
             models: [
+              // gemma4:e2b-it-qat is the config default (Config.DEFAULT_MODEL);
+              // list it so the summarizer finds the configured model installed
+              // instead of taking the pull path. llama3.2:3b kept for tests that
+              // pin the older model explicitly.
+              {
+                name: 'gemma4:e2b-it-qat',
+                model: 'gemma4:e2b-it-qat',
+                modified_at: '2024-01-01T00:00:00Z',
+                size: 4301000000,
+                digest: 'mock',
+              },
               {
                 name: 'llama3.2:3b',
                 model: 'llama3.2:3b',

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -51,6 +51,19 @@ function assertInstalledShape(models: Record<string, ModelInfo> | undefined) {
   }
 }
 
+test('a fresh install defaults the summary model to gemma4:e2b-it-qat', async ({
+  launchApp,
+}) => {
+  // No config is seeded, so get-current-model returns Config.DEFAULT_MODEL.
+  // This pins the WS1 default swap (was llama3.2:3b).
+  const { page } = await launchApp();
+  const current = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.models.getCurrent(),
+  );
+  expect(current.success).toBe(true);
+  expect(current.model).toBe('gemma4:e2b-it-qat');
+});
+
 test('summary model set persists to config.model and round-trips through get-current-model', async ({
   launchApp,
   userDataDir,

--- a/plans/chat-models-and-default.md
+++ b/plans/chat-models-and-default.md
@@ -1,0 +1,132 @@
+# Plan — Chat model accuracy, local chat, and a new default model
+
+_Drafted 2026-06-19. Source: discussion around issue #198 + PR #205._
+
+Four independent workstreams. Each is its own branch + PR (own luffy run). Sequence:
+**WS0 → WS1 → WS2 → WS3** (WS2/WS3 can run in parallel after WS0/WS1 land).
+
+Locked decisions:
+- New default summarization model: **`gemma4:e2b-it-qat`** (already in the registry; 2B, 128K ctx, 4.3GB).
+- Local models in cross-note chat: **enable, but cap the assembled context** to fit the local model's window.
+- Chat model indicator: **accurate display only** (no in-Chat picker).
+
+---
+
+## WS0 — Merge PR #205 (prereq, no new code)
+
+#205 fixes the Settings OpenAI model list (sort newest-first, chat-only filter, cap 25).
+It is OpenAI-specific by design — Anthropic (`client.models.list(limit=10)`, recent-first)
+and Bedrock (curated `SUPPORTED_BEDROCK_MODELS`) are already clean. Green + cubic-approved.
+
+- **Action:** merge #205 (blocked only on the review gate). Everything below assumes the
+  good Settings list exists.
+
+---
+
+## WS1 — Swap the default summarization model to `gemma4:e2b-it-qat`
+
+**Why:** `llama3.2:3b` is the current default; we want Gemma as the out-of-box model.
+
+**Touch:**
+- `src/config.py:112` — `DEFAULT_MODEL = "gemma4:e2b-it-qat"`.
+- `src/config.py` `SUPPORTED_MODELS` (~:118) — move `gemma4:e2b-it-qat` to first and update its
+  description to `(default)`; drop `(default)` from the `llama3.2:3b` entry. **Do not remove**
+  `llama3.2:3b` — keep it (un-deprecated is fine) so existing users keep a recognised selection.
+- `src/summarizer.py:156` — the hardcoded `"llama3.2:3b"` config-load fallback → `"gemma4:e2b-it-qat"`.
+- `src/summarizer.py:319` — reorder `fallback_models` to lead with `"gemma4:e2b-it-qat"`.
+
+**Migration / safety:**
+- Only **new installs / first run** get the new default (existing `config.json` keeps the user's
+  `model`). Verify the setup flow pulls `DEFAULT_MODEL` (it's backend-driven; `Setup.tsx` has no
+  hardcoded model). Audit `setup-check` / first-run pull path in `app/main.js` (~:4379, model-pull
+  handlers ~:6321) for any literal `llama3.2`.
+- **Onboarding download grows 2GB → 4.3GB.** Call this out in the PR; confirm it's acceptable.
+
+**`num_ctx` (folded in):** the summarizer sets `max_tokens` but **never sets `num_ctx`/`options`**
+on the local Ollama call (verified — no `options=`/`num_ctx` in `src/summarizer.py`). So today the
+model runs at Ollama's small default context (~2–4K) regardless of its 128K capability — the new
+default's window would go unused. As part of WS1, set an explicit `num_ctx` in the local Ollama
+request `options` (sized to the model / clamped to a sane ceiling) so long meetings actually use the
+context. This also matters because quantized `llama3.2:3b` effectively caps ~8K while QAT
+`gemma4:e2b-it-qat` is a real 128K — the swap only pays off if `num_ctx` is set.
+
+**Tests (model-free):**
+- Unit: `tests/test_config.py` — assert `Config.DEFAULT_MODEL == "gemma4:e2b-it-qat"` and that the
+  registry's first/active entry matches.
+- Update the `model-management.t2` e2e if it pins the default id.
+- If `num_ctx` is set via a helper, unit-test the helper's clamp/sizing (pure function, no model).
+
+**Acceptance:** fresh `config.json` → `get_model()` returns `gemma4:e2b-it-qat`; setup pulls it;
+existing configs untouched; local Ollama requests carry an explicit `num_ctx`.
+
+---
+
+## WS2 — Make the Chat model indicator accurate (no picker)
+
+**Why:** `Chat.tsx:230` / `ChatConversation.tsx:471` render a read-only `<span>` keyed on stored
+`cloud_provider`/`cloud_model`, so a local/adapter user sees `openai · gpt-4o` — a label that
+*lies* about what's answering (root of #198's confusion).
+
+**Design — label reflects the **active** `ai_provider`:**
+- `cloud` → `${cloud_provider} · ${cloud_model}` (current behavior, now only in cloud mode).
+- `local` → `Ollama · <model>` where `<model>` is the configured local model.
+- `remote` → `Remote Ollama · <model>`.
+- `adapter` → `Organisation` (server brokers the model; client has no id — do **not** show a cloud id).
+
+**Touch:**
+- Provider payload lacks the local/remote model name. Two options — pick one:
+  - (a) Add `model: string` (the local Ollama model) to the `get-ai-provider` handler in
+    `app/main.js` and to `GetAiProviderResponse` in `app/renderer/src/lib/ipc.ts:406`; **or**
+  - (b) Source the active local model from the existing `useModels` hook in the renderer.
+  Prefer (a) for a single source of truth in the same payload the label already reads.
+- `app/renderer/src/routes/Chat.tsx:230-234` and `ChatConversation.tsx:471-475` — replace the
+  `cloud_provider ? … : 'Auto'` expression with an `ai_provider`-driven helper (extract a small
+  `formatActiveModel(provider.data)` shared util so the two call sites can't drift).
+
+**Tests:** T1 renderer spec (mock IPC) asserting the label string for each `ai_provider` value.
+
+**Acceptance:** the indicator never shows a cloud model when local/adapter is active; matches the
+provider actually used for the answer.
+
+---
+
+## WS3 — Allow local models in cross-note chat (enable + cap context)
+
+**Why:** chat is hard-blocked for local today. `chat_global_streaming` (`simple_recorder.py:2876`)
+rejects anything but cloud/adapter (`"Local models can't fit"`) and the renderer's `localReady`
+(`Chat.tsx:67`) only counts cloud/adapter. The block exists because cross-note chat assembles
+~400k chars (~100k tokens) of context, which small local models can't hold.
+
+**Backend (`simple_recorder.py` `chat_global_streaming` ~:2876):**
+- Remove the hard `if get_ai_provider() not in ("cloud","adapter")` rejection; allow `local`/`remote`.
+- **Cap the assembled context to the model's window.** The context is already assembled
+  most-recent-first (comment ~:2939), so truncate from the tail: keep whole notes until a char
+  budget is hit. Derive the budget from the local model's context window
+  (`gemma4:e2b-it-qat` is 128K ctx) with headroom for the prompt + reply; fall back to a
+  conservative default for unknown models. Emit a signal (e.g. a `CHAT_SCOPE_CAPPED:` line or a
+  field) when notes were dropped so the UI can disclose it.
+
+**Renderer (`Chat.tsx`):**
+- Extend `localReady` to include local/remote ready states (provider configured + model present).
+- Update the disabled-state placeholder copy (`Chat.tsx:223`) so it no longer implies cloud-only.
+- When local and context was capped, show a subtle note ("Answering over your most recent notes").
+
+**Tests (model-free T2):** drive `chat_global_streaming` with `ai_provider=local` through the
+capturing `mock-ollama.js`; assert (1) it's no longer rejected, and (2) the prompt is capped /
+the capped signal fires when over-budget. Keep any real-model assertions in `@pipeline`.
+
+**Acceptance:** with a local model selected, cross-note chat answers (capped to recent notes) and
+discloses the cap; cloud/adapter behavior unchanged.
+
+**Risks / follow-ups:**
+- Local cross-note quality is lower than cloud; the cap silently narrows scope — disclosure is the
+  mitigation. A fuller fix is map-reduce over note summaries (ties into issue #188) — out of scope here.
+
+---
+
+## Cross-cutting
+
+- Per CLAUDE.md: add/update a model-free e2e spec **in the same change** for each WS that touches
+  user-facing behavior (WS1 model-management, WS2 a chat-label T1, WS3 a chat-local T2).
+- Gate nothing on `process.platform` here — all four WS are cross-platform.
+- Each WS ships as its own PR via luffy → nami; WS0 is just a merge.

--- a/plans/chat-models-and-default.md
+++ b/plans/chat-models-and-default.md
@@ -32,8 +32,8 @@ and Bedrock (curated `SUPPORTED_BEDROCK_MODELS`) are already clean. Green + cubi
 - `src/config.py` `SUPPORTED_MODELS` (~:118) — move `gemma4:e2b-it-qat` to first and update its
   description to `(default)`; drop `(default)` from the `llama3.2:3b` entry. **Do not remove**
   `llama3.2:3b` — keep it (un-deprecated is fine) so existing users keep a recognised selection.
-- `src/summarizer.py:156` — the hardcoded `"llama3.2:3b"` config-load fallback → `"gemma4:e2b-it-qat"`.
-- `src/summarizer.py:319` — reorder `fallback_models` to lead with `"gemma4:e2b-it-qat"`.
+- `src/summarizer.py` (config-load fallback, ~:156) — the hardcoded `"llama3.2:3b"` → the registry default.
+- `src/summarizer.py` `fallback_models` (~:368, in `_ensure_model_available`) — lead with the default; derive the rest from active `SUPPORTED_MODELS`.
 
 **Migration / safety:**
 - Only **new installs / first run** get the new default (existing `config.json` keeps the user's

--- a/src/config.py
+++ b/src/config.py
@@ -109,7 +109,7 @@ def is_bundled() -> bool:
 class Config:
     """Manages application configuration with file persistence."""
 
-    DEFAULT_MODEL = "llama3.2:3b"
+    DEFAULT_MODEL = "gemma4:e2b-it-qat"
 
     # Supported models with metadata. Active models first (roughly ascending by
     # capability/size, default first), deprecated models last — the Settings UI
@@ -118,20 +118,20 @@ class Config:
     # so a user already on the model keeps a recognised selection; fully retired
     # models are dropped from this dict.
     SUPPORTED_MODELS = {
-        "llama3.2:3b": {
-            "name": "Llama 3.2 3B",
-            "size": "2GB",
-            "params": "3B",
-            "description": "Fast and lightweight for quick meetings (default)",
-            "speed": "very fast",
-            "quality": "good"
-        },
         "gemma4:e2b-it-qat": {
             "name": "Gemma 4 E2B (QAT)",
             "size": "4.3GB",
             "params": "2B",
-            "description": "Lightest Gemma 4, quantization-aware, 128K context",
+            "description": "Lightest Gemma 4, quantization-aware, real 128K context (default)",
             "speed": "fast",
+            "quality": "good"
+        },
+        "llama3.2:3b": {
+            "name": "Llama 3.2 3B",
+            "size": "2GB",
+            "params": "3B",
+            "description": "Fast and lightweight for quick meetings",
+            "speed": "very fast",
             "quality": "good"
         },
         "qwen3.5:9b": {

--- a/src/ollama_manager.py
+++ b/src/ollama_manager.py
@@ -250,7 +250,7 @@ def run_ollama_command(args: list, timeout: int = 300) -> Tuple[bool, str, str]:
     Run an Ollama CLI command.
 
     Args:
-        args: Command arguments (e.g., ['pull', 'llama3.2:3b'])
+        args: Command arguments (e.g., ['pull', 'gemma4:e2b-it-qat'])
         timeout: Command timeout in seconds
 
     Returns:
@@ -281,7 +281,7 @@ def pull_model(model_name: str, progress_callback=None) -> bool:
     Pull an Ollama model.
 
     Args:
-        model_name: Name of model to pull (e.g., 'llama3.2:3b')
+        model_name: Name of model to pull (e.g., 'gemma4:e2b-it-qat')
         progress_callback: Optional callback function for progress updates
 
     Returns:

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -364,8 +364,18 @@ class OllamaSummarizer:
             except Exception as e:
                 logger.error(f"Failed to download model {self.model_name}: {e}")
 
-            # Try fallback models from supported list (default first)
-            fallback_models = ["gemma4:e2b-it-qat", "llama3.2:3b", "qwen3.5:9b", "gemma4:12b"]
+            # Try fallback models: a preferred order (default, then small/fast)
+            # followed by every other active supported model, so an
+            # installed-but-omitted model can still rescue summarisation rather
+            # than forcing a (possibly offline) pull. Derived from the registry
+            # so it can't drift out of sync with SUPPORTED_MODELS.
+            from .config import Config
+            preferred = ["gemma4:e2b-it-qat", "llama3.2:3b", "qwen3.5:9b", "gemma4:12b"]
+            active = [
+                mid for mid, info in Config.SUPPORTED_MODELS.items()
+                if not info.get("deprecated")
+            ]
+            fallback_models = preferred + [m for m in active if m not in preferred]
             for fallback in fallback_models:
                 if fallback in model_names:
                     logger.info(f"Using already-installed fallback model: {fallback}")

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -58,6 +58,8 @@ OLLAMA_NUM_CTX_DEFAULT = 32768
 OLLAMA_NUM_CTX_CEILING = 131072
 _OLLAMA_MODEL_NUM_CTX = {
     "gemma4:e2b-it-qat": 32768,
+    # gemma4:12b advertises 256K; capped well under that — a meeting fits in 32K
+    # and the full window would be a large KV-cache allocation.
     "gemma4:12b": 32768,
     "gemma3:4b": 16384,
     # llama3.2:3b's quantized build effectively caps ~8K despite the headline 128K

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -42,6 +42,43 @@ def bedrock_converse_url(region: str, target_id: str) -> str:
     return f"https://bedrock-runtime.{region}.amazonaws.com/model/{encoded}/converse"
 
 
+# Ollama applies a small default context window (num_ctx ~4K) regardless of the
+# model's real capability, silently truncating long meeting transcripts before
+# the model ever sees them. We request a larger window per Ollama call, sized per
+# model where the window is known, clamped to a floor and ceiling:
+#   - floor keeps short-context models usable,
+#   - ceiling bounds the KV-cache memory a request can allocate on edge-class
+#     machines (gemma4:e2b advertises a real 128K window, but a meeting fits well
+#     under our ceiling, so we don't ask Ollama to allocate the whole 128K).
+# NB: keep the SAME num_ctx across every call to a given model in one run —
+# Ollama reloads the model when num_ctx changes, so a mismatched title/summary
+# request would force an expensive reload.
+OLLAMA_NUM_CTX_FLOOR = 8192
+OLLAMA_NUM_CTX_DEFAULT = 32768
+OLLAMA_NUM_CTX_CEILING = 131072
+_OLLAMA_MODEL_NUM_CTX = {
+    "gemma4:e2b-it-qat": 32768,
+    "gemma4:12b": 32768,
+    "gemma3:4b": 16384,
+    # llama3.2:3b's quantized build effectively caps ~8K despite the headline 128K
+    "llama3.2:3b": 8192,
+    "qwen3.5:9b": 32768,
+    "gpt-oss:20b": 32768,
+    "deepseek-r1:14b": 32768,
+}
+
+
+def resolve_num_ctx(model_name: str) -> int:
+    """Context window (num_ctx) to request from Ollama for ``model_name``.
+
+    Sized per known model, clamped to ``[FLOOR, CEILING]``; unknown models fall
+    back to the conservative default. Pure function — unit-testable without a
+    running model or Ollama.
+    """
+    base = _OLLAMA_MODEL_NUM_CTX.get(model_name, OLLAMA_NUM_CTX_DEFAULT)
+    return max(OLLAMA_NUM_CTX_FLOOR, min(base, OLLAMA_NUM_CTX_CEILING))
+
+
 class OllamaSummarizer:
     def __init__(self, model_name: Optional[str] = None):
         """
@@ -153,7 +190,7 @@ class OllamaSummarizer:
                     logger.info(f"Using configured model: {model_name}")
                 except Exception as e:
                     logger.warning(f"Failed to load model from config: {e}, using default")
-                    model_name = "llama3.2:3b"
+                    model_name = config.DEFAULT_MODEL
 
             self.model_name = model_name
             self._ensure_ollama_ready()
@@ -175,6 +212,16 @@ class OllamaSummarizer:
         """Start the Ollama service if not running."""
         logger.info("Starting Ollama service...")
         return ollama_manager.start_ollama_server(wait=True, timeout=30)
+
+    def _ollama_options(self) -> Dict[str, Any]:
+        """Per-request options for local/remote Ollama ``chat`` calls.
+
+        Sets an explicit ``num_ctx`` so the model uses a real context window
+        instead of Ollama's small default (which would truncate long meetings).
+        Applied to every local/remote call for the active model so num_ctx stays
+        consistent and Ollama doesn't reload the model between calls.
+        """
+        return {"num_ctx": resolve_num_ctx(self.model_name)}
     
     def _repair_json(self, json_text: str) -> Optional[str]:
         """
@@ -315,8 +362,8 @@ class OllamaSummarizer:
             except Exception as e:
                 logger.error(f"Failed to download model {self.model_name}: {e}")
 
-            # Try fallback models from supported list
-            fallback_models = ["llama3.2:3b", "gemma3:4b", "qwen3.5:9b", "deepseek-r1:14b"]
+            # Try fallback models from supported list (default first)
+            fallback_models = ["gemma4:e2b-it-qat", "llama3.2:3b", "qwen3.5:9b", "gemma4:12b"]
             for fallback in fallback_models:
                 if fallback in model_names:
                     logger.info(f"Using already-installed fallback model: {fallback}")
@@ -811,6 +858,7 @@ Return ONLY the response in this exact JSON format:
                                     'content': prompt
                                 }
                             ],
+                            options=self._ollama_options(),
                         )
                         break  # Success, exit retry loop
 
@@ -1071,6 +1119,7 @@ TRANSCRIPT:
                     model=self.model_name,
                     messages=[{'role': 'user', 'content': prompt}],
                     stream=True,
+                    options=self._ollama_options(),
                 )
                 for chunk in response:
                     content = chunk.get('message', {}).get('content', '')
@@ -1103,7 +1152,8 @@ TRANSCRIPT:
             # Test with a simple prompt
             test_response = self.client.chat(
                 model=self.model_name,
-                messages=[{'role': 'user', 'content': 'Hello'}]
+                messages=[{'role': 'user', 'content': 'Hello'}],
+                options=self._ollama_options(),
             )
             
             logger.info("Ollama connection test successful")
@@ -1220,6 +1270,7 @@ TITLE:"""
                 ollama_response = title_client.chat(
                     model=self.model_name,
                     messages=[{'role': 'user', 'content': prompt}],
+                    options=self._ollama_options(),
                 )
                 response_text = ollama_response['message']['content'].strip()
 
@@ -1322,6 +1373,7 @@ ANSWER:"""
                     model=self.model_name,
                     messages=[{"role": "user", "content": prompt}],
                     stream=True,
+                    options=self._ollama_options(),
                 )
                 for chunk in stream:
                     content = chunk['message']['content']
@@ -1379,6 +1431,7 @@ ANSWER:"""
                                     'content': prompt
                                 }
                             ],
+                            options=self._ollama_options(),
                         )
                         break
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,6 +75,44 @@ class ConfigWhisperModelTests(unittest.TestCase):
             self.assertEqual(config.get_whisper_model(), "small")
 
 
+class ConfigSummaryModelTests(unittest.TestCase):
+    def test_default_model_is_gemma4_e2b(self):
+        self.assertEqual(Config.DEFAULT_MODEL, "gemma4:e2b-it-qat")
+
+    def test_get_model_returns_default_on_fresh_config(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertEqual(config.get_model(), "gemma4:e2b-it-qat")
+
+    def test_default_model_is_first_active_entry_in_registry(self):
+        # The Settings UI relies on active models being listed first, default
+        # first. The default must be a registered model and the first key.
+        self.assertIn(Config.DEFAULT_MODEL, Config.SUPPORTED_MODELS)
+        first_key = next(iter(Config.SUPPORTED_MODELS))
+        self.assertEqual(first_key, Config.DEFAULT_MODEL)
+        self.assertNotEqual(
+            Config.SUPPORTED_MODELS[Config.DEFAULT_MODEL].get("deprecated"), True
+        )
+
+    def test_llama32_kept_as_recognised_active_model(self):
+        # Kept (not removed/deprecated) so users already on it keep a recognised
+        # selection after the default swap.
+        self.assertIn("llama3.2:3b", Config.SUPPORTED_MODELS)
+        self.assertNotEqual(
+            Config.SUPPORTED_MODELS["llama3.2:3b"].get("deprecated"), True
+        )
+
+    def test_existing_user_choice_survives_default_swap(self):
+        # Migration safety: a user already on the old default keeps it; only a
+        # fresh config (no stored "model") gets the new gemma4 default.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertTrue(config.set_model("llama3.2:3b"))
+            reloaded = Config(config_path=path)
+            self.assertEqual(reloaded.get_model(), "llama3.2:3b")
+
+
 class ConfigWhisperModelMigrationTests(unittest.TestCase):
     """_migrate_whisper_model runs at load time to rescue configs that hold
     values outside the current SUPPORTED_WHISPER_MODELS list. Bare 'large'

--- a/tests/test_summarizer_num_ctx.py
+++ b/tests/test_summarizer_num_ctx.py
@@ -7,6 +7,7 @@ running Ollama required.
 """
 
 import unittest
+from unittest import mock
 
 from src.config import Config
 from src.summarizer import (
@@ -36,21 +37,18 @@ class ResolveNumCtxTests(unittest.TestCase):
             self.assertLessEqual(value, OLLAMA_NUM_CTX_CEILING, msg=model)
 
     def test_clamps_below_floor_up(self):
-        # A model mapped below the floor is raised to the floor.
-        tiny = "tiny-test-model"
-        _OLLAMA_MODEL_NUM_CTX[tiny] = 512
-        try:
-            self.assertEqual(resolve_num_ctx(tiny), OLLAMA_NUM_CTX_FLOOR)
-        finally:
-            del _OLLAMA_MODEL_NUM_CTX[tiny]
+        # A model mapped below the floor is raised to the floor. patch.dict
+        # restores the shared map even on failure (no leaked test state).
+        with mock.patch.dict(_OLLAMA_MODEL_NUM_CTX, {"tiny-test-model": 512}):
+            self.assertEqual(resolve_num_ctx("tiny-test-model"), OLLAMA_NUM_CTX_FLOOR)
 
     def test_clamps_above_ceiling_down(self):
-        huge = "huge-test-model"
-        _OLLAMA_MODEL_NUM_CTX[huge] = OLLAMA_NUM_CTX_CEILING * 4
-        try:
-            self.assertEqual(resolve_num_ctx(huge), OLLAMA_NUM_CTX_CEILING)
-        finally:
-            del _OLLAMA_MODEL_NUM_CTX[huge]
+        with mock.patch.dict(
+            _OLLAMA_MODEL_NUM_CTX, {"huge-test-model": OLLAMA_NUM_CTX_CEILING * 4}
+        ):
+            self.assertEqual(
+                resolve_num_ctx("huge-test-model"), OLLAMA_NUM_CTX_CEILING
+            )
 
     def test_every_active_registry_model_has_an_explicit_window(self):
         # Drift guard: a model added to the config registry without a num_ctx

--- a/tests/test_summarizer_num_ctx.py
+++ b/tests/test_summarizer_num_ctx.py
@@ -1,0 +1,56 @@
+"""Tests for the Ollama num_ctx sizing helper in src.summarizer.
+
+Ollama otherwise applies a small default context window (~4K) regardless of the
+model's real capability, silently truncating long meetings. `resolve_num_ctx`
+picks a per-model window clamped to a floor/ceiling. Pure function — no model or
+running Ollama required.
+"""
+
+import unittest
+
+from src.summarizer import (
+    resolve_num_ctx,
+    OLLAMA_NUM_CTX_FLOOR,
+    OLLAMA_NUM_CTX_DEFAULT,
+    OLLAMA_NUM_CTX_CEILING,
+    _OLLAMA_MODEL_NUM_CTX,
+)
+
+
+class ResolveNumCtxTests(unittest.TestCase):
+    def test_known_model_returns_mapped_window(self):
+        self.assertEqual(resolve_num_ctx("gemma4:e2b-it-qat"), 32768)
+
+    def test_quantized_llama_is_capped_low(self):
+        # llama3.2:3b's quantized build effectively caps ~8K despite the headline.
+        self.assertEqual(resolve_num_ctx("llama3.2:3b"), 8192)
+
+    def test_unknown_model_falls_back_to_default(self):
+        self.assertEqual(resolve_num_ctx("some-future-model:99b"), OLLAMA_NUM_CTX_DEFAULT)
+
+    def test_result_is_always_within_floor_and_ceiling(self):
+        for model in list(_OLLAMA_MODEL_NUM_CTX) + ["unknown:1b", ""]:
+            value = resolve_num_ctx(model)
+            self.assertGreaterEqual(value, OLLAMA_NUM_CTX_FLOOR, msg=model)
+            self.assertLessEqual(value, OLLAMA_NUM_CTX_CEILING, msg=model)
+
+    def test_clamps_below_floor_up(self):
+        # A model mapped below the floor is raised to the floor.
+        tiny = "tiny-test-model"
+        _OLLAMA_MODEL_NUM_CTX[tiny] = 512
+        try:
+            self.assertEqual(resolve_num_ctx(tiny), OLLAMA_NUM_CTX_FLOOR)
+        finally:
+            del _OLLAMA_MODEL_NUM_CTX[tiny]
+
+    def test_clamps_above_ceiling_down(self):
+        huge = "huge-test-model"
+        _OLLAMA_MODEL_NUM_CTX[huge] = OLLAMA_NUM_CTX_CEILING * 4
+        try:
+            self.assertEqual(resolve_num_ctx(huge), OLLAMA_NUM_CTX_CEILING)
+        finally:
+            del _OLLAMA_MODEL_NUM_CTX[huge]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarizer_num_ctx.py
+++ b/tests/test_summarizer_num_ctx.py
@@ -8,6 +8,7 @@ running Ollama required.
 
 import unittest
 
+from src.config import Config
 from src.summarizer import (
     resolve_num_ctx,
     OLLAMA_NUM_CTX_FLOOR,
@@ -50,6 +51,22 @@ class ResolveNumCtxTests(unittest.TestCase):
             self.assertEqual(resolve_num_ctx(huge), OLLAMA_NUM_CTX_CEILING)
         finally:
             del _OLLAMA_MODEL_NUM_CTX[huge]
+
+    def test_every_active_registry_model_has_an_explicit_window(self):
+        # Drift guard: a model added to the config registry without a num_ctx
+        # entry would silently get the generic default. Fail loudly instead so
+        # the per-model window is a deliberate choice, not an oversight.
+        active = {
+            mid
+            for mid, info in Config.SUPPORTED_MODELS.items()
+            if not info.get("deprecated")
+        }
+        missing = active - set(_OLLAMA_MODEL_NUM_CTX)
+        self.assertEqual(
+            missing,
+            set(),
+            msg=f"active registry models missing a num_ctx entry: {missing}",
+        )
 
 
 if __name__ == "__main__":

--- a/website/src/sections/Models.jsx
+++ b/website/src/sections/Models.jsx
@@ -3,15 +3,15 @@ import { Check } from "lucide-react";
 import { motion as Motion } from "framer-motion";
 
 const models = [
-  { id: "llama3.2:3b",        label: "Llama 3.2",   detail: "3B · Fast" },
   { id: "gemma4:e2b-it-qat",  label: "Gemma 4 E2B", detail: "2B · Light" },
+  { id: "llama3.2:3b",        label: "Llama 3.2",   detail: "3B · Fast" },
   { id: "qwen3.5:9b",         label: "Qwen 3.5",    detail: "9B · Smart" },
   { id: "gemma4:12b",         label: "Gemma 4",     detail: "12B · Long meetings" },
   { id: "gpt-oss:20b",        label: "GPT-OSS",     detail: "20B · Capable" },
 ];
 
 export function Models() {
-  const [active, setActive] = useState("llama3.2:3b");
+  const [active, setActive] = useState("gemma4:e2b-it-qat");
 
   return (
     <section id="models" className="sect">


### PR DESCRIPTION
## What

WS1 of a 4-part effort (see `plans/chat-models-and-default.md`): make **`gemma4:e2b-it-qat`** the default local summarization model and have Ollama actually use a real context window.

### Changes
- **Default model** `llama3.2:3b` → `gemma4:e2b-it-qat` (QAT, real 128K context). `Config.DEFAULT_MODEL` + registry reordered so it leads with `(default)`.
- **Keep `llama3.2:3b`** as an active, recognised registry entry — existing users keep their selection. Only *fresh installs* get the new default; a stored `model` is never rewritten.
- **Explicit `num_ctx`** on every local/remote Ollama `chat` call via a small clamped helper (`resolve_num_ctx` + `_ollama_options`). Ollama otherwise applies a ~4K default regardless of the model's window, silently truncating long meetings. Sized per model, clamped `[8192, 131072]`; applied uniformly so Ollama doesn't reload the model between summary/title calls. Cloud/Bedrock/adapter paths untouched.
- **Setup pull fix:** `app/main.js` first-run pull hardcoded `llama3.2:3b` (not backend-driven) — now a single `DEFAULT_AI_MODEL` constant kept in sync with the Python source of truth.
- Docs (README/CONTRIBUTING) + marketing site model picker updated to lead with Gemma.

### Tests (model-free)
- `tests/test_config.py`: fresh default, registry ordering, `llama3.2:3b` kept active, existing-choice-survives-swap.
- `tests/test_summarizer_num_ctx.py`: clamp/sizing + a **drift-guard** asserting every active registry model has an explicit `num_ctx`.
- `e2e/specs/model-management.t2.spec.ts`: fresh install defaults to `gemma4:e2b-it-qat`; `mock-ollama` lists the new default.

### Verification
- Full Python suite green (159 tests). `node --check app/main.js` OK.
- Runtime-verified: real CLI `list-models` on a fresh data dir → `current_model = gemma4:e2b-it-qat`; `_ollama_options()` returns the correct per-model `num_ctx`. The num_ctx-over-live-Ollama round trip is pipeline-tier (needs the 4.3GB model) and runs in the `@pipeline` lane.

### Heads-up
- **Onboarding download grows ~2GB → 4.3GB** (the chosen tradeoff — `gemma4:e2b-it-qat` is the smallest gemma4 build; its 128K window is *real* QAT, whereas quantized `llama3.2:3b` effectively caps ~8K).

Reviewed via QA + senior-eng lenses (nothing critical/high); medium/low follow-ups applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `gemma4:e2b-it-qat` as the default local summarization model and add an explicit `num_ctx` to all `Ollama` chat calls to use real context windows and prevent truncation. Fallback model selection now derives from the registry (with a preferred order) to avoid drift and unnecessary pulls; new installs pull Gemma by default, existing users stay unchanged.

- New Features
  - Default model `llama3.2:3b` → `gemma4:e2b-it-qat`; `llama3.2:3b` stays active in the registry.
  - Explicit `num_ctx` on local/remote `Ollama` chat calls; per-model clamp [8192, 131072] and consistent per model to avoid reloads.
  - Fallback models are derived from `SUPPORTED_MODELS` with a preferred order, so installed supported models are used before pulling.
  - First-run pull uses a single `DEFAULT_AI_MODEL` constant aligned with the backend default.
  - Docs, website, and tests updated; added a drift-guard ensuring every active registry model defines a `num_ctx`.

- Migration
  - No action for existing users; stored `model` is unchanged.
  - Fresh installs download ~4.3GB for `gemma4:e2b-it-qat` (was ~2GB for `llama3.2:3b`).

<sup>Written for commit d227e8be06d328d679e93f18bfa4accf63f26f0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

