### PR TITLE
fix(chat): accurate model indicator per active provider (WS2)

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -28,6 +28,9 @@ function install({ ipcMain }) {
     provider: 'local', // 'local' | 'remote' | 'cloud' | 'adapter'
     orgSession: null, // { adapterUrl, email, name, orgId, exp } when signed in
     everSignedIn: false,
+    model: 'gemma4:e2b-it-qat', // local/remote Ollama model (config.model)
+    cloudProvider: 'openai',
+    cloudModel: 'gpt-4o',
   };
 
   // Channels with behaviour a test depends on. Each is (event, ...args) like a
@@ -37,6 +40,9 @@ function install({ ipcMain }) {
     'get-ai-provider': async () => ({
       success: true,
       ai_provider: state.provider,
+      cloud_provider: state.cloudProvider,
+      cloud_model: state.cloudModel,
+      model: state.model,
       cloud_api_key_set: false,
     }),
 

--- a/app/renderer/src/lib/chat.ts
+++ b/app/renderer/src/lib/chat.ts
@@ -1,5 +1,38 @@
 // Shared helpers for the Chat tab + conversation view.
 
+import type { AiProvider, CloudProvider } from '@/lib/ipc';
+
+/** The AI-provider config fields the active-model label reads. */
+type ActiveModelFields = {
+  ai_provider: AiProvider;
+  cloud_provider: CloudProvider;
+  cloud_model: string;
+  model: string;
+};
+
+/**
+ * Human label for the model that will actually answer, driven by the ACTIVE
+ * `ai_provider`. The stored `cloud_*` prefs persist even when local/adapter is
+ * the active engine, so keying off them (the old behaviour) showed e.g.
+ * "openai · gpt-4o" to a local user — this keys off the active provider so the
+ * label can't lie. Returns 'Auto' until provider config has loaded.
+ */
+export function formatActiveModel(p: ActiveModelFields | undefined): string {
+  if (!p) return 'Auto';
+  switch (p.ai_provider) {
+    case 'cloud':
+      return `${p.cloud_provider} · ${p.cloud_model}`;
+    case 'remote':
+      return `Remote Ollama · ${p.model}`;
+    case 'adapter':
+      // The org adapter brokers the model server-side; the desktop has no id.
+      return 'Organisation';
+    case 'local':
+    default:
+      return `Ollama · ${p.model}`;
+  }
+}
+
 // Sentinel summaryFile that marks a chat session as belonging to the global
 // Chat tab rather than any specific meeting. Stored on the session record so
 // the Recents list can filter to chat-tab sessions and skip in-meeting

--- a/app/renderer/src/lib/chat.ts
+++ b/app/renderer/src/lib/chat.ts
@@ -19,17 +19,20 @@ type ActiveModelFields = {
  */
 export function formatActiveModel(p: ActiveModelFields | undefined): string {
   if (!p) return 'Auto';
+  // Guard each interpolation: an optimistic provider switch can briefly leave the
+  // cache holding {ai_provider} without the model fields, which would otherwise
+  // render "Ollama · undefined" for a frame.
   switch (p.ai_provider) {
     case 'cloud':
-      return `${p.cloud_provider} · ${p.cloud_model}`;
+      return [p.cloud_provider, p.cloud_model].filter(Boolean).join(' · ') || 'Cloud';
     case 'remote':
-      return `Remote Ollama · ${p.model}`;
+      return p.model ? `Remote Ollama · ${p.model}` : 'Remote Ollama';
     case 'adapter':
       // The org adapter brokers the model server-side; the desktop has no id.
       return 'Organisation';
     case 'local':
     default:
-      return `Ollama · ${p.model}`;
+      return p.model ? `Ollama · ${p.model}` : 'Ollama';
   }
 }
 

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -409,6 +409,8 @@ export type GetAiProviderResponse = Result<{
   cloud_api_url: string;
   cloud_provider: CloudProvider;
   cloud_model: string;
+  /** The local/remote Ollama summarisation model (config.model). */
+  model: string;
   cloud_api_key_set: boolean;
   /** AWS region used as the Bedrock endpoint host (defaults to us-east-1). */
   bedrock_region: string;

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -21,7 +21,7 @@ import { useAiProvider } from '@/hooks/useAi';
 import { useUserName } from '@/hooks/useSettings';
 import { useOrgSession } from '@/hooks/useOrg';
 import { navigate } from '@/lib/router';
-import { GLOBAL_SCOPE, bucketKey, deriveSessionName, toBucketLabel } from '@/lib/chat';
+import { GLOBAL_SCOPE, bucketKey, deriveSessionName, toBucketLabel, formatActiveModel } from '@/lib/chat';
 import { PRESETS, PresetGlyph } from '@/lib/chatPresets';
 
 export function Chat() {
@@ -227,10 +227,12 @@ export function Chat() {
           <div className="flex items-center justify-between gap-2 px-1">
             <div className="flex items-center gap-1">
               <FolderScopePicker value={scopeFolderId} onChange={setScopeFolderId} />
-              <span className="text-[12px]" style={{ color: 'var(--fg-muted)' }}>
-                {provider.data?.cloud_provider
-                  ? `${provider.data.cloud_provider} · ${provider.data.cloud_model}`
-                  : 'Auto'}
+              <span
+                data-testid="chat-model-indicator"
+                className="text-[12px]"
+                style={{ color: 'var(--fg-muted)' }}
+              >
+                {formatActiveModel(provider.data)}
               </span>
             </div>
             <div className="flex items-center gap-1">

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -34,6 +34,7 @@ import {
   bucketKey,
   deriveSessionName,
   toBucketLabel,
+  formatActiveModel,
 } from '@/lib/chat';
 import { consumePendingNewChat } from '@/routes/Chat';
 import { renderMarkdown } from '@/lib/markdown';
@@ -469,10 +470,12 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
           <div className="flex items-center justify-between gap-2 px-1">
             <div className="flex items-center gap-1">
               <FolderScopePicker value={scopeFolderId} onChange={setScopeFolderId} />
-              <span className="text-[12px]" style={{ color: 'var(--fg-muted)' }}>
-                {provider.data?.cloud_provider
-                  ? `${provider.data.cloud_provider} · ${provider.data.cloud_model}`
-                  : 'Auto'}
+              <span
+                data-testid="chat-model-indicator"
+                className="text-[12px]"
+                style={{ color: 'var(--fg-muted)' }}
+              >
+                {formatActiveModel(provider.data)}
               </span>
             </div>
             <div className="flex items-center gap-1">

--- a/e2e/specs/ai-provider.t2.spec.ts
+++ b/e2e/specs/ai-provider.t2.spec.ts
@@ -20,6 +20,7 @@ type ProviderSnapshot = {
   cloud_provider?: string;
   cloud_api_url?: string;
   cloud_model?: string;
+  model?: string;
   cloud_api_key_set?: boolean;
   bedrock_region?: string;
   bedrock_inference_profile?: string;
@@ -58,6 +59,9 @@ test('provider switch + cloud/bedrock config persist and round-trip through get-
   const initial = await getProvider(page);
   expect(initial.success).toBe(true);
   expect(initial.ai_provider).toBe('local');
+  // The active local Ollama model is exposed so the Chat indicator can show it
+  // (WS2). Fresh config → the registry default.
+  expect(initial.model).toBe('gemma4:e2b-it-qat');
 
   // Provider switches persist to config.ai_provider and reflect in the snapshot.
   for (const provider of ['remote', 'cloud', 'local']) {

--- a/e2e/specs/chat-model-indicator.t1.spec.ts
+++ b/e2e/specs/chat-model-indicator.t1.spec.ts
@@ -26,6 +26,38 @@ test('local provider shows the Ollama model, not a stale cloud model', async ({ 
   await expect(label).not.toContainText('gpt-4o');
 });
 
+test('cloud provider shows "<provider> · <model>"', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  // Switch to cloud on a non-chat route, then mount Chat fresh so the provider
+  // query refetches the new state.
+  await page.evaluate(() => {
+    window.location.hash = '#/settings';
+  });
+  await page.evaluate(() => (window as unknown as { stenoai: { ai: { setProvider: (p: string) => Promise<unknown> } } }).stenoai.ai.setProvider('cloud'));
+  await page.evaluate(() => {
+    window.location.hash = '#/chat';
+  });
+
+  const label = page.locator(indicator).first();
+  await expect(label).toHaveText('openai · gpt-4o');
+});
+
+test('remote provider shows "Remote Ollama · <model>"', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  await page.evaluate(() => {
+    window.location.hash = '#/settings';
+  });
+  await page.evaluate(() => (window as unknown as { stenoai: { ai: { setProvider: (p: string) => Promise<unknown> } } }).stenoai.ai.setProvider('remote'));
+  await page.evaluate(() => {
+    window.location.hash = '#/chat';
+  });
+
+  const label = page.locator(indicator).first();
+  await expect(label).toHaveText('Remote Ollama · gemma4:e2b-it-qat');
+});
+
 test('org/adapter provider shows "Organisation", never a cloud model id', async ({ launchApp }) => {
   const { page } = await launchApp({ mockIpc: true });
 

--- a/e2e/specs/chat-model-indicator.t1.spec.ts
+++ b/e2e/specs/chat-model-indicator.t1.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 — renderer-only, mock IPC. Pins the Chat composer's model indicator
+ * (WS2): the label must reflect the ACTIVE ai_provider, not stored cloud_*
+ * prefs. The old label keyed off cloud_provider, so a local/adapter user saw a
+ * stale "openai · gpt-4o" — the bug behind #198. Wire shapes are stubbed in
+ * app/e2e-mock-ipc.js; the mapping itself is formatActiveModel in lib/chat.ts.
+ */
+
+const indicator = '[data-testid="chat-model-indicator"]';
+
+test('local provider shows the Ollama model, not a stale cloud model', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  // Default mock provider is 'local' with model gemma4:e2b-it-qat.
+  await page.evaluate(() => {
+    window.location.hash = '#/chat';
+  });
+
+  const label = page.locator(indicator).first();
+  await expect(label).toBeVisible();
+  await expect(label).toHaveText('Ollama · gemma4:e2b-it-qat');
+  // Must NOT leak the stored cloud default (the #198 regression).
+  await expect(label).not.toContainText('openai');
+  await expect(label).not.toContainText('gpt-4o');
+});
+
+test('org/adapter provider shows "Organisation", never a cloud model id', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  // Sign in to the org → hard-lock flips the provider to adapter.
+  await page.evaluate(() => {
+    window.location.hash = '#/settings?tab=organisation';
+  });
+  await expect(page.getByTestId('org-sign-in-card')).toBeVisible();
+  await page.getByPlaceholder('https://steno-adapter.yourcompany.com').fill('https://e2e.example.com');
+  await page.getByPlaceholder('you@yourcompany.com').fill('e2e@example.com');
+  await page.getByPlaceholder('••••••').fill('hunter2');
+  await page.getByRole('button', { name: /sign in with password/i }).click();
+  await expect(page.getByTestId('org-signed-in-card')).toBeVisible();
+
+  await page.evaluate(() => {
+    window.location.hash = '#/chat';
+  });
+
+  const label = page.locator(indicator).first();
+  await expect(label).toBeVisible();
+  await expect(label).toHaveText('Organisation');
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3758,6 +3758,10 @@ def get_ai_provider():
         "cloud_api_key_set": bool(config.get_cloud_api_key()),
         "cloud_provider": config.get_cloud_provider(),
         "cloud_model": config.get_cloud_model(),
+        # The local/remote Ollama summarisation model, so the UI can show the
+        # model that's actually answering under ai_provider=local/remote
+        # (cloud/adapter use cloud_model / the org's server-side model).
+        "model": config.get_model(),
         "bedrock_region": config.get_bedrock_region(),
         "bedrock_inference_profile": config.get_bedrock_inference_profile(),
         "bedrock_supported_models": list(config.SUPPORTED_BEDROCK_MODELS),


### PR DESCRIPTION
## What

WS2 of `plans/chat-models-and-default.md`: make the Chat composer's model indicator **accurate**.

### Problem
The label keyed off the stored `cloud_provider`/`cloud_model`, which persist even when local/adapter is the active engine — so a local or org user saw a stale **`openai · gpt-4o`**. That's the confusion behind #198 ("I can only select gpt4o"): the label was *lying* about which model answers.

### Change
- New shared `formatActiveModel(provider.data)` helper (`app/renderer/src/lib/chat.ts`), driven off the **active `ai_provider`**:
  - `local` → `Ollama · <model>`
  - `remote` → `Remote Ollama · <model>`
  - `cloud` → `<provider> · <model>`
  - `adapter` → `Organisation` (the org brokers the model server-side; the desktop has no id)
  - loading / partial cache → `Auto` / graceful fallback (no `· undefined` flash)
- Both call sites (`Chat.tsx`, `ChatConversation.tsx`) use the helper — can't drift.
- `get-ai-provider` now exposes the active local Ollama `model` (Python + `ipc.ts` + mock IPC) so the label has a source for local/remote.

This is **display-only** — no in-Chat model picker (that was a deliberate scope decision; changing the model stays in Settings).

### Tests (model-free)
- `e2e/specs/chat-model-indicator.t1.spec.ts` — asserts the rendered label for **all four** providers (local / cloud / remote / adapter), incl. the regression: local must not show a cloud id.
- `ai-provider.t2` — asserts `get-ai-provider` returns `model`.

### Verification
- Full T1 suite green locally (5 specs); renderer typecheck clean; backend `get-ai-provider` returns `model` (verified via real CLI).

Reviewed via QA + senior-eng lenses (nothing critical/high); medium/low follow-ups applied (partial-cache guard + cloud/remote coverage). Design: text-only label fix, no visual/layout change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Chat model indicator so it reflects the active provider (local, remote, cloud, adapter) instead of stale cloud settings. Prevents misleading labels like "openai · gpt-4o" when local/adapter is active.

- **Bug Fixes**
  - Drive the label from the active `ai_provider` via `formatActiveModel`, with clear mappings and a safe "Auto" fallback.
  - Use the helper in both `Chat.tsx` and `ChatConversation.tsx` to keep behavior consistent.
  - Extend `get-ai-provider` to return the local/remote `model`; updated mock IPC and backend to supply it.
  - Added e2e coverage for all providers; asserts local/adapter never show a cloud model.

<sup>Written for commit a70b1fa4f21658a488b10190bba042ed3cf63ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

