### PR TITLE
fix(org): adopt OS system proxy at startup so net.fetch routes through it

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, Notification, powerMonitor, net } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, Notification, powerMonitor, net, session } = require('electron');
 
 // Prevent EPIPE crashes when stdout/stderr pipe is broken (e.g. launching terminal closed)
 process.stdout?.on('error', () => {});
@@ -1121,6 +1121,22 @@ if (!gotSingleInstanceLock) {
   });
 
   app.whenReady().then(async () => {
+    // Follow the OS system proxy for all main-process HTTP (net.fetch uses the
+    // default session). net.fetch alone honours the *session* proxy, but the
+    // default session does NOT auto-adopt the Windows system proxy — without
+    // this, the org adapter + S3 calls still went direct and failed behind a
+    // corporate proxy (verified on a Windows VM: net::ERR_NETWORK_ACCESS_DENIED
+    // until the session was pointed at the system proxy). mode:'system' is a
+    // no-op on a machine with no proxy configured, so the no-proxy happy path
+    // (and the signed macOS build) is unchanged. Best-effort.
+    try {
+      session.defaultSession.setProxy({ mode: 'system' }).catch((e) => {
+        console.warn('setProxy(system) failed (non-fatal):', e?.message);
+      });
+    } catch (e) {
+      console.warn('setProxy(system) threw (non-fatal):', e?.message);
+    }
+
     // Persistent diagnostic log under <userData>/logs (honors
     // STENOAI_USER_DATA_DIR via getUserDataDir, so e2e/tests stay isolated).
     // The startup marker is a stable anchor that separates sessions.


### PR DESCRIPTION
## Description

Follow-up to #241. That PR moved the org/S3 calls to Electron `net.fetch` (which honours the *session* proxy), but Electron's **default session does not auto-adopt the Windows system proxy** — so on a corporate-proxied machine the adapter + S3 calls still went **direct** and failed.

**Verified on a Windows VM:** with #241 installed, a share failed with `net::ERR_NETWORK_ACCESS_DENIED` (Chromium net stack hitting a firewall block → still going direct). Launching the same build with `--proxy-server=127.0.0.1:8080` made the backup **succeed** through the proxy — confirming `net.fetch` is correct and the only gap is system-proxy adoption.

Fix: `session.defaultSession.setProxy({ mode: 'system' })` at startup, so all main-process HTTP follows the OS proxy. `mode:'system'` is a no-op when no proxy is configured, so the no-proxy happy path and the signed macOS build are unchanged.

## Type of Change
- [x] Bug fix

## Testing
- [x] Existing `proxy-routing.t2` + `org-crud.t2` + `org-backup-failure.t2` stay green.
- [x] **Pending: Windows VM validation** — install this build (no `--proxy-server`), with mitmproxy + system proxy + the Steno-scoped S3-direct block: the S3 PUT should now route through the proxy automatically and the backup succeed.

## Notes
The plumbing (net.fetch → session proxy) is covered by `proxy-routing.t2`; this one-line startup config can't be unit/e2e-tested without a real system proxy in the test env, so it's validated on the VM rig.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopt the OS system proxy at startup so all main-process HTTP via `net.fetch` routes through it. Sets `session.defaultSession.setProxy({ mode: 'system' })` to fix Windows corporate-proxy failures where org and S3 calls went direct; no-op when no proxy is configured.

<sup>Written for commit a11c606230ef424739d41aff1cc575193366cb20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

