### PR TITLE
fix: surface context-overflow as a clear error instead of silent empty summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ ollama.pid
 
 # Local design reference library (cloned, not vendored)
 .reference/
+.worktrees
+worktrees

--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -11,21 +11,48 @@
 // PR1 org-lock spec doesn't exercise Ollama and so doesn't start it.
 //
 // Contract testing (Phase 4): pass { chatReply } to return a fixed assistant
-// message instead of the default 'ok', and read lastChatPrompt() to assert what
-// prompt the summarizer built (e.g. that it embedded the transcript). Default
-// behaviour is unchanged, so the existing @pipeline specs are unaffected.
+// message instead of the default summary, and read lastChatPrompt() to assert
+// what prompt the summarizer built (e.g. that it embedded the transcript).
+//
+// The default reply is a minimal but *valid* meeting summary markdown — it must
+// contain a `## Summary` header. process_streaming (simple_recorder.py) now
+// rejects a streamed summary with no `## Summary` section (a context-overflow
+// truncation signal) by exiting non-zero without writing the *_summary.md the
+// @pipeline specs poll for, so a bare 'ok' reply would make those specs hang
+// until their file-poll timeout. Specs that assert on the reply text override
+// chatReply explicitly and are unaffected.
 const http = require('http');
 
 const OLLAMA_PORT = 11434;
 
+// Minimal valid summary the @pipeline specs accept: a real `## Summary` header
+// plus the other sections the markdown prompt asks for, so _parse_streamed_markdown
+// yields a non-empty meeting and process_streaming writes the summary file.
+const DEFAULT_CHAT_REPLY = [
+  '## Summary',
+  'A short end-to-end test summary of the pipeline run.',
+  '',
+  '## Key Topics',
+  '### Pipeline',
+  'The synthetic recording exercised the transcribe-and-summarise pipeline.',
+  '',
+  '## Key Points',
+  '- The pipeline ran end to end.',
+  '',
+  '## Action Items',
+  '- None.',
+  '',
+].join('\n');
+
 /**
  * Start the mock Ollama on 11434.
  * @param {object} [opts]
- * @param {string} [opts.chatReply='ok'] assistant content returned by /api/chat.
+ * @param {string} [opts.chatReply] assistant content returned by /api/chat.
+ *   Defaults to a minimal valid summary markdown (with a `## Summary` header).
  * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number, pullCalls: () => number }>}
  */
 function startMockOllama(opts = {}) {
-  const chatReply = opts.chatReply ?? 'ok';
+  const chatReply = opts.chatReply ?? DEFAULT_CHAT_REPLY;
   let lastChatPrompt = null;
   let chatCalls = 0;
   let pullCalls = 0;

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -861,6 +861,40 @@ def process_streaming(audio_file, name, notes):
 
         print("STREAM_COMPLETE", flush=True)
 
+        # Validate the streamed summary before we treat it as a success. A
+        # context overflow (e.g. a transcript longer than the model's num_ctx)
+        # makes the model emit truncated output with no `## Summary` header.
+        # _parse_meeting_markdown then yields an empty summary and the UI shows
+        # "No summary available" — but the file was saved as a success and a
+        # title was hallucinated from the garbage. Detect the missing header
+        # (same convention _parse_streamed_markdown / _parse_meeting_markdown
+        # use) and fail loudly instead. We still write the raw output to a
+        # debug sidecar (NOT the *_summary.md the renderer reads) so the broken
+        # output can be inspected without the app navigating to a fake meeting.
+        has_summary_header = any(
+            line.strip().startswith('## Summary')
+            for line in streamed_md.split('\n')
+        )
+        if not has_summary_header:
+            audio_path = Path(audio_file)
+            debug_path = recorder.output_dir / f"{audio_path.stem}_summary.invalid.md"
+            try:
+                debug_path.write_text(streamed_md, encoding='utf-8')
+            except Exception as e:
+                logger.warning(f"Failed to write invalid-summary debug file: {e}")
+            # ERROR: + non-zero exit mirrors the existing failure contract the
+            # Electron main relies on (close code != 0 -> processing-complete
+            # success:false). No SAVED: is emitted, so no hallucinated meeting
+            # is navigated to.
+            print(
+                "ERROR: Summary generation failed: the model returned no "
+                "'## Summary' section, which usually means the transcript "
+                "exceeded the model's context window. Try a model with a "
+                "larger context window or a shorter recording.",
+                flush=True,
+            )
+            sys.exit(1)
+
         # Step 3: Generate title
         session_name = name
         if _AUTO_NAMED_PATTERN.match(name):
@@ -915,7 +949,18 @@ def process_streaming(audio_file, name, notes):
 
         print(f"SAVED:{summary_path}", flush=True)
 
-    asyncio.run(run())
+    try:
+        asyncio.run(run())
+    except SystemExit:
+        # An explicit sys.exit() (e.g. the invalid-summary guard above) has
+        # already printed its ERROR: line — let it propagate unchanged.
+        raise
+    except Exception as e:
+        # Surface failures (e.g. the pre-flight context-window check raising
+        # before any token streams) as a clean ERROR: line + non-zero exit,
+        # matching the run_process() contract instead of dumping a traceback.
+        print(f"ERROR: {e}", flush=True)
+        sys.exit(1)
 
 
 @cli.command(name='get-whisper-model')

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1065,6 +1065,28 @@ TRANSCRIPT:
         Yields:
             str: Text chunks as they arrive from the LLM
         """
+        # Pre-flight context check (Ollama only). Ollama silently truncates a
+        # transcript that exceeds num_ctx before the model sees it, which makes
+        # the model emit output with no `## Summary` header — surfacing
+        # downstream as an empty/"No summary available" meeting. Catch it here
+        # with a rough token estimate (~4 chars/token) and a 20% buffer for the
+        # prompt scaffolding around the transcript, and fail with a clear,
+        # actionable message instead of producing a silently-truncated summary.
+        # Cloud/adapter providers manage their own (much larger) context, so
+        # this only applies to local/remote Ollama where resolve_num_ctx is the
+        # real window we request.
+        if self.ai_provider in ("local", "remote"):
+            num_ctx = resolve_num_ctx(self.model_name)
+            estimated_tokens = len(transcript) / 4
+            if estimated_tokens > num_ctx * 0.8:
+                raise ValueError(
+                    "Transcript is too long for this model's context window "
+                    f"(~{int(estimated_tokens):,} estimated tokens vs a "
+                    f"{num_ctx:,}-token window for {self.model_name}). The "
+                    "summary would be silently truncated. Use a model with a "
+                    "larger context window or a shorter recording."
+                )
+
         prompt = self._create_markdown_prompt(transcript, language, notes)
         logger.info(f"Starting streaming summary with {self.ai_provider} model: {self.model_name}")
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -830,7 +830,19 @@ Return ONLY the response in this exact JSON format:
                     decisions=[],
                     duration_minutes=duration_minutes
                 )
-            
+
+            if self.ai_provider in ("local", "remote"):
+                num_ctx = resolve_num_ctx(self.model_name)
+                estimated_tokens = (len(transcript) + len(notes or "")) / 4
+                if estimated_tokens > num_ctx * 0.8:
+                    raise ValueError(
+                        "Transcript is too long for this model's context window "
+                        f"(~{int(estimated_tokens):,} estimated tokens vs a "
+                        f"{num_ctx:,}-token window for {self.model_name}). The "
+                        "summary would be silently truncated. Use a model with a "
+                        "larger context window or a shorter recording."
+                    )
+
             prompt = self._create_permissive_prompt(transcript, language, notes=notes)
             logger.info(f"Sending transcript to {self.ai_provider} model: {self.model_name}")
             logger.info(f"Transcript length: {len(transcript)} characters")
@@ -1077,7 +1089,7 @@ TRANSCRIPT:
         # real window we request.
         if self.ai_provider in ("local", "remote"):
             num_ctx = resolve_num_ctx(self.model_name)
-            estimated_tokens = len(transcript) / 4
+            estimated_tokens = (len(transcript) + len(notes or "")) / 4
             if estimated_tokens > num_ctx * 0.8:
                 raise ValueError(
                     "Transcript is too long for this model's context window "


### PR DESCRIPTION
## Problem

Closes #245.

When a transcript exceeds the model's context window (reproducible: `llama3.2:3b` at 8,192 tokens, 57-min meeting → ~15,000 transcript tokens), Ollama silently truncates the formatting instructions from the front of the prompt. The model echoes the raw transcript without a `## Summary` header. `_parse_meeting_markdown` reads this as an empty summary and the UI shows **"No summary available"** — while a hallucinated title is generated and the broken file is saved as a success.

## What this PR does

Two guards, no protocol changes, no new dependencies:

**1. Pre-flight token check** (`src/summarizer.py`, `summarize_transcript_streaming`)
Before the Ollama API call: estimates `len(transcript) / 4` against `num_ctx * 0.8` and raises `ValueError` with an actionable message if the transcript won't fit. Ollama-only (`local`/`remote` providers) — cloud adapters manage their own larger context.

**2. Post-stream header validation** (`simple_recorder.py`, `process_streaming`)
After streaming completes: checks for a `## Summary` header using the same `startswith` convention as `_parse_streamed_markdown` / `_parse_meeting_markdown`. If missing:
- Writes a debug sidecar `*_summary.invalid.md` (not `*_summary.md` — the renderer never sees it, so no phantom meeting is created)
- Emits `ERROR:` + exits with code 1

This backstops edge cases where the pre-flight estimate misses (unknown model, unusual tokenisation ratio).

The outer `asyncio.run()` call is wrapped so `ValueError` from the pre-flight check surfaces as `ERROR: <msg>` + exit 1, matching the existing failure contract. `SystemExit` is re-raised unchanged so the post-stream guard's own message isn't swallowed.

## Before / after

**Before:** `STREAM_COMPLETE` → hallucinated title → `SAVED:` → UI shows "No summary available"

**After (pre-flight):** `ERROR: Transcript is too long for this model's context window (~15,088 estimated tokens vs a 8,192-token window for llama3.2:3b). Use a model with a larger context window or a shorter recording.`

## What this PR does NOT do

No summary is generated for over-long meetings — that requires map-reduce chunking, tracked in #188. This PR only makes the failure visible and prevents the hallucinated-title / phantom-success state.

## Test plan

- [ ] Short meeting (<50% of model context): happy path unchanged, `SAVED:` emitted as before
- [ ] Long meeting with `llama3.2:3b` (>~26k chars transcript): `ERROR:` emitted before API call, no meeting entry created
- [ ] Manually set `num_ctx` above transcript length: pre-flight passes, post-stream header check acts as backstop if model still returns no `## Summary`
- [ ] Existing `summarize-contract.t2` e2e spec passes (no protocol regression)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear error when transcripts + notes exceed the model’s context window to prevent empty summaries and “phantom” saved meetings. Fixes #245.

- **Bug Fixes**
  - Add pre-flight context check for `local`/`remote` Ollama in `src/summarizer.py` (streaming and non-streaming): estimate `(len(transcript)+len(notes))/4` vs `num_ctx*0.8` and fail with a clear ERROR before the API call if too long.
  - Validate streamed output in `simple_recorder.py`: require a `## Summary` header; if missing, write `*_summary.invalid.md`, print ERROR, and exit 1; wrap `asyncio.run()` to surface failures as a single ERROR line and preserve `SystemExit`.
  - Update `e2e/fixtures/mock-ollama.js` to default to a minimal valid summary with a `## Summary` header so pipeline specs don’t hang under the new guard.

<sup>Written for commit 12f2e0ce7adaf0a4bd9808c2bb829d1124c94779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

