### PR TITLE
feat(chat): local + remote models in cross-note chat (WS3)

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -31,6 +31,7 @@ function install({ ipcMain }) {
     model: 'gemma4:e2b-it-qat', // local/remote Ollama model (config.model)
     cloudProvider: 'openai',
     cloudModel: 'gpt-4o',
+    remoteUrl: '', // remote Ollama URL (empty = not configured)
   };
 
   // Channels with behaviour a test depends on. Each is (event, ...args) like a
@@ -43,6 +44,7 @@ function install({ ipcMain }) {
       cloud_provider: state.cloudProvider,
       cloud_model: state.cloudModel,
       model: state.model,
+      remote_ollama_url: state.remoteUrl,
       cloud_api_key_set: false,
     }),
 

--- a/app/main.js
+++ b/app/main.js
@@ -1837,9 +1837,10 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
 
 // Cross-note chat (Chat tab). Same wire protocol as query-transcript-stream
 // (CHAT_CHUNK / CHAT_STREAM_COMPLETE / CHAT_STREAM_ERROR -> query-chunk /
-// query-done) so the renderer can reuse useStreamingQuery. Cloud-only —
-// the Python CLI rejects local providers because we don't have retrieval
-// yet and a full-corpus prompt blows local context windows.
+// query-done) so the renderer can reuse useStreamingQuery. Works with every
+// provider — the Python CLI sizes the assembled corpus to the active model's
+// context window (smaller for local/remote), so a local model answers over
+// fewer recent notes instead of overflowing. No retrieval (RAG) yet.
 ipcMain.on('chat-global-stream', (event, queryId, question, folderId) => {
   sendDebugLog(`💬 Global chat query: ${String(question || '').slice(0, 80)}... (folder: ${folderId || 'all'})`);
   const env = { ...process.env, ...getAiEnv() };

--- a/app/main.js
+++ b/app/main.js
@@ -1875,9 +1875,13 @@ ipcMain.on('chat-global-stream', (event, queryId, question, folderId) => {
   let chunkCount = 0;
   proc.stdout.on('data', (data) => {
     buf += data.toString();
-    const lines = buf.split('\n');
-    buf = lines.pop();
-    for (const line of lines) {
+    const rawLines = buf.split('\n');
+    buf = rawLines.pop();
+    // Strip a trailing CR: on Windows the backend's stdout is \r\n, so splitting
+    // on \n leaves "CHAT_STREAM_COMPLETE\r" which the exact-match below would
+    // miss — the stream would then never signal done. (The CHUNK/ERROR prefixes
+    // tolerate it, but the completion sentinel must be matched exactly.)
+    for (const line of rawLines.map((l) => (l.endsWith('\r') ? l.slice(0, -1) : l))) {
       if (line.startsWith('CHAT_CHUNK:')) {
         try {
           const chunk = Buffer.from(line.slice(11), 'base64').toString('utf-8');

--- a/app/renderer/src/lib/chat.ts
+++ b/app/renderer/src/lib/chat.ts
@@ -10,6 +10,33 @@ type ActiveModelFields = {
   model: string;
 };
 
+/** Provider-readiness fields the chat composer gates on. */
+type ChatProviderFields = {
+  ai_provider: AiProvider;
+  cloud_api_key_set?: boolean;
+  remote_ollama_url?: string;
+};
+
+/**
+ * Whether the cloud/local/remote provider is configured well enough to answer
+ * chat: local always works, remote needs its Ollama URL, cloud needs its key.
+ * Callers layer their own adapter / org-scope rules on top (those differ
+ * between the Chat tab and a conversation), so this covers only the shared core.
+ */
+export function chatProviderReady(p: ChatProviderFields | undefined): boolean {
+  if (!p) return false;
+  switch (p.ai_provider) {
+    case 'local':
+      return true;
+    case 'remote':
+      return !!p.remote_ollama_url;
+    case 'cloud':
+      return !!p.cloud_api_key_set;
+    default:
+      return false;
+  }
+}
+
 /**
  * Human label for the model that will actually answer, driven by the ACTIVE
  * `ai_provider`. The stored `cloud_*` prefs persist even when local/adapter is

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -21,7 +21,7 @@ import { useAiProvider } from '@/hooks/useAi';
 import { useUserName } from '@/hooks/useSettings';
 import { useOrgSession } from '@/hooks/useOrg';
 import { navigate } from '@/lib/router';
-import { GLOBAL_SCOPE, bucketKey, deriveSessionName, toBucketLabel, formatActiveModel } from '@/lib/chat';
+import { GLOBAL_SCOPE, bucketKey, deriveSessionName, toBucketLabel, formatActiveModel, chatProviderReady } from '@/lib/chat';
 import { PRESETS, PresetGlyph } from '@/lib/chatPresets';
 
 export function Chat() {
@@ -50,24 +50,17 @@ export function Chat() {
   const submittingRef = React.useRef(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  const isCloud = provider.data?.ai_provider === 'cloud';
   const isAdapter = provider.data?.ai_provider === 'adapter';
   const isLocalEngine =
     provider.data?.ai_provider === 'local' || provider.data?.ai_provider === 'remote';
-  const cloudKeySet = provider.data?.cloud_api_key_set ?? false;
-  const remoteUrlSet = !!provider.data?.remote_ollama_url;
-  // Which providers can answer cross-note chat:
-  //  - cloud needs its API key set; adapter needs an active org session
-  //    (a signed-out adapter user would otherwise get an opaque submit failure);
-  //  - local always works; remote needs its Ollama URL configured.
-  // Local/remote answer over a context-capped, most-recent slice of notes
-  // (the backend sizes the corpus to the model's window) — see the hint below.
+  // Cloud/local/remote readiness is the shared core (chatProviderReady); adapter
+  // adds an active-org-session requirement here (a signed-out adapter user would
+  // otherwise get an opaque submit failure). Local/remote answer over a
+  // context-capped, most-recent slice (the backend sizes the corpus to the
+  // model's window) — see the hint below.
   const orgSignedIn = orgSession.data?.signedIn === true;
   const providerReady =
-    (isCloud && cloudKeySet) ||
-    (isAdapter && orgSignedIn) ||
-    provider.data?.ai_provider === 'local' ||
-    (provider.data?.ai_provider === 'remote' && remoteUrlSet);
+    chatProviderReady(provider.data) || (isAdapter && orgSignedIn);
   const orgScopeActive = scopeFolderId === ORG_SHARED_SCOPE;
   const ready = providerReady || orgScopeActive;
 
@@ -241,14 +234,16 @@ export function Chat() {
               </span>
               {isLocalEngine && (
                 // Local/remote windows are smaller than cloud, so the backend
-                // caps the corpus to the most-recent notes. Disclose it so a
-                // local user knows the answer may not span their whole history.
+                // caps the corpus to the most-recent notes when it's over budget.
+                // "may omit" (not "omits") since a small library fits entirely.
+                // TODO: tie to the actual per-response cap (CHAT_SCOPE_CAPPED,
+                // descoped from WS3) so the hint only shows when truncation ran.
                 <span
                   data-testid="chat-local-scope-hint"
                   className="text-[12px]"
                   style={{ color: 'var(--fg-muted)' }}
                 >
-                  · covers recent notes
+                  · may omit older notes
                 </span>
               )}
             </div>

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -52,19 +52,24 @@ export function Chat() {
 
   const isCloud = provider.data?.ai_provider === 'cloud';
   const isAdapter = provider.data?.ai_provider === 'adapter';
+  const isLocalEngine =
+    provider.data?.ai_provider === 'local' || provider.data?.ai_provider === 'remote';
   const cloudKeySet = provider.data?.cloud_api_key_set ?? false;
-  // Org chat goes through the adapter's central key, so it doesn't need
-  // the local cloud provider configured. Adapter mode also works — the
-  // adapter brokers a cloud model server-side, fitting the same
-  // "remote-hosted model" requirement that cross-note chat needs.
-  // Critically: adapter mode is only "ready" when the org session is
-  // actually signed in. Without this, a user on ai_provider=adapter but
-  // signed out (e.g. session expired mid-app, restore not yet run) sees
-  // the chat input enabled and gets an opaque failure on submit.
+  const remoteUrlSet = !!provider.data?.remote_ollama_url;
+  // Which providers can answer cross-note chat:
+  //  - cloud needs its API key set; adapter needs an active org session
+  //    (a signed-out adapter user would otherwise get an opaque submit failure);
+  //  - local always works; remote needs its Ollama URL configured.
+  // Local/remote answer over a context-capped, most-recent slice of notes
+  // (the backend sizes the corpus to the model's window) — see the hint below.
   const orgSignedIn = orgSession.data?.signedIn === true;
-  const localReady = (isCloud && cloudKeySet) || (isAdapter && orgSignedIn);
+  const providerReady =
+    (isCloud && cloudKeySet) ||
+    (isAdapter && orgSignedIn) ||
+    provider.data?.ai_provider === 'local' ||
+    (provider.data?.ai_provider === 'remote' && remoteUrlSet);
   const orgScopeActive = scopeFolderId === ORG_SHARED_SCOPE;
-  const ready = localReady || orgScopeActive;
+  const ready = providerReady || orgScopeActive;
 
   // Recents = global-scope chats only (sessions started from THIS tab),
   // never the in-meeting AskBar history.
@@ -106,7 +111,7 @@ export function Chat() {
     // the adapter's centrally-managed key). Local chat still does.
     const isOrgScope = scopeFolderId === ORG_SHARED_SCOPE;
     if (!q || submittingRef.current) return;
-    if (!isOrgScope && !localReady) return;
+    if (!isOrgScope && !providerReady) return;
     submittingRef.current = true;
     setSubmitError(null);
     let createdSessionId: string | null = null;
@@ -174,7 +179,7 @@ export function Chat() {
           {greetingName ? `Hi ${greetingName}, ask anything` : 'Ask anything'}
         </h1>
 
-        {!localReady && !orgScopeActive && provider.isFetched && <CloudRequiredBanner />}
+        {!providerReady && !orgScopeActive && provider.isFetched && <ProviderRequiredBanner />}
         {submitError && (
           <div
             role="alert"
@@ -220,7 +225,7 @@ export function Chat() {
                   }
                 }}
                 disabled={!ready}
-                placeholder={ready ? 'Summarise my meetings this week  /' : 'Connect a cloud provider in Settings to ask across notes'}
+                placeholder={ready ? 'Summarise my meetings this week  /' : 'Set up an AI provider in Settings to ask across notes'}
                 className="block w-full bg-transparent px-2 pb-3 pt-1 outline-none disabled:cursor-not-allowed"
                 style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
               />
@@ -234,6 +239,18 @@ export function Chat() {
               >
                 {formatActiveModel(provider.data)}
               </span>
+              {isLocalEngine && (
+                // Local/remote windows are smaller than cloud, so the backend
+                // caps the corpus to the most-recent notes. Disclose it so a
+                // local user knows the answer may not span their whole history.
+                <span
+                  data-testid="chat-local-scope-hint"
+                  className="text-[12px]"
+                  style={{ color: 'var(--fg-muted)' }}
+                >
+                  · covers recent notes
+                </span>
+              )}
             </div>
             <div className="flex items-center gap-1">
               <button
@@ -398,7 +415,7 @@ export function consumePendingNewChat(sessionId: string): PendingNewChat | null 
   return out;
 }
 
-function CloudRequiredBanner() {
+function ProviderRequiredBanner() {
   return (
     <div
       className="mb-4 flex items-start gap-3 rounded-md border px-3 py-2.5 text-[13px]"
@@ -410,8 +427,8 @@ function CloudRequiredBanner() {
     >
       <Sparkles className="mt-0.5 size-[14px] flex-shrink-0" style={{ color: 'var(--fg-2)' }} />
       <div className="flex-1">
-        Cross-note chat needs a remote-hosted model — local models can't fit
-        a full-corpus prompt yet. Switch to Cloud API or your Organisation in{' '}
+        Your AI provider isn't ready for chat yet — add a cloud API key, sign in
+        to your Organisation, or set your remote Ollama URL in{' '}
         <button
           type="button"
           className="underline transition-colors hover:text-[color:var(--fg-1)]"

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -35,6 +35,7 @@ import {
   deriveSessionName,
   toBucketLabel,
   formatActiveModel,
+  chatProviderReady,
 } from '@/lib/chat';
 import { consumePendingNewChat } from '@/routes/Chat';
 import { renderMarkdown } from '@/lib/markdown';
@@ -62,17 +63,11 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const scrollRef = React.useRef<HTMLDivElement>(null);
 
-  const isCloud = provider.data?.ai_provider === 'cloud';
-  const cloudKeySet = provider.data?.cloud_api_key_set ?? false;
-  const remoteUrlSet = !!provider.data?.remote_ollama_url;
   const isLocalEngine =
     provider.data?.ai_provider === 'local' || provider.data?.ai_provider === 'remote';
-  // Local always works; remote needs its Ollama URL; cloud needs its key.
-  // Local/remote answer over a context-capped, most-recent slice (see hint).
-  const providerReady =
-    (isCloud && cloudKeySet) ||
-    provider.data?.ai_provider === 'local' ||
-    (provider.data?.ai_provider === 'remote' && remoteUrlSet);
+  // Shared cloud/local/remote readiness; local/remote answer over a
+  // context-capped, most-recent slice (see hint).
+  const providerReady = chatProviderReady(provider.data);
   // Org-scoped follow-ups go through the adapter and don't need the local
   // cloud provider configured — the cloud-key gate becomes irrelevant.
   const isOrgScope = (s: string | null | undefined) => s === ORG_SHARED_SCOPE;
@@ -491,7 +486,7 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
                   className="text-[12px]"
                   style={{ color: 'var(--fg-muted)' }}
                 >
-                  · covers recent notes
+                  · may omit older notes
                 </span>
               )}
             </div>

--- a/app/renderer/src/routes/ChatConversation.tsx
+++ b/app/renderer/src/routes/ChatConversation.tsx
@@ -64,11 +64,19 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
 
   const isCloud = provider.data?.ai_provider === 'cloud';
   const cloudKeySet = provider.data?.cloud_api_key_set ?? false;
-  const localReady = isCloud && cloudKeySet;
+  const remoteUrlSet = !!provider.data?.remote_ollama_url;
+  const isLocalEngine =
+    provider.data?.ai_provider === 'local' || provider.data?.ai_provider === 'remote';
+  // Local always works; remote needs its Ollama URL; cloud needs its key.
+  // Local/remote answer over a context-capped, most-recent slice (see hint).
+  const providerReady =
+    (isCloud && cloudKeySet) ||
+    provider.data?.ai_provider === 'local' ||
+    (provider.data?.ai_provider === 'remote' && remoteUrlSet);
   // Org-scoped follow-ups go through the adapter and don't need the local
   // cloud provider configured — the cloud-key gate becomes irrelevant.
   const isOrgScope = (s: string | null | undefined) => s === ORG_SHARED_SCOPE;
-  const ready = localReady || isOrgScope(scopeFolderId);
+  const ready = providerReady || isOrgScope(scopeFolderId);
 
   // Make THIS session the active one as soon as the route mounts so
   // chat.activeSession / chat.appendMessage operate on the right record
@@ -477,6 +485,15 @@ export function ChatConversation({ sessionId }: ChatConversationProps) {
               >
                 {formatActiveModel(provider.data)}
               </span>
+              {isLocalEngine && (
+                <span
+                  data-testid="chat-local-scope-hint"
+                  className="text-[12px]"
+                  style={{ color: 'var(--fg-muted)' }}
+                >
+                  · covers recent notes
+                </span>
+              )}
             </div>
             <div className="flex items-center gap-1">
               {isStreaming ? (

--- a/e2e/specs/chat-local-access.t1.spec.ts
+++ b/e2e/specs/chat-local-access.t1.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 — renderer-only, mock IPC. Pins WS3's renderer surface: cross-note chat is
+ * now usable with a LOCAL provider (was gated to cloud/adapter), and local/remote
+ * mode discloses that answers cover a context-capped, most-recent slice of notes.
+ * Wire shapes stubbed in app/e2e-mock-ipc.js; readiness logic in routes/Chat.tsx.
+ */
+
+const READY_PLACEHOLDER = 'Summarise my meetings this week  /';
+const NOT_READY_PLACEHOLDER = 'Set up an AI provider in Settings to ask across notes';
+const hint = '[data-testid="chat-local-scope-hint"]';
+
+test('local provider enables chat and discloses the recent-notes scope', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  // Default mock provider is 'local'.
+  await page.evaluate(() => {
+    window.location.hash = '#/chat';
+  });
+
+  // Input is enabled (ready) — the composer shows the active-state placeholder.
+  await expect(page.getByPlaceholder(READY_PLACEHOLDER)).toBeVisible();
+  // And the local-scope disclosure is shown.
+  await expect(page.locator(hint).first()).toBeVisible();
+});
+
+test('cloud without an API key keeps chat gated and shows no local-scope hint', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  // Switch to cloud (mock reports cloud_api_key_set:false) on a non-chat route,
+  // then mount Chat fresh so the provider query refetches.
+  await page.evaluate(() => {
+    window.location.hash = '#/settings';
+  });
+  await page.evaluate(() => (window as unknown as { stenoai: { ai: { setProvider: (p: string) => Promise<unknown> } } }).stenoai.ai.setProvider('cloud'));
+  await page.evaluate(() => {
+    window.location.hash = '#/chat';
+  });
+
+  // Not ready → the gated placeholder; no local-scope hint (cloud isn't capped).
+  await expect(page.getByPlaceholder(NOT_READY_PLACEHOLDER)).toBeVisible();
+  await expect(page.locator(hint)).toHaveCount(0);
+});

--- a/e2e/specs/chat-local.t2.spec.ts
+++ b/e2e/specs/chat-local.t2.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+
+/**
+ * T2 — cross-note chat with a LOCAL provider (WS3). Proves the hard cloud/adapter
+ * gate is gone: with ai_provider=local, chat_global_streaming assembles the local
+ * notes into a prompt and streams an answer via the capturing mock Ollama —
+ * NO real model. Pairs with the chat-corpus-budget unit test (cap sizing) and the
+ * chat-local-access T1 (renderer readiness).
+ */
+
+const ANSWER = 'Based on your notes, the team is shipping on Friday.';
+
+type StreamResult = { ok: boolean; text: string; error?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    query: { chatGlobalStream: (id: string, q: string, folder: string | null) => void };
+    subscribeQueryStream: (
+      id: string,
+      cbs: { onChunk: (c: string) => void; onDone: () => void; onError: (e: Error) => void },
+    ) => () => void;
+  };
+};
+
+test('local provider answers cross-note chat (no cloud/adapter required)', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  writeMeetingSummary(userDataDir, 'standup', {
+    name: 'Monday Standup',
+    summary: 'The team agreed to ship the release on Friday.',
+  });
+  writeMeetingSummary(userDataDir, 'budget', {
+    name: 'Budget Review',
+    summary: 'Quarterly budget is fifty thousand dollars.',
+  });
+
+  const ollama = await startMockOllama({ chatReply: ANSWER });
+  try {
+    const { page } = await launchApp();
+
+    const result: StreamResult = await page.evaluate(
+      (q) =>
+        new Promise<StreamResult>((resolve) => {
+          const id = 'e2e-chat-local';
+          let text = '';
+          const timer = setTimeout(
+            () => resolve({ ok: false, text, error: 'timeout' }),
+            25_000,
+          );
+          const w = window as unknown as StenoWindow;
+          w.stenoai.subscribeQueryStream(id, {
+            onChunk: (c) => {
+              text += c;
+            },
+            onDone: () => {
+              clearTimeout(timer);
+              resolve({ ok: true, text });
+            },
+            onError: (e) => {
+              clearTimeout(timer);
+              resolve({ ok: false, text, error: e.message });
+            },
+          });
+          w.stenoai.query.chatGlobalStream(id, q, null);
+        }),
+      'What are we shipping and when?',
+    );
+
+    // Not rejected (the old gate would have produced a CHAT_STREAM_ERROR
+    // "needs a cloud or organisation AI provider") and the mock reply streamed.
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain('shipping on Friday');
+
+    // The prompt the local model received embedded the assembled note corpus.
+    const prompt = ollama.lastChatPrompt();
+    expect(prompt).toBeTruthy();
+    expect(prompt).toContain('ship the release on Friday');
+    expect(prompt).toContain('Budget Review');
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2870,32 +2870,42 @@ def query_streaming(transcript_file, question):
         print(f"CHAT_STREAM_ERROR:{e}", flush=True)
 
 
+def _chat_corpus_char_budget(ai_provider: str, model: str) -> int:
+    """Char budget for the cross-note chat corpus, sized to the active model.
+
+    Cloud/adapter models have large windows (Anthropic 200k, recent OpenAI
+    128k+ tokens), so we use a generous fixed budget. Local/remote Ollama
+    windows are smaller, so we derive the budget from the model's num_ctx (the
+    same window the summariser requests) — a smaller local model then answers
+    over fewer, most-recent notes instead of overflowing. ~3.5 chars/token;
+    reserve ~45% of the window for the question, prompt scaffold and reply.
+    Pure function so it's unit-testable without notes or a model.
+    """
+    if ai_provider in ("local", "remote"):
+        from src.summarizer import resolve_num_ctx
+        return int(resolve_num_ctx(model) * 3.5 * 0.55)
+    return 400_000
+
+
 @cli.command(name='chat-global-streaming')
 @click.option('--question', '-q', required=True, help='Question to ask across notes')
 @click.option('--folder', '-f', default=None, help='Folder ID to scope the corpus to (default: all notes)')
 def chat_global_streaming(question, folder):
     """Cross-note chat: gather meeting title + summary + key points, feed as
-    context to the cloud LLM, stream the answer. Optionally scope to a single
-    folder; default queries every note.
+    context to the configured LLM, stream the answer. Optionally scope to a
+    single folder; default queries every note.
 
-    Requires a remote-hosted model — either a direct cloud API key OR a
-    signed-in organisation adapter that brokers one. Local models can't fit
-    a full corpus of summaries reliably and we don't have retrieval (RAG)
-    yet — caller (main.js) is responsible for gating accordingly."""
+    Works with every provider — cloud / org adapter / local / remote Ollama.
+    The assembled corpus is capped to the active model's context window
+    (model-aware budget below), so a local model with a smaller window simply
+    answers over fewer (most-recent) notes rather than overflowing. We don't
+    have retrieval (RAG) yet, so older notes beyond the budget are omitted."""
     import sys
     import base64
     from pathlib import Path
     from src.config import get_config, get_data_dirs
 
     config = get_config()
-    if config.get_ai_provider() not in ("cloud", "adapter"):
-        print(
-            "CHAT_STREAM_ERROR:Cross-note chat needs a cloud or organisation AI provider. "
-            "Switch in Settings → AI.",
-            flush=True,
-        )
-        return
-
     dirs = get_data_dirs()
     output_dir = dirs["output"]
 
@@ -2945,10 +2955,10 @@ def chat_global_streaming(question, folder):
     summaries.sort(key=sort_key, reverse=True)
 
     # Cap the assembled corpus so a user with hundreds of meetings can't blow
-    # past the cloud model's context window. ~400k chars ≈ 100k tokens, well
-    # under both Anthropic (200k) and recent OpenAI (128k+) limits while
-    # leaving headroom for the prompt scaffold and the model's reply.
-    CORPUS_CHAR_BUDGET = 400_000
+    # past the active model's context window (see _chat_corpus_char_budget).
+    CORPUS_CHAR_BUDGET = _chat_corpus_char_budget(
+        config.get_ai_provider(), config.get_model()
+    )
     blocks = []
     used_chars = 0
     truncated = 0

--- a/tests/test_chat_corpus_budget.py
+++ b/tests/test_chat_corpus_budget.py
@@ -1,0 +1,46 @@
+"""Tests for the cross-note chat corpus budget (_chat_corpus_char_budget).
+
+The budget caps how much note context is assembled for cross-note chat. Cloud/
+adapter get a generous fixed budget; local/remote are sized to the model's
+num_ctx so a smaller local window answers over fewer recent notes rather than
+overflowing (WS3). Pure function — no notes or model needed.
+"""
+
+import unittest
+
+from simple_recorder import _chat_corpus_char_budget
+from src.summarizer import resolve_num_ctx
+
+
+class ChatCorpusBudgetTests(unittest.TestCase):
+    def test_cloud_and_adapter_use_the_generous_fixed_budget(self):
+        self.assertEqual(_chat_corpus_char_budget("cloud", "gpt-4o"), 400_000)
+        self.assertEqual(_chat_corpus_char_budget("adapter", "adapter (org)"), 400_000)
+
+    def test_local_budget_is_derived_from_the_model_window(self):
+        expected = int(resolve_num_ctx("gemma4:e2b-it-qat") * 3.5 * 0.55)
+        self.assertEqual(_chat_corpus_char_budget("local", "gemma4:e2b-it-qat"), expected)
+
+    def test_remote_is_sized_like_local(self):
+        self.assertEqual(
+            _chat_corpus_char_budget("remote", "gemma4:e2b-it-qat"),
+            _chat_corpus_char_budget("local", "gemma4:e2b-it-qat"),
+        )
+
+    def test_local_budget_is_smaller_than_cloud(self):
+        # The whole point: a local window must not be handed the cloud-sized
+        # corpus, or it would overflow.
+        local = _chat_corpus_char_budget("local", "gemma4:e2b-it-qat")
+        cloud = _chat_corpus_char_budget("cloud", "gpt-4o")
+        self.assertLess(local, cloud)
+        self.assertGreater(local, 0)
+
+    def test_unknown_local_model_still_gets_a_sane_budget(self):
+        budget = _chat_corpus_char_budget("local", "some-future-model:7b")
+        # Falls back to the default num_ctx → a positive, sub-cloud budget.
+        self.assertGreater(budget, 0)
+        self.assertLess(budget, 400_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

WS3 of `plans/chat-models-and-default.md`: **open cross-note chat to local + remote Ollama** (it was hard-gated to cloud/adapter — *"Local models can't fit"*).

### Change
- **Backend (`chat_global_streaming`):** removed the cloud/adapter-only rejection. The assembled corpus is now sized to the active model's window via `_chat_corpus_char_budget`:
  - cloud/adapter keep the generous fixed budget (200k/128k+ windows),
  - local/remote derive from the model's `num_ctx` (the same window the summariser requests), so a smaller local model answers over fewer **most-recent** notes instead of overflowing. Older notes beyond budget are omitted (existing truncation + in-corpus note).
- **Renderer:** chat is now "ready" for local (always) and remote (URL set); a shared `chatProviderReady()` helper replaces the duplicated readiness logic in `Chat.tsx` + `ChatConversation.tsx`. The composer discloses **"· may omit older notes"** in local/remote mode, and the old cloud-only banner is reframed for any unready provider.

### Scope note
The disclosure is a **static** local-mode hint, not a per-response signal — the precise `CHAT_SCOPE_CAPPED` signal (only show when truncation actually ran) is descoped to a follow-up (breadcrumbed in code). Also noted: a *mid-stream* local Ollama failure currently surfaces as inline `[Error: …]` text rather than the error banner (the common Ollama-down case is caught at init → `CHAT_STREAM_ERROR`); not regressed by this PR, tracked as a follow-up.

### Tests (model-free)
- `tests/test_chat_corpus_budget.py` — budget helper (local < cloud, model-aware, sane unknown-model fallback).
- `e2e/specs/chat-local.t2.spec.ts` — drives `chat_global_streaming` with `ai_provider=local` through the mock Ollama: proves it's no longer rejected, the corpus embeds local notes, and the answer streams.
- `e2e/specs/chat-local-access.t1.spec.ts` — local enables chat + shows the scope hint; cloud-without-key stays gated.

### Verification
- Rebuilt the PyInstaller backend and ran the **full model-free T2 suite (26/26 green)** incl. `chat-local.t2`, plus all 9 T1. Renderer typecheck clean; 169 Python tests pass.

Reviewed via QA + senior-eng lenses (nothing critical/high); follow-ups applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cross-note chat now works with local and remote Ollama. The backend sizes the note corpus to the active model’s context window, the UI reflects provider readiness and scope, and a Windows streaming completion bug is fixed.

- **New Features**
  - Backend `chat_global_streaming`: removed the cloud/adapter-only gate. Added `_chat_corpus_char_budget` that keeps a generous fixed budget for cloud/adapter and derives a smaller, model-aware budget for local/remote from `num_ctx`; older notes beyond budget are omitted.
  - UI: added shared `chatProviderReady()` (used in `Chat.tsx` and `ChatConversation.tsx`) — local is always ready, remote requires its URL, cloud requires an API key; adapter also requires a signed-in org. Composer shows “· may omit older notes” in local/remote, and the banner now covers any unready provider.
  - IPC/mock: added `remote_ollama_url` to the mock provider payload; refreshed the `chat-global-stream` handler comment in `app/main.js`.
  - Tests: added `tests/test_chat_corpus_budget.py` plus e2e `chat-local-access.t1.spec.ts` and `chat-local.t2.spec.ts` to verify readiness, corpus assembly, and streaming without a real model.

- **Bug Fixes**
  - Windows: strip trailing CR from `chat-global-stream` lines so `CHAT_STREAM_COMPLETE` matches and streams finish correctly.

<sup>Written for commit 98584549a1d19072a565e2cf89edb77957e2c89b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

