### PR TITLE
fix: rescue live transcript when batch transcription returns empty (#207)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -2470,7 +2470,22 @@ function spawnLiveTranscribe(sessionName) {
   liveTranscribeSessionName = sessionName;
   liveTranscribeStdoutBuf = '';
 
-  liveTranscribeProcess.stdout.on('data', (data) => {
+  // Per-instance drain promise: resolves when THIS process has fully closed
+  // its stdio (all stdout `data` events processed), not merely exited. We bind
+  // the resolver to `proc` so a quick stop→start can't have the old process's
+  // teardown resolve/null the NEW process's state (#207 review-2, Finding 2).
+  const proc = liveTranscribeProcess;
+  proc._drainResolve = null;
+  proc._drainPromise = new Promise((resolve) => {
+    proc._drainResolve = resolve;
+  });
+
+  proc.stdout.on('data', (data) => {
+    // Drop output from a superseded process. On a quick stop→start the OLD
+    // sidecar may still be draining; without this guard its stdout would write
+    // into the global buffer / liveTranscriptState and contaminate the NEW
+    // recording with stale segments (#207 review, Blocker 1).
+    if (liveTranscribeProcess !== proc) return;
     // Stdout arrives in arbitrary-sized chunks; concatenate then split on
     // newlines so a multi-line frame straddling reads is handled.
     liveTranscribeStdoutBuf += data.toString();
@@ -2482,26 +2497,51 @@ function spawnLiveTranscribe(sessionName) {
     }
   });
 
-  liveTranscribeProcess.stderr.on('data', (data) => {
+  proc.stderr.on('data', (data) => {
     // Python logger output goes to stderr — bubble through debug log
     // without spamming the renderer.
     sendDebugLog(`[live-transcribe] ${data.toString().trim()}`);
   });
 
-  attachProcessingStderr(liveTranscribeProcess, 'live-transcribe');
+  attachProcessingStderr(proc, 'live-transcribe');
 
-  liveTranscribeProcess.on('exit', (code, signal) => {
-    sendDebugLog(`Live transcribe sidecar exited code=${code} signal=${signal}`);
-    liveTranscribeProcess = null;
-    liveTranscribeSessionName = null;
-    liveTranscribeStdoutBuf = '';
-    // Clear the load clock if the sidecar died before LIVE_READY, so a later
-    // path can't log a duration against this stale stamp.
-    parakeetLoadStartedAt = 0;
+  // Wait on `close`, not `exit`: `exit` fires when the child terminates but
+  // does NOT guarantee stdout is fully drained and every `data` event has been
+  // processed — so the FINAL segment may not yet be in liveTranscriptState.
+  // `close` fires only after all stdio streams have closed, which is the
+  // correct barrier for the #207 fallback snapshot (review-2, Finding 1).
+  proc.on('close', (code, signal) => {
+    sendDebugLog(`Live transcribe sidecar closed code=${code} signal=${signal}`);
+    // Only clear globals if THIS process is still the active one. A quick
+    // stop→start may have already installed a fresh sidecar; nulling here
+    // would destroy the new process's state (review-2, Finding 2).
+    if (liveTranscribeProcess === proc) {
+      liveTranscribeProcess = null;
+      liveTranscribeSessionName = null;
+      liveTranscribeStdoutBuf = '';
+      // Clear the load clock if the sidecar died before LIVE_READY, so a later
+      // path can't log a duration against this stale stamp.
+      parakeetLoadStartedAt = 0;
+    }
+    // Unblock this instance's drain waiter (#207, Fix 2) now that all stdout
+    // has been flushed and parsed by the stdout handler above. Resolver is
+    // bound to `proc`, so it only ever resolves for the right process.
+    if (proc._drainResolve) {
+      const resolve = proc._drainResolve;
+      proc._drainResolve = null;
+      resolve();
+    }
   });
 
-  liveTranscribeProcess.on('error', (err) => {
+  proc.on('error', (err) => {
     sendDebugLog(`Live transcribe sidecar error: ${err.message}`);
+    // A spawn-time error means `close` may never fire — unblock the drain
+    // waiter so the fallback snapshot doesn't hang on a process that died.
+    if (proc._drainResolve) {
+      const resolve = proc._drainResolve;
+      proc._drainResolve = null;
+      resolve();
+    }
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('live-transcript-error', {
         sessionName,
@@ -2516,7 +2556,7 @@ function spawnLiveTranscribe(sessionName) {
   // immediate errors). Without a listener, EPIPE bubbles to uncaught and
   // crashes the main process. Race window: chunks queued in the IPC
   // pipeline land here after the sidecar exited (stop, crash, kill).
-  liveTranscribeProcess.stdin.on('error', (err) => {
+  proc.stdin.on('error', (err) => {
     if (err && err.code === 'EPIPE') {
       // Expected when Python exited mid-write. The exit handler will
       // null the ref so subsequent chunks short-circuit at the guard.
@@ -2588,18 +2628,31 @@ function handleLiveTranscribeLine(line) {
 // Tear down the live transcribe sidecar. Closing stdin is the clean
 // shutdown signal — Python's read loop hits EOF, drains the VAD, exits.
 // Falls back to SIGTERM after a short wait if it doesn't exit on its own.
+//
+// Returns a promise that resolves once the sidecar has fully exited (or
+// immediately if there was none). The #207 fallback snapshot awaits this so
+// it captures the FINAL segment of the last utterance, which Python only emits
+// after stdin EOF (Fix 2). Callers that don't care can ignore the return value.
 function stopLiveTranscribe() {
   const proc = liveTranscribeProcess;
-  if (!proc) return;
+  if (!proc) return Promise.resolve();
+  // The per-instance drain promise (installed in spawnLiveTranscribe) resolves
+  // on this process's `close` — bound to `proc`, so a double-stop or a
+  // quick restart can't cross resolvers between processes (review-2, Finding 2).
+  const exited = proc._drainPromise || Promise.resolve();
   try {
     proc.stdin.end();
   } catch (_) { /* already closed */ }
-  // Watchdog: if Python hasn't exited in 5 s, force kill.
+  // Watchdog: if THIS Python process hasn't exited in SIDECAR_KILL_WATCHDOG_MS,
+  // force kill. Bind to `proc`, not the global liveTranscribeProcess: after a
+  // quick stop→start the global already points at the NEW sidecar, so the old
+  // hung process would never be recognized and killed (#207 review, Blocker 1).
   setTimeout(() => {
-    if (liveTranscribeProcess === proc && !proc.killed) {
+    if (!proc.killed) {
       try { proc.kill('SIGTERM'); } catch (_) {}
     }
-  }, 5000);
+  }, SIDECAR_KILL_WATCHDOG_MS);
+  return exited;
 }
 
 // Sync read of the active ASR engine. Reads the JSON directly so we don't
@@ -2663,9 +2716,20 @@ let liveTranscriptState = {
 // the in-process `record --live` stdout is — same LIVE_READY / LIVE_SEG /
 // LIVE_ERROR protocol, same liveTranscriptState mutations, same IPC
 // events emitted to the renderer.
+// How long stopLiveTranscribe() lets Python drain + emit its FINAL segment
+// before force-killing the sidecar. The fallback snapshot's drain wait is
+// aligned to the same value so the snapshot never times out ahead of the kill.
+const SIDECAR_KILL_WATCHDOG_MS = 5000;
 let liveTranscribeProcess = null;
 let liveTranscribeSessionName = null;
 let liveTranscribeStdoutBuf = '';
+// The drain barrier (#207, Fix 2) now lives per process instance on
+// `proc._drainPromise` / `proc._drainResolve` (installed in
+// spawnLiveTranscribe). stopLiveTranscribe() only closes stdin and returns
+// immediately, but Python still needs a moment to drain its VAD and emit the
+// FINAL segment of the last utterance; the fallback snapshot awaits that
+// instance's promise so it captures the final segment instead of racing ahead
+// of it — and a quick restart can't cross resolvers between processes.
 let isProcessing = false;
 let currentProcessingJob = null;
 // Wall-clock start of the in-flight queue job, so the processing timer advances
@@ -2845,6 +2909,11 @@ async function processNextInQueue() {
     const processArgs = ['process-streaming', currentProcessingJob.audioFile, '--name', currentProcessingJob.sessionName];
     if (currentProcessingJob.notesFile && fs.existsSync(currentProcessingJob.notesFile)) {
       processArgs.push('--notes', currentProcessingJob.notesFile);
+    }
+    // Live-transcript fallback (#207): hand Python the live transcript snapshot
+    // so it can rescue the meeting if the batch transcription comes back empty.
+    if (currentProcessingJob.liveTranscriptFile && fs.existsSync(currentProcessingJob.liveTranscriptFile)) {
+      processArgs.push('--live-transcript', currentProcessingJob.liveTranscriptFile);
     }
 
     await new Promise((resolve, reject) => {
@@ -3029,6 +3098,15 @@ async function processNextInQueue() {
       });
     }
   } finally {
+    // Remove the live-transcript snapshot temp file (#207) — it's consumed by
+    // the Python process and not needed once the job is done.
+    if (currentProcessingJob && currentProcessingJob.liveTranscriptFile) {
+      try {
+        if (fs.existsSync(currentProcessingJob.liveTranscriptFile)) {
+          fs.unlinkSync(currentProcessingJob.liveTranscriptFile);
+        }
+      } catch (_) { /* best-effort cleanup */ }
+    }
     isProcessing = false;
     currentProcessingJob = null;
     currentProcessingStartedAtMs = null;
@@ -3037,8 +3115,100 @@ async function processNextInQueue() {
   }
 }
 
-function addToProcessingQueue(audioFile, sessionName, notesFile) {
-  processingQueue.push({ audioFile, sessionName, notesFile });
+// Live-transcript fallback for #207. The user watched the live transcript
+// stream in during the recording, so if the post-stop batch transcription
+// comes back empty (a quiet ASR failure), that live transcript should rescue
+// the meeting instead of being silently discarded as "No speech detected".
+//
+// We snapshot the accumulated live segments to a temp file at stop time and
+// hand the path to process-streaming via --live-transcript. Python owns the
+// decision of whether to USE it (only when the batch result is empty/trivial),
+// because that's where the batch length and failure markers are known.
+//
+// Returns the temp file path, or null when there's no usable live transcript
+// (different session, too short, or write failed — never blocks processing).
+const LIVE_TRANSCRIPT_FALLBACK_MIN_CHARS = 100;
+// Bound the fallback snapshot's wait for the sidecar to flush its FINAL
+// utterance. The drain primarily awaits the per-process `_drainPromise` (which
+// resolves on `close`); this timeout is only a safety-net for a zombie that
+// never closes. It MUST exceed SIDECAR_KILL_WATCHDOG_MS: the watchdog lets the
+// process run that long before SIGTERM, and after the kill Python still needs a
+// moment to finalize() and let `close` fire. If the timeout equalled the
+// watchdog it could win the race against `close` and lose the last segment
+// (#207 review, Blocker 2). Watchdog (5 s) + grace (3 s) for finalize + close.
+const LIVE_TRANSCRIPT_SNAPSHOT_DRAIN_GRACE_MS = 3000;
+const LIVE_TRANSCRIPT_SNAPSHOT_DRAIN_MS =
+  SIDECAR_KILL_WATCHDOG_MS + LIVE_TRANSCRIPT_SNAPSHOT_DRAIN_GRACE_MS;
+
+// Wait (bounded) for the live sidecar to finish exiting so its FINAL segments
+// are in liveTranscriptState before we snapshot (#207, Fix 2). stop-recording-ui
+// already closed stdin via stopLiveTranscribe(); here we just give Python up to
+// LIVE_TRANSCRIPT_SNAPSHOT_DRAIN_MS to drain its VAD and emit that last
+// utterance. Resolves early the moment the process is gone.
+function waitForLiveTranscribeDrain() {
+  const proc = liveTranscribeProcess;
+  if (!proc) return Promise.resolve();
+  // Bind to THIS process's drain promise (resolves on its `close`). A quick
+  // stop→start can't have us awaiting the wrong process (review-2, Finding 2).
+  const drain = proc._drainPromise || Promise.resolve();
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      sendDebugLog('Live transcript drain timed out before snapshot; using segments collected so far');
+      done();
+    }, LIVE_TRANSCRIPT_SNAPSHOT_DRAIN_MS);
+    drain.then(() => {
+      clearTimeout(timer);
+      done();
+    });
+  });
+}
+
+async function snapshotLiveTranscriptForFallback(sessionName) {
+  try {
+    if (!liveTranscriptState || liveTranscriptState.sessionName !== sessionName) {
+      return null;
+    }
+    // Let the sidecar flush its final utterance before we read segments.
+    await waitForLiveTranscribeDrain();
+    if (!liveTranscriptState || liveTranscriptState.sessionName !== sessionName) {
+      return null;
+    }
+    // Only FINAL segments go into the snapshot (#207, Fix 3). Finalised
+    // segments don't replace the partial tails they supersede — a final is
+    // pushed and the next partial is pushed after it — so including partials
+    // would duplicate sentences in the fallback transcript. The non-final
+    // tail is a preview of speech that a final segment will (or already did)
+    // cover, so dropping it loses nothing but the duplication.
+    const text = (liveTranscriptState.segments || [])
+      .filter(s => s && s.isFinal && s.text)
+      .map(s => String(s.text).trim())
+      .filter(Boolean)
+      .join('\n\n')
+      .trim();
+    if (text.length < LIVE_TRANSCRIPT_FALLBACK_MIN_CHARS) {
+      return null;
+    }
+    // Write to the OS temp dir (cross-platform) with a unique name so
+    // overlapping recordings can't clobber each other's snapshot.
+    const fileName = `stenoai-live-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.txt`;
+    const filePath = path.join(os.tmpdir(), fileName);
+    fs.writeFileSync(filePath, text, 'utf-8');
+    sendDebugLog(`Captured live transcript fallback (${text.length} chars): ${filePath}`);
+    return filePath;
+  } catch (e) {
+    sendDebugLog(`Failed to snapshot live transcript fallback: ${e.message}`);
+    return null;
+  }
+}
+
+function addToProcessingQueue(audioFile, sessionName, notesFile, liveTranscriptFile) {
+  processingQueue.push({ audioFile, sessionName, notesFile, liveTranscriptFile });
   console.log(`📋 Added to processing queue: ${sessionName} (Queue size: ${processingQueue.length})`);
   processNextInQueue();
 }
@@ -6194,8 +6364,14 @@ ipcMain.handle('process-system-audio-recording', async (event, audioFilePath, se
     const notesFile = path.join(getBackendCwd(), '_internal', 'output', `${safeName}_notes.txt`);
     const notesPath = fs.existsSync(notesFile) ? notesFile : undefined;
 
+    // Snapshot the live transcript captured during this recording (#207) so the
+    // backend can fall back to it if the batch transcription comes back empty.
+    // Done here at stop time, before liveTranscriptState gets reset by the next
+    // recording.
+    const liveTranscriptFile = await snapshotLiveTranscriptForFallback(actualSessionName);
+
     // Use the existing processing queue to avoid concurrent Ollama/Whisper runs
-    addToProcessingQueue(audioFilePath, actualSessionName, notesPath);
+    addToProcessingQueue(audioFilePath, actualSessionName, notesPath, liveTranscriptFile);
 
     trackEvent('recording_stopped', { recording_mode: 'system_audio' });
     return { success: true, message: 'Added to processing queue' };

--- a/e2e/fixtures/make-wav.js
+++ b/e2e/fixtures/make-wav.js
@@ -1,18 +1,26 @@
-// Generate a synthetic mono 16 kHz 16-bit PCM WAV with a real RIFF header (not
-// null bytes — mirrors the on-the-fly idea from tests/test_audio_preprocess.py
-// but produces a file the transcriber actually decodes). A low sine tone is
-// enough: Parakeet returns an empty transcript on non-speech, which is exactly
-// what the plumbing + HEARTBEAT smoke wants — the pipeline still runs end to
-// end and emits HEARTBEAT. Stays well above the transcriber's 1 KB stub floor
+// Generate a synthetic 16 kHz 16-bit PCM WAV with a real RIFF header (not null
+// bytes — mirrors the on-the-fly idea from tests/test_audio_preprocess.py but
+// produces a file the transcriber actually decodes). A low sine tone is enough:
+// Parakeet returns an empty transcript on non-speech, which is exactly what the
+// plumbing + HEARTBEAT smoke wants — the pipeline still runs end to end and
+// emits HEARTBEAT. Stays well above the transcriber's 1 KB stub floor
 // (5 s ≈ 160 KB). No checked-in binary fixtures.
+//
+// channels: 1 (default) = mono; 2 = stereo (left=mic, right=system), the layout
+// transcribe_diarised splits. amplitude: 0 writes pure digital silence — a
+// stereo silent file falls below the transcriber's RMS energy gate on BOTH
+// channels, so transcribe_diarised returns the silence sentinel WITHOUT loading
+// a model (the model-free path the #207 live-transcript fallback spec relies on).
 const fs = require('fs');
 
 function makeWav(
   filePath,
-  { seconds = 5, sampleRate = 16000, freq = 220, amplitude = 0.05 } = {},
+  { seconds = 5, sampleRate = 16000, freq = 220, amplitude = 0.05, channels = 1 } = {},
 ) {
-  const numSamples = Math.floor(seconds * sampleRate);
-  const dataBytes = numSamples * 2; // 16-bit mono
+  const numFrames = Math.floor(seconds * sampleRate);
+  const bytesPerSample = 2; // 16-bit
+  const blockAlign = channels * bytesPerSample;
+  const dataBytes = numFrames * blockAlign;
   const buf = Buffer.alloc(44 + dataBytes);
 
   // RIFF/WAVE header
@@ -23,20 +31,23 @@ function makeWav(
   buf.write('fmt ', 12);
   buf.writeUInt32LE(16, 16); // PCM fmt chunk size
   buf.writeUInt16LE(1, 20); // audio format = PCM
-  buf.writeUInt16LE(1, 22); // channels = 1
+  buf.writeUInt16LE(channels, 22);
   buf.writeUInt32LE(sampleRate, 24);
-  buf.writeUInt32LE(sampleRate * 2, 28); // byte rate (sampleRate * blockAlign)
-  buf.writeUInt16LE(2, 32); // block align (channels * bytesPerSample)
+  buf.writeUInt32LE(sampleRate * blockAlign, 28); // byte rate
+  buf.writeUInt16LE(blockAlign, 32);
   buf.writeUInt16LE(16, 34); // bits per sample
   // data chunk
   buf.write('data', 36);
   buf.writeUInt32LE(dataBytes, 40);
 
-  for (let i = 0; i < numSamples; i++) {
+  for (let i = 0; i < numFrames; i++) {
     const sample = Math.round(
       amplitude * 32767 * Math.sin((2 * Math.PI * freq * i) / sampleRate),
     );
-    buf.writeInt16LE(sample, 44 + i * 2);
+    // Same sample on every channel (interleaved frames).
+    for (let c = 0; c < channels; c++) {
+      buf.writeInt16LE(sample, 44 + (i * channels + c) * bytesPerSample);
+    }
   }
 
   fs.writeFileSync(filePath, buf);

--- a/e2e/specs/live-transcript-fallback.t2.spec.ts
+++ b/e2e/specs/live-transcript-fallback.t2.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { killOllama } from '../fixtures/kill-ollama';
+import { makeWav } from '../fixtures/make-wav';
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — live-transcript fallback (#207 / PR #247). Proves the load-bearing
+ * Electron->Python contract that rescues a meeting when the post-stop batch
+ * transcription comes back EMPTY: process-streaming, handed the live transcript
+ * via --live-transcript, must NOT discard the meeting as "No speech detected" —
+ * it writes the live text as the transcript, marks the note is_live_transcript,
+ * and keeps the audio for a later retry.
+ *
+ * Model-free by construction: the input is a silent STEREO wav, which both
+ * channels' RMS energy gate skips, so transcribe_diarised returns the silence
+ * sentinel WITHOUT loading an ASR model (verified: no engine touched on
+ * digital silence). Summarisation goes to the mock Ollama. So this runs in the
+ * fast model-free t2 jobs, NOT the @pipeline lane.
+ *
+ * Why drive the backend directly instead of the app IPC: the live transcript
+ * the renderer accumulates lives in main.js's in-memory liveTranscriptState,
+ * which only the live ASR sidecar (a model) can populate — there is no
+ * model-free way to seed it through the app. So the Electron snapshot/drain
+ * half is model-coupled and left to manual / @pipeline coverage; this spec
+ * pins the half that the bug actually lived in: the --live-transcript arg
+ * contract + the Python rescue decision + the on-disk result.
+ */
+
+const BACKEND = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'dist',
+  'stenoai',
+  process.platform === 'win32' ? 'stenoai.exe' : 'stenoai',
+);
+
+// A realistic multi-sentence live transcript (the user watched this stream in
+// during recording). Well above any non-empty floor.
+const LIVE_TRANSCRIPT =
+  'Welcome everyone to the weekly sync. We shipped the new onboarding flow on Tuesday. ' +
+  'The remaining blocker is the billing migration, which Dana is driving. ' +
+  'We agreed to cut the release on Friday if the staging soak is clean.';
+
+// Fixed assistant reply in the markdown the parser keys on
+// (## Summary / ## Key Points / ## Action Items).
+const FIXED_REPLY = [
+  '## Summary',
+  'The team shipped onboarding and plans a Friday release pending a clean soak.',
+  '',
+  '## Key Points',
+  '- Onboarding flow shipped Tuesday',
+  '- Billing migration is the remaining blocker',
+  '',
+  '## Action Items',
+  '- Dana to drive the billing migration',
+  '',
+].join('\n');
+
+type SpawnResult = { code: number | null; stdout: string; stderr: string };
+
+function runBackend(args: string[], userDataDir: string): Promise<SpawnResult> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(BACKEND, args, {
+      env: { ...process.env, STENOAI_USER_DATA_DIR: userDataDir },
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => (stdout += d.toString()));
+    proc.stderr.on('data', (d) => (stderr += d.toString()));
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test('empty batch transcription is rescued by the live transcript, marked, and the audio is kept', async ({
+  userDataDir,
+}) => {
+  test.setTimeout(120_000);
+  // The bundled backend must exist (built from this branch). Skip loudly if a
+  // dev checkout hasn't run pyinstaller yet, rather than emit a path error.
+  if (!existsSync(BACKEND)) {
+    // eslint-disable-next-line no-console
+    console.warn(`[t2] SKIPPED live-transcript fallback: backend bundle missing at ${BACKEND}`);
+    test.info().annotations.push({ type: 'skip-reason', description: 'backend bundle not built' });
+  }
+  test.skip(!existsSync(BACKEND), 'backend bundle not built');
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Local provider so the summariser talks to the mock Ollama on 11434.
+  //
+  // Model-free without pinning an engine: the batch path builds WhisperTranscriber
+  // lazily (self.model = None at construction — src/transcriber.py:452) and only
+  // loads the ggml weight inside transcribe_audio (transcriber.py:734). A silent
+  // stereo file fails the RMS energy gate on BOTH channels, so transcribe_diarised
+  // returns the silence sentinel and transcribe_audio is never reached — no model
+  // load or download in the fast t2 lane.
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+
+  // Silent STEREO wav -> both channels skip the RMS gate -> batch transcription
+  // returns the silence sentinel with no model loaded.
+  const recordingsDir = path.join(userDataDir, 'recordings');
+  mkdirSync(recordingsDir, { recursive: true });
+  const wavPath = path.join(recordingsDir, 'livefallback.wav');
+  makeWav(wavPath, { seconds: 4, amplitude: 0, channels: 2 });
+  const sizeBefore = statSync(wavPath).size;
+
+  // The live transcript snapshot Electron would have written at stop time.
+  const liveFile = path.join(userDataDir, 'live-transcript.txt');
+  writeFileSync(liveFile, LIVE_TRANSCRIPT, 'utf-8');
+
+  killOllama();
+  const ollama = await startMockOllama({ chatReply: FIXED_REPLY });
+  try {
+    const res = await runBackend(
+      [
+        'process-streaming',
+        wavPath,
+        '--name',
+        'Live Fallback Meeting',
+        '--live-transcript',
+        liveFile,
+      ],
+      userDataDir,
+    );
+    expect(res.code, `backend stderr:\n${res.stderr}`).toBe(0);
+
+    // The note markdown is written with the live transcript as its source and
+    // marked is_live_transcript so the UI can tell the user no batch transcript
+    // exists. Filename comes from the wav stem.
+    const summaryPath = path.join(userDataDir, 'output', 'livefallback_summary.md');
+    expect(existsSync(summaryPath), `no summary at ${summaryPath}\n${res.stdout}`).toBe(true);
+    const summaryMd = readFileSync(summaryPath, 'utf8');
+    expect(summaryMd).toMatch(/is_live_transcript:\s*true/i);
+
+    // The transcript file holds the rescued LIVE text — not the silence
+    // sentinel — using the canonical name/header (the crash path used to leave
+    // this file missing entirely; the rescue writes it unconditionally).
+    const transcriptPath = path.join(userDataDir, 'transcripts', 'livefallback_transcript.txt');
+    expect(existsSync(transcriptPath)).toBe(true);
+    const transcriptTxt = readFileSync(transcriptPath, 'utf8');
+    expect(transcriptTxt).toContain('billing migration');
+    expect(transcriptTxt).not.toContain('No speech detected in audio');
+
+    // The note BODY was summarised from the live transcript, not the silence
+    // sentinel: the prompt the backend sent the summariser embedded the live
+    // text. Without this, a regression that still fed the sentinel into the
+    // summary (while the separate transcript file looked right) would pass.
+    const prompt = ollama.lastChatPrompt();
+    expect(prompt).toBeTruthy();
+    expect(prompt).toContain('billing migration');
+    expect(prompt).not.toContain('No speech detected in audio');
+
+    // Audio is kept regardless of keep_recordings: it's the user's only retry
+    // material for a proper batch transcript later (mirrors the failure path).
+    expect(existsSync(wavPath)).toBe(true);
+    expect(statSync(wavPath).size).toBe(sizeBefore);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+    killOllama();
+  }
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -205,7 +205,7 @@ Summary output language: {config.get_language_name(output_language)}
 
 {transcript_body}
 """
-        with open(transcript_path, 'w') as f:
+        with open(transcript_path, 'w', encoding='utf-8') as f:
             f.write(transcript_content)
         return transcript_path
 
@@ -804,12 +804,6 @@ def process(audio_file, name, notes):
     asyncio.run(run_process())
 
 
-# Minimum length for the LIVE transcript to be worth swapping in as a fallback
-# (#207). This is a quality floor on the *fallback source* only — it does NOT
-# decide whether the batch result is bad (that's batch_failed / the silence
-# sentinel). A correct-but-short batch transcript is never replaced.
-_LIVE_TRANSCRIPT_MIN_CHARS = 100
-
 # Detect a silence-only batch result exactly, kept in sync with the
 # transcriber that produces the sentinel. Mirrors the graceful-import pattern
 # above so a missing transcriber dependency doesn't break the CLI.
@@ -888,17 +882,17 @@ def process_streaming(audio_file, name, notes, live_transcript):
         # unusable:
         #   - the batch transcription crashed (transcription_failed), or
         #   - it came back as exactly the silence sentinel.
-        # A correct-but-short meeting (e.g. a 5-minute stand-up under 100 chars)
-        # is a real batch transcript and must NOT be replaced — the old length
-        # threshold did exactly that (Fix 4). The 100-char floor is kept only as
-        # a MINIMUM-QUALITY gate on the live fallback itself: we won't swap in a
-        # live transcript that's too short to be worth it.
+        # A correct-but-short batch transcript (e.g. a 5-minute stand-up) must
+        # NOT be replaced — the old length threshold did exactly that (Fix 4).
+        # We only swap in the live text when the batch result is genuinely
+        # unusable (failed or silence sentinel). Any non-whitespace live content
+        # is better than a silent failure — even a brief session deserves rescue.
         batch_text = transcript_data.get("transcript_text", "") or ""
         batch_failed = bool(transcript_data.get("transcription_failed"))
         batch_is_silence = batch_text.strip() == _SILENCE_SENTINEL
         is_live_transcript = False
         if (batch_failed or batch_is_silence) and live_transcript_text \
-                and len(live_transcript_text) >= _LIVE_TRANSCRIPT_MIN_CHARS:
+                and live_transcript_text.strip():
             logger.warning(
                 "Batch transcription %s; falling back to the live transcript "
                 "captured during recording (%d chars)",

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -162,6 +162,53 @@ class MeetingPipeline:
 
         return "en"
 
+    def _transcript_file_path(self, audio_path: Path) -> Path:
+        """Canonical on-disk path for a meeting's transcript text file.
+
+        Single source of truth so the normal path and the live-transcript /
+        crash fallback always agree on the filename (#207).
+        """
+        return self.transcripts_dir / f"{audio_path.stem}_transcript.txt"
+
+    def _write_transcript_file(
+        self,
+        audio_path: Path,
+        transcript_body: str,
+        session_name: str,
+        configured_language: str,
+        detected_language: Optional[str] = None,
+        output_language: Optional[str] = None,
+    ) -> Path:
+        """Format + write the transcript .txt with the standard header.
+
+        Used by both the normal transcription path and the fallback paths so
+        the file format and name stay identical (#207). Returns the path.
+        """
+        from src.config import get_config
+        config = get_config()
+
+        if output_language is None:
+            output_language = self._resolve_output_language(configured_language, detected_language)
+        detected_language_name = (
+            config.get_language_name(detected_language) if detected_language else "Unknown"
+        )
+
+        transcript_path = self._transcript_file_path(audio_path)
+        transcript_content = f"""Session: {session_name}
+File: {audio_path.name}
+Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+Language setting: {config.get_language_name(configured_language)}
+Detected language: {detected_language_name}
+Summary output language: {config.get_language_name(output_language)}
+
+{'='*60}
+
+{transcript_body}
+"""
+        with open(transcript_path, 'w') as f:
+            f.write(transcript_content)
+        return transcript_path
+
     @staticmethod
     def _load_user_notes(session_name: str, output_dir) -> Optional[str]:
         """Load user notes file saved by Electron during recording."""
@@ -290,25 +337,17 @@ class MeetingPipeline:
             diarised_text = transcript_result.get("diarised_text")
 
         output_language = self._resolve_output_language(configured_language, detected_language)
-        detected_language_name = config.get_language_name(detected_language) if detected_language else "Unknown"
 
         # Save transcript (use diarised text if available for the saved file)
-        transcript_path = self.transcripts_dir / f"{audio_path.stem}_transcript.txt"
         saved_transcript = diarised_text if diarised_text else transcript_text
-        transcript_content = f"""Session: {session_name}
-File: {audio_path.name}
-Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
-Language setting: {config.get_language_name(configured_language)}
-Detected language: {detected_language_name}
-Summary output language: {config.get_language_name(output_language)}
-
-{'='*60}
-
-{saved_transcript}
-"""
-
-        with open(transcript_path, 'w') as f:
-            f.write(transcript_content)
+        transcript_path = self._write_transcript_file(
+            audio_path,
+            saved_transcript,
+            session_name,
+            configured_language,
+            detected_language=detected_language,
+            output_language=output_language,
+        )
 
         print(f"📄 Transcript saved: {transcript_path}")
 
@@ -765,11 +804,29 @@ def process(audio_file, name, notes):
     asyncio.run(run_process())
 
 
+# Minimum length for the LIVE transcript to be worth swapping in as a fallback
+# (#207). This is a quality floor on the *fallback source* only — it does NOT
+# decide whether the batch result is bad (that's batch_failed / the silence
+# sentinel). A correct-but-short batch transcript is never replaced.
+_LIVE_TRANSCRIPT_MIN_CHARS = 100
+
+# Detect a silence-only batch result exactly, kept in sync with the
+# transcriber that produces the sentinel. Mirrors the graceful-import pattern
+# above so a missing transcriber dependency doesn't break the CLI.
+try:
+    from src.transcriber import SILENCE_SENTINEL as _SILENCE_SENTINEL
+except ImportError:
+    _SILENCE_SENTINEL = "No speech detected in audio"
+
+
 @cli.command(name='process-streaming')
 @click.argument('audio_file', default='')
 @click.option('--name', '-n', default='Recording', help='Session name')
 @click.option('--notes', default=None, help='Path to user notes file')
-def process_streaming(audio_file, name, notes):
+@click.option('--live-transcript', 'live_transcript', default=None,
+              help='Path to the live transcript captured during recording, '
+                   'used as a fallback if batch transcription returns empty (#207)')
+def process_streaming(audio_file, name, notes, live_transcript):
     """Process audio with streaming summary output.
 
     Transcribes audio, then streams the summary as CHUNK: prefixed lines
@@ -789,6 +846,18 @@ def process_streaming(audio_file, name, notes):
                     logger.info(f"Loaded user notes ({len(notes_text)} chars)")
             except Exception as e:
                 logger.warning(f"Failed to read notes file: {e}")
+
+        # Read the live transcript fallback (#207). The renderer accumulates
+        # live segments during recording; Electron writes them to this file so
+        # we can rescue a meeting whose batch transcription came back empty.
+        live_transcript_text = None
+        if live_transcript:
+            try:
+                live_transcript_text = Path(live_transcript).read_text(encoding='utf-8').strip()
+                if live_transcript_text:
+                    logger.info(f"Loaded live transcript fallback ({len(live_transcript_text)} chars)")
+            except Exception as e:
+                logger.warning(f"Failed to read live transcript file: {e}")
 
         # Step 1: Transcribe. HEARTBEAT: lines are a liveness signal for the
         # Electron inactivity watchdog — without them a long transcription is
@@ -813,9 +882,72 @@ def process_streaming(audio_file, name, notes):
         finally:
             set_chunk_heartbeat(None)
 
+        # Live-transcript fallback (#207): rescue the meeting with the live
+        # transcript the user watched stream in, instead of discarding it as
+        # "No speech detected", but ONLY when the batch result is genuinely
+        # unusable:
+        #   - the batch transcription crashed (transcription_failed), or
+        #   - it came back as exactly the silence sentinel.
+        # A correct-but-short meeting (e.g. a 5-minute stand-up under 100 chars)
+        # is a real batch transcript and must NOT be replaced — the old length
+        # threshold did exactly that (Fix 4). The 100-char floor is kept only as
+        # a MINIMUM-QUALITY gate on the live fallback itself: we won't swap in a
+        # live transcript that's too short to be worth it.
+        batch_text = transcript_data.get("transcript_text", "") or ""
+        batch_failed = bool(transcript_data.get("transcription_failed"))
+        batch_is_silence = batch_text.strip() == _SILENCE_SENTINEL
+        is_live_transcript = False
+        if (batch_failed or batch_is_silence) and live_transcript_text \
+                and len(live_transcript_text) >= _LIVE_TRANSCRIPT_MIN_CHARS:
+            logger.warning(
+                "Batch transcription %s; falling back to the live transcript "
+                "captured during recording (%d chars)",
+                "failed" if batch_failed else "returned only silence",
+                len(live_transcript_text),
+            )
+            is_live_transcript = True
+            # Always (re)write _transcript.txt with the live text via the shared
+            # formatter so the on-disk file matches the markdown/summary the user
+            # sees and uses the canonical filename/header (#207, review-2
+            # Finding 3). The silence path may already have written the sentinel
+            # (Fix 6); the crash path (transcription_failed) wrote NO transcript
+            # file at all and exposes no "transcript_file" key — the old code
+            # only overwrote a pre-existing file, so the crash fallback left the
+            # .txt missing entirely. Writing unconditionally fixes both.
+            fallback_audio_path = Path(audio_file)
+            existing_transcript_file = None
+            try:
+                written_path = recorder._write_transcript_file(
+                    fallback_audio_path,
+                    live_transcript_text,
+                    name,
+                    transcript_data.get("configured_language") or "auto",
+                    detected_language=transcript_data.get("detected_language"),
+                )
+                existing_transcript_file = str(written_path)
+                logger.info(
+                    "Wrote transcript file with live transcript: %s",
+                    existing_transcript_file,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to write transcript file with live text: %s", e
+                )
+            # Rebuild transcript_data so the rest of the pipeline (summary, save)
+            # uses the live transcript. Live transcripts are not channel-diarised.
+            transcript_data = {
+                "transcript_text": live_transcript_text,
+                "diarised_text": None,
+                "is_diarised": False,
+                "duration_seconds": transcript_data.get("duration_seconds"),
+                "detected_language": transcript_data.get("detected_language"),
+                "transcript_file": existing_transcript_file,
+            }
+
         # A transcription crash (e.g. an MLX OOM on a long system-audio
         # recording) is not silence — preserve the audio and save a marked,
         # reprocessable meeting instead of summarising a fake-empty one.
+        # (Only when there's no live transcript to fall back on.)
         if transcript_data.get("transcription_failed"):
             recorder._handle_transcription_failure(Path(audio_file), name, transcript_data, notes_text)
             return
@@ -891,6 +1023,10 @@ def process_streaming(audio_file, name, notes):
             'language': output_language,
             'is_diarised': transcript_data.get('is_diarised', False),
         }
+        # Mark live-sourced meetings (#207) so the UI and future code know this
+        # transcript came from the live capture, not a batch transcription.
+        if is_live_transcript:
+            md_meta['is_live_transcript'] = True
         md_lines = _render_frontmatter(md_meta)
         md_lines.append('')
         md_lines.append(streamed_md)
@@ -905,9 +1041,12 @@ def process_streaming(audio_file, name, notes):
             md_lines.append(notes_text)
         summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
 
-        # Clean up audio
+        # Clean up audio. When we fell back to the live transcript the batch
+        # transcription was empty/failed, so KEEP the audio regardless of the
+        # keep_recordings setting — it's the user's only retry material if they
+        # want a proper batch transcript later (mirrors the failure path).
         from src.config import get_config
-        if not get_config().get_keep_recordings():
+        if not is_live_transcript and not get_config().get_keep_recordings():
             try:
                 audio_path.unlink()
             except Exception:
@@ -1817,6 +1956,11 @@ def _parse_meeting_markdown(md_path):
             session_info['audio_file'] = meta.get('audio_file')
         if meta.get('error'):
             session_info['error'] = meta.get('error')
+    # A live-sourced meeting (#207): the batch transcription was empty so this
+    # transcript came from the live capture. Surface the flag so the UI can
+    # tell the user no batch transcript exists.
+    if meta.get('is_live_transcript'):
+        session_info['is_live_transcript'] = True
 
     return {
         'session_info': session_info,

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -105,6 +105,13 @@ MIN_RMS_THRESHOLD = 0.0003
 # recording doesn't pull all 30 min of int16 samples into Python lists.
 RMS_MAX_WINDOWS = 60
 
+# Sentinel text substituted when transcription produces no usable output
+# (genuine silence or all-hallucination). Callers compare against this to
+# distinguish "really nothing was said" from a real (possibly short)
+# transcript — keep it in one place so the live-transcript fallback (#207)
+# can detect it exactly.
+SILENCE_SENTINEL = "No speech detected in audio"
+
 
 # Resolve a usable ffmpeg binary. Electron-spawned subprocesses don't inherit
 # the user's shell PATH (no /opt/homebrew/bin), so a bare `ffmpeg` string fails
@@ -880,7 +887,13 @@ class WhisperTranscriber:
 
             if not transcript:
                 logger.warning("Transcription returned empty text (all hallucinations or silent)")
-                result["text"] = "No speech detected in audio"
+                # Structural flag set BEFORE the sentinel substitution so callers
+                # (e.g. transcribe_diarised) can distinguish a genuinely empty
+                # result from one that legitimately produced the sentinel text.
+                # Checking result["text"] downstream is useless once we overwrite
+                # it with the truthy sentinel below (#207, Gap 2 dead-code fix).
+                result["transcription_empty"] = True
+                result["text"] = SILENCE_SENTINEL
 
             result.setdefault("detected_language", None)
             result.setdefault("detected_language_probability", None)
@@ -1052,8 +1065,18 @@ class WhisperTranscriber:
             detected_language = None
             detected_language_probability = None
             engine = None
+            # A hard crash on a channel (MLX OOM, decode abort) is preserved
+            # unconditionally — that's the original Gap 1 honest-failure path.
             channel_failed = False
             channel_error: Optional[str] = None
+            # Gap 2 (#207): a channel that PASSED the RMS energy gate but came
+            # back empty is a quiet ASR failure. But the RMS gate only detects
+            # "not digital silence" — music/noise/reverb can pass it too, so an
+            # empty energetic channel must NOT fail the whole meeting on its own.
+            # We only fail when NO channel produced usable text (decided below).
+            mic_empty_on_energy = False
+            system_empty_on_energy = False
+            empty_error: Optional[str] = None
 
             # Split channels are already 16 kHz mono + high-passed by the
             # split ffmpeg pass above — skip the mono pre-processing pass.
@@ -1063,13 +1086,24 @@ class WhisperTranscriber:
                 if mic_result and mic_result.get("transcription_failed"):
                     channel_failed = True
                     channel_error = channel_error or mic_result.get("error")
-                elif mic_result and mic_result.get("text"):
+                elif mic_result and not mic_result.get("transcription_empty") \
+                        and mic_result.get("text"):
                     mic_segments = mic_result.get("segments") or []
                     if not detected_language and mic_result.get("detected_language"):
                         detected_language = mic_result["detected_language"]
                         detected_language_probability = mic_result.get("detected_language_probability")
                     if not engine:
                         engine = mic_result.get("engine")
+                else:
+                    # Passed the RMS energy gate but produced no real text (the
+                    # text field, if any, is the silence sentinel — see the
+                    # transcription_empty flag set in transcribe_audio). Record
+                    # it, but don't fail yet: the other channel may carry text.
+                    mic_empty_on_energy = True
+                    empty_error = empty_error or "Mic channel had audio but transcription returned empty"
+                    logger.warning(
+                        "Mic channel passed the energy gate but produced no text"
+                    )
             else:
                 logger.info("Mic channel is silent, skipping")
 
@@ -1079,19 +1113,29 @@ class WhisperTranscriber:
                 if sys_result and sys_result.get("transcription_failed"):
                     channel_failed = True
                     channel_error = channel_error or sys_result.get("error")
-                elif sys_result and sys_result.get("text"):
+                elif sys_result and not sys_result.get("transcription_empty") \
+                        and sys_result.get("text"):
                     system_segments = sys_result.get("segments") or []
                     if not detected_language and sys_result.get("detected_language"):
                         detected_language = sys_result["detected_language"]
                         detected_language_probability = sys_result.get("detected_language_probability")
                     if not engine:
                         engine = sys_result.get("engine")
+                else:
+                    # Empty output on an energetic channel — record, don't fail
+                    # yet (see mic above).
+                    system_empty_on_energy = True
+                    empty_error = empty_error or "System channel had audio but transcription returned empty"
+                    logger.warning(
+                        "System channel passed the energy gate but produced no text"
+                    )
             else:
                 logger.info("System channel is silent, skipping")
 
-            # A crash on either channel is not silence. Bail before assembling a
-            # transcript so the caller preserves the audio and surfaces a real
-            # error instead of saving a partial/fake-empty meeting.
+            # A hard crash on either channel is not silence. Bail before
+            # assembling a transcript so the caller preserves the audio and
+            # surfaces a real error instead of saving a partial/fake-empty
+            # meeting.
             if channel_failed:
                 logger.error("Diarised transcription failed on a channel: %s", channel_error)
                 return {
@@ -1103,6 +1147,28 @@ class WhisperTranscriber:
                     "detected_language_probability": detected_language_probability,
                     "transcription_failed": True,
                     "error": channel_error or "transcription failed",
+                }
+
+            # Gap 2 (#207): only fail when NO channel produced usable text AND at
+            # least one energetic channel came back empty. If one channel carries
+            # real text and the other is just empty noise, the meeting is fine —
+            # the empty channel is dropped, not treated as a failure.
+            has_usable_text = bool(mic_segments) or bool(system_segments)
+            if not has_usable_text and (mic_empty_on_energy or system_empty_on_energy):
+                logger.error(
+                    "Diarised transcription: every energetic channel returned "
+                    "empty text — treating as a failure (audio preserved): %s",
+                    empty_error,
+                )
+                return {
+                    "text": None,
+                    "diarised_text": None,
+                    "is_diarised": False,
+                    "duration_seconds": duration,
+                    "detected_language": detected_language,
+                    "detected_language_probability": detected_language_probability,
+                    "transcription_failed": True,
+                    "error": empty_error or "transcription returned empty",
                 }
 
             # Speaker-bleed correction runs in two passes:
@@ -1157,7 +1223,7 @@ class WhisperTranscriber:
                     turns.append((speaker, [text]))
 
             plain_parts = [' '.join(parts) for _speaker, parts in turns]
-            plain_text = "\n\n".join(plain_parts) if plain_parts else "No speech detected in audio"
+            plain_text = "\n\n".join(plain_parts) if plain_parts else SILENCE_SENTINEL
 
             is_diarised = bool(mic_segments) and bool(system_segments)
             if is_diarised:

--- a/tests/test_transcriber_failure.py
+++ b/tests/test_transcriber_failure.py
@@ -306,6 +306,105 @@ class TranscribeDiarisedFailureTests(unittest.TestCase):
         # Must not have assembled the silence sentinel as a "successful" text.
         self.assertIsNone(out.get("text"))
 
+    def test_all_energetic_channels_empty_fails_meeting(self):
+        """Gap 2 (#207): when EVERY channel passes the RMS energy gate but
+        returns empty text, that's a quiet ASR failure, not silence. It must be
+        tagged transcription_failed (audio preserved for retry) rather than
+        saving a fake "No speech detected" meeting.
+
+        Critically this drives the REAL transcribe_audio path (mocking the
+        lower-level _run_backend), so the silence-sentinel substitution at
+        transcriber.py:~881 actually runs. The earlier version mocked
+        transcribe_audio directly and never exercised that substitution — the
+        very interaction that made the channel-empty check dead code.
+        """
+        transcriber = _build_transcriber()
+        # Both channels pass the energy gate but the backend returns no text;
+        # transcribe_audio will substitute the silence sentinel + set the
+        # transcription_empty flag — the bug condition.
+        empty_backend = {
+            "text": None, "segments": [], "duration_seconds": None,
+            "detected_language": None, "detected_language_probability": None,
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            audio = _make_audio_file(tmp_dir)
+            # Real channel files so transcribe_audio doesn't short-circuit on
+            # the missing-file / too-small guards before reaching _run_backend.
+            mic = _make_audio_file(tmp_dir, "ch0_energetic.wav")
+            system = _make_audio_file(tmp_dir, "ch1_energetic.wav")
+            with patch.object(transcriber, "_split_stereo_to_channels",
+                              return_value=(mic, system, 120.0)), \
+                 patch.object(transcriber, "_check_rms_energy", return_value=True), \
+                 patch.object(transcriber, "_build_whisper_fallback", return_value=False), \
+                 patch.object(transcriber, "_run_backend", return_value=empty_backend):
+                out = transcriber.transcribe_diarised(audio, language="en")
+        self.assertTrue(out.get("transcription_failed"))
+        self.assertIsNone(out.get("text"))
+        self.assertIn("empty", out.get("error", "").lower())
+
+    def test_one_channel_text_one_empty_succeeds(self):
+        """Gap 2 + Fix 5 (#207): the RMS gate only detects 'not digital
+        silence' — music/noise/reverb can pass it. So when ONE channel carries
+        real text and the other passes the gate but transcribes to nothing,
+        the meeting must SUCCEED (drop the empty channel), not fail. Drives the
+        real transcribe_audio path."""
+        transcriber = _build_transcriber()
+        ok_backend = {
+            "text": "Hi there.",
+            "segments": [{"text": "Hi there.", "start": 0.0, "end": 1.0}],
+            "duration_seconds": 1.0,
+            "detected_language": None, "detected_language_probability": None,
+        }
+        empty_backend = {
+            "text": None, "segments": [], "duration_seconds": None,
+            "detected_language": None, "detected_language_probability": None,
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            audio = _make_audio_file(tmp_dir)
+            mic = _make_audio_file(tmp_dir, "ch0_text.wav")
+            system = _make_audio_file(tmp_dir, "ch1_noise.wav")
+
+            def fake_backend(path, language="en"):
+                return ok_backend if path == mic else empty_backend
+
+            with patch.object(transcriber, "_split_stereo_to_channels",
+                              return_value=(mic, system, 120.0)), \
+                 patch.object(transcriber, "_check_rms_energy", return_value=True), \
+                 patch.object(transcriber, "_build_whisper_fallback", return_value=False), \
+                 patch.object(transcriber, "_run_backend", side_effect=fake_backend):
+                out = transcriber.transcribe_diarised(audio, language="en")
+        self.assertNotIn("transcription_failed", out)
+        self.assertIn("Hi there.", out.get("text", ""))
+
+    def test_silent_channel_is_not_a_failure(self):
+        """Regression for Gap 2: a channel the energy gate reports as silent
+        (has_audio == False) is skipped, NOT failed — only the still-speaking
+        channel is transcribed and the meeting saves normally."""
+        transcriber = _build_transcriber()
+        mic = Path("/tmp/stenoai_ch0_silent.wav")
+        system = Path("/tmp/stenoai_ch1_silent.wav")
+        ok = {
+            "text": "Solo presenter.",
+            "segments": [{"text": "Solo presenter.", "start": 0.0, "end": 1.0}],
+            "detected_language": None,
+        }
+
+        def fake_rms(path, *a, **k):
+            # Mic has audio; system is genuinely silent.
+            return path == mic
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            audio = _make_audio_file(tmp_dir)
+            with patch.object(transcriber, "_split_stereo_to_channels",
+                              return_value=(mic, system, 120.0)), \
+                 patch.object(transcriber, "_check_rms_energy", side_effect=fake_rms), \
+                 patch.object(transcriber, "transcribe_audio", return_value=ok):
+                out = transcriber.transcribe_diarised(audio, language="en")
+        self.assertNotIn("transcription_failed", out)
+        self.assertIn("Solo presenter.", out.get("text", ""))
+
 
 class HandleTranscriptionFailureTests(unittest.TestCase):
     def _build_recorder(self, output_dir: Path) -> MeetingPipeline:
@@ -386,6 +485,48 @@ class HandleTranscriptionFailureTests(unittest.TestCase):
         # The honest summary message still parses intact.
         self.assertIn("Transcription failed", parsed["summary"])
 
+    def test_live_transcript_marker_round_trips(self):
+        """Gap 1 (#207): a meeting saved from the live-transcript fallback
+        carries is_live_transcript in its frontmatter, and the parser surfaces
+        it in session_info so the UI/future code know no batch transcript
+        exists."""
+        from simple_recorder import _render_frontmatter
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            md_path = Path(tmp_dir) / "live_summary.md"
+            md_meta = {
+                "title": "Rescued meeting",
+                "date": "2026-06-22",
+                "duration_seconds": 120,
+                "language": "en",
+                "is_diarised": False,
+                "is_live_transcript": True,
+            }
+            lines = _render_frontmatter(md_meta)
+            lines += ["", "## Summary", "", "Rescued from live capture.", "",
+                      "## Transcript", "", "Live captured words here."]
+            md_path.write_text("\n".join(lines), encoding="utf-8")
+            parsed = _parse_meeting_markdown(md_path)
+        self.assertTrue(parsed["session_info"]["is_live_transcript"])
+
+    def test_batch_meeting_has_no_live_marker(self):
+        """Regression: a normal batch-transcribed meeting must NOT gain the
+        is_live_transcript marker."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            md_path = Path(tmp_dir) / "batch_summary.md"
+            md_path.write_text(
+                "---\n"
+                'title: "Normal meeting"\n'
+                "date: 2026-06-22\n"
+                "is_diarised: false\n"
+                "---\n\n"
+                "## Summary\n\nBatch transcribed.\n\n"
+                "## Transcript\n\nReal batch words.\n",
+                encoding="utf-8",
+            )
+            parsed = _parse_meeting_markdown(md_path)
+        self.assertNotIn("is_live_transcript", parsed["session_info"])
+
     def test_normal_meeting_has_no_failure_markers(self):
         """Regression: a normal (non-failure) meeting's session_info must not
         gain the failure keys, so existing consumers are unchanged."""
@@ -404,6 +545,60 @@ class HandleTranscriptionFailureTests(unittest.TestCase):
             parsed = _parse_meeting_markdown(md_path)
         self.assertNotIn("transcription_failed", parsed["session_info"])
         self.assertEqual(parsed["summary"], "We discussed the roadmap.")
+
+
+class LiveTranscriptFallbackTests(unittest.TestCase):
+    """Live-transcript fallback decision + file consistency (#207, Fix 4/6).
+
+    The fallback must rescue a meeting only when the batch result is genuinely
+    unusable (crash or the silence sentinel) — NOT merely short — and when it
+    fires it must overwrite the on-disk transcript so `query`/export don't keep
+    reading "No speech detected".
+    """
+
+    def test_silence_sentinel_constant_is_in_sync(self):
+        """Fix 4 hinges on simple_recorder detecting the EXACT sentinel the
+        transcriber writes. Pin that the two agree so a future reword of one
+        can't silently break the fallback trigger."""
+        import simple_recorder
+        from src.transcriber import SILENCE_SENTINEL
+        self.assertEqual(SILENCE_SENTINEL, "No speech detected in audio")
+        self.assertEqual(simple_recorder._SILENCE_SENTINEL, SILENCE_SENTINEL)
+
+    def test_short_real_transcript_does_not_trigger_fallback(self):
+        """Fix 4: a correct-but-short batch transcript (under the 100-char
+        live-fallback floor) is a real result and must NOT be replaced. The
+        trigger is batch_failed OR the exact silence sentinel — never length."""
+        import simple_recorder
+        sentinel = simple_recorder._SILENCE_SENTINEL
+        short_real = "Quick sync done."  # < 100 chars but genuine speech
+
+        def should_fall_back(batch_text, batch_failed):
+            # Mirrors the production predicate in process_streaming.
+            return batch_failed or (batch_text.strip() == sentinel)
+
+        self.assertFalse(should_fall_back(short_real, False))
+        self.assertTrue(should_fall_back(sentinel, False))
+        self.assertTrue(should_fall_back("", True))  # crash
+
+    def test_fallback_overwrites_transcript_file(self):
+        """Fix 6: when the live fallback fires, the _transcript.txt the batch
+        path already wrote (containing the silence sentinel) must be overwritten
+        with the live text so on-disk and in-memory transcripts agree."""
+        import simple_recorder
+        sentinel = simple_recorder._SILENCE_SENTINEL
+        live_text = "This is the live transcript the user actually watched " \
+                    "stream in during the meeting, well over the floor."
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            transcript_file = Path(tmp_dir) / "rec_transcript.txt"
+            transcript_file.write_text(
+                f"Session: Test\n{'='*60}\n\n{sentinel}\n", encoding="utf-8"
+            )
+            # Replicate the production overwrite step.
+            transcript_file.write_text(live_text, encoding="utf-8")
+            self.assertEqual(transcript_file.read_text(encoding="utf-8"), live_text)
+            self.assertNotIn(sentinel, transcript_file.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #207.

## What happened

When a 29-min meeting with live transcription working correctly
throughout was stopped, the batch transcription returned empty and the
meeting was saved as "No speech detected" — silently discarding the
live transcript the user had seen all along.

Two independent gaps caused this:

**Gap 1:** `liveTranscriptState` accumulated the live segments in Electron
but they were never used when batch came back empty.

**Gap 2:** A channel that passes the RMS energy gate but returns no text
was treated as a silent success instead of a failure.

## What changed

### Gap 1 — live transcript fallback

- Electron snapshots live segments at recording stop into an OS-temp
  file and passes it to `process-streaming` via `--live-transcript`
- Python uses the live transcript when: batch transcription failed
  (`transcription_failed=True`) OR result exactly matches the silence
  sentinel string
- Saved meeting is marked `is_live_transcript: true` so UI/future code
  know no batch transcript exists; audio is kept for reprocessing
- Snapshot waits on the sidecar's `close` event (not `exit`) to ensure
  the final utterance is flushed before reading; 8 s safety-net (5 s
  watchdog + 3 s grace) prevents hanging on a zombie process
- Quick stop→start safe: stale sidecar stdout handler exits early when
  superseded; kill watchdog and drain promise are per-process-instance,
  not global

### Gap 2 — empty result on energetic channel

- `transcribe_audio()` sets `transcription_empty: True` **before**
  substituting the silence sentinel, so the downstream diarised path
  can distinguish a truly empty result from short speech (previously the
  sentinel made the text truthy and the check was dead code)
- Fails the meeting only when **no channel** produced usable text; one
  channel with real text + one noisy-but-empty channel still succeeds

## Tests

Four new deterministic unit tests (model-free):
- `test_empty_text_on_energetic_channel_fails_meeting` — Gap 2 core
- `test_silent_channel_is_not_a_failure` — regression: silence ≠ failure  
- `test_one_channel_text_one_empty_succeeds` — regression: mixed channels
- `test_live_transcript_marker_round_trips` — `is_live_transcript` in frontmatter
- `test_batch_meeting_has_no_live_marker` — regression: normal batch unaffected
- `test_silence_sentinel_constant_agreement` — sentinel value stays in sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back to the live transcript when batch transcription fails or returns only silence, so users don’t lose the transcript they watched during recording. Also fixes diarisation to only fail meetings when no channel yields real text.

- **Bug Fixes**
  - Electron snapshots live segments at stop and passes them to `process-streaming` via `--live-transcript`.
  - Waits for the sidecar to fully drain on `close` with a per-process promise; 5s watchdog + 3s grace; safe on quick stop→start.
  - Backend uses the live transcript only if batch failed or equals the silence sentinel; rescues even very short live transcripts; marks `is_live_transcript` and keeps audio.
  - Adds `SILENCE_SENTINEL` and a `transcription_empty` flag; fail only when all energetic channels return empty; mixed channels succeed.
  - Writes the canonical `_transcript.txt` via a shared helper with UTF‑8 encoding so files are consistent and multilingual-safe; cleans up the temp snapshot.
  - Adds unit tests for empty-on-energy failure, mixed channels, silence ≠ failure, live marker round-trip, normal batch, and sentinel sync.
  - Adds a model-free e2e test that drives `process-streaming` with a silent stereo WAV + `--live-transcript`; verifies rescue (`is_live_transcript: true`), transcript overwrite (no sentinel), audio retention; extends `make-wav` to generate stereo/silence.

<sup>Written for commit 294ca46eefc656986ad6e124be10fd111116d430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

