### PR TITLE
chore: add CODEOWNERS requiring @ruzin review on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require @ruzin review on all changes. With require_code_owner_reviews
+# enabled on main, every PR needs the owner's approval before merge.
+* @ruzin


### PR DESCRIPTION
Adds `.github/CODEOWNERS` (`* @ruzin`). Paired with `require_code_owner_reviews` (just enabled on `main`), this **guarantees your approval on every PR** — not just any single approval.

Part of locking down the write collaborator: also enabled `require_last_push_approval` and a ruleset protecting `v*` release tags (admins-only).

**Note:** this bootstrap PR needs your merge to take effect — once CODEOWNERS is on `main`, the code-owner rule is live for all subsequent PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.github/CODEOWNERS` with `* @ruzin` to require the owner’s review on all changes. With `require_code_owner_reviews` enabled on `main`, every PR must be approved by `@ruzin` before merge.

<sup>Written for commit f6c001d003bfe5b1e5d0bc942163422855078a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

