### PR TITLE
fix: agree on the data dir in dev so import dedup works (#233)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -636,14 +636,19 @@ function getAllowedBaseDirs() {
 // handler that can't `await runPythonScript`.
 function resolveRecordingsDir() {
   let dir;
-  if (_cachedCustomStoragePath) {
+  if (_cachedCustomStoragePath && !process.env.STENOAI_USER_DATA_DIR) {
     dir = path.join(_cachedCustomStoragePath, 'recordings');
-  } else if (app.isPackaged) {
-    // getUserDataDir() (not a macOS literal) so the packaged path is correct on
-    // Windows (%APPDATA%/stenoai) too; identical on macOS.
-    dir = path.join(getUserDataDir(), 'recordings');
   } else {
-    dir = path.join(__dirname, '..', 'recordings');
+    // getUserDataDir() resolves the per-OS data dir when packaged (Windows
+    // %APPDATA%/stenoai; identical on macOS) AND honors STENOAI_USER_DATA_DIR
+    // (the e2e temp dir) — so JS agrees with the backend's get_data_dirs() in
+    // every mode. The old hardcoded REPO/recordings dev branch ignored both,
+    // so the dev app (and e2e) disagreed with the frozen backend, which writes
+    // notes under ~/Library even in dev — that mismatch broke import-collision
+    // dedup in `npm start` (#233). The STENOAI_USER_DATA_DIR guard above mirrors
+    // get_data_dirs()'s precedence (config.py): the e2e isolation override beats
+    // a configured custom storage path, so a test can never escape the temp dir.
+    dir = path.join(getUserDataDir(), 'recordings');
   }
   fs.mkdirSync(dir, { recursive: true });
   return dir;
@@ -5990,13 +5995,17 @@ ipcMain.handle('get-recordings-dir', async () => {
     const jsonData = JSON.parse(result.trim());
 
     let recordingsDir;
-    if (jsonData.storage_path) {
+    if (jsonData.storage_path && !process.env.STENOAI_USER_DATA_DIR) {
       recordingsDir = path.join(jsonData.storage_path, 'recordings');
-    } else if (app.isPackaged) {
-      // getUserDataDir() for the correct Windows path (%APPDATA%); identical on macOS.
-      recordingsDir = path.join(getUserDataDir(), 'recordings');
     } else {
-      recordingsDir = path.join(__dirname, '..', 'recordings');
+      // getUserDataDir() resolves the per-OS data dir when packaged (Windows
+      // %APPDATA%; identical on macOS) AND honors STENOAI_USER_DATA_DIR (the
+      // e2e temp dir). The old hardcoded REPO/recordings dev branch disagreed
+      // with the frozen backend (which writes under ~/Library even in dev),
+      // breaking import-collision dedup in `npm start` (#233). The override
+      // guard mirrors get_data_dirs() precedence (config.py): e2e isolation
+      // beats custom storage. Mirrors resolveRecordingsDir().
+      recordingsDir = path.join(getUserDataDir(), 'recordings');
     }
 
     // Ensure directory exists

--- a/e2e/specs/audio-import-collision-roundtrip.t2.spec.ts
+++ b/e2e/specs/audio-import-collision-roundtrip.t2.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { makeWav } from '../fixtures/make-wav';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { selectEngine, isEngineModelReady, E2E_ENGINE } from '../fixtures/engine';
+import { killOllama } from '../fixtures/kill-ollama';
+import { mkdirSync, existsSync, readFileSync, rmSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — import-collision dedup, end-to-end through the real backend (@pipeline).
+ *
+ * The model-free audio-import-collision.t2 seeds a fake note in the JS-computed
+ * output dir and asserts only the JS-side copy bumps the stem. It structurally
+ * CANNOT catch a JS↔Python directory disagreement, because it never drives the
+ * Python round-trip that writes the real note. That blind spot is exactly how
+ * #233 slipped through: in dev the JS resolvers returned repo-root recordings/
+ * while the frozen backend wrote under ~/Library, so noteExists() checked an
+ * always-empty dir and a re-import silently overwrote the first note.
+ *
+ * This spec closes the gap. It runs the FULL pipeline twice with the same
+ * basename, letting the real backend write each summary, and asserts the second
+ * import is bumped to <stem>-1 with the first note byte-for-byte intact. It is
+ * the precise #233 scenario: by the time the second import runs, the first
+ * import's audio has been unlinked (keep_recordings off) but its durable note
+ * survives — so the dedup MUST consult the output dir the backend actually
+ * wrote to. Fails on the pre-fix resolvers (JS checks repo output/, backend
+ * wrote temp output/), passes once both layers honor STENOAI_USER_DATA_DIR.
+ *
+ * Tagged @pipeline: needs the model-bearing lane (two real transcriptions) and
+ * stays out of the fast model-free T2 lane.
+ */
+
+type StenoWindow = Window & {
+  stenoai: {
+    recording: {
+      processFile: (filePath: string, name: string) => Promise<{ success?: boolean; error?: string }>;
+      getDir: () => Promise<{ success?: boolean; path?: string }>;
+    };
+  };
+};
+
+test('@pipeline a re-import of a same-basename file is deduped end-to-end and keeps the first note', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // Two full transcribe+summarise passes plus two completion polls and an unlink
+  // poll; budget well above double the single-run @pipeline spec (180 s) so a
+  // cold CI runner (whisper, no Metal) has headroom and doesn't flake.
+  test.setTimeout(480_000);
+
+  // Mock Ollama on 11434 so summarisation never reaches a real LLM (kill any
+  // stray real one first so the successful bind proves the port is ours).
+  killOllama();
+  const ollama = await startMockOllama();
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Summaries land in the isolated temp output dir (both layers honor the
+  // STENOAI_USER_DATA_DIR keystone). process-streaming writes <stem>_summary.md
+  // (and emits SAVED:) — NOT _summary.json — so we poll the .md.
+  const outputDir = path.join(userDataDir, 'output');
+  const firstNote = path.join(outputDir, 'imported_summary.md');
+  const secondNote = path.join(outputDir, 'imported-1_summary.md');
+
+  let recordingsDir: string | undefined;
+
+  try {
+    const { page } = await launchApp();
+    await selectEngine(page);
+
+    // Skip loudly if the active engine's model isn't installed (transcribe would
+    // otherwise auto-download ~0.5 GB). CI installs it before this spec.
+    const modelReady = await isEngineModelReady(page);
+    if (!modelReady) {
+      // eslint-disable-next-line no-console
+      console.warn(`[t2:@pipeline] SKIPPED: ${E2E_ENGINE} model not installed on this runner.`);
+      test.info().annotations.push({ type: 'skip-reason', description: `${E2E_ENGINE} model not installed` });
+    }
+    test.skip(!modelReady, `${E2E_ENGINE} model not installed`);
+
+    const dir = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.recording.getDir(),
+    );
+    recordingsDir = dir?.path;
+    // getDir() must resolve to the isolated temp dir — the heart of #233. If it
+    // returned repo-root recordings/ (the old dev quirk) while the backend wrote
+    // under the override, the dedup would consult the wrong output dir.
+    expect(recordingsDir).toBe(path.join(userDataDir, 'recordings'));
+
+    // First import: a file that lives OUTSIDE the recordings dir.
+    const srcDir1 = path.join(userDataDir, 'import-src-1');
+    mkdirSync(srcDir1, { recursive: true });
+    const srcPath1 = path.join(srcDir1, 'imported.wav');
+    makeWav(srcPath1, { seconds: 5 });
+
+    const queued1 = await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.recording.processFile(p, 'Imported Note'),
+      srcPath1,
+    );
+    expect(queued1?.success).toBe(true);
+
+    // Let the FIRST import finish: the note is written and (keep_recordings off)
+    // the copied audio is unlinked. This is the trap — the stem is now free in
+    // recordings/ but the durable note exists in output/.
+    await expect
+      .poll(() => existsSync(firstNote), { timeout: 150_000, intervals: [1000] })
+      .toBe(true);
+    await expect
+      .poll(() => existsSync(path.join(recordingsDir!, 'imported.wav')), {
+        timeout: 30_000,
+        intervals: [500],
+      })
+      .toBe(false);
+    const firstNoteBody = readFileSync(firstNote, 'utf8');
+    expect(firstNoteBody.length).toBeGreaterThan(0);
+
+    // Second import: a DIFFERENT file that happens to share the basename.
+    const srcDir2 = path.join(userDataDir, 'import-src-2');
+    mkdirSync(srcDir2, { recursive: true });
+    const srcPath2 = path.join(srcDir2, 'imported.wav');
+    makeWav(srcPath2, { seconds: 5 });
+
+    const queued2 = await page.evaluate(
+      (p) => (window as StenoWindow).stenoai.recording.processFile(p, 'Imported Note Again'),
+      srcPath2,
+    );
+    expect(queued2?.success).toBe(true);
+
+    // The dedup must have bumped it: the second note lands at imported-1, not
+    // imported. On the pre-fix code JS checked the wrong (empty) output dir, so
+    // the second import reused "imported" and overwrote the first note.
+    await expect
+      .poll(() => existsSync(secondNote), { timeout: 150_000, intervals: [1000] })
+      .toBe(true);
+
+    // The first import's note is byte-for-byte intact — nothing overwrote it.
+    expect(readFileSync(firstNote, 'utf8')).toBe(firstNoteBody);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    // Teardown: the app may have spawned its own `ollama serve` despite the
+    // mock (probe race); don't let it outlive the test.
+    killOllama();
+    // Best-effort copy cleanup (the temp dir is torn down by the fixture anyway).
+    if (recordingsDir) {
+      rmSync(path.join(recordingsDir, 'imported.wav'), { force: true });
+      rmSync(path.join(recordingsDir, 'imported-1.wav'), { force: true });
+    }
+  }
+});

--- a/e2e/specs/audio-import-collision.t2.spec.ts
+++ b/e2e/specs/audio-import-collision.t2.spec.ts
@@ -25,10 +25,11 @@ import path from 'path';
  * unlink" case stays in audio-import.t2 (@pipeline).
  *
  * The seeded note goes in the output dir that copyImportIntoRecordings actually
- * checks — the sibling of the app's recordings dir (from getDir()). In an
- * unpackaged run that's the repo-root output/ (resolveRecordingsDir doesn't
- * honor STENOAI_USER_DATA_DIR in dev — a pre-existing quirk; the dirs coincide
- * with the user-data root once packaged), so the finally cleans up that scratch.
+ * checks — the sibling of the app's recordings dir (from getDir()). Both
+ * resolvers now honor STENOAI_USER_DATA_DIR, so under e2e that's the per-test
+ * temp dir (the keystone): fully isolated, never the real ~/Library or repo
+ * scratch. (#233 fixed the old dev quirk where getDir() returned repo-root
+ * recordings/ while the frozen backend wrote under ~/Library.)
  */
 
 type StenoWindow = Window & {
@@ -219,11 +220,10 @@ test('a stale .import marker left by a crash does not permanently force a suffix
 
   const realDirBefore = fileSig(realUserDataDir());
 
-  // The dir resolveRecordingsDir() uses in an unpackaged (dev) run — repo-root/
-  // recordings, independent of STENOAI_USER_DATA_DIR (the same pre-existing dev
-  // quirk the other tests in this file rely on). Seeded BEFORE launch so the
-  // marker is present when the startup sweep runs.
-  const recordingsDir = path.resolve(__dirname, '..', '..', 'recordings');
+  // The dir the app copies into. Both resolvers now honor STENOAI_USER_DATA_DIR,
+  // so under e2e this is the per-test temp dir (isolated). Seeded BEFORE launch
+  // so the marker is present when the startup sweep runs.
+  const recordingsDir = path.join(userDataDir, 'recordings');
   mkdirSync(recordingsDir, { recursive: true });
   const stem = 'crashedimport';
   const staleMarker = path.join(recordingsDir, `.${stem}.import`);

--- a/e2e/specs/audio-import.t2.spec.ts
+++ b/e2e/specs/audio-import.t2.spec.ts
@@ -114,10 +114,10 @@ test('@pipeline importing a file creates a note and leaves the original on disk'
     // Teardown: the app may have spawned its own `ollama serve` despite the
     // mock (probe race); don't let it outlive the test.
     killOllama();
-    // Best-effort: the copy lands in the app's recordings dir. keep_recordings
-    // defaults off so a successful transcribe already unlinked it, but if the
-    // run skipped or failed mid-way, clean up so the dev recordings/ dir (which
-    // isn't STENOAI_USER_DATA_DIR-isolated in an unpackaged run) stays tidy.
+    // Best-effort: the copy lands in the app's recordings dir (now
+    // STENOAI_USER_DATA_DIR-isolated, so the fixture tears it down anyway).
+    // keep_recordings defaults off, so a successful transcribe already unlinked
+    // it; this just tidies a skipped/failed mid-way run.
     if (recordingsDir) {
       rmSync(path.join(recordingsDir, 'imported.wav'), { force: true });
     }


### PR DESCRIPTION
Fixes #233.

## Problem
In dev (`npm start`) the JS layer and the spawned **frozen** Python backend disagree on the data dir. Both JS recordings-dir resolvers (`resolveRecordingsDir` and the `get-recordings-dir` handler) hardcoded `REPO/recordings`, while the frozen bundle writes notes under `~/Library` (`is_bundled()`). So `copyImportIntoRecordings`'s collision check (#185) consulted `REPO/output` — always empty in dev — and a same-basename re-import silently overwrote the first note instead of bumping to `<stem>-1`. Production was unaffected (packaged JS already used `getUserDataDir()`).

## Fix
Route both resolvers through `getUserDataDir()` for the non-custom case, so JS agrees with the backend's `get_data_dirs()` in every mode:

| Mode | recordings/output root | Backend | Agree? |
|---|---|---|---|
| Dev, no custom storage | `~/Library/.../stenoai` | `~/Library` (is_bundled) | yes |
| Dev, custom storage | `CUSTOM` | `CUSTOM` | yes |
| E2E (override = temp) | `temp` | `temp` | yes + isolated |
| Packaged | `~/Library` | `~/Library` | yes (unchanged) |

Also guards custom storage with `!STENOAI_USER_DATA_DIR` so the e2e isolation override beats a configured `storage_path`, mirroring `get_data_dirs()` precedence (config.py). **No Python change, no new env var.**

Behavioral note: in dev, imports now copy into `~/Library/.../stenoai/recordings` (where the frozen backend already writes), instead of the repo-root scratch. `config.json`/credentials are unaffected (already resolve to `~/Library` in dev).

## Tests
- **New `@pipeline` round-trip regression** (`audio-import-collision-roundtrip.t2`): drives the real backend twice with the same basename and asserts the re-import is deduped to `<stem>-1` with the first note byte-for-byte intact. Verified RED on the pre-fix resolvers (the second note never appears → first is overwritten), green after.
- The existing model-free collision specs become hermetic now that `getDir()` honors the override (was a documented "pre-existing quirk"). All green; `save-notes-location`/`settings-roundtrip` (custom storage) green too.

## Out of scope (spotted while here, not fixed)
- `process-system-audio-recording` looks for a notes file under `getBackendCwd()/_internal/output` (main.js ~6184) while notes are written to the canonical output dir — system-audio processing can miss a user notes file. Unverified; possibly a separate bug.
- `setup-system-check` still has the packaged/dev `REPO` split (main.js ~3300), pre-creating empty repo-root dirs in dev. Runtime-harmless but could use `getUserDataDir()`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align dev data directories between the JS app and the frozen Python backend so import dedup works. Prevents same-basename re-imports from overwriting the first note in dev and `@pipeline` runs.

- **Bug Fixes**
  - Both recordings-dir resolvers now use getUserDataDir() for non-custom paths, matching the backend’s get_data_dirs() in dev, e2e, and packaged modes.
  - Custom storage is ignored when STENOAI_USER_DATA_DIR is set, mirroring backend precedence and ensuring e2e isolation.
  - Dev imports now copy into the OS user data dir (e.g., ~/Library/.../stenoai/recordings), not the repo root.
  - Added `@pipeline` round-trip regression spec to verify dedup bumps to "<stem>-1" and keeps the first note intact. No Python changes or new env vars.

<sup>Written for commit ea36b0a7a0704d7f161d14f0e72c86cfeddb5cda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

