### PR TITLE
feat(recording): cut over to the renderer path, retire Python mic subprocess (PR2/3)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -963,22 +963,15 @@ if (!gotSingleInstanceLock) {
   app.on('before-quit', async (event) => {
     if (isQuitting) return;
 
-    // Use synchronous flag -- systemAudioRecordingActive is updated via IPC on each state change
-    if (currentRecordingProcess || systemAudioRecordingActive) {
+    // Synchronous flag — systemAudioRecordingActive is updated via IPC on each
+    // state change. Capture is renderer-driven on every platform now.
+    if (systemAudioRecordingActive) {
       event.preventDefault();
       const confirmed = await showCustomQuitDialog('recording');
       if (confirmed) {
-        if (currentRecordingProcess) {
-          currentRecordingProcess.kill('SIGTERM');
-          currentRecordingProcess = null;
-          currentRecordingSessionName = null;
-          // Intentionally do NOT clear the sidecar here. SIGTERM is async;
-          // if the subprocess doesn't honour it before Electron exits, we
-          // need the sidecar to survive so the next launch can detect and
-          // reap the orphan. The 'close' event handler clears the sidecar
-          // when the process actually exits — that's the right moment.
-        }
-        if (systemAudioRecordingActive && mainWindow && !mainWindow.isDestroyed()) {
+        // Ask the renderer to finalise its WebM (incremental file is already on
+        // disk) and queue processing before we exit — best-effort.
+        if (mainWindow && !mainWindow.isDestroyed()) {
           try {
             await mainWindow.webContents.executeJavaScript('stopSystemAudioRecording("quit")');
           } catch (e) {
@@ -1092,15 +1085,6 @@ if (!gotSingleInstanceLock) {
       }
     }
 
-    // Reap any orphan recording subprocess left over from a prior crash
-    // before creating the window. We don't want to surface "Recording in
-    // progress" UI while the prior orphan still holds the mic / writes to
-    // disk. Failures here are non-fatal — the helper logs and returns.
-    try {
-      await cleanupOrphanRecording();
-    } catch (e) {
-      sendDebugLog(`[orphan-cleanup] unexpected error during startup cleanup: ${e.message}`);
-    }
 
     // Dev runs otherwise show the default Electron dock icon. Packaged builds
     // already get this icon via electron-builder's `mac.icon` setting.
@@ -2499,27 +2483,8 @@ function stopLiveTranscribe() {
   }, 5000);
 }
 
-function loadSystemAudioEnabled() {
-  if (!isSystemAudioSupported()) return false;
-  // Default differs by platform: macOS ships system audio ON (CoreAudio tap is
-  // verified); Windows ships it OFF (opt-in/experimental — see src/config.py).
-  const defaultOn = process.platform === 'darwin';
-  try {
-    const cfgPath = path.join(getUserDataDir(), 'config.json');
-    if (!fs.existsSync(cfgPath)) return defaultOn; // new install
-    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
-    // Honour an explicit boolean; an absent key means "haven't been asked
-    // yet" → fall back to the platform default.
-    return typeof cfg.system_audio_enabled === 'boolean'
-      ? cfg.system_audio_enabled
-      : defaultOn;
-  } catch (_) {
-    return defaultOn;
-  }
-}
-
-// Sync read of the active ASR engine. Mirrors loadSystemAudioEnabled —
-// reading the JSON directly so we don't spawn a Python subprocess on
+// Sync read of the active ASR engine. Reads the JSON directly so we don't
+// spawn a Python subprocess on
 // every recording start just to ask. Default 'parakeet' matches the
 // Python migration (fresh installs default to Parakeet); existing users
 // will have had transcription_engine written on their first launch by
@@ -2536,9 +2501,8 @@ function loadTranscriptionEngine() {
   }
 }
 
-// Sync read of the auto-detect-meetings setting; default ON. Mirrors
-// loadSystemAudioEnabled — we avoid spawning Python during startup just
-// to read a boolean. Wire any new defaults through the Python config so
+// Sync read of the auto-detect-meetings setting; default ON. Reads the JSON
+// directly to avoid spawning Python during startup just to read a boolean. Wire any new defaults through the Python config so
 // the truth lives in one place.
 function loadAutoDetectMeetingsEnabled() {
   try {
@@ -2557,123 +2521,6 @@ let currentRecordingProcess = null;
 let currentRecordingSessionName = null;  // Surfaced in get-queue-status so renderer knows which meeting is live
 let processingQueue = [];
 
-// ── Orphan-recording cleanup ────────────────────────────────────────────
-//
-// When the user starts a recording, we spawn the Python `record` subprocess
-// as a child of Electron. If Electron crashes between start and stop (renderer
-// OOM, native module segfault, force-quit), the OS *usually* tears the child
-// down via broken stdio pipes — but not always, and not immediately. To
-// guarantee the next launch ends any orphan rather than leaving it writing
-// audio in the background, we persist the spawned PID + backend path to a
-// sidecar file. On startup we read the sidecar and, if the recorded PID is
-// still alive AND still looks like our backend, signal it to exit and remove
-// the sidecar.
-//
-// Lives in its own sidecar file rather than `recorder_state.json` so it stays
-// purely a renderer/main-side concern — the Python state file format doesn't
-// change.
-const RECORD_PID_SIDECAR_FILENAME = 'last-record.json';
-function recordPidSidecarPath() {
-  return path.join(app.getPath('userData'), RECORD_PID_SIDECAR_FILENAME);
-}
-
-function writeRecordPidSidecarSync(info) {
-  const filePath = recordPidSidecarPath();
-  const tmpPath = `${filePath}.tmp`;
-  try {
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(tmpPath, JSON.stringify(info), 'utf-8');
-    fs.renameSync(tmpPath, filePath);
-  } catch (e) {
-    sendDebugLog(`[orphan-cleanup] Failed to write PID sidecar: ${e.message}`);
-    try { if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath); } catch (_) {}
-  }
-}
-
-function clearRecordPidSidecarSync() {
-  try {
-    const filePath = recordPidSidecarPath();
-    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
-  } catch (e) {
-    sendDebugLog(`[orphan-cleanup] Failed to clear PID sidecar: ${e.message}`);
-  }
-}
-
-// Returns true only when (a) the PID is alive and (b) it looks like our
-// backend binary. The `ps` check guards against PID reuse — a long-since-dead
-// orphan whose PID was recycled to an unrelated process must not be killed.
-function isOrphanedRecordProcess(pid, expectedBackendPath) {
-  try {
-    process.kill(pid, 0); // throws ESRCH if no such process
-  } catch (_) {
-    return false;
-  }
-  try {
-    const { execSync } = require('child_process');
-    const cmd = execSync(`ps -p ${pid} -o command=`, { timeout: 1500 }).toString().trim();
-    // The first whitespace-separated token in `ps -o command=` is argv[0]
-    // — the executable path. Match its basename against ours so dev
-    // (`dist/stenoai/stenoai`) and packaged (`<resourcesPath>/stenoai/stenoai`)
-    // both resolve, but a stranger that merely *mentions* "stenoai" in its
-    // arguments doesn't get killed.
-    const binaryName = path.basename(expectedBackendPath);
-    if (!binaryName) return false;
-    const argv0 = cmd.split(/\s+/)[0] || '';
-    return path.basename(argv0) === binaryName;
-  } catch (_) {
-    // ps unavailable or pid disappeared between the kill(0) and the ps;
-    // err on the side of "not orphan" rather than signalling a stranger.
-    return false;
-  }
-}
-
-async function cleanupOrphanRecording() {
-  const filePath = recordPidSidecarPath();
-  if (!fs.existsSync(filePath)) return;
-
-  let info;
-  try {
-    info = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  } catch (e) {
-    sendDebugLog(`[orphan-cleanup] PID sidecar unreadable, removing: ${e.message}`);
-    try { fs.unlinkSync(filePath); } catch (_) {}
-    return;
-  }
-
-  const pid = info && info.pid;
-  const backendPath = info && info.backendPath;
-  const sessionName = (info && info.sessionName) || '';
-  if (!Number.isInteger(pid) || !backendPath) {
-    try { fs.unlinkSync(filePath); } catch (_) {}
-    return;
-  }
-
-  if (!isOrphanedRecordProcess(pid, backendPath)) {
-    sendDebugLog(`[orphan-cleanup] pid=${pid} is not our backend; clearing sidecar`);
-    try { fs.unlinkSync(filePath); } catch (_) {}
-    return;
-  }
-
-  sendDebugLog(`[orphan-cleanup] Orphan record subprocess detected pid=${pid} session="${sessionName}"; sending SIGTERM`);
-  try { process.kill(pid, 'SIGTERM'); } catch (_) {}
-
-  // Wait up to 5s for clean exit, then escalate to SIGKILL.
-  const deadline = Date.now() + 5000;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch (_) {
-      sendDebugLog(`[orphan-cleanup] pid=${pid} exited cleanly`);
-      try { fs.unlinkSync(filePath); } catch (_) {}
-      return;
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-
-  sendDebugLog(`[orphan-cleanup] pid=${pid} still alive after SIGTERM; sending SIGKILL`);
-  try { process.kill(pid, 'SIGKILL'); } catch (_) {}
-  try { fs.unlinkSync(filePath); } catch (_) {}
-}
 // ── End orphan-recording cleanup ────────────────────────────────────────
 // Live-transcript ring buffer for the in-flight recording. Populated by the
 // Python `record --live` subprocess's LIVE_SEG: stdout lines. The renderer
@@ -3085,313 +2932,49 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
     const engine = loadTranscriptionEngine();
     const liveEnabled = engine === 'parakeet';
 
-    // Renderer-driven dual-stream path: when system audio is enabled the
-    // renderer (useSystemAudioCapture) captures mic + system loopback and
-    // mixes them in Web Audio. We MUST NOT spawn the Python `record`
-    // subprocess here or we'd produce two parallel recordings → two notes.
-    // The renderer will write its mixed WebM and queue it through the
-    // existing process-system-audio-recording IPC.
-    if (loadSystemAudioEnabled()) {
-      sendDebugLog(`Starting renderer-driven recording (system audio mode): ${actualSessionName}`);
-      currentRecordingSessionName = actualSessionName;
-      startRecordingRuntimeState();
-      // Flip the active flag immediately so the queue handler reports
-      // hasRecording=true on the very next poll. Without this the renderer
-      // hook would see status='idle' (queue says no recording) at the
-      // moment we want it to fire startCapture, and the dual-stream
-      // capture would never start. The renderer's reportSystemAudioState
-      // IPC is then idempotent on success and clears the flag on failure.
-      systemAudioRecordingActive = true;
-      // Reset live transcript buffer for this session before the live
-      // sidecar spawns and starts emitting events.
-      liveTranscriptState = {
-        sessionName: actualSessionName,
-        segments: [],
-        ready: false,
-        error: null,
-      };
-      // Spawn the Parakeet+Silero transcribe-stream subprocess. Whisper
-      // recordings skip this entirely — the renderer's useSystemAudioCapture
-      // gates its IPC writes on the same engine, so no chunks are produced
-      // when the sidecar isn't running.
-      if (liveEnabled) {
-        try {
-          spawnLiveTranscribe(actualSessionName);
-        } catch (e) {
-          sendDebugLog(`Failed to spawn live transcribe sidecar: ${e.message}`);
-        }
-      } else {
-        sendDebugLog(`Live transcription off — engine=${engine}`);
-      }
-      updateTrayIcon(true);
-      trackEvent('recording_started', { recording_mode: 'system_audio' });
-      return {
-        success: true,
-        sessionName: actualSessionName,
-        message: 'Renderer-driven recording started'
-      };
-    }
-
-    // Legacy mic-only path: spawn Python `record` subprocess.
-    console.log('Starting long recording process...');
-    sendDebugLog(`Starting recording process: ${actualSessionName} (engine=${engine})`);
-    sendDebugLog('$ stenoai record 7200' + (liveEnabled ? ' --live' : ''));
-
-    // Start background recording with 2-hour limit
-    // Pass AI env (cloud key and/or org-adapter url+token) so the
-    // recorder subprocess can summarise via whichever provider is active.
-    const recordEnv = getAiEnv();
-
-    // --live engages the Parakeet streaming consumer thread inside the
-    // record subprocess. Whisper recordings record without --live so the
-    // subprocess captures audio only — the post-stop pipeline transcribes
-    // the WAV via WhisperTranscriber.
-    const recordArgs = ['record', '7200', actualSessionName];
-    if (liveEnabled) recordArgs.push('--live');
-    // Only the --live (Parakeet) path emits LIVE_READY; stamp the load clock
-    // so we can log model-load latency against it below.
-    if (liveEnabled) parakeetLoadStartedAt = Date.now();
-    currentRecordingProcess = spawn(getBackendPath(), recordArgs, {
-      cwd: getBackendCwd(),
-      env: Object.keys(recordEnv).length > 0 ? { ...require('process').env, ...recordEnv } : undefined
-    });
+    // Renderer-driven capture (useSystemAudioCapture) is the ONLY recording
+    // path: it captures the mic (+ system loopback when the Settings toggle is
+    // on) and streams its WebM to disk, queued through the
+    // process-system-audio-recording IPC. The legacy Python `record`
+    // subprocess — signal-controlled and thus unworkable on Windows — is
+    // retired, so there is no longer a mic-XOR-system fork here.
+    sendDebugLog(`Starting renderer-driven recording: ${actualSessionName}`);
     currentRecordingSessionName = actualSessionName;
-    // Persist {pid, sessionName, backendPath} so the next launch can detect
-    // an orphan if Electron crashes between here and the close handler.
-    writeRecordPidSidecarSync({
-      pid: currentRecordingProcess.pid,
-      sessionName: actualSessionName,
-      startedAt: Date.now(),
-      backendPath: getBackendPath(),
-    });
-    // Reset the live transcript buffer for this session. We do it here
-    // (before spawn parses anything) so a late-mounting LiveTranscriptPanel
-    // can never see a stale segments array from a previous recording.
+    startRecordingRuntimeState();
+    // Flip the active flag immediately so the queue handler reports
+    // hasRecording=true on the very next poll, which is what cues the renderer
+    // hook to fire startCapture. reportSystemAudioState then re-affirms it on
+    // success / clears it on failure.
+    systemAudioRecordingActive = true;
+    // Reset the live transcript buffer before the sidecar starts emitting.
     liveTranscriptState = {
       sessionName: actualSessionName,
       segments: [],
       ready: false,
       error: null,
     };
-    startRecordingRuntimeState();
-
-    let hasStarted = false;
-    let processingSucceeded = false;
-    let recordedAudioFile = null;
-    // Authoritative pointer to the final summary file once Python finishes
-    // auto-renaming + writing it (emitted as `SAVED:<path>`). Use this in
-    // preference to the name/audio fallbacks since it can't drift.
-    let savedSummaryFile = null;
-
-    currentRecordingProcess.stdout.on('data', (data) => {
-      const output = data.toString();
-
-      // Capture the audio file path when the recording is saved
-      const audioMatch = output.match(/Recording saved:\s*(.+\.wav)/);
-      if (audioMatch) {
-        recordedAudioFile = audioMatch[1].trim();
+    // Spawn the Parakeet+Silero transcribe-stream sidecar for live partials.
+    // Whisper recordings skip it — the renderer gates its live-tap IPC on the
+    // same engine, so no chunks are produced when the sidecar isn't running.
+    if (liveEnabled) {
+      try {
+        spawnLiveTranscribe(actualSessionName);
+      } catch (e) {
+        sendDebugLog(`Failed to spawn live transcribe sidecar: ${e.message}`);
       }
-      console.log('Recording stdout:', output);
-
-      // Parse streaming protocol + send to debug panel (CRLF-tolerant: Windows
-      // stdout is \r\n, so the STREAM_COMPLETE exact-match must not see a \r).
-      output.split(/\r?\n/).forEach(line => {
-        if (line.startsWith('CHUNK:')) {
-          const encoded = line.slice(6);
-          try {
-            const chunk = Buffer.from(encoded, 'base64').toString('utf-8');
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('summary-chunk', { chunk, sessionName: actualSessionName });
-            }
-          } catch (e) { /* ignore decode errors */ }
-        } else if (line.startsWith('TITLE:')) {
-          const title = line.slice(6);
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('summary-title', { title, sessionName: actualSessionName });
-          }
-        } else if (line === 'STREAM_COMPLETE') {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('summary-complete', { success: true, sessionName: actualSessionName });
-          }
-        } else if (line.startsWith('LIVE_READY:')) {
-          // Model finished loading — UI uses this to swap "Loading…" for
-          // the empty consent-only state.
-          if (parakeetLoadStartedAt) {
-            sendDebugLog(`[parakeet-load] model ready in ${Date.now() - parakeetLoadStartedAt}ms (record --live)`);
-            parakeetLoadStartedAt = 0;
-          }
-          liveTranscriptState.ready = true;
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('live-transcript-ready', {
-              sessionName: actualSessionName,
-            });
-          }
-        } else if (line.startsWith('LIVE_SEG:')) {
-          try {
-            const seg = JSON.parse(line.slice('LIVE_SEG:'.length));
-            // Map snake_case wire shape to camelCase for the renderer.
-            const segment = {
-              text: seg.text,
-              start: seg.start,
-              end: seg.end,
-              isFinal: !!seg.is_final,
-            };
-            // Final segments append. Partials overwrite the trailing entry
-            // when it was also a partial; otherwise they're appended as
-            // the new tail.
-            if (segment.isFinal) {
-              liveTranscriptState.segments.push(segment);
-            } else {
-              const tail = liveTranscriptState.segments[liveTranscriptState.segments.length - 1];
-              if (tail && !tail.isFinal) {
-                liveTranscriptState.segments[liveTranscriptState.segments.length - 1] = segment;
-              } else {
-                liveTranscriptState.segments.push(segment);
-              }
-            }
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('live-transcript-chunk', {
-                sessionName: actualSessionName,
-                segment,
-              });
-            }
-          } catch (e) {
-            sendDebugLog(`LIVE_SEG parse error: ${e.message}`);
-          }
-        } else if (line.startsWith('LIVE_ERROR:')) {
-          try {
-            const payload = JSON.parse(line.slice('LIVE_ERROR:'.length));
-            liveTranscriptState.error = payload;
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('live-transcript-error', {
-                sessionName: actualSessionName,
-                ...payload,
-              });
-            }
-          } catch (e) {
-            sendDebugLog(`LIVE_ERROR parse error: ${e.message}`);
-          }
-        } else if (line.startsWith('SAVED:')) {
-          savedSummaryFile = line.slice(6).trim();
-        } else if (line.trim()) {
-          sendDebugLog(line.trim());
-        }
-      });
-
-      // Background recording process handles complete pipeline - just notify when done
-      if (output.includes('✅ Complete processing finished!')) {
-        processingSucceeded = true;
-        console.log(`🎉 Recording and processing completed for: ${actualSessionName}`);
-        // Notify frontend that everything is done
-        if (mainWindow) {
-          // Get the processed meeting data to send to frontend
-          runPythonScript('simple_recorder.py', ['list-meetings'], true)
-            .then(meetingsResult => {
-              const allMeetings = JSON.parse(meetingsResult);
-              // Prefer the SAVED:<path> pointer Python emits — that's the
-              // exact summary file written this session and survives the
-              // auto-rename. Fall back to name match (only if user kept the
-              // placeholder), then to audio-file basename.
-              let processedMeeting = null;
-              if (savedSummaryFile) {
-                processedMeeting = allMeetings.find(
-                  m => m.session_info?.summary_file === savedSummaryFile,
-                );
-              }
-              if (!processedMeeting) {
-                processedMeeting = allMeetings.find(m => m.session_info?.name === actualSessionName);
-              }
-              if (!processedMeeting && recordedAudioFile) {
-                const audioBasename = path.basename(recordedAudioFile);
-                processedMeeting = allMeetings.find(m =>
-                  m.session_info?.audio_file && path.basename(m.session_info.audio_file) === audioBasename
-                );
-              }
-
-              mainWindow.webContents.send('processing-complete', {
-                success: true,
-                sessionName: actualSessionName,
-                message: 'Recording and processing completed successfully',
-                meetingData: processedMeeting
-              });
-            })
-            .catch(error => {
-              console.error('Error getting processed meeting data:', error);
-              // Fallback - send without meetingData, frontend will refresh
-              mainWindow.webContents.send('processing-complete', {
-                success: true,
-                sessionName: actualSessionName,
-                message: 'Recording and processing completed successfully'
-              });
-            });
-        }
-      }
-
-      // Detect explicit processing failure from backend
-      if (output.includes('❌ Processing pipeline failed')) {
-        processingSucceeded = true; // Prevent duplicate notification from close handler
-        console.error(`Processing failed for: ${actualSessionName}`);
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('processing-complete', {
-            success: false,
-            sessionName: actualSessionName,
-            message: 'Processing failed: summarization error (check that Ollama and a model are available)'
-          });
-        }
-      }
-
-      // Don't queue background recordings for additional processing - they handle it themselves!
-
-      if (output.includes('Recording to:') && !hasStarted) {
-        hasStarted = true;
-      }
-    });
-
-    currentRecordingProcess.stderr.on('data', (data) => {
-      const output = data.toString();
-      console.log('Recording stderr:', output);
-
-      // Send real-time stderr to debug panel (same as runPythonScript)
-      output.split('\n').forEach(line => {
-        if (line.trim()) sendDebugLog('STDERR: ' + line.trim());
-      });
-    });
-
-    currentRecordingProcess.on('close', (code) => {
-      console.log(`Recording process closed with code ${code}`);
-      sendDebugLog(`Recording process completed with exit code: ${code}`);
-      // Normal exit — drop the orphan-detection sidecar so the next launch
-      // doesn't try to kill a long-dead PID (or worse, a recycled one).
-      clearRecordPidSidecarSync();
-      currentRecordingProcess = null;
-      currentRecordingSessionName = null;
-      resetRecordingRuntimeState();
-      updateTrayIcon(false);
-
-      // If process exited without a success or failure message, notify the user
-      if (!processingSucceeded && hasStarted && mainWindow && !mainWindow.isDestroyed()) {
-        console.error(`Recording process exited (code ${code}) without completing processing`);
-        mainWindow.webContents.send('processing-complete', {
-          success: false,
-          sessionName: actualSessionName,
-          message: `Processing failed unexpectedly (exit code ${code})`
-        });
-      }
-    });
-
-    // Give it time to start
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    if (currentRecordingProcess) {
-      trackEvent('recording_started');
-      updateTrayIcon(true);
-      return { success: true, message: 'Recording started successfully' };
     } else {
-      return { success: false, error: 'Failed to start recording process' };
+      sendDebugLog(`Live transcription off — engine=${engine}`);
     }
+    updateTrayIcon(true);
+    trackEvent('recording_started', { recording_mode: 'system_audio' });
+    return {
+      success: true,
+      sessionName: actualSessionName,
+      message: 'Renderer-driven recording started',
+    };
   } catch (error) {
     console.error('Start recording UI error:', error.message);
-    currentRecordingProcess = null;
+    systemAudioRecordingActive = false;
     currentRecordingSessionName = null;
     resetRecordingRuntimeState();
     updateTrayIcon(false);
@@ -3407,15 +2990,10 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
 // is still going. Instead a notification offers Resume, reusing the same
 // auto-resume-requested renderer affordance as meeting-end auto-pause.
 //
-// Mode × platform matrix:
-// - backend (mic-only) mode, macOS/Linux: SIGUSR1 to the record subprocess
-//   (same as pause-recording-ui) + markRecordingPaused.
-// - backend mode, Windows: SIGUSR1 is unsupported (mirrors the
-//   pause-recording-ui gate) — log and skip; acceptable for alpha.
-// - system-audio mode, both OSes: markRecordingPaused + auto-pause-requested
-//   to the renderer, which pauses its MediaRecorder (possibly only after
-//   wake — the renderer is suspended too — but nothing records during sleep
-//   either way).
+// Capture is renderer-driven (MediaRecorder) on every platform now, so this is
+// uniform: markRecordingPaused + auto-pause-requested to the renderer, which
+// pauses its MediaRecorder (possibly only after wake — the renderer is
+// suspended too — but nothing records during sleep either way).
 let pausedBySleep = false;
 // Live "Recording paused / Resume" notification, so a manual resume/stop can
 // dismiss it — a stale banner clicked later would fire auto-resume-requested
@@ -3432,23 +3010,14 @@ function closeSleepPausedNotification() {
 function autoPauseForSleep() {
   try {
     if (recordingRuntimeState.isPaused) return;
-    const hasBackendRecording = currentRecordingProcess !== null;
-    if (!hasBackendRecording && !systemAudioRecordingActive) return;
-
-    if (hasBackendRecording) {
-      if (process.platform === 'win32') {
-        sendDebugLog('[power] suspend during recording — pause unsupported on Windows backend mode, skipping');
-        return;
-      }
-      sendDebugLog('[power] system suspend — pausing recording (SIGUSR1)');
-      currentRecordingProcess.kill('SIGUSR1');
-      markRecordingPaused();
-    } else {
-      sendDebugLog('[power] system suspend — pausing system-audio recording');
-      markRecordingPaused();
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('auto-pause-requested');
-      }
+    if (!systemAudioRecordingActive) return;
+    // Capture is renderer-driven (MediaRecorder). Mark paused and ask the
+    // renderer to pause — possibly only honoured after wake, since the renderer
+    // is suspended too, but nothing records during sleep either way.
+    sendDebugLog('[power] system suspend — pausing recording');
+    markRecordingPaused();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('auto-pause-requested');
     }
     pausedBySleep = true;
   } catch (e) {
@@ -3491,22 +3060,11 @@ function showSleepPausedNotification() {
 
 ipcMain.handle('pause-recording-ui', async () => {
   try {
-    // Mic-only mode: signal the Python `record` subprocess directly.
-    if (currentRecordingProcess) {
-      if (process.platform === 'win32') {
-        return { success: false, error: 'Pause not supported on Windows' };
-      }
-      sendDebugLog('Sending SIGUSR1 to pause recording...');
-      currentRecordingProcess.kill('SIGUSR1');
-      markRecordingPaused();
-      return { success: true, message: 'Recording paused' };
-    }
-    // System-audio mode: capture is renderer-driven (MediaRecorder via
-    // useSystemAudioCapture). Just flip the runtime-state flag — the queue
-    // endpoint reports isPaused=true, status becomes 'paused', and the
-    // renderer effect pauses the MediaRecorder.
+    // Capture is renderer-driven (MediaRecorder via useSystemAudioCapture).
+    // Flip the runtime-state flag — the queue endpoint reports isPaused=true,
+    // status becomes 'paused', and the renderer effect pauses the MediaRecorder.
     if (systemAudioRecordingActive) {
-      sendDebugLog('Pause (system-audio mode): marking paused, renderer will pause MediaRecorder');
+      sendDebugLog('Pause: marking paused, renderer will pause MediaRecorder');
       markRecordingPaused();
       return { success: true, message: 'Recording paused' };
     }
@@ -3524,17 +3082,8 @@ ipcMain.handle('resume-recording-ui', async () => {
     // Any resume (manual or notification-driven) ends the sleep-pause state.
     pausedBySleep = false;
     closeSleepPausedNotification();
-    if (currentRecordingProcess) {
-      if (process.platform === 'win32') {
-        return { success: false, error: 'Resume not supported on Windows' };
-      }
-      sendDebugLog('Sending SIGUSR2 to resume recording...');
-      currentRecordingProcess.kill('SIGUSR2');
-      markRecordingResumed();
-      return { success: true, message: 'Recording resumed' };
-    }
     if (systemAudioRecordingActive) {
-      sendDebugLog('Resume (system-audio mode): marking resumed, renderer will resume MediaRecorder');
+      sendDebugLog('Resume: marking resumed, renderer will resume MediaRecorder');
       markRecordingResumed();
       return { success: true, message: 'Recording resumed' };
     }
@@ -3553,46 +3102,21 @@ ipcMain.handle('stop-recording-ui', async () => {
     // recording that no longer exists.
     pausedBySleep = false;
     closeSleepPausedNotification();
-    // Always clear system-audio active state. The renderer's stopCapture flow
-    // also reports false, but races (renderer already torn down, recorder
-    // errored before reportSystemAudioState) can leave this stuck true and
-    // the UI thinks a recording is still in progress.
+    // Capture is renderer-driven; the renderer's stopCapture flow finalises the
+    // WebM and reports systemAudioRecordingActive=false. Clear it here too in
+    // case a race (renderer torn down / recorder errored before reporting) left
+    // it stuck true. Closing the live sidecar lets Python drain its final
+    // utterance; a watchdog SIGTERM in stopLiveTranscribe covers stuck cases.
     systemAudioRecordingActive = false;
-    // Shut down the live transcribe sidecar if it's running (system-audio
-    // path). Closing stdin lets Python drain any final utterance before
-    // exiting; a watchdog SIGTERM in stopLiveTranscribe covers stuck cases.
     stopLiveTranscribe();
-
-    if (!currentRecordingProcess) {
-      // Idempotent: clicking stop with no active recording is not an error
-      // (it's a stale-state race). Reset everything and report success so
-      // the renderer can finish its own cleanup.
-      currentRecordingSessionName = null;
-      resetRecordingRuntimeState();
-      updateTrayIcon(false);
-      return { success: true, message: 'No active recording to stop' };
-    }
-
-    console.log('Stopping recording process...');
-
-    // Send SIGTERM to trigger graceful stop and processing
-    currentRecordingProcess.kill('SIGTERM');
-
-    // Don't wait - let the process complete independently
-    // The process will handle: stop recording → transcribe → summarize → exit
-    currentRecordingProcess = null;
     currentRecordingSessionName = null;
     resetRecordingRuntimeState();
     updateTrayIcon(false);
-
     trackEvent('recording_stopped');
-    return {
-      success: true,
-      message: 'Recording stopped - processing will complete in background'
-    };
+    return { success: true, message: 'Recording stopped' };
   } catch (error) {
     console.error('Stop recording UI error:', error.message);
-    currentRecordingProcess = null;
+    systemAudioRecordingActive = false;
     currentRecordingSessionName = null;
     resetRecordingRuntimeState();
     updateTrayIcon(false);

--- a/app/main.js
+++ b/app/main.js
@@ -2310,22 +2310,9 @@ ipcMain.handle('get-live-transcript-state', async () => {
   };
 });
 
-// Synchronously read system_audio_enabled from the user config so
-// start-recording-ui can decide whether to spawn the Python `record`
-// subprocess (off) or let the renderer drive the dual-stream capture (on).
-//
-// Always returns false on macOS without CoreAudio Process Tap support
-// (< 14.4 or non-darwin), regardless of the user's config setting — the
-// Python pipeline is the only working capture path there. Without this
-// gate, a user on older macOS with the new default `true` config would
-// produce no audio at all (Python skipped by main.js, renderer skipped
-// by useSystemAudioCapture's own OS check). Falls through to the config
-// default (currently true on a missing/empty config) when the OS does
-// support CoreAudio Tap so new installs get system audio out of the box.
-// Spawn the Python transcribe-stream sidecar for the system-audio path.
-// Wires stdout NDJSON to the same live-transcript-{ready,chunk,error}
-// IPC events the in-process `record --live` consumer uses, so the
-// renderer doesn't care which path produced the events.
+// Spawn the Python transcribe-stream sidecar that produces live partials for
+// the renderer-driven capture (Parakeet engine only). Wires its stdout NDJSON
+// to the live-transcript-{ready,chunk,error} IPC events the renderer consumes.
 function spawnLiveTranscribe(sessionName) {
   if (liveTranscribeProcess) {
     // Race-safe restart: a quick stop→start can land here while the
@@ -2966,7 +2953,7 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
       sendDebugLog(`Live transcription off — engine=${engine}`);
     }
     updateTrayIcon(true);
-    trackEvent('recording_started', { recording_mode: 'system_audio' });
+    trackEvent('recording_started');
     return {
       success: true,
       sessionName: actualSessionName,

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -162,12 +162,13 @@ function RecordingOptionsPopover() {
   const systemAudio = useSystemAudioSetting();
   const setSystemAudio = useSetSystemAudio();
   const systemAudioSupport = useSystemAudioSupport();
-  const enabled = systemAudio.data ?? false;
-  // Show the toggle wherever loopback capture is available (macOS 14.4+ or
-  // Windows 10+), not just on mac. Hidden while support is still loading or
-  // on unsupported OSes.
-  const showSystemAudio = systemAudioSupport.data?.supported === true;
-  const experimental = systemAudioSupport.data?.experimental === true;
+  // macOS default is on (system_audio_enabled defaults true on darwin).
+  const enabled = systemAudio.data ?? true;
+  // macOS only: the toggle chooses mic-only vs mic+system. On Windows the
+  // product decision is always mic+system, so the toggle is hidden (the
+  // renderer forces loopback on there). Also hidden while support is loading
+  // or on a Mac without loopback support (pre-14.4).
+  const showSystemAudio = isMac && systemAudioSupport.data?.supported === true;
 
   return (
     <Popover>
@@ -204,11 +205,6 @@ function RecordingOptionsPopover() {
                     className="text-sm font-medium"
                   >
                     Record system audio
-                    {experimental && (
-                      <span className="ml-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                        Experimental
-                      </span>
-                    )}
                   </label>
                   <Switch
                     id="maintoolbar-system-audio"
@@ -218,9 +214,7 @@ function RecordingOptionsPopover() {
                   />
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  {experimental
-                    ? 'Capture both sides of calls (experimental on Windows). Verify your first recording captures system audio.'
-                    : 'Capture both sides of calls on macOS. Grants microphone permission on first use.'}
+                  Capture both sides of calls. Turn off to record your mic only.
                 </p>
               </div>
             </div>

--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ipc } from '@/lib/ipc';
+import { isMac } from '@/lib/utils';
 import {
   LIVE_RMS_HZ,
   pushRmsSample,
@@ -22,24 +23,20 @@ const SILENCE_RMS_THRESHOLD = 0.01;
 const SILENCE_SAMPLE_INTERVAL_MS = 1_000;
 
 /**
- * Mounts ONCE at App level. When system audio is enabled and the user starts
- * recording, captures BOTH mic (getUserMedia) and system loopback
- * (getDisplayMedia routed through CoreAudio Process Taps via
- * `electron-audio-loopback` with forceCoreAudioTap) and emits a single
- * STEREO WebM/Opus blob with **mic in channel 0 (L), system in channel 1
- * (R)**. The backend's `transcribe_diarised` (src/transcriber.py) detects
- * the stereo layout, splits the channels, transcribes each separately with
- * per-segment timestamps, and emits a chronologically interleaved
- * `[You]` / `[Others]` transcript that TranscriptPanel renders as
- * alternating speaker bubbles.
+ * Mounts ONCE at App level. This is the ONLY recording path — whenever the
+ * user starts recording it captures the mic (getUserMedia) and, when loopback
+ * is enabled (macOS toggle on; Windows always; OS must support it), also the
+ * system loopback (getDisplayMedia routed through CoreAudio Process Taps via
+ * `electron-audio-loopback` with forceCoreAudioTap). It emits a single STEREO
+ * WebM/Opus blob with **mic in channel 0 (L), system in channel 1 (R)**,
+ * streamed incrementally to disk. The backend's `transcribe_diarised`
+ * (src/transcriber.py) detects the stereo layout, splits the channels,
+ * transcribes each separately with per-segment timestamps, and emits a
+ * chronologically interleaved `[You]` / `[Others]` transcript.
  *
- * macOS 14.4+ only — older versions are gated out at the Settings toggle.
- * This hook also short-circuits if support reports false, so an older
- * machine never reaches getDisplayMedia.
- *
- * The Python `record` subprocess is bypassed in this mode (main.js skips
- * spawning it on start-recording-ui) so we don't end up with two parallel
- * recordings → two notes.
+ * When loopback is off/unsupported the recording is MIC-ONLY: the R channel is
+ * silent and the transcript is You-only. There is no longer a Python `record`
+ * subprocess fallback — capture always happens here, on every platform.
  */
 export function useSystemAudioCapture() {
   const { status, sessionName } = useRecording();
@@ -57,11 +54,26 @@ export function useSystemAudioCapture() {
   React.useEffect(() => {
     liveTapEnabledRef.current = liveTapEnabled;
   }, [liveTapEnabled]);
-  // While the support query is still loading (data === undefined), assume
-  // supported so a fast user who hits record before the IPC resolves still
-  // gets system audio. The result-aware false case only fires after the
-  // query has confirmed the OS is unsupported.
-  const enabled = (systemAudio.data ?? false) && (systemAudioSupport.data?.supported ?? true);
+  // Renderer-driven capture is the ONLY recording path now, so capture ALWAYS
+  // runs while status === 'recording' (the mic is captured regardless). The
+  // "Record system audio" setting no longer gates whether we record — it only
+  // decides whether system LOOPBACK is mixed in:
+  //  - Windows: always on when the OS supports it (the toggle is hidden; the
+  //    product decision is always mic+system).
+  //  - macOS: follows the user's setting (default on; off = mic-only).
+  // When the support query is still loading we assume supported so a fast user
+  // who records before the IPC resolves still gets loopback.
+  const loopbackSupported = systemAudioSupport.data?.supported ?? true;
+  const loopbackEnabled = isMac
+    ? (systemAudio.data ?? true) && loopbackSupported
+    : loopbackSupported;
+  // Read into a ref so startCapture (closed over once) sees the current value
+  // without the capture effect depending on it — toggling mid-recording must
+  // not tear down or restart the active capture.
+  const loopbackEnabledRef = React.useRef(loopbackEnabled);
+  React.useEffect(() => {
+    loopbackEnabledRef.current = loopbackEnabled;
+  }, [loopbackEnabled]);
 
   const recorderRef = React.useRef<MediaRecorder | null>(null);
   const micStreamRef = React.useRef<MediaStream | null>(null);
@@ -184,18 +196,22 @@ export function useSystemAudioCapture() {
         if (cancelled()) { stopAcquired(); return; }
         micStreamRef.current = micStream;
 
-        // 2. System audio loopback — BEST-EFFORT. With `forceCoreAudioTap: true`
-        //    in main.js's initMain(), getDisplayMedia is intercepted by
-        //    electron-audio-loopback's setDisplayMediaRequestHandler and
-        //    served via CoreAudio Process Taps (macOS 14.4+). video:true is
-        //    required by the API; we drop the track immediately.
+        // 2. System audio loopback — OPTIONAL + BEST-EFFORT. Skipped entirely
+        //    when loopback is disabled (macOS toggle off) or the OS doesn't
+        //    support it; otherwise attempted via getDisplayMedia (intercepted by
+        //    electron-audio-loopback's setDisplayMediaRequestHandler and served
+        //    via CoreAudio Process Taps when `forceCoreAudioTap` is set). video:
+        //    true is required by the API; we drop the track immediately.
         //
-        //    If loopback is unavailable (permission denied, no tap on this OS,
-        //    or no audio track) we DEGRADE TO MIC-ONLY rather than failing the
-        //    whole recording: sysStream stays null and the stereo graph below
-        //    wires mic → L with a silent R channel (the backend tolerates an
-        //    empty Others side). A genuine mic failure above still aborts.
+        //    If loopback is disabled OR unavailable (permission denied, no tap,
+        //    no audio track) we record MIC-ONLY rather than failing: sysStream
+        //    stays null and the stereo graph below wires mic → L with a silent R
+        //    channel (the backend tolerates an empty Others side). A genuine mic
+        //    failure above still aborts.
         try {
+          if (!loopbackEnabledRef.current) {
+            throw new Error('loopback disabled');
+          }
           await bridge.recording.enableLoopbackAudio();
           if (cancelled()) { stopAcquired(); return; }
           sysStream = await navigator.mediaDevices.getDisplayMedia({
@@ -212,8 +228,13 @@ export function useSystemAudioCapture() {
           }
           sysStreamRef.current = sysStream;
         } catch (loopbackErr) {
-          // eslint-disable-next-line no-console
-          console.warn('[systemAudioCapture] loopback unavailable, continuing mic-only', loopbackErr);
+          // Intentionally-disabled loopback (toggle off) is the expected
+          // mic-only case — don't log it as a failure; only a genuine
+          // unavailability warrants a warning.
+          if (loopbackEnabledRef.current) {
+            // eslint-disable-next-line no-console
+            console.warn('[systemAudioCapture] loopback unavailable, continuing mic-only', loopbackErr);
+          }
           sysStream?.getTracks().forEach((t) => t.stop());
           sysStream = null;
           sysStreamRef.current = null;
@@ -600,16 +621,11 @@ export function useSystemAudioCapture() {
       });
     };
 
-    // If support resolved false or the user toggled system audio off
-    // during an active recording, gracefully stop the capture rather
-    // than leaving streams unmanaged. The stop path tears down the
-    // mic/system streams, hands off the recorded blob for processing,
-    // and resets the tray state.
-    if (!enabled) {
-      if (activeRef.current) void stopCapture();
-      return;
-    }
-
+    // Capture is driven purely by the recording status now — it is the only
+    // recording path, so it always runs while recording (mic-only when loopback
+    // is off/unsupported). The system-audio toggle no longer starts or stops
+    // capture; it only affects whether loopback is mixed in on the NEXT start
+    // (read via loopbackEnabledRef inside startCapture).
     if (status === 'recording' && !activeRef.current) {
       void startCapture();
     } else if (
@@ -628,7 +644,7 @@ export function useSystemAudioCapture() {
     ) {
       void stopCapture();
     }
-  }, [enabled, status]);
+  }, [status]);
 
   // Unmount-only safety net (empty deps = no cleanup on dep changes). Runs
   // when the App tree unmounts (e.g. window close, page reload, StrictMode

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -747,24 +747,24 @@ function GeneralTab() {
         />
       </SettingRow>
 
-      <SettingRow
-        label="Record system audio"
-        description={
-          systemAudioSupport.data && !systemAudioSupport.data.supported
-            ? isMac
-              ? `Capture audio from virtual meetings (requires macOS 14.4+, you're on ${systemAudioSupport.data.osVersion || 'an older version'})`
-              : 'Capture audio from virtual meetings (not supported on this OS).'
-            : systemAudioSupport.data?.experimental
-              ? 'Capture audio from virtual meetings (experimental on Windows — verify your first recording captures system audio).'
-              : 'Capture audio from virtual meetings (requires macOS 14.4+).'
-        }
-      >
-        <Switch
-          checked={(systemAudio.data ?? false) && (systemAudioSupport.data?.supported ?? true)}
-          onCheckedChange={(v) => setSystemAudio.mutate(v)}
-          disabled={systemAudio.data === undefined || systemAudioSupport.data?.supported === false}
-        />
-      </SettingRow>
+      {/* macOS only: chooses mic-only vs mic+system. Windows always records
+          mic+system (toggle hidden), so this control isn't shown there. */}
+      {isMac && (
+        <SettingRow
+          label="Record system audio"
+          description={
+            systemAudioSupport.data && !systemAudioSupport.data.supported
+              ? `Capture both sides of a call (requires macOS 14.4+, you're on ${systemAudioSupport.data.osVersion || 'an older version'}). Mic-only recording still works.`
+              : 'Capture both sides of a call. Turn off to record your mic only.'
+          }
+        >
+          <Switch
+            checked={(systemAudio.data ?? true) && (systemAudioSupport.data?.supported ?? true)}
+            onCheckedChange={(v) => setSystemAudio.mutate(v)}
+            disabled={systemAudio.data === undefined || systemAudioSupport.data?.supported === false}
+          />
+        </SettingRow>
+      )}
 
       <SettingRow
         label="Auto-detect meetings"

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -36,10 +36,10 @@ export function writeUserConfig(
 }
 
 /**
- * Configure the app so `start-recording-ui` takes the renderer-driven path
+ * Configure the app for the renderer-driven capture path
  * (system audio ON) with the Whisper engine (so no Parakeet live-transcribe
  * sidecar spawns). That path sets the recording state machine WITHOUT spawning
- * the Python `record` subprocess, touching a real microphone, or loading any
+ * a model (the renderer-driven path is now the only recording path), without loading any
  * model — see app/main.js `start-recording-ui` + `loadSystemAudioEnabled` /
  * `loadTranscriptionEngine`. This is what makes the lifecycle deterministic on a
  * headless CI runner. It still requires `isSystemAudioSupported()` to be true on

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -36,13 +36,12 @@ export function writeUserConfig(
 }
 
 /**
- * Configure the app for the renderer-driven capture path
- * (system audio ON) with the Whisper engine (so no Parakeet live-transcribe
- * sidecar spawns). That path sets the recording state machine WITHOUT spawning
- * a model (the renderer-driven path is now the only recording path), without loading any
- * model — see app/main.js `start-recording-ui` + `loadSystemAudioEnabled` /
- * `loadTranscriptionEngine`. This is what makes the lifecycle deterministic on a
- * headless CI runner. It still requires `isSystemAudioSupported()` to be true on
+ * Configure the app for the renderer-driven capture path (system audio ON) with
+ * the Whisper engine, so no Parakeet live-transcribe sidecar spawns. The
+ * renderer-driven path is the only recording path now; this sets the recording
+ * state machine without loading any model — see app/main.js `start-recording-ui`
+ * + `loadTranscriptionEngine`. This is what makes the lifecycle deterministic on
+ * a headless CI runner. It still requires `isSystemAudioSupported()` to be true on
  * the host (macOS >= 14.4 / Windows >= 10); the spec guards on that and skips
  * loudly otherwise rather than spawning a real recorder.
  */

--- a/e2e/specs/recording-lifecycle.t2.spec.ts
+++ b/e2e/specs/recording-lifecycle.t2.spec.ts
@@ -52,12 +52,11 @@ test('recording state machine: start -> pause -> resume -> stop is reflected in 
 
   const { page } = await launchApp();
 
-  // The renderer-driven (no-subprocess) path needs OS system-audio support
-  // (macOS >= 14.4 / Windows >= 10). Without it, start would fall back to the
-  // mic subprocess and need a real device — skip LOUDLY rather than emit a
-  // misleading failure or silently spawn a recorder. Windows CI (>= 10) always
-  // runs this; macOS only skips on a pre-14.4 runner (hosted images are well
-  // past that), so the loud annotation surfaces any regression to a no-op skip.
+  // The deterministic capture path drives real getUserMedia/getDisplayMedia, so
+  // it needs OS loopback support (macOS >= 14.4 / Windows >= 10) to exercise the
+  // mic+system graph headlessly — skip LOUDLY otherwise rather than emit a
+  // misleading failure. Windows CI (>= 10) always runs this; macOS only skips on
+  // a pre-14.4 runner (hosted images are well past that).
   const support = await page.evaluate(() =>
     (window as StenoWindow).stenoai.recording.getSystemAudioSupport(),
   );


### PR DESCRIPTION
**PR 2 of 3** — unify recording onto the renderer-driven path and retire the broken Python mic subprocess.

Follows **#223 (PR1, merged)** — this branch is rebased onto `main`, so the diff is PR2's cutover changes only.

This is the **behavioral cutover**: the renderer-driven capture path (hardened in PR1) becomes the **only** recording mechanism on both platforms. The legacy Python `record` subprocess — controlled by POSIX signals Windows can't deliver — is no longer spawned. PR3 deletes the now-dead Python code.

## main.js
- `start-recording-ui` always takes the renderer path; deleted the mic-only `record` spawn + its stdout/stderr/close handlers + PID-sidecar write.
- `stop`/`pause`/`resume-recording-ui` and sleep auto-pause dropped their dead `SIGTERM`/`SIGUSR1`/`SIGUSR2` branches. **Pause/resume and sleep-auto-pause now work on Windows** (via the renderer state machine) — they were no-ops there before.
- Removed `loadSystemAudioEnabled()` and the entire orphan-recording-cleanup + PID-sidecar cluster (they only served the retired subprocess) + its startup call. Simplified the before-quit handler's dead branch.
- `currentRecordingProcess` kept as a permanently-`null` vestige (its ~8 remaining reads all collapse correctly via `|| systemAudioRecordingActive`); PR3 excises it.

## renderer
- `useSystemAudioCapture`: capture is **unconditional** (driven by `status` only). The "Record system audio" toggle no longer starts/stops capture — it only decides whether **loopback** is mixed in (`loopbackEnabled`: Windows always on, macOS follows the setting; read via a ref so mid-recording toggles don't tear down capture). Mic-only when off/unsupported.
- Toggle **hidden on Windows** (always mic+system per product decision), **kept on macOS** (mic-only vs mic+system) — `MainToolbar` + `Settings` gated on `isMac`; dropped the dead "experimental" Windows copy.

## Tests & verification
- Full **model-free T2 suite (28) green**; renderer typecheck clean.
- **Ran the real Electron app**: start → pause → resume → stop all succeed through the renderer state machine with **no `record` subprocess spawned** (verified via `pgrep`). Real audio-capture content is device-dependent (headless-BLOCKED) — covered by `@pipeline`.

## Risk / macOS safety
macOS default is `system_audio_enabled=on`, so it already used the renderer path — the **mac happy path is behaviorally unchanged**. Every deletion was Unix-signal or subprocess/sidecar code; `forceCoreAudioTap`/`enableLoopbackAudio`/entitlements are untouched. Reviewed clean at critical/high by QA + staff-eng lenses.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut recording over to the renderer-driven path on macOS and Windows and retired the Python mic subprocess. This unblocks pause/resume/sleep auto‑pause on Windows and simplifies startup/shutdown.

- **New Features**
  - Renderer is now the only recording path; mic always records, loopback mixes in when enabled.
  - Windows always records mic+system; the toggle is hidden. macOS keeps the toggle (default on) for mic-only vs mic+system.
  - Pause, resume, and sleep auto‑pause now work on Windows via the renderer state machine.
  - Live partials still come from the Parakeet sidecar; Whisper runs without it.

- **Refactors**
  - Removed Python `record` spawn, POSIX signal handling, PID sidecar, and orphan cleanup; simplified `before-quit`.
  - Dropped `loadSystemAudioEnabled()`. `currentRecordingProcess` remains a no-op vestige until PR3.
  - `useSystemAudioCapture` is unconditional and driven only by recording status; the toggle now only controls loopback (reads via ref to avoid mid‑recording restarts). Uses `getDisplayMedia` via `electron-audio-loopback` when supported.
  - UI: hide system-audio toggle on Windows; updated copy in `MainToolbar` and `Settings` (macOS only).
  - E2E: refreshed deterministic recording fixture/docs; lifecycle spec now assumes OS loopback support.

<sup>Written for commit 9a5f215bfeaa31875d106c7a5f10ec6809249158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

