### PR TITLE
fix(org): route adapter + S3 calls through Electron net.fetch (honor system proxy + cert store)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, Notification, powerMonitor } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, Notification, powerMonitor, net } = require('electron');
 
 // Prevent EPIPE crashes when stdout/stderr pipe is broken (e.g. launching terminal closed)
 process.stdout?.on('error', () => {});
@@ -8082,7 +8082,12 @@ async function adapterFetch(pathname, opts = {}) {
     authorization: 'Bearer ' + session.token,
     ...(opts.headers || {}),
   };
-  const res = await fetch(session.adapterUrl + pathname, { ...opts, headers });
+  // net.fetch (Chromium's network stack) rather than Node's global fetch
+  // (undici): undici ignores the OS system proxy + certificate store, so on a
+  // corporate-proxied machine every adapter call — and the S3 PUT below — would
+  // fail. net.fetch honours the system proxy (incl. PAC) and the OS trust store
+  // on both Windows and macOS. Same for every other org/S3 call in this file.
+  const res = await net.fetch(session.adapterUrl + pathname, { ...opts, headers });
   const text = await res.text();
   let body;
   try {
@@ -8168,7 +8173,7 @@ ipcMain.handle('org-login', async (_event, payload) => {
     const url = normaliseAdapterUrl(adapterUrl);
     if (!url) return { success: false, error: 'adapter URL is required' };
     if (!email || !password) return { success: false, error: 'email and password are required' };
-    const res = await fetch(url + '/auth/login', {
+    const res = await net.fetch(url + '/auth/login', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ email, password }),
@@ -8340,7 +8345,7 @@ ipcMain.handle('org-sso-google-start', async (_event, payload) => {
     const redirectUri = `http://127.0.0.1:${port}/callback`;
 
     // 3. Ask the adapter to mint the authorize URL.
-    const startRes = await fetch(adapterUrl + '/auth/sso/google/start', {
+    const startRes = await net.fetch(adapterUrl + '/auth/sso/google/start', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -8363,7 +8368,7 @@ ipcMain.handle('org-sso-google-start', async (_event, payload) => {
     const code = await waitForCallback(state, 5 * 60 * 1000);
 
     // 6. Exchange via the adapter.
-    const cbRes = await fetch(adapterUrl + '/auth/sso/google/callback', {
+    const cbRes = await net.fetch(adapterUrl + '/auth/sso/google/callback', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -8527,10 +8532,13 @@ async function uploadMeetingToOrg({ title, body, transcript = '', visibility = '
 
   // Step 2: PUT the markdown bytes straight to S3. Bucket has SSE-AES256
   // by default; the upload inherits that.
-  const putRes = await fetch(presign.upload_url, {
+  const putRes = await net.fetch(presign.upload_url, {
     method: 'PUT',
     headers: { 'content-type': 'text/markdown' },
     body,
+    // Presigned URL carries its own auth in the query string — don't let the
+    // session attach cookies/credentials to the S3 request.
+    credentials: 'omit',
   });
   if (!putRes.ok) {
     const detail = await putRes.text().catch(() => '');
@@ -8555,10 +8563,11 @@ async function uploadMeetingToOrg({ title, body, transcript = '', visibility = '
           content_type: 'text/plain',
         }),
       });
-      const tPut = await fetch(tPresign.upload_url, {
+      const tPut = await net.fetch(tPresign.upload_url, {
         method: 'PUT',
         headers: { 'content-type': 'text/plain' },
         body: transcriptText,
+        credentials: 'omit',
       });
       if (tPut.ok) {
         transcriptKey = tPresign.s3_key;
@@ -8786,7 +8795,7 @@ ipcMain.on('org-chat-stream', async (event, streamId, payload) => {
   sender.once('destroyed', onDestroyed);
 
   try {
-    const res = await fetch(session.adapterUrl + '/ai/chat/stream', {
+    const res = await net.fetch(session.adapterUrl + '/ai/chat/stream', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',

--- a/app/main.js
+++ b/app/main.js
@@ -8087,7 +8087,9 @@ async function adapterFetch(pathname, opts = {}) {
   // corporate-proxied machine every adapter call — and the S3 PUT below — would
   // fail. net.fetch honours the system proxy (incl. PAC) and the OS trust store
   // on both Windows and macOS. Same for every other org/S3 call in this file.
-  const res = await net.fetch(session.adapterUrl + pathname, { ...opts, headers });
+  // credentials:'omit' — the adapter authenticates via the Bearer header above,
+  // not session cookies; net.fetch defaults to 'include', so be explicit.
+  const res = await net.fetch(session.adapterUrl + pathname, { ...opts, headers, credentials: 'omit' });
   const text = await res.text();
   let body;
   try {
@@ -8177,6 +8179,7 @@ ipcMain.handle('org-login', async (_event, payload) => {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ email, password }),
+      credentials: 'omit',
     });
     const text = await res.text();
     let body;
@@ -8353,6 +8356,7 @@ ipcMain.handle('org-sso-google-start', async (_event, payload) => {
         code_challenge: codeChallenge,
         state,
       }),
+      credentials: 'omit',
     });
     const startBody = await startRes.json().catch(() => ({}));
     if (!startRes.ok) {
@@ -8376,6 +8380,7 @@ ipcMain.handle('org-sso-google-start', async (_event, payload) => {
         code_verifier: codeVerifier,
         redirect_uri: redirectUri,
       }),
+      credentials: 'omit',
     });
     const cbBody = await cbRes.json().catch(() => ({}));
     if (!cbRes.ok) {
@@ -8803,6 +8808,7 @@ ipcMain.on('org-chat-stream', async (event, streamId, payload) => {
       },
       body: JSON.stringify(payload || {}),
       signal: controller.signal,
+      credentials: 'omit',
     });
     if (!res.ok) {
       let detail = '';

--- a/e2e/fixtures/mock-proxy.js
+++ b/e2e/fixtures/mock-proxy.js
@@ -1,0 +1,61 @@
+// Minimal forward HTTP proxy for the T2 tier. Records every absolute-form
+// request URL it's asked to proxy, then forwards it to the real target and
+// pipes the response back. Used by proxy-routing.t2 to prove the desktop's
+// org/S3 HTTP calls go through the system/session proxy (i.e. Electron
+// net.fetch, not Node's undici which ignores the proxy entirely).
+//
+// The mock adapter is plain HTTP on loopback, so Chromium would normally
+// BYPASS the proxy for it — the spec defeats that with proxyBypassRules
+// '<-loopback>', which forces even loopback requests through here.
+const http = require('http');
+
+/**
+ * Start the proxy on an ephemeral loopback port.
+ * @returns {Promise<{ url: string, port: number, requests: () => string[], close: () => Promise<void> }>}
+ */
+function startMockProxy() {
+  const seen = [];
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      // In forward-proxy mode req.url is absolute-form: http://host:port/path
+      seen.push(req.url);
+      let target;
+      try {
+        target = new URL(req.url);
+      } catch {
+        res.writeHead(400);
+        return res.end();
+      }
+      const proxyReq = http.request(
+        {
+          host: target.hostname,
+          port: target.port || 80,
+          path: target.pathname + target.search,
+          method: req.method,
+          headers: req.headers,
+        },
+        (proxyRes) => {
+          res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+          proxyRes.pipe(res);
+        },
+      );
+      proxyReq.on('error', () => {
+        if (!res.headersSent) res.writeHead(502);
+        res.end();
+      });
+      req.pipe(proxyReq);
+    });
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        port,
+        requests: () => seen.slice(),
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+module.exports = { startMockProxy };

--- a/e2e/specs/proxy-routing.t2.spec.ts
+++ b/e2e/specs/proxy-routing.t2.spec.ts
@@ -101,7 +101,11 @@ test('org/S3 traffic routes through the system proxy (net.fetch, not undici); re
     const proxied = proxy.requests();
     const adapterHost = adapter.url.replace(/^https?:\/\//, '');
     expect(proxied.some((u) => u.includes(adapterHost))).toBe(true);
-    expect(proxied.some((u) => u.includes('/auth/login') || u.includes('/meetings') || u.includes('/uploads/presign'))).toBe(true);
+    // The adapter auth/CRUD call traversed the proxy...
+    expect(proxied.some((u) => u.includes('/auth/login'))).toBe(true);
+    // ...and so did the S3 PUT specifically (the originally-broken leg — the
+    // mock's presigned upload_url points back at itself as /s3/<key>).
+    expect(proxied.some((u) => u.includes('/s3/'))).toBe(true);
 
     // Keystone: nothing leaked into the real user-data dir.
     expect(fileSig(realUserDataDir())).toBe(realDirBefore);

--- a/e2e/specs/proxy-routing.t2.spec.ts
+++ b/e2e/specs/proxy-routing.t2.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockAdapter } from '../fixtures/mock-adapter';
+import { startMockProxy } from '../fixtures/mock-proxy';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import path from 'path';
+
+/**
+ * T2 — the desktop's org/S3 HTTP calls honour the system/session proxy.
+ *
+ * Regression guard for the corporate-proxy fix: the main process now uses
+ * Electron net.fetch (Chromium's network stack) instead of Node's global
+ * fetch (undici, which ignores the OS proxy + cert store). We point the
+ * Electron default session at a recording forward-proxy, drive an org
+ * sign-in + share through the real IPC, and assert the proxy actually SAW
+ * the adapter traffic. If anyone reverts to undici fetch, undici bypasses
+ * the session proxy → the proxy records nothing → this fails.
+ *
+ * The mock adapter is loopback HTTP, which Chromium would normally bypass,
+ * so we set proxyBypassRules '<-loopback>' to force it through the proxy.
+ */
+
+type Result = { success: boolean; error?: string };
+type Meeting = { id: string; title?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    org: {
+      login: (url: string, email: string, password: string) => Promise<Result & { signedIn?: boolean }>;
+      status: () => Promise<{ signedIn: boolean }>;
+      shareMeeting: (payload: unknown) => Promise<Result & { meeting?: Meeting }>;
+      listMeetings: () => Promise<Result & { meetings: Meeting[] }>;
+    };
+  };
+};
+
+test('org/S3 traffic routes through the system proxy (net.fetch, not undici); real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const adapter = await startMockAdapter();
+  const proxy = await startMockProxy();
+  try {
+    const { app, page } = await launchApp();
+
+    // .org-session needs safeStorage; skip LOUDLY on a headless runner without
+    // a usable keyring (mirrors org-crud.t2 / org-backup-failure.t2).
+    const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
+      safeStorage.isEncryptionAvailable(),
+    );
+    if (!encryptionAvailable) {
+      // eslint-disable-next-line no-console
+      console.warn('[t2] SKIPPED proxy-routing: safeStorage unavailable on this runner.');
+      test.info().annotations.push({
+        type: 'skip-reason',
+        description: 'safeStorage unavailable; org session cannot persist',
+      });
+    }
+    test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
+
+    // Point the default session at the recording proxy. '<-loopback>' removes
+    // Chromium's implicit loopback bypass so the loopback adapter goes through
+    // it (net.fetch uses the default session).
+    await app.evaluate(({ session }, proxyPort) =>
+      session.defaultSession.setProxy({
+        proxyRules: `http=127.0.0.1:${proxyPort}`,
+        proxyBypassRules: '<-loopback>',
+      }),
+      proxy.port,
+    );
+
+    // Sign in (an adapter call) + share (presign + S3 PUT + register) — all
+    // org/S3 net.fetch traffic that must now traverse the proxy.
+    const login = await page.evaluate(
+      (url) => (window as StenoWindow).stenoai.org.login(url, 'e2e@example.com', 'pw'),
+      adapter.url,
+    );
+    expect(login.success).toBe(true);
+    await expect
+      .poll(async () =>
+        (await page.evaluate(() => (window as StenoWindow).stenoai.org.status())).signedIn,
+      )
+      .toBe(true);
+
+    const summaryFile = path.join(userDataDir, 'output', 'proxied-note_summary.json');
+    const share = await page.evaluate(
+      (sf) =>
+        (window as StenoWindow).stenoai.org.shareMeeting({
+          title: 'Proxied Note',
+          body: '# Proxied Note\n\nbody',
+          summaryFile: sf,
+        }),
+      summaryFile,
+    );
+    expect(share.success).toBe(true);
+    // The markdown + transcript PUTs in the mock point back at the adapter, so
+    // they also count as proxied traffic.
+    expect(adapter.s3Puts()).toBeGreaterThan(0);
+
+    // The proxy must have seen the adapter traffic — proof net.fetch honoured
+    // the session proxy. (undici would have bypassed it entirely.)
+    const proxied = proxy.requests();
+    const adapterHost = adapter.url.replace(/^https?:\/\//, '');
+    expect(proxied.some((u) => u.includes(adapterHost))).toBe(true);
+    expect(proxied.some((u) => u.includes('/auth/login') || u.includes('/meetings') || u.includes('/uploads/presign'))).toBe(true);
+
+    // Keystone: nothing leaked into the real user-data dir.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await proxy.close();
+    await adapter.close();
+  }
+});


### PR DESCRIPTION
## Description

The Electron main process used Node's global `fetch` (undici), which **ignores the OS system proxy and certificate store**. Behind a corporate proxy that blocks direct egress and/or TLS-intercepts, the **S3 PUT always went direct to AWS and failed** (`fetch failed`) — the silent org-backup failure an enterprise client hit. Adapter calls (sign-in, AI chat) worked because the adapter was directly reachable, so the symptom was "AI works, S3 fails."

**Reproduced + root-caused on a Windows VM:** with a recording proxy, the app's S3 PUT never appeared in the proxy — it bypassed it entirely and went direct. Blocking the direct S3 path (≈ corporate egress block) made the backup fail exactly like the client's, with the new `[org-backup] … fetch failed` log line (from #239) capturing it.

**Fix:** route the org-adapter + S3 HTTP calls through **Electron's `net.fetch`** (Chromium's network stack), which honors the system proxy (incl. PAC/WPAD) and the OS certificate store on **both Windows and macOS**. Covered sites in `app/main.js`:
- `adapterFetch` wrapper (all 9 adapter call sites: meetings CRUD, `/uploads/presign`, register `/meetings`, `/policy`)
- `org-login`, SSO start + callback
- both S3 PUTs (markdown + transcript)
- `/ai/chat/stream`

All org calls pass `credentials: 'omit'` (auth is via the `Authorization: Bearer` header / presigned query string, not session cookies; `net.fetch` defaults to `'include'`). The no-proxy happy path is an identical direct connection, so the signed macOS build isn't regressed.

## Type of Change

- [x] Bug fix

## Testing

- [x] Tested locally with `npm start` — **verified against the live adapter + real AWS S3 through a recording proxy:** the real S3 PUT (`…s3.eu-west-2.amazonaws.com:443`) now routes **through the proxy** and the backup succeeds. (Before: the PUT bypassed the proxy and failed behind a corporate egress block.)
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

New coverage:
- `e2e/specs/proxy-routing.t2.spec.ts` + `e2e/fixtures/mock-proxy.js` — sets the Electron session proxy at a recording forward-proxy and asserts the org `/auth/login` **and** the S3 PUT (`/s3/…`) traversed it. Guards against a regression back to undici (which would bypass the proxy → the proxy records nothing → test fails).
- Existing `org-crud.t2` + `org-backup-failure.t2` stay green (loopback mock, no proxy → `net.fetch` goes direct = same behavior).

## Additional Notes

**Out of scope (follow-up):** the Node `https.request` calls for Google/Outlook OAuth + calendar, the GitHub update check, PostHog telemetry, and `electron-updater` *also* bypass the proxy. They're separate features (not the org-backup failure) and a clean follow-up; kept out to keep this PR scoped + verifiable.

Reviewed by QA, staff-engineer, and `/security-review` lenses (nothing critical/high; security-neutral-to-positive — `net.fetch` uses the OS cert store, no TLS bypass). Cross-platform: no `process.platform` gating; macOS signed build untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route org adapter and S3 HTTP calls through `electron` `net.fetch` so the app honors the system proxy and OS certificate store on Windows and macOS. Fixes org backups failing behind corporate proxies; no-proxy behavior is unchanged.

- **Bug Fixes**
  - Replaced Node global `fetch` (`undici`) with `electron` `net.fetch` for adapter calls and S3 presigned PUTs: login, SSO start/callback, meetings CRUD, `/uploads/presign`, `/policy`, and `/ai/chat/stream`.
  - Set `credentials: 'omit'` on all requests (auth via `Authorization` header or presigned query params).
  - Added `e2e/specs/proxy-routing.t2.spec.ts` and `e2e/fixtures/mock-proxy.js` to assert adapter traffic and S3 PUT go through the configured proxy.
  - Follow-up: other `https.request` callers (OAuth/calendar, update check, telemetry, `electron-updater`) still bypass the proxy.

<sup>Written for commit 958b720dac848d91c997029db66c3a1683c38511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

