### PR TITLE
feat: persist processing/transcription logs to disk (#208)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -2728,6 +2728,7 @@ async function processNextInQueue() {
         // Parse protocol lines (CRLF-tolerant: Windows stdout is \r\n, and the
         // STREAM_COMPLETE exact-match below must not carry a trailing \r).
         text.split(/\r?\n/).forEach(line => {
+          logPipelineStdoutLine(line);
           if (line.startsWith('CHUNK:')) {
             try {
               const encoded = line.slice(6);
@@ -3909,6 +3910,30 @@ function attachProcessingStderr(proc, label) {
     if (buf.trim()) processingLog.logLine(label, buf);
     buf = '';
   });
+}
+
+// Persist only an allowlist of pipeline stdout protocol events. Excludes
+// CHUNK/CHAT_CHUNK/TITLE/LIVE_SEG and any free-text/query answer (privacy).
+// HEARTBEAT is throttled to once per 10s so a long transcription doesn't flood.
+let lastHeartbeatLoggedAt = 0;
+function logPipelineStdoutLine(line) {
+  const l = line.trim();
+  if (!l) return;
+  if (l.startsWith('HEARTBEAT')) {
+    const now = Date.now();
+    if (now - lastHeartbeatLoggedAt < 10_000) return;
+    lastHeartbeatLoggedAt = now;
+    processingLog.logLine('pipeline', l);
+    return;
+  }
+  if (
+    l.startsWith('TRANSCRIPTION_COMPLETE') ||
+    l.startsWith('TRANSCRIPTION_FAILED') ||
+    l.startsWith('SAVED:') ||
+    l === 'STREAM_COMPLETE'
+  ) {
+    processingLog.logLine('pipeline', l);
+  }
 }
 
 ipcMain.handle('setup-ollama-and-model', async () => {

--- a/app/main.js
+++ b/app/main.js
@@ -35,6 +35,7 @@ if (process.platform !== 'darwin') {
 
 const path = require('path');
 const { spawn: _spawnRaw, exec } = require('child_process');
+const processingLog = require('./processing-log');
 
 // Wrap spawn so every backend / ollama launch defaults to windowsHide:true.
 // The PyInstaller backend (stenoai.exe) and bundled ollama.exe are console
@@ -1016,6 +1017,16 @@ if (!gotSingleInstanceLock) {
   });
 
   app.whenReady().then(async () => {
+    // Persistent diagnostic log under <userData>/logs (honors
+    // STENOAI_USER_DATA_DIR via getUserDataDir, so e2e/tests stay isolated).
+    // The startup marker is a stable anchor that separates sessions.
+    try {
+      processingLog.init({ dir: path.join(getUserDataDir(), 'logs') });
+      processingLog.logLine('app', `startup v${app.getVersion()} platform=${process.platform}`);
+    } catch (e) {
+      console.warn('processing-log init failed (non-fatal):', e?.message);
+    }
+
     // Application menu. macOS uses the global menu bar with mac-only roles
     // (services/hide/unhide). Windows/Linux get a slimmer, platform-correct
     // menu — kept (editing accelerators, Settings, Help) but hidden by default

--- a/app/main.js
+++ b/app/main.js
@@ -1349,7 +1349,7 @@ ipcMain.handle('get-system-audio-support', async () => {
 // Debug functionality handled by side panel now
 
 // Backend communication - always uses bundled stenoai executable
-function runPythonScript(script, args = [], silent = false, extraEnv = {}) {
+function runPythonScript(script, args = [], silent = false, extraEnv = {}, logLabel = null) {
   return new Promise((resolve, reject) => {
     const backendPath = getBackendPath();
 
@@ -1363,6 +1363,11 @@ function runPythonScript(script, args = [], silent = false, extraEnv = {}) {
       cwd: getBackendCwd(),
       env: Object.keys(extraEnv).length > 0 ? { ...require('process').env, ...extraEnv } : undefined
     });
+
+    // Opt-in persistent capture for the legacy process-recording path only.
+    // Default null → generic backend calls (config reads, chat query, …) are
+    // NOT persisted, preserving the no-global-tee privacy boundary.
+    if (logLabel) attachProcessingStderr(process, logLabel);
 
     let stdout = '';
     let stderr = '';
@@ -1442,7 +1447,7 @@ ipcMain.handle('get-status', handleGetStatus);
 ipcMain.handle('process-recording', async (event, audioFile, sessionName) => {
   try {
     const env = getAiEnv();
-    const result = await runPythonScript('simple_recorder.py', ['process', audioFile, '--name', sessionName], false, env);
+    const result = await runPythonScript('simple_recorder.py', ['process', audioFile, '--name', sessionName], false, env, 'process-recording');
     trackEvent('transcription_completed', { success: true });
     trackEvent('summarization_completed', { success: true });
     return { success: true, result: result };
@@ -2331,6 +2336,8 @@ function spawnLiveTranscribe(sessionName) {
     sendDebugLog(`[live-transcribe] ${data.toString().trim()}`);
   });
 
+  attachProcessingStderr(liveTranscribeProcess, 'live-transcribe');
+
   liveTranscribeProcess.on('exit', (code, signal) => {
     sendDebugLog(`Live transcribe sidecar exited code=${code} signal=${signal}`);
     liveTranscribeProcess = null;
@@ -2772,6 +2779,8 @@ async function processNextInQueue() {
           sendDebugLog(`STDERR: ${msg}`);
         }
       });
+
+      attachProcessingStderr(proc, 'process-streaming');
 
       proc.on('close', (code) => {
         watchdog.clear();
@@ -3877,6 +3886,29 @@ function sendDebugLog(message) {
   if (mainWindow) {
     mainWindow.webContents.send('debug-log', message);
   }
+}
+
+// Feed a child process's stderr into the persistent processing log, one record
+// per complete line. Node 'data' events deliver arbitrary chunks (not lines),
+// so we keep a residual buffer and flush the remainder on close. Additive: this
+// does NOT replace the existing per-pipeline sendDebugLog calls (renderer panel)
+// — it persists the same low-PII backend logger output to disk alongside them.
+function attachProcessingStderr(proc, label) {
+  if (!proc || !proc.stderr) return;
+  let buf = '';
+  proc.stderr.on('data', (data) => {
+    buf += data.toString();
+    let nl;
+    while ((nl = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      if (line.trim()) processingLog.logLine(label, line);
+    }
+  });
+  proc.on('close', () => {
+    if (buf.trim()) processingLog.logLine(label, buf);
+    buf = '';
+  });
 }
 
 ipcMain.handle('setup-ollama-and-model', async () => {

--- a/app/main.js
+++ b/app/main.js
@@ -2728,7 +2728,7 @@ async function processNextInQueue() {
         // Parse protocol lines (CRLF-tolerant: Windows stdout is \r\n, and the
         // STREAM_COMPLETE exact-match below must not carry a trailing \r).
         text.split(/\r?\n/).forEach(line => {
-          logPipelineStdoutLine(line);
+          logPipelineStdoutLine(line, 'process-streaming');
           if (line.startsWith('CHUNK:')) {
             try {
               const encoded = line.slice(6);
@@ -3894,6 +3894,7 @@ function sendDebugLog(message) {
 // so we keep a residual buffer and flush the remainder on close. Additive: this
 // does NOT replace the existing per-pipeline sendDebugLog calls (renderer panel)
 // — it persists the same low-PII backend logger output to disk alongside them.
+const STDERR_BUF_CAP = 64 * 1024; // flush a newline-less stream so buf can't grow unbounded
 function attachProcessingStderr(proc, label) {
   if (!proc || !proc.stderr) return;
   let buf = '';
@@ -3905,6 +3906,13 @@ function attachProcessingStderr(proc, label) {
       buf = buf.slice(nl + 1);
       if (line.trim()) processingLog.logLine(label, line);
     }
+    // Flood guard: a backend that emits stderr without newlines (e.g. \r-based
+    // progress) would grow buf unboundedly. Flush the residual as one record
+    // (processing-log truncates it to its own per-line cap) and reset.
+    if (buf.length > STDERR_BUF_CAP) {
+      if (buf.trim()) processingLog.logLine(label, buf);
+      buf = '';
+    }
   });
   proc.on('close', () => {
     if (buf.trim()) processingLog.logLine(label, buf);
@@ -3914,16 +3922,18 @@ function attachProcessingStderr(proc, label) {
 
 // Persist only an allowlist of pipeline stdout protocol events. Excludes
 // CHUNK/CHAT_CHUNK/TITLE/LIVE_SEG and any free-text/query answer (privacy).
-// HEARTBEAT is throttled to once per 10s so a long transcription doesn't flood.
-let lastHeartbeatLoggedAt = 0;
-function logPipelineStdoutLine(line) {
+// HEARTBEAT is throttled to once per 10s, keyed per source so concurrent
+// pipelines (e.g. a queued process-streaming run during a live record) don't
+// mask each other's heartbeats. Records are logged under the source label.
+const lastHeartbeatLoggedAt = new Map();
+function logPipelineStdoutLine(line, source) {
   const l = line.trim();
   if (!l) return;
   if (l.startsWith('HEARTBEAT')) {
     const now = Date.now();
-    if (now - lastHeartbeatLoggedAt < 10_000) return;
-    lastHeartbeatLoggedAt = now;
-    processingLog.logLine('pipeline', l);
+    if (now - (lastHeartbeatLoggedAt.get(source) || 0) < 10_000) return;
+    lastHeartbeatLoggedAt.set(source, now);
+    processingLog.logLine(source, l);
     return;
   }
   if (
@@ -3932,7 +3942,7 @@ function logPipelineStdoutLine(line) {
     l.startsWith('SAVED:') ||
     l === 'STREAM_COMPLETE'
   ) {
-    processingLog.logLine('pipeline', l);
+    processingLog.logLine(source, l);
   }
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
+    "test:unit": "node --test processing-log.test.js",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/processing-log.js
+++ b/app/processing-log.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// Append-only, byte-counted, size-rotated diagnostic log. Pure fs/path (no
+// Electron imports) so it is unit-testable in plain Node and the target dir is
+// injected. Never throws to callers: every fs op is best-effort with a short
+// cooldown after a failure so a persistent problem (locked file, full disk, AV
+// scanner) doesn't cost a throw on every subsequent line. See spec
+// docs/superpowers/specs/2026-06-19-processing-log-design.md.
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_BYTES = 5 * 1024 * 1024; // rotate at 5 MiB → net ≈ 10 MiB across 2 files
+const LINE_CAP_BYTES = 8 * 1024; // truncate any single record to 8 KiB
+const COOLDOWN_MS = 30 * 1000; // pause writes this long after an fs failure
+
+let targetDir = null;
+let logPath = null;
+let backupPath = null;
+let bytes = 0; // running byte total of the current file
+let disabledUntil = 0; // epoch ms; writes are skipped until then
+
+function _reset() {
+  targetDir = null;
+  logPath = null;
+  backupPath = null;
+  bytes = 0;
+  disabledUntil = 0;
+}
+
+function init({ dir }) {
+  targetDir = dir;
+  logPath = path.join(dir, 'processing.log');
+  backupPath = path.join(dir, 'processing.log.1');
+  // Seed the byte counter from any existing file (once), so we don't lose the
+  // bound across restarts.
+  try {
+    bytes = fs.statSync(logPath).size;
+  } catch {
+    bytes = 0;
+  }
+}
+
+function disabled() {
+  return Date.now() < disabledUntil;
+}
+
+function backoff() {
+  disabledUntil = Date.now() + COOLDOWN_MS;
+}
+
+function ensureDir() {
+  fs.mkdirSync(targetDir, { recursive: true });
+}
+
+function rotate() {
+  // Windows renameSync fails if the target exists → pre-unlink the backup.
+  try {
+    fs.unlinkSync(backupPath);
+  } catch {
+    // no existing backup — fine
+  }
+  fs.renameSync(logPath, backupPath); // may throw → caller backs off
+  bytes = 0;
+}
+
+function formatRecord(label, message) {
+  let body = String(message);
+  // Truncate by bytes so multi-byte content can't blow the cap.
+  if (Buffer.byteLength(body, 'utf8') > LINE_CAP_BYTES) {
+    // Slice generously by chars then hard-trim by bytes.
+    body = body.slice(0, LINE_CAP_BYTES);
+    while (Buffer.byteLength(body, 'utf8') > LINE_CAP_BYTES - 32) {
+      body = body.slice(0, -16);
+    }
+    body += '…(truncated)';
+  }
+  return `[${new Date().toISOString()}] [${label}] ${body}\n`;
+}
+
+function writeRecord(record) {
+  const lineBytes = Buffer.byteLength(record, 'utf8');
+  if (bytes + lineBytes >= MAX_BYTES) {
+    rotate();
+  }
+  fs.appendFileSync(logPath, record);
+  bytes += lineBytes;
+}
+
+function logLine(label, message) {
+  if (!logPath || disabled()) return;
+  try {
+    ensureDir();
+    // One record per physical line in the message.
+    const parts = String(message).split('\n');
+    for (const part of parts) {
+      writeRecord(formatRecord(label, part));
+    }
+  } catch {
+    backoff();
+  }
+}
+
+module.exports = { init, logLine, _reset };

--- a/app/processing-log.test.js
+++ b/app/processing-log.test.js
@@ -1,0 +1,104 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const log = require('./processing-log');
+
+let dir;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plog-'));
+  log._reset();
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function readLog() {
+  return fs.readFileSync(path.join(dir, 'processing.log'), 'utf8');
+}
+
+test('logLine writes an ISO-timestamped, labelled record', () => {
+  log.init({ dir });
+  log.logLine('app', 'hello world');
+  const content = readLog();
+  assert.match(content, /^\[\d{4}-\d{2}-\d{2}T[\d:.]+Z\] \[app\] hello world\n$/);
+});
+
+test('a multi-line message becomes one record per line', () => {
+  log.init({ dir });
+  log.logLine('pipeline', 'line one\nline two');
+  const lines = readLog().trimEnd().split('\n');
+  assert.strictEqual(lines.length, 2);
+  assert.match(lines[0], /\[pipeline\] line one$/);
+  assert.match(lines[1], /\[pipeline\] line two$/);
+});
+
+test('an oversized line is truncated to the 8 KiB cap with a marker', () => {
+  log.init({ dir });
+  const huge = 'x'.repeat(20000);
+  log.logLine('pipeline', huge);
+  const written = readLog();
+  assert.ok(written.includes('…(truncated)'));
+  // The record (one line) must not exceed cap + prefix + marker + newline budget.
+  assert.ok(Buffer.byteLength(written, 'utf8') < 9000);
+});
+
+test('rotation triggers at the 5 MiB boundary and creates a single backup', () => {
+  log.init({ dir });
+  // Each line is ~1 KiB; write enough to cross 5 MiB. Margin (+60) generously
+  // absorbs the per-record prefix overhead so the boundary is always crossed.
+  const kib = 'y'.repeat(1024 - 40); // leave room for prefix/newline
+  const linesNeeded = Math.ceil((5 * 1024 * 1024) / 1024) + 60;
+  for (let i = 0; i < linesNeeded; i++) log.logLine('x', kib);
+  assert.ok(fs.existsSync(path.join(dir, 'processing.log.1')), 'backup exists');
+  // Current log was reset after rotation, so it is well under 5 MiB.
+  const curSize = fs.statSync(path.join(dir, 'processing.log')).size;
+  assert.ok(curSize < 5 * 1024 * 1024, 'current log reset after rotation');
+});
+
+test('byte counting is UTF-8 aware (multi-byte near the edge)', () => {
+  log.init({ dir });
+  // '€' is 3 bytes in UTF-8; a naive .length count would under-count and overshoot 5 MiB.
+  const euros = '€'.repeat(300); // 900 bytes
+  const linesNeeded = Math.ceil((5 * 1024 * 1024) / 900) + 10;
+  for (let i = 0; i < linesNeeded; i++) log.logLine('x', euros);
+  assert.ok(fs.existsSync(path.join(dir, 'processing.log.1')), 'rotated using byte count');
+});
+
+test('rotation overwrites an existing .1 backup (Windows rename safety)', () => {
+  fs.writeFileSync(path.join(dir, 'processing.log.1'), 'STALE BACKUP');
+  log.init({ dir });
+  const big = 'z'.repeat(1024 - 40);
+  const linesNeeded = Math.ceil((5 * 1024 * 1024) / 1024) + 60;
+  for (let i = 0; i < linesNeeded; i++) log.logLine('x', big);
+  const backup = fs.readFileSync(path.join(dir, 'processing.log.1'), 'utf8');
+  assert.ok(!backup.includes('STALE BACKUP'), 'stale backup was replaced');
+});
+
+test('a rename failure degrades quietly and backs off (no throw per line)', () => {
+  log.init({ dir });
+  // Force rotation to fail by making renameSync throw.
+  const realRename = fs.renameSync;
+  let renameCalls = 0;
+  fs.renameSync = () => { renameCalls++; throw Object.assign(new Error('EPERM'), { code: 'EPERM' }); };
+  try {
+    const big = 'q'.repeat(1024 - 40);
+    const linesNeeded = Math.ceil((5 * 1024 * 1024) / 1024) + 60;
+    // Must not throw.
+    assert.doesNotThrow(() => {
+      for (let i = 0; i < linesNeeded; i++) log.logLine('x', big);
+    });
+    // Backoff: after the first failed rotation it stops hammering renameSync.
+    assert.ok(renameCalls <= 2, `renameSync called ${renameCalls}x — backoff not engaged`);
+  } finally {
+    fs.renameSync = realRename;
+  }
+});
+
+test('logLine before init is a no-op (never throws)', () => {
+  assert.doesNotThrow(() => log.logLine('app', 'dropped'));
+});

--- a/e2e/specs/processing-log.t1.spec.ts
+++ b/e2e/specs/processing-log.t1.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '../fixtures/electron';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * T1 — renderer-only, mock IPC, no backend build. main.js still runs, so the
+ * processing-log init + startup marker execute. Asserts the disk sink is wired
+ * without coupling to volatile auto-updater/protocol lines.
+ */
+test('writes a processing.log with an [app] startup marker', async ({ launchApp, userDataDir }) => {
+  await launchApp({ mockIpc: true });
+
+  const logPath = path.join(userDataDir, 'logs', 'processing.log');
+
+  await expect
+    .poll(() => fs.existsSync(logPath), { timeout: 10_000 })
+    .toBe(true);
+
+  const content = fs.readFileSync(logPath, 'utf8');
+  expect(content).toMatch(/\[app\] startup/);
+});

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -435,6 +435,11 @@ class WhisperTranscriber:
         else:
             self.backend = "whisper.cpp"
             self._load_whisper_cpp()
+        fallback = (self.backend == "whisper.cpp") != (requested == "whisper")
+        logger.info(
+            "ASR engine selected: requested=%s using=%s fallback=%s",
+            requested, self.backend, fallback,
+        )
         self._ensure_ffmpeg_in_path()
 
     def _load_whisper_cpp(self) -> None:


### PR DESCRIPTION
Closes #208.

## What & why

There's no persistent log of the recording/transcription pipeline today: `sendDebugLog()` only reaches the renderer and is gone on the next view update or restart, and the backend's diagnostic stderr (engine, ffmpeg resolution, per-channel RMS gate, transcript lengths, swallowed exceptions) is buffered in `stderrBuf` and discarded on success. So when transcription fails transiently (e.g. #207 — a meeting saved as "No speech detected" despite a working live transcript) there's no on-disk trail. This adds a bounded, rotating on-disk log under `<userData>/logs/processing.log` capturing that diagnostic data — the prerequisite for diagnosing #207.

## Design — a deliberate allowlist, not a global tee

The key decision: **not** tee'ing every `sendDebugLog` to disk. That would be a privacy regression — `sendDebugLog` carries session/meeting titles, file paths, and (via `runPythonScript`'s non-silent stdout) potentially query answers. Instead we persist only:

- **Backend stderr** — the diagnostic goldmine and low-PII: Python `logging` status lines (RMS, channel split, lengths, "empty text" warnings), not transcript content. Captured via a shared `attachProcessingStderr(proc, label)` helper with a real line buffer (Node `data` events deliver chunks, not lines) + flush-on-close, attached to the live-transcribe, process-streaming, and mic-record pipelines.
- **An allowlist of stdout protocol events**: `TRANSCRIPTION_COMPLETE`, `TRANSCRIPTION_FAILED`, `SAVED:`, `STREAM_COMPLETE`, and a throttled `HEARTBEAT`. Explicitly excludes `CHUNK`, `CHAT_CHUNK`, `TITLE`, `LIVE_SEG`, and any free text / query answer.
- **One startup marker** (`[app] startup …`) as a stable per-session anchor.
- **One `logger.info` line** in `transcriber.py` recording the chosen ASR engine + whether it's a fallback — the single highest-value field for #207, and the only backend change.

The log module (`app/processing-log.js`) is self-contained (pure `fs`/`path`, no Electron imports), byte-counted rotation at 5 MiB with one backup (≈10 MiB cap), Windows-safe (pre-unlink before rename), best-effort with backoff (never throws to callers), 8 KiB per-line cap. Path resolves via the existing `getUserDataDir()` so it honors `STENOAI_USER_DATA_DIR` (e2e/test isolation) and is correct on macOS + Windows. No IPC channel added or changed.

## One thing for reviewer attention

The legacy `process-recording` path runs through the shared `runPythonScript()` helper (it has no standalone spawn). Rather than duplicate that helper's ~50 lines of spawn/stdout/stderr/close handling just to attach the sink, I added a single opt-in `logLabel` parameter to `runPythonScript` defaulting to `null` — only the `process-recording` call sets it. Logging stays non-generic (default off; every other caller — config reads, chat query, etc. — is unaffected and unpersisted), which preserves the no-global-tee privacy boundary. Happy to refactor if you'd prefer a dedicated spawn there instead.

## Testing

- **Unit** (`node --test`, no new deps): 8 tests for `processing-log.js` — format, multi-line splitting, 8 KiB truncation, 5 MiB rotation boundary + single backup, UTF-8-aware byte counting, stale-backup overwrite (Windows), rename-failure degrade+backoff, pre-init no-op. New `npm run test:unit` script.
- **e2e T1** (`processing-log.t1`, mock-IPC, no backend build): asserts the disk sink is wired (`logs/processing.log` + `[app] startup`).
- The backend-stderr capture + the engine line are exercised by the existing `@pipeline` T2 lane (verified locally: `transcription-pipeline.t2` + `honest-failure.t2` green on the real parakeet pipeline).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rotating on-disk processing/transcription log to diagnose pipeline failures without the renderer. Captures backend stderr and a small allowlist of pipeline events while avoiding transcript content.

- **New Features**
  - Writes `<userData>/logs/processing.log` with 5 MiB rotation (single backup) and 8 KiB per-line cap; best-effort with backoff and Windows-safe.
  - Captures backend stderr for `live-transcribe`, `process-streaming`, and legacy `process-recording` via opt-in `runPythonScript(..., logLabel)`.
  - Allowlists stdout events: `TRANSCRIPTION_COMPLETE`, `TRANSCRIPTION_FAILED`, `SAVED:`, and `STREAM_COMPLETE`.
  - Adds a per-session `[app] startup …` marker; backend logs the selected ASR engine and whether it’s a fallback.

- **Bug Fixes**
  - Throttle `HEARTBEAT` per source (10s) so concurrent pipelines don’t mask each other; log under each source label.
  - Cap and flush newline-less stderr buffers at 64 KiB to prevent unbounded growth.

<sup>Written for commit 55ca1bbcf8c09d4d72d3fe8c15c9f05befa7f5e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

