### PR TITLE
feat(search): global ⌘K command palette for note search

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -115,17 +115,20 @@ function install({ ipcMain }) {
   // permissive { success: true } — enough to keep invoke() from rejecting.
   // Optional seeded notes for specs that exercise note lists / search
   // (e.g. the command-palette T1). Gated so other specs keep the empty list.
-  const seedMeeting = (name, summaryFile, summary) => ({
-    session_info: { name, summary_file: summaryFile },
+  const seedMeeting = (name, summaryFile, summary, processedAt) => ({
+    session_info: { name, summary_file: summaryFile, processed_at: processedAt },
     summary,
     transcript: '',
   });
+  // Inserted oldest-first on purpose: distinct processed_at timestamps let the
+  // command-palette spec prove the recency sort actually reorders them (without
+  // timestamps every row tied at epoch 0 and insertion order masked a missing sort).
   const SEEDED_MEETINGS =
     process.env.STENOAI_E2E_SEED_MEETINGS === '1'
       ? [
-          seedMeeting('Q3 Budget review', 'q3-budget.json', 'We revised the budget numbers for Q3.'),
-          seedMeeting('Marketing sync', 'marketing.json', 'Budget owner is now Sarah.'),
-          seedMeeting('Standup notes', 'standup.json', 'No blockers today.'),
+          seedMeeting('Standup notes', 'standup.json', 'No blockers today.', '2026-06-18T10:00:00Z'),
+          seedMeeting('Marketing sync', 'marketing.json', 'Budget owner is now Sarah.', '2026-06-19T10:00:00Z'),
+          seedMeeting('Q3 Budget review', 'q3-budget.json', 'We revised the budget numbers for Q3.', '2026-06-20T10:00:00Z'),
         ]
       : [];
 

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -113,6 +113,22 @@ function install({ ipcMain }) {
   // render if the shape is wrong (consumers that .map / .filter / for-of over
   // the result). Everything not listed here and not in MOCKS falls through to a
   // permissive { success: true } — enough to keep invoke() from rejecting.
+  // Optional seeded notes for specs that exercise note lists / search
+  // (e.g. the command-palette T1). Gated so other specs keep the empty list.
+  const seedMeeting = (name, summaryFile, summary) => ({
+    session_info: { name, summary_file: summaryFile },
+    summary,
+    transcript: '',
+  });
+  const SEEDED_MEETINGS =
+    process.env.STENOAI_E2E_SEED_MEETINGS === '1'
+      ? [
+          seedMeeting('Q3 Budget review', 'q3-budget.json', 'We revised the budget numbers for Q3.'),
+          seedMeeting('Marketing sync', 'marketing.json', 'Budget owner is now Sarah.'),
+          seedMeeting('Standup notes', 'standup.json', 'No blockers today.'),
+        ]
+      : [];
+
   const DEFAULTS = {
     'get-app-version': '0.0.0-e2e',
     // Fires on first paint once signed in (Sidebar + RouteView gate the
@@ -126,7 +142,7 @@ function install({ ipcMain }) {
         shared_notes_enabled: process.env.STENOAI_E2E_SHARED_NOTES !== '0',
       },
     },
-    'list-meetings': { success: true, meetings: [] },
+    'list-meetings': { success: true, meetings: SEEDED_MEETINGS },
     'list-folders': { success: true, folders: [] },
     'get-calendar-events': { success: true, events: [] },
     'parakeet-status': { success: true, model: '', installed: false },

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -20,6 +20,7 @@ import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { useTranscriptionEngine } from '@/hooks/useModels';
 import { QuitDialog } from '@/components/QuitDialog';
 import { ImportDropZone } from '@/components/ImportDropZone';
+import { CommandPaletteProvider, useCommandPalette } from '@/components/CommandPalette';
 import { AskBarProvider } from '@/lib/askBarContext';
 import {
   useRecording,
@@ -158,25 +159,6 @@ export function App() {
     })();
   }, [recording.isLoading, recording.status, route]);
 
-  // ⌘K — focus sidebar search. Capture-phase listener so it wins over nested
-  // handlers; fires even when focus is in a form control (the search input
-  // itself is exempt by the data-sidebar-search check).
-  React.useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'k') return;
-      const search = document.querySelector<HTMLInputElement>(
-        '[data-sidebar-search]',
-      );
-      if (search) {
-        e.preventDefault();
-        search.focus();
-        search.select();
-      }
-    };
-    document.addEventListener('keydown', onKey, true);
-    return () => document.removeEventListener('keydown', onKey, true);
-  }, []);
-
   const isRecordingRoute = route === '/recording';
   const isProcessingRoute = route === '/meetings/processing';
   // The /chat page has its own large composer, so the floating AskBar dock
@@ -186,7 +168,9 @@ export function App() {
   const showAskBar = !isRecordingRoute && !isProcessingRoute && !isChatRoute;
 
   return (
-    <StreamingProvider>
+    <CommandPaletteProvider>
+      <CommandPaletteHotkey />
+      <StreamingProvider>
       <AskBarProvider>
         <RouteView route={route} />
         <QuitDialog />
@@ -210,8 +194,25 @@ export function App() {
           </BottomDockSlot>
         )}
       </AskBarProvider>
-    </StreamingProvider>
+      </StreamingProvider>
+    </CommandPaletteProvider>
   );
+}
+
+/** Global ⌘K → open the command palette. Capture-phase so it fires even when
+ *  focus is in a form control. */
+function CommandPaletteHotkey() {
+  const { open } = useCommandPalette();
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'k') return;
+      e.preventDefault();
+      open();
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [open]);
+  return null;
 }
 
 /**

--- a/app/renderer/src/components/CommandPalette.tsx
+++ b/app/renderer/src/components/CommandPalette.tsx
@@ -19,6 +19,12 @@ export function useCommandPalette(): PaletteContextValue {
 
 const RECENT_COUNT = 8;
 
+/** Most-recent first. The backend list (useMeetings) is unsorted; Home re-sorts
+ *  in groupPrevious by the same key, so we mirror it here. */
+function recencyMs(m: Meeting): number {
+  return new Date(m.session_info.processed_at ?? m.session_info.updated_at ?? 0).getTime();
+}
+
 /**
  * Global ⌘K search. Provides `open()` to descendants (the sidebar trigger) and
  * renders the overlay itself. Searches notes (title + summary) from any screen
@@ -37,27 +43,42 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
 
 function CommandPalette({ onClose }: { onClose: () => void }) {
   const meetings = useMeetings();
-  const all = React.useMemo(
-    () => (meetings.data ?? []).filter((m) => !m.is_recording),
+  // One recency sort feeds both paths: empty-query recents and search results
+  // (searchNotes preserves input order, so results stay newest-first).
+  const sorted = React.useMemo(
+    () => (meetings.data ?? []).filter((m) => !m.is_recording).slice().sort((a, b) => recencyMs(b) - recencyMs(a)),
     [meetings.data],
   );
   const [query, setQuery] = React.useState('');
   const [selected, setSelected] = React.useState(0);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const listRef = React.useRef<HTMLUListElement>(null);
 
+  // Autofocus the input on open; restore focus to the previously-focused
+  // element (e.g. the sidebar trigger) when the palette closes.
   React.useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
     inputRef.current?.focus();
+    return () => prev?.focus?.();
   }, []);
 
   const results = React.useMemo<Meeting[]>(() => {
-    if (!query.trim()) return all.slice(0, RECENT_COUNT);
-    return searchNotes(all, query);
-  }, [all, query]);
+    if (!query.trim()) return sorted.slice(0, RECENT_COUNT);
+    return searchNotes(sorted, query);
+  }, [sorted, query]);
 
-  // Keep selection in range as results change.
+  // Keep selection within [0, len-1]; never let it stick at -1 once results
+  // appear (ArrowDown on an empty list would otherwise leave it negative).
   React.useEffect(() => {
-    setSelected((s) => Math.min(s, Math.max(0, results.length - 1)));
+    setSelected((s) => Math.max(0, Math.min(s, results.length - 1)));
   }, [results.length]);
+
+  // Scroll the active option into view as the keyboard selection moves.
+  React.useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-index="${selected}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [selected]);
 
   const openMeeting = (m: Meeting | undefined) => {
     if (!m) return;
@@ -78,8 +99,14 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
     } else if (e.key === 'Enter') {
       e.preventDefault();
       openMeeting(results[selected]);
+    } else if (e.key === 'Tab') {
+      // The input is the only tab stop in the dialog; trap Tab so focus can't
+      // escape behind the aria-modal overlay.
+      e.preventDefault();
     }
   };
+
+  const activeId = results[selected] ? `cmdk-opt-${selected}` : undefined;
 
   return (
     <div
@@ -109,6 +136,10 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
             style={{ color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
             placeholder="Search notes…"
             aria-label="Search notes"
+            role="combobox"
+            aria-expanded="true"
+            aria-controls="cmdk-listbox"
+            aria-activedescendant={activeId}
             value={query}
             onChange={(e) => {
               setQuery(e.target.value);
@@ -117,7 +148,13 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
           />
         </div>
 
-        <ul role="listbox" className="scrollbar-clean max-h-[50vh] overflow-auto py-1">
+        <ul
+          ref={listRef}
+          id="cmdk-listbox"
+          role="listbox"
+          aria-label="Search results"
+          className="scrollbar-clean max-h-[50vh] overflow-auto py-1"
+        >
           {results.length === 0 ? (
             <li
               className="px-3.5 py-6 text-center text-[13px]"
@@ -132,8 +169,10 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
               return (
                 <li
                   key={m.session_info.summary_file}
+                  id={`cmdk-opt-${i}`}
                   role="option"
                   aria-selected={i === selected}
+                  data-index={i}
                   data-testid="command-palette-result"
                   className="mx-1 cursor-pointer rounded-md px-2.5 py-2"
                   style={i === selected ? { background: 'var(--surface-active)' } : undefined}

--- a/app/renderer/src/components/CommandPalette.tsx
+++ b/app/renderer/src/components/CommandPalette.tsx
@@ -130,7 +130,7 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
       className="fixed inset-0 z-[200] flex items-start justify-center"
       onMouseDown={onClose}
     >
-      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.32)' }} />
+      <div className="absolute inset-0 bg-ink-900/40 backdrop-blur-sm" />
       <div
         role="dialog"
         aria-modal="true"

--- a/app/renderer/src/components/CommandPalette.tsx
+++ b/app/renderer/src/components/CommandPalette.tsx
@@ -1,0 +1,175 @@
+import * as React from 'react';
+import { Search } from 'lucide-react';
+import { useMeetings } from '@/hooks/useMeetings';
+import { searchNotes, snippet } from '@/lib/noteSearch';
+import { navigate } from '@/lib/router';
+import type { Meeting } from '@/lib/ipc';
+
+interface PaletteContextValue {
+  open: () => void;
+}
+
+const PaletteContext = React.createContext<PaletteContextValue | null>(null);
+
+export function useCommandPalette(): PaletteContextValue {
+  const ctx = React.useContext(PaletteContext);
+  if (!ctx) throw new Error('useCommandPalette must be used within CommandPaletteProvider');
+  return ctx;
+}
+
+const RECENT_COUNT = 8;
+
+/**
+ * Global ⌘K search. Provides `open()` to descendants (the sidebar trigger) and
+ * renders the overlay itself. Searches notes (title + summary) from any screen
+ * via the shared matcher and opens the selected note. See #213.
+ */
+export function CommandPaletteProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const value = React.useMemo(() => ({ open: () => setIsOpen(true) }), []);
+  return (
+    <PaletteContext.Provider value={value}>
+      {children}
+      {isOpen && <CommandPalette onClose={() => setIsOpen(false)} />}
+    </PaletteContext.Provider>
+  );
+}
+
+function CommandPalette({ onClose }: { onClose: () => void }) {
+  const meetings = useMeetings();
+  const all = React.useMemo(
+    () => (meetings.data ?? []).filter((m) => !m.is_recording),
+    [meetings.data],
+  );
+  const [query, setQuery] = React.useState('');
+  const [selected, setSelected] = React.useState(0);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const results = React.useMemo<Meeting[]>(() => {
+    if (!query.trim()) return all.slice(0, RECENT_COUNT);
+    return searchNotes(all, query);
+  }, [all, query]);
+
+  // Keep selection in range as results change.
+  React.useEffect(() => {
+    setSelected((s) => Math.min(s, Math.max(0, results.length - 1)));
+  }, [results.length]);
+
+  const openMeeting = (m: Meeting | undefined) => {
+    if (!m) return;
+    navigate(`/meetings/${encodeURIComponent(m.session_info.summary_file)}`);
+    onClose();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelected((s) => Math.min(s + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelected((s) => Math.max(s - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      openMeeting(results[selected]);
+    }
+  };
+
+  return (
+    <div
+      data-testid="command-palette"
+      className="fixed inset-0 z-[200] flex items-start justify-center"
+      onMouseDown={onClose}
+    >
+      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.32)' }} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search notes"
+        className="relative mt-[12vh] w-[min(620px,92vw)] overflow-hidden rounded-xl shadow-[var(--shadow-md)]"
+        style={{ background: 'var(--surface-raised)', border: '1px solid hsl(var(--border))' }}
+        onMouseDown={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+      >
+        <div
+          className="flex items-center gap-2 px-3.5 py-3"
+          style={{ borderBottom: '1px solid var(--border-subtle)' }}
+        >
+          <Search className="size-[15px]" style={{ color: 'var(--fg-2)' }} />
+          <input
+            ref={inputRef}
+            data-testid="command-palette-input"
+            className="w-full bg-transparent text-[14px] outline-none"
+            style={{ color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
+            placeholder="Search notes…"
+            aria-label="Search notes"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelected(0);
+            }}
+          />
+        </div>
+
+        <ul role="listbox" className="scrollbar-clean max-h-[50vh] overflow-auto py-1">
+          {results.length === 0 ? (
+            <li
+              className="px-3.5 py-6 text-center text-[13px]"
+              style={{ color: 'var(--fg-muted)' }}
+            >
+              {query.trim() ? `No notes match “${query.trim()}”` : 'No notes yet'}
+            </li>
+          ) : (
+            results.map((m, i) => {
+              const title = m.session_info.name || 'Untitled Meeting';
+              const sub = snippet(m.summary, query);
+              return (
+                <li
+                  key={m.session_info.summary_file}
+                  role="option"
+                  aria-selected={i === selected}
+                  data-testid="command-palette-result"
+                  className="mx-1 cursor-pointer rounded-md px-2.5 py-2"
+                  style={i === selected ? { background: 'var(--surface-active)' } : undefined}
+                  onMouseEnter={() => setSelected(i)}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    openMeeting(m);
+                  }}
+                >
+                  <div className="truncate text-[13.5px]" style={{ color: 'var(--fg-1)' }}>
+                    {title}
+                  </div>
+                  {sub && (
+                    <div className="truncate text-[12px]" style={{ color: 'var(--fg-muted)' }}>
+                      {sub}
+                    </div>
+                  )}
+                </li>
+              );
+            })
+          )}
+        </ul>
+
+        <div
+          className="flex items-center gap-3 px-3.5 py-2 text-[11px]"
+          style={{
+            color: 'var(--fg-muted)',
+            borderTop: '1px solid var(--border-subtle)',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/renderer/src/components/CommandPalette.tsx
+++ b/app/renderer/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Search } from 'lucide-react';
-import { useMeetings } from '@/hooks/useMeetings';
+import { useMeetings, LIVE_SUMMARY_PREFIX } from '@/hooks/useMeetings';
 import { searchNotes, snippet } from '@/lib/noteSearch';
 import { navigate } from '@/lib/router';
 import type { Meeting } from '@/lib/ipc';
@@ -18,6 +18,10 @@ export function useCommandPalette(): PaletteContextValue {
 }
 
 const RECENT_COUNT = 8;
+// Bound how many matches we render/snippet per keystroke; a broad term against a
+// large library would otherwise build hundreds of rows. Refine the query to reach
+// the rest — standard command-palette behavior.
+const MAX_RESULTS = 50;
 
 /** Most-recent first. The backend list (useMeetings) is unsorted; Home re-sorts
  *  in groupPrevious by the same key, so we mirror it here. */
@@ -46,7 +50,16 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
   // One recency sort feeds both paths: empty-query recents and search results
   // (searchNotes preserves input order, so results stay newest-first).
   const sorted = React.useMemo(
-    () => (meetings.data ?? []).filter((m) => !m.is_recording).slice().sort((a, b) => recencyMs(b) - recencyMs(a)),
+    () =>
+      (meetings.data ?? [])
+        // Drop the synthetic in-progress placeholders (live recording + the
+        // processing row). They share the __live__/ sentinel summary_file, so
+        // opening one would navigate to a detail route that doesn't exist on
+        // disk. Real notes being reprocessed keep their real summary_file and
+        // stay searchable.
+        .filter((m) => !m.is_recording && !m.session_info.summary_file.startsWith(LIVE_SUMMARY_PREFIX))
+        .slice()
+        .sort((a, b) => recencyMs(b) - recencyMs(a)),
     [meetings.data],
   );
   const [query, setQuery] = React.useState('');
@@ -64,7 +77,7 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
 
   const results = React.useMemo<Meeting[]>(() => {
     if (!query.trim()) return sorted.slice(0, RECENT_COUNT);
-    return searchNotes(sorted, query);
+    return searchNotes(sorted, query).slice(0, MAX_RESULTS);
   }, [sorted, query]);
 
   // Keep selection within [0, len-1]; never let it stick at -1 once results
@@ -89,6 +102,9 @@ function CommandPalette({ onClose }: { onClose: () => void }) {
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault();
+      // Stop the Escape from also reaching document-level handlers (e.g. the
+      // QuitDialog's), which would otherwise close both at once.
+      e.stopPropagation();
       onClose();
     } else if (e.key === 'ArrowDown') {
       e.preventDefault();

--- a/app/renderer/src/components/MeetingsShell.tsx
+++ b/app/renderer/src/components/MeetingsShell.tsx
@@ -76,7 +76,6 @@ export function MeetingsShell({
   const { sidebarCollapsed, toggleSidebar } = useSidebarCollapsed();
   const { width: sidebarWidth, setWidth: setSidebarWidth } = useSidebarWidth();
 
-  const [search, setSearch] = React.useState('');
   const [newFolderOpen, setNewFolderOpen] = React.useState(false);
   const [newFolderName, setNewFolderName] = React.useState('');
   const [renameTarget, setRenameTarget] = React.useState<
@@ -217,8 +216,6 @@ export function MeetingsShell({
             onToggleCollapsed={toggleSidebar}
             width={sidebarWidth}
             onWidthChange={setSidebarWidth}
-            search={search}
-            onSearchChange={setSearch}
             folders={sidebarFolders}
             totalMeetings={totalMeetings}
             onNewFolder={() => setNewFolderOpen(true)}

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -330,7 +330,6 @@ export function Sidebar({
             />
             <button
               type="button"
-              data-sidebar-search
               data-testid="sidebar-search-trigger"
               onClick={() => palette.open()}
               className="flex h-[30px] w-full items-center rounded-md border-0 px-[10px] pl-[30px] text-left text-[13px] outline-none transition-colors hover:shadow-[inset_0_0_0_1px_hsl(var(--border))]"

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -332,7 +332,7 @@ export function Sidebar({
               type="button"
               data-testid="sidebar-search-trigger"
               onClick={() => palette.open()}
-              className="flex h-[30px] w-full items-center rounded-md border-0 px-[10px] pl-[30px] text-left text-[13px] outline-none transition-colors hover:shadow-[inset_0_0_0_1px_hsl(var(--border))]"
+              className="flex h-[30px] w-full items-center rounded-md border-0 px-[10px] pl-[30px] text-left text-[13px] outline-none transition-colors hover:shadow-[inset_0_0_0_1px_hsl(var(--border))] focus-visible:shadow-[inset_0_0_0_1px_hsl(var(--border))]"
               style={{ background: 'rgba(27,27,25,0.04)', color: 'var(--fg-muted)', fontFamily: 'var(--font-sans)' }}
               aria-label="Search notes"
             >

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import { cn, shortcut } from '@/lib/utils';
 import { LucideIcon, IconPicker } from '@/components/IconPicker';
 import { useUpdateFolderIcon } from '@/hooks/useFolders';
 import { useOrgLogout, useOrgSession, useSharedNotesGate } from '@/hooks/useOrg';
+import { useCommandPalette } from '@/components/CommandPalette';
 
 export interface SidebarMeeting {
   summaryFile: string;
@@ -137,8 +138,6 @@ interface SidebarProps {
   onToggleCollapsed: () => void;
   width: number;
   onWidthChange: (w: number) => void;
-  search: string;
-  onSearchChange: (value: string) => void;
   folders: SidebarFolder[];
   totalMeetings: number;
   onNewFolder: () => void;
@@ -152,8 +151,6 @@ export function Sidebar({
   onToggleCollapsed: _onToggleCollapsed,
   width,
   onWidthChange,
-  search,
-  onSearchChange,
   folders,
   totalMeetings,
   onNewFolder,
@@ -161,6 +158,7 @@ export function Sidebar({
   onContextAction,
   currentRoute,
 }: SidebarProps) {
+  const palette = useCommandPalette();
   const [foldersOpen, setFoldersOpen] = React.useState(true);
   const [dragOverFolder, setDragOverFolder] = React.useState<string | null>(null);
   const [dragOverAllMeetings, setDragOverAllMeetings] = React.useState(false);
@@ -234,11 +232,6 @@ export function Sidebar({
     [width, onWidthChange],
   );
 
-  const filteredFolders = React.useMemo(() => {
-    const needle = search.trim().toLowerCase();
-    if (!needle) return folders;
-    return folders.filter((f) => f.name.toLowerCase().includes(needle));
-  }, [folders, search]);
 
   return (
     <aside
@@ -335,15 +328,17 @@ export function Sidebar({
               className="pointer-events-none absolute left-[9px] top-1/2 -translate-y-1/2 size-[13px]"
               style={{ color: 'var(--fg-2)' }}
             />
-            <input
+            <button
+              type="button"
               data-sidebar-search
-              className="h-[30px] w-full rounded-md border-0 px-[10px] pl-[30px] text-[13px] outline-none transition-colors focus:shadow-[inset_0_0_0_1px_hsl(var(--border))]"
-              style={{ background: 'rgba(27,27,25,0.04)', color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
-              placeholder="Search"
-              value={search}
-              onChange={(e) => onSearchChange(e.target.value)}
-              aria-label="Search folders"
-            />
+              data-testid="sidebar-search-trigger"
+              onClick={() => palette.open()}
+              className="flex h-[30px] w-full items-center rounded-md border-0 px-[10px] pl-[30px] text-left text-[13px] outline-none transition-colors hover:shadow-[inset_0_0_0_1px_hsl(var(--border))]"
+              style={{ background: 'rgba(27,27,25,0.04)', color: 'var(--fg-muted)', fontFamily: 'var(--font-sans)' }}
+              aria-label="Search notes"
+            >
+              Search
+            </button>
             <span
               className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded px-1.5 py-px text-[11px] tabular-nums tracking-[0.02em]"
               style={{ color: 'var(--fg-muted)', background: 'rgba(27,27,25,0.04)', fontFamily: 'var(--font-sans)' }}
@@ -440,7 +435,7 @@ export function Sidebar({
             </div>
 
             {foldersOpen &&
-              filteredFolders.map((folder) => {
+              folders.map((folder) => {
                 const isOver = dragOverFolder === folder.id;
                 const isActive = activeFolderId === folder.id;
                 return (

--- a/app/renderer/src/lib/noteSearch.ts
+++ b/app/renderer/src/lib/noteSearch.ts
@@ -1,0 +1,43 @@
+import type { Meeting } from '@/lib/ipc';
+
+/**
+ * Single source of truth for note search. Case-insensitive substring match
+ * over title + summary, null-guarded so a missing name/summary can never throw
+ * (the old folder filter did `name.toLowerCase()` unguarded — the most
+ * plausible source of the "search is unresponsive" report in #213).
+ *
+ * Input order is preserved: callers pass the recency-ordered `useMeetings()`
+ * list, so results stay newest-first. An empty/whitespace query returns [] —
+ * callers decide what to show in that case (the palette shows recents).
+ */
+export function searchNotes(meetings: Meeting[], query: string): Meeting[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+  return meetings.filter((m) => {
+    const name = m.session_info.name?.toLowerCase() ?? '';
+    const summary = m.summary?.toLowerCase() ?? '';
+    return name.includes(needle) || summary.includes(needle);
+  });
+}
+
+/**
+ * Short summary excerpt for a result row. Returns a window around the first
+ * occurrence of the query in the summary (with ellipses), or the leading slice
+ * when the match was title-only / there's no summary. Never throws on null.
+ */
+export function snippet(
+  summary: string | null | undefined,
+  query: string,
+  radius = 40,
+): string {
+  const text = (summary ?? '').replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+  const needle = query.trim().toLowerCase();
+  const idx = needle ? text.toLowerCase().indexOf(needle) : -1;
+  if (idx === -1) {
+    return text.length > radius * 2 ? `${text.slice(0, radius * 2)}…` : text;
+  }
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(text.length, idx + needle.length + radius);
+  return `${start > 0 ? '…' : ''}${text.slice(start, end)}${end < text.length ? '…' : ''}`;
+}

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/hooks/useCalendarEvents';
 import { useFolders } from '@/hooks/useFolders';
 import { ipc, type CalendarEvent, type Meeting } from '@/lib/ipc';
+import { searchNotes } from '@/lib/noteSearch';
 import { navigate } from '@/lib/router';
 
 interface HomeProps {
@@ -201,13 +202,8 @@ export function Home({ mode }: HomeProps) {
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const filtered = React.useMemo(() => {
     if (mode !== 'meetings') return previous;
-    const needle = search.trim().toLowerCase();
-    if (!needle) return previous;
-    return previous.filter((m) => {
-      const name = m.session_info.name?.toLowerCase() ?? '';
-      const summary = m.summary?.toLowerCase() ?? '';
-      return name.includes(needle) || summary.includes(needle);
-    });
+    if (!search.trim()) return previous;
+    return searchNotes(previous, search);
   }, [mode, previous, search]);
   const groups = React.useMemo(() => groupPrevious(filtered), [filtered]);
 

--- a/e2e/specs/command-palette.t1.spec.ts
+++ b/e2e/specs/command-palette.t1.spec.ts
@@ -33,14 +33,29 @@ test('arrow + enter opens the selected note; esc closes', async ({ launchApp }) 
   const { page } = await launchApp(launchOpts);
 
   await page.keyboard.press('ControlOrMeta+k');
-  await page.locator(input).fill('marketing');
-  await expect(page.locator(result)).toHaveCount(1);
+  // "budget" matches two notes (Q3 Budget review title, Marketing sync summary),
+  // newest-first. ArrowDown moves selection from the first to the second.
+  await page.locator(input).fill('budget');
+  await expect(page.locator(result)).toHaveCount(2);
+  await expect(page.locator('[data-index="0"]')).toHaveAttribute('aria-selected', 'true');
+
+  await page.keyboard.press('ArrowDown');
+  await expect(page.locator('[data-index="1"]')).toHaveAttribute('aria-selected', 'true');
 
   await page.keyboard.press('Enter');
   await expect(page.locator(palette)).toBeHidden();
   await expect
     .poll(() => page.evaluate(() => window.location.hash))
     .toContain('/meetings/marketing.json');
+});
+
+test('esc closes the palette', async ({ launchApp }) => {
+  const { page } = await launchApp(launchOpts);
+
+  await page.keyboard.press('ControlOrMeta+k');
+  await expect(page.locator(palette)).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator(palette)).toBeHidden();
 });
 
 test('sidebar search box opens the palette', async ({ launchApp }) => {

--- a/e2e/specs/command-palette.t1.spec.ts
+++ b/e2e/specs/command-palette.t1.spec.ts
@@ -19,8 +19,12 @@ test('⌘K opens the palette and searches note content', async ({ launchApp }) =
   await page.keyboard.press('ControlOrMeta+k');
   await expect(page.locator(palette)).toBeVisible();
 
-  // Empty query shows recent notes (all 3 seeds).
+  // Empty query shows recent notes (all 3 seeds), newest-first. The seeds are
+  // inserted oldest-first, so this order proves the recency sort runs (not just
+  // insertion order).
   await expect(page.locator(result)).toHaveCount(3);
+  await expect(page.locator(result).nth(0)).toContainText('Q3 Budget review');
+  await expect(page.locator(result).nth(2)).toContainText('Standup notes');
 
   // "budget" matches a title (Q3 Budget review) + a summary (Marketing sync).
   await page.locator(input).fill('budget');

--- a/e2e/specs/command-palette.t1.spec.ts
+++ b/e2e/specs/command-palette.t1.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 — renderer-only, mock IPC. Drives the global ⌘K command palette (#213):
+ * opens from the shortcut + the sidebar trigger, searches note title/summary,
+ * keyboard-navigates, and opens a note. Meetings are seeded via the mock
+ * (STENOAI_E2E_SEED_MEETINGS=1 in app/e2e-mock-ipc.js).
+ */
+
+const palette = '[data-testid="command-palette"]';
+const input = '[data-testid="command-palette-input"]';
+const result = '[data-testid="command-palette-result"]';
+
+const launchOpts = { mockIpc: true, env: { STENOAI_E2E_SEED_MEETINGS: '1' } } as const;
+
+test('⌘K opens the palette and searches note content', async ({ launchApp }) => {
+  const { page } = await launchApp(launchOpts);
+
+  await page.keyboard.press('ControlOrMeta+k');
+  await expect(page.locator(palette)).toBeVisible();
+
+  // Empty query shows recent notes (all 3 seeds).
+  await expect(page.locator(result)).toHaveCount(3);
+
+  // "budget" matches a title (Q3 Budget review) + a summary (Marketing sync).
+  await page.locator(input).fill('budget');
+  await expect(page.locator(result)).toHaveCount(2);
+  await expect(page.locator(palette)).toContainText('Q3 Budget review');
+  await expect(page.locator(palette)).toContainText('Marketing sync');
+});
+
+test('arrow + enter opens the selected note; esc closes', async ({ launchApp }) => {
+  const { page } = await launchApp(launchOpts);
+
+  await page.keyboard.press('ControlOrMeta+k');
+  await page.locator(input).fill('marketing');
+  await expect(page.locator(result)).toHaveCount(1);
+
+  await page.keyboard.press('Enter');
+  await expect(page.locator(palette)).toBeHidden();
+  await expect
+    .poll(() => page.evaluate(() => window.location.hash))
+    .toContain('/meetings/marketing.json');
+});
+
+test('sidebar search box opens the palette', async ({ launchApp }) => {
+  const { page } = await launchApp(launchOpts);
+
+  // Under mock IPC the app lands on the setup wizard (no model installed),
+  // which has no sidebar. Go to Home, which renders it. The one-shot setup
+  // gate already fired on launch, so it won't redirect us back.
+  await page.evaluate(() => {
+    window.location.hash = '#/';
+  });
+
+  await page.locator('[data-testid="sidebar-search-trigger"]').click();
+  await expect(page.locator(palette)).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator(palette)).toBeHidden();
+});


### PR DESCRIPTION
## Summary

Replaces the misleading folder-name `⌘K` filter with a single global **command palette** that searches notes (title + summary) from any screen and opens them. This is the concrete implementation of the direction agreed in the thread (#213).

**What changes**
- `⌘K` now opens a command palette overlay (search field + live note results, `↑↓` navigate / `↵` open / `esc` close), rendered above any screen. Picking a result opens the note.
- The top-left **"Search" box stays visible as the trigger** (click/focus opens the palette, keeps the `⌘K` hint) — it no longer live-filters folder names. The folder tree stays for navigation.
- The **"Search notes" box on All notes stays** as an in-page list filter.
- Both the palette and the All-notes box call **one shared matcher** (`lib/noteSearch.ts`) — a single search code path instead of two divergent ones. The matcher is null-guarded (`name?.toLowerCase() ?? ''`), which also removes the unguarded `name.toLowerCase()` the old folder filter had — the most plausible source of the "search is unresponsive" report.

**Open questions answered with defaults** (easy to flip if you'd prefer otherwise):
- Empty query shows the ~8 most-recent notes (palette is useful the instant it opens).
- Results are notes only — no per-result folder label in v1.

## Test Plan
- New T1 e2e `command-palette.t1.spec.ts` (renderer-only, mock IPC): `⌘K` opens the palette; query matches title + summary; `↓`+`↵` opens the note; sidebar box opens the palette; `esc` closes.
- `npm run typecheck:renderer` — clean.
- `npm run lint:renderer` — 0 errors.
- Full T1 suite — 12/12 pass (no regressions).

Closes #213

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global ⌘K command palette that searches notes (title + summary) from any screen and opens them. The sidebar “Search” now triggers the palette; the All notes search stays as an in-page filter, and results are newest-first with 8 recent notes on empty queries.

- **New Features**
  - ⌘K opens a command palette overlay with live results (capped at 50); ↑↓ to navigate, Enter to open, Esc to close.
  - Sidebar “Search” button launches the palette (folder-name filtering removed).
  - Empty query shows the 8 most recent notes; results keep newest-first.
  - Palette and All notes share one matcher in `lib/noteSearch.ts` (title + summary search with a summary snippet).

- **Bug Fixes**
  - The shared matcher is null-guarded (name/summary), preventing crashes that caused the “search is unresponsive” issue.
  - Palette a11y and keyboard reliability: clamp selection to >=0, combobox roles with `aria-activedescendant`, scroll active option into view, restore focus to the trigger on close, trap Tab, and show a visible focus ring on the sidebar trigger.
  - Exclude synthetic in-progress placeholders (live recording and processing rows) from results to avoid broken navigation.
  - Stop Escape from bubbling to app-level handlers when closing the palette.

<sup>Written for commit 49088e8d8c37c7604037b331186333a87a42d1b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

