### PR TITLE
chore(recorder): retire recorder_state.json read/write machinery

### DIFF
--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -150,52 +150,6 @@ class SimpleRecorder:
         # State file
         self.state_file = Path("recorder_state.json")
 
-    def get_state(self) -> dict:
-        """Get current recorder state.
-
-        Distinguishes "file missing" (normal — return default) from "file
-        unreadable / corrupt" (real failure — log and quarantine so the
-        user can recover the file and we don't pretend we were idle while
-        an orphan subprocess may still be writing audio).
-        """
-        if not self.state_file.exists():
-            return {"recording": False, "current_file": None, "session_name": None}
-        try:
-            with open(self.state_file, 'r') as f:
-                return json.load(f)
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            # Corrupt state — most likely a non-atomic write was killed
-            # mid-flight before save_state's tempfile + rename pattern was
-            # in place. UnicodeDecodeError covers the case where binary
-            # garbage from a partial write fails UTF-8 decoding before
-            # json.load even sees it. Both are "content unparseable" —
-            # quarantine and return default.
-            logger.error(f"State file corrupt at {self.state_file}: {e}")
-            try:
-                quarantine = self.state_file.with_suffix(self.state_file.suffix + '.corrupt')
-                self.state_file.replace(quarantine)
-                logger.error(f"Moved corrupt state aside to {quarantine}")
-            except OSError as move_err:
-                logger.error(f"Failed to quarantine corrupt state file: {move_err}")
-        except OSError as e:
-            # Permission / IO error reading the file. Don't pretend we're
-            # idle — surface this loudly so the user can fix file perms or
-            # disk issues instead of silently losing recording state.
-            logger.error(f"Failed to read state file {self.state_file}: {e}")
-        return {"recording": False, "current_file": None, "session_name": None}
-
-    def save_state(self, state: dict):
-        """Save recorder state atomically.
-
-        Writes to a tempfile in the same directory (so os.replace is an
-        atomic rename within one filesystem) and then renames over the
-        real path. A crash mid-write either leaves the prior valid state
-        intact or leaves an orphan tempfile alongside it — never a
-        partially-written recorder_state.json that get_state would
-        misread as "idle" while audio is still being captured.
-        """
-        _atomic_write_json(self.state_file, state)
-
     def _resolve_output_language(self, configured_language: str, detected_language: Optional[str] = None) -> str:
         """Resolve which language should be used for summary/title/query output."""
         from src.config import get_config
@@ -537,12 +491,8 @@ Transcript:
         """Complete processing: transcribe + summarize."""
         print(f"🔄 Processing recording: {audio_file}")
         
-        # If no audio file provided, use the last recording
         if not audio_file:
-            state = self.get_state()
-            audio_file = state.get("last_recording")
-            if not audio_file:
-                raise Exception("No audio file specified and no recent recording found")
+            raise Exception("No audio file specified")
         
         # Ensure we have a proper path
         audio_file = str(audio_file)  # Convert to string if it's a Path object
@@ -657,10 +607,7 @@ Transcript:
         print(f"🔄 Processing recording: {audio_file}")
 
         if not audio_file:
-            state = self.get_state()
-            audio_file = state.get("last_recording")
-            if not audio_file:
-                raise Exception("No audio file specified and no recent recording found")
+            raise Exception("No audio file specified")
 
         audio_path = Path(audio_file)
         if not audio_path.exists():
@@ -1284,21 +1231,19 @@ def set_silence_auto_stop_minutes_cmd(minutes: int):
 
 @cli.command()
 def status():
-    """Show recorder status"""
+    """Show recorder status.
+
+    Recording state is tracked in the Electron main process now (capture is
+    renderer-driven), not in recorder_state.json — so this reports backend
+    readiness ("READY") plus recent recordings. Used by main.js as a backend
+    health check (get-status).
+    """
     recorder = SimpleRecorder()
-    state = recorder.get_state()
-    
+
     print("🎙️ Steno Recorder Status")
     print("=" * 25)
-    
-    if state.get("recording"):
-        print("STATUS: RECORDING")
-        print(f"Session: {state.get('session_name')}")
-        print(f"File: {state.get('current_file')}")
-        print(f"Started: {state.get('start_time')}")
-    else:
-        print("STATUS: READY")
-    
+    print("STATUS: READY")
+
     # Show recent recordings
     recordings = list(recorder.recordings_dir.glob("*.wav"))
     if recordings:

--- a/tests/test_recorder_state.py
+++ b/tests/test_recorder_state.py
@@ -1,14 +1,16 @@
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
 
-from simple_recorder import SimpleRecorder, _atomic_write_json
+from simple_recorder import _atomic_write_json
 
 
 class AtomicWriteJsonTests(unittest.TestCase):
+    """`_atomic_write_json` is the shared tempfile-then-rename writer used for
+    the summary JSON (it originally also backed recorder_state.json, which is
+    retired — capture state now lives in the Electron main process)."""
+
     def test_writes_valid_json_to_new_path(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             target = Path(tmp_dir) / "state.json"
@@ -59,132 +61,6 @@ class AtomicWriteJsonTests(unittest.TestCase):
             target = Path(tmp_dir) / "nested" / "deeper" / "state.json"
             _atomic_write_json(target, {"ok": True})
             self.assertTrue(target.exists())
-
-
-class GetStateTests(unittest.TestCase):
-    """get_state distinguishes 'missing' (return default) from 'corrupt'
-    (quarantine + return default + log) from 'unreadable' (log + return
-    default). Previously it swallowed all three identically via a bare
-    `except:`."""
-
-    def _recorder_in(self, tmp_dir):
-        """Build a SimpleRecorder rooted at tmp_dir for its state file.
-        Patches the data-dirs side effect since we don't need real data
-        dirs for these tests."""
-        with patch("src.config.get_data_dirs") as mock_dirs:
-            base = Path(tmp_dir)
-            mock_dirs.return_value = {
-                "recordings": base / "rec",
-                "transcripts": base / "trs",
-                "output": base / "out",
-            }
-            recorder = SimpleRecorder()
-        # Redirect the state file into our tmp dir for isolation.
-        recorder.state_file = Path(tmp_dir) / "recorder_state.json"
-        return recorder
-
-    def test_missing_file_returns_default(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            recorder = self._recorder_in(tmp_dir)
-            self.assertEqual(
-                recorder.get_state(),
-                {"recording": False, "current_file": None, "session_name": None},
-            )
-
-    def test_valid_state_round_trip(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            recorder = self._recorder_in(tmp_dir)
-            payload = {
-                "recording": True,
-                "current_file": "/tmp/x.wav",
-                "session_name": "Test",
-            }
-            recorder.save_state(payload)
-            self.assertEqual(recorder.get_state(), payload)
-
-    def test_corrupt_json_is_quarantined(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            recorder = self._recorder_in(tmp_dir)
-            recorder.state_file.write_text('{"recording": tru')  # truncated
-
-            result = recorder.get_state()
-
-            # Returns default rather than crashing.
-            self.assertEqual(
-                result,
-                {"recording": False, "current_file": None, "session_name": None},
-            )
-            # Original is gone — moved aside.
-            self.assertFalse(recorder.state_file.exists())
-            # Quarantined copy exists alongside, preserving the corrupt bytes
-            # so a human can inspect them.
-            quarantine = recorder.state_file.with_suffix(
-                recorder.state_file.suffix + ".corrupt"
-            )
-            self.assertTrue(quarantine.exists())
-            self.assertEqual(quarantine.read_text(), '{"recording": tru')
-
-    def test_invalid_utf8_is_quarantined(self):
-        """A partial write can leave the file with bytes that aren't valid
-        UTF-8 — open(..., 'r') raises UnicodeDecodeError before json.load
-        sees it. That's the same 'content unparseable' failure mode as
-        JSONDecodeError and must be quarantined, not propagated."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            recorder = self._recorder_in(tmp_dir)
-            # 0xFF / 0xFE are not valid leading UTF-8 bytes.
-            recorder.state_file.write_bytes(b'\xff\xfe\x00\x01')
-
-            result = recorder.get_state()
-
-            self.assertEqual(
-                result,
-                {"recording": False, "current_file": None, "session_name": None},
-            )
-            self.assertFalse(recorder.state_file.exists())
-            quarantine = recorder.state_file.with_suffix(
-                recorder.state_file.suffix + ".corrupt"
-            )
-            self.assertTrue(quarantine.exists())
-
-    def test_unreadable_file_does_not_quarantine(self):
-        """A permission error is transient (user could fix it). Don't
-        destroy the file — just log and return default."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            recorder = self._recorder_in(tmp_dir)
-            recorder.state_file.write_text('{"recording": true}')
-
-            with patch("builtins.open", side_effect=PermissionError("denied")):
-                result = recorder.get_state()
-
-            self.assertEqual(
-                result,
-                {"recording": False, "current_file": None, "session_name": None},
-            )
-            # File is still where it was — we don't move it aside on a
-            # transient OS error.
-            self.assertTrue(recorder.state_file.exists())
-
-    def test_save_state_is_atomic_under_crash(self):
-        """Simulate a crash by making json.dump raise after partial work.
-        The prior state file must survive intact."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            recorder = self._recorder_in(tmp_dir)
-            recorder.save_state({"recording": False, "current_file": None})
-
-            original_dump = json.dump
-
-            def explode(*_args, **_kwargs):
-                raise RuntimeError("simulated crash mid-write")
-
-            with patch("simple_recorder.json.dump", side_effect=explode):
-                with self.assertRaises(RuntimeError):
-                    recorder.save_state({"recording": True, "current_file": "/x.wav"})
-
-            # Prior state preserved.
-            self.assertEqual(
-                json.loads(recorder.state_file.read_text()),
-                {"recording": False, "current_file": None},
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Dead-code cleanup flagged in the PR3 review. After the recording cutover (#225/#226), capture state lives in the Electron main process (`systemAudioRecordingActive`), so `recorder_state.json`'s read/write path is dead.

## Removed (dead read/write machinery)
- `SimpleRecorder.get_state` / `save_state` — **zero production callers** (only the deleted `record`/`start`/`stop` commands wrote the file).
- The `last_recording` resume fallback in `process_recording` / `process_recording_streaming` — the key was only ever written by the removed `stop` path, so the branch was unreachable. A missing audio file now raises a clear error directly.
- The always-false `recording` branch in the `status` command — it now reports backend readiness (`READY`) + recent recordings.
- The `get_state`/`save_state` tests in `test_recorder_state.py` (kept `AtomicWriteJsonTests` — `_atomic_write_json` is still used for the summary JSON).

## Kept (deliberate seam)
`state_file` + the `clear-state` command and its **"Clear recording state" Settings button**, plus the pre-process legacy-file cleanup — so an upgrader's stale `recorder_state.json` is still removable. The user-facing button is untouched (a UX change would be out of scope for a cleanup).

## Verification
- 163 unit tests pass (the 6 removed are the deleted `get_state`/`save_state` tests); `ruff` baseline unchanged (no new errors).
- Rebuilt the PyInstaller bundle and ran the full **T2 suite incl. both `@pipeline` jobs** green — confirms the touched `process_recording_streaming` path still works end-to-end.

## Net
~180 lines of dead state machinery removed; no behavior change for users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the `recorder_state.json` read/write path; capture state now lives in the Electron main process. Simplifies processing and status commands with no user-facing changes.

- **Refactors**
  - Removed `SimpleRecorder.get_state`/`save_state` and the `last_recording` fallback in `process_recording`/`process_recording_streaming` (missing audio now raises a clear error).
  - Updated `status` to report backend readiness (READY) and recent recordings; recording state is tracked in main via `systemAudioRecordingActive`.
  - Trimmed tests by dropping `get_state`/`save_state` cases; kept `AtomicWriteJsonTests` for `_atomic_write_json` used by summary JSON.
  - Kept `state_file`, the `clear-state` command, and legacy cleanup so stale `recorder_state.json` can still be cleared on upgrade.

<sup>Written for commit 0079b8f916fc5c075eb9aa04ed373bfa3522a010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

