### PR TITLE
fix(windows): CRLF-tolerant stdout parsing — unstick processing 'in analysis'

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1579,7 +1579,9 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
       proc.stdout.on('data', (data) => {
         watchdog.reset();
         const text = data.toString();
-        text.split('\n').forEach(line => {
+        // CRLF-tolerant: Windows stdout is \r\n; exact-match lines (STREAM_COMPLETE)
+        // would otherwise carry a trailing \r and never match.
+        text.split(/\r?\n/).forEach(line => {
           if (line.startsWith('CHUNK:')) {
             try {
               const encoded = line.slice(6);
@@ -1781,7 +1783,9 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
   let chunkCount = 0;
   proc.stdout.on('data', (data) => {
     buf += data.toString();
-    const lines = buf.split('\n');
+    // Split on CRLF or LF: the backend's stdout is \r\n on Windows, and an exact
+    // match below (=== 'STREAM_COMPLETE') would otherwise miss the trailing \r.
+    const lines = buf.split(/\r?\n/);
     buf = lines.pop();
     for (const line of lines) {
       if (line.startsWith('CHAT_CHUNK:') || line.startsWith('CHUNK:')) {
@@ -2907,8 +2911,9 @@ async function processNextInQueue() {
       proc.stdout.on('data', (data) => {
         watchdog.reset();
         const text = data.toString();
-        // Parse protocol lines
-        text.split('\n').forEach(line => {
+        // Parse protocol lines (CRLF-tolerant: Windows stdout is \r\n, and the
+        // STREAM_COMPLETE exact-match below must not carry a trailing \r).
+        text.split(/\r?\n/).forEach(line => {
           if (line.startsWith('CHUNK:')) {
             try {
               const encoded = line.slice(6);
@@ -3188,8 +3193,9 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
       }
       console.log('Recording stdout:', output);
 
-      // Parse streaming protocol + send to debug panel
-      output.split('\n').forEach(line => {
+      // Parse streaming protocol + send to debug panel (CRLF-tolerant: Windows
+      // stdout is \r\n, so the STREAM_COMPLETE exact-match must not see a \r).
+      output.split(/\r?\n/).forEach(line => {
         if (line.startsWith('CHUNK:')) {
           const encoded = line.slice(6);
           try {

--- a/e2e/specs/summarize-contract.t2.spec.ts
+++ b/e2e/specs/summarize-contract.t2.spec.ts
@@ -44,6 +44,9 @@ type StenoWindow = Window & {
     meetings: {
       reprocess: (summaryFile: string, regenTitle: boolean, name: string) => Promise<ReprocessResult>;
     };
+    on: {
+      summaryComplete: (cb: (e: { success: boolean }) => void) => () => void;
+    };
   };
 };
 
@@ -104,6 +107,49 @@ test('@contract reprocess builds a transcript-bearing prompt and parses the repl
 
     // Keystone: the real user-data dir is byte-for-byte untouched.
     expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});
+
+test('@contract reprocess fires the summary-complete event (Windows CRLF completion guard)', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // The summary streaming UI finalises on the `summary-complete` event, which
+  // main.js emits when it sees the exact line `STREAM_COMPLETE`. On Windows the
+  // backend's stdout is \r\n, so an exact match must tolerate a trailing \r —
+  // otherwise the event never fires and the UI is stuck "in analysis". This
+  // asserts the event actually arrives (regression guard for that fix).
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  const summaryFile = writeMeetingSummary(userDataDir, 'complete-event', {
+    name: 'Complete Event Meeting',
+    summary: 'stale',
+    transcript: TRANSCRIPT,
+  });
+
+  const ollama = await startMockOllama({ chatReply: FIXED_REPLY });
+  try {
+    const { page } = await launchApp();
+
+    const completed: boolean = await page.evaluate(
+      (f) =>
+        new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(false), 25_000);
+          const w = window as unknown as StenoWindow;
+          const off = w.stenoai.on.summaryComplete((e) => {
+            if (e && e.success) {
+              clearTimeout(timer);
+              off();
+              resolve(true);
+            }
+          });
+          w.stenoai.meetings.reprocess(f, false, 'Complete Event Meeting');
+        }),
+      summaryFile,
+    );
+
+    expect(completed).toBe(true);
   } finally {
     await ollama.close();
   }

--- a/e2e/specs/summarize-contract.t2.spec.ts
+++ b/e2e/specs/summarize-contract.t2.spec.ts
@@ -121,6 +121,8 @@ test('@contract reprocess fires the summary-complete event (Windows CRLF complet
   // backend's stdout is \r\n, so an exact match must tolerate a trailing \r —
   // otherwise the event never fires and the UI is stuck "in analysis". This
   // asserts the event actually arrives (regression guard for that fix).
+  // Content-agnostic: it only checks that completion fires (e.success), so it's
+  // unaffected by tuning the shared FIXED_REPLY/TRANSCRIPT constants above.
   writeUserConfig(userDataDir, { ai_provider: 'local' });
   const summaryFile = writeMeetingSummary(userDataDir, 'complete-event', {
     name: 'Complete Event Meeting',

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -28,10 +28,15 @@ from typing import Optional
 
 # Force UTF-8 on stdout/stderr so emoji and non-ASCII prints don't crash under
 # Windows' default cp1252 codepage. Must run before any print() in this module.
+# newline="\n" disables Windows' \n -> \r\n translation: the Electron host parses
+# our streaming protocol line-by-line and matches exact sentinels (e.g.
+# STREAM_COMPLETE); a translated trailing \r would make those exact matches fail
+# and strand the UI "in analysis". (main.js also splits CRLF-tolerantly as a
+# belt-and-suspenders, but fixing it at the source covers every sentinel.)
 if sys.platform == "win32":
     try:
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace", newline="\n")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace", newline="\n")
     except (AttributeError, OSError):
         pass
 


### PR DESCRIPTION
## What

Fixes meetings getting **stuck "in analysis" on Windows**.

### Root cause
`app/main.js` matched the streaming completion sentinel by exact equality (`line === 'STREAM_COMPLETE'`) in **four** stdout handlers:
- reprocess (`:1596`), in-meeting transcript query (`:1800`), the main record→transcribe→summarise pipeline (`:2928`), and live record (`:3206`).

On Windows the backend's stdout is `\r\n`. The handlers split on `\n`, leaving `"STREAM_COMPLETE\r"`, so the exact match failed and `summary-complete` was **never emitted** → the summary UI sat stuck "in analysis". (The main Processing screen still advanced via the CR-safe `proc.on('close')` path, but the streaming summary view never finalised.)

This is the same `\r\n` bug class fixed for the chat stream in #220 — these four handlers weren't covered then.

### Fix
Split those handlers on `/\r?\n/` (CRLF-tolerant). Identical behaviour on macOS (LF-only); correct on Windows. The other stdout handlers use `startsWith(...)` markers (`SAVED:`, `CHUNK:`, `LIVE_SEG:`, …) which already tolerate a trailing `\r`, so no exact-match completion sentinel remains broken.

### Not a 0.5.4 regression
These handlers are byte-unchanged across `v0.5.3..v0.5.4`. The bug pre-dates both — 0.5.4's `getUserDataDir()` path fix (#201) just unblocked the Windows pipeline far enough to *reach* the analysis stage where this stall lives.

### Test
`summarize-contract.t2` now asserts the **`summary-complete` event** fires through `reprocess` (the existing test only checked the written file, which completes via the CR-safe `SAVED:`/close path and so couldn't catch this). It runs in the model-free T2 lane on **Windows + macOS** — without this fix it fails on the Windows runner.

Verified locally on macOS (both contract tests green). Windows CI is the real proof.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows streams getting stuck “in analysis” by standardizing backend stdout to LF and making parsing CRLF‑tolerant so `STREAM_COMPLETE` is detected and `summary-complete` fires.

- **Bug Fixes**
  - In `app/main.js`, split stdout on `/\r?\n/` in four handlers (reprocess, in‑meeting transcript query, main pipeline, live record) so exact `STREAM_COMPLETE` matches work on Windows.
  - In `simple_recorder.py` (Windows), reconfigure `sys.stdout`/`sys.stderr` with `newline="\n"` to stop `\n`→`\r\n` translation; covers current and future sentinels (JS splits stay as defense‑in‑depth).
  - Prevents stalled summary UI on Windows; macOS behavior is unchanged.
  - Added an e2e test in `e2e/specs/summarize-contract.t2.spec.ts` asserting the `summary-complete` event during reprocess on Windows and macOS.

<sup>Written for commit 9abbb155cd66bcb657e503110a75b13cef2b83db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

