### PR TITLE
feat: map-reduce summarization for long meetings (#188)

### DIFF
--- a/app/docs/ipc-contract.md
+++ b/app/docs/ipc-contract.md
@@ -161,6 +161,7 @@ truth for elapsed time and paused state so remounts recover correctly.
 | `summary-title` | M→R | yes | `stenoai.on.summaryTitle(cb)` |
 | `summary-complete` | M→R | yes | `stenoai.on.summaryComplete(cb)` |
 | `processing-complete` | M→R | yes | `stenoai.on.processingComplete(cb)` |
+| `processing-progress` | M→R | yes | `stenoai.on.processingProgress(cb)` |
 
 ```ts
 interface SessionInfo {
@@ -213,6 +214,14 @@ interface ProcessingCompleteEvent {
   meetingData?: Meeting;
 }
 ```
+
+### `processing-progress` (M→R)
+
+Emitted during map-reduce summarization of long meetings to update the processing-row badge.
+
+**Payload:** `{ line: string }` — e.g. `"PROGRESS:summarize:2/5"` or `"PROGRESS:summarize:reducing"`
+
+**Renderer:** `ipc().on.processingProgress(cb)` → updates Processing.tsx label to *"Summarizing part 2 of 5…"* or *"Merging summaries…"*.
 
 **Orphan listener.** `meetings-refreshed` is listened for in
 `app/index.html:9008` but `main.js` never sends it. Only the e2e mock

--- a/app/main.js
+++ b/app/main.js
@@ -1709,6 +1709,10 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
             if (mainWindow && !mainWindow.isDestroyed()) {
               mainWindow.webContents.send('summary-complete', { success: true, sessionName });
             }
+          } else if (line.startsWith('PROGRESS:')) {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('processing-progress', { line });
+            }
           } else if (line.trim()) {
             sendDebugLog(line.trim());
           }
@@ -2912,7 +2916,9 @@ async function processNextInQueue() {
             sendDebugLog(`Transcription failed (audio preserved): ${transcriptionFailedMsg}`);
             trackEvent('transcription_completed', { success: false });
           } else if (line.startsWith('PROGRESS:')) {
-            mainWindow.webContents.send('processing-progress', { line });
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('processing-progress', { line });
+            }
           } else if (line.startsWith('HEARTBEAT:')) {
             // Liveness signal — its real job (resetting the watchdog) already
             // happened at the top of this handler. Throttle debug-log output

--- a/app/main.js
+++ b/app/main.js
@@ -1771,24 +1771,40 @@ ipcMain.handle('get-meeting', async (_event, summaryFile) => {
     if (!summaryFile || (!summaryFile.endsWith('.json') && !summaryFile.endsWith('.md'))) {
       return { success: false, error: 'Invalid file path' };
     }
-    // Path containment: the resolved path must live under one of the known
-    // output directories (default data dir, custom storage, or dev project
-    // root). Use separator-safe prefix check to prevent /output-evil bypass.
-    const resolved = path.resolve(summaryFile);
-    const allowedOutputDirs = getAllowedBaseDirs().map(
-      d => path.resolve(d, 'output') + path.sep,
+    // Path containment: the file's REAL path (symlinks resolved) must live under
+    // one of the known output directories (default data dir, custom storage, or
+    // dev project root). We canonicalize BOTH the target and the allowed dirs
+    // with realpath so (a) a symlink planted in the output dir can't escape the
+    // allowlist into an arbitrary-file read — path.resolve only collapses '..',
+    // it does not follow symlinks — and (b) a legitimately symlinked base dir
+    // (e.g. macOS /tmp -> /private/tmp, which the e2e temp data dir uses) still
+    // matches. realpath needs the path to exist; a missing target -> denied.
+    let realResolved;
+    try {
+      realResolved = await fs.promises.realpath(path.resolve(summaryFile));
+    } catch {
+      return { success: false, error: 'Access denied' };
+    }
+    const allowedOutputDirs = await Promise.all(
+      getAllowedBaseDirs().map(async d => {
+        try {
+          return (await fs.promises.realpath(path.resolve(d, 'output'))) + path.sep;
+        } catch {
+          return null; // output dir may not exist yet
+        }
+      }),
     );
-    const allowed = allowedOutputDirs.some(base => resolved.startsWith(base));
+    const allowed = allowedOutputDirs.some(base => base && realResolved.startsWith(base));
     if (!allowed) {
       return { success: false, error: 'Access denied' };
     }
-    const content = await fs.promises.readFile(resolved, 'utf-8');
-    if (resolved.endsWith('.md')) {
+    const content = await fs.promises.readFile(realResolved, 'utf-8');
+    if (summaryFile.endsWith('.md')) {
       // Legacy .md meetings are still listed by list-meetings, so their detail
       // pages route through here. Unlike the list payload, the detail page
       // needs the full data INCLUDING the transcript (for the AskBar /
       // TranscriptPanel), so we return everything parseMeetingMarkdown yields.
-      return { success: true, meeting: parseMeetingMarkdown(content, resolved) };
+      return { success: true, meeting: parseMeetingMarkdown(content, realResolved) };
     }
     return { success: true, meeting: JSON.parse(content) };
   } catch (error) {
@@ -1869,7 +1885,7 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
             }
           } else if (line.startsWith('PROGRESS:')) {
             if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('processing-progress', { line });
+              mainWindow.webContents.send('processing-progress', { line, summaryFile });
             }
           } else if (line.startsWith('STREAM_ERROR:')) {
             const errMsg = line.slice('STREAM_ERROR:'.length);
@@ -3089,6 +3105,9 @@ async function processNextInQueue() {
             trackEvent('transcription_completed', { success: false });
           } else if (line.startsWith('PROGRESS:')) {
             if (mainWindow && !mainWindow.isDestroyed()) {
+              // No summaryFile yet in the record->summarise flow (it's assigned
+              // via SAVED: later); this progress is consumed by the single-job
+              // Processing view, which doesn't need per-meeting scoping.
               mainWindow.webContents.send('processing-progress', { line });
             }
           } else if (line.startsWith('HEARTBEAT:')) {

--- a/app/main.js
+++ b/app/main.js
@@ -1771,12 +1771,15 @@ ipcMain.handle('get-meeting', async (_event, summaryFile) => {
     if (!summaryFile || (!summaryFile.endsWith('.json') && !summaryFile.endsWith('.md'))) {
       return { success: false, error: 'Invalid file path' };
     }
-    // Path containment: the resolved path must live under the user-data
-    // output dir. Without this a caller could pass an arbitrary path ending
-    // in .json/.md and read any file on disk.
-    const allowedBase = path.resolve(getUserDataDir(), 'output');
+    // Path containment: the resolved path must live under one of the known
+    // output directories (default data dir, custom storage, or dev project
+    // root). Use separator-safe prefix check to prevent /output-evil bypass.
     const resolved = path.resolve(summaryFile);
-    if (!resolved.startsWith(allowedBase)) {
+    const allowedOutputDirs = getAllowedBaseDirs().map(
+      d => path.resolve(d, 'output') + path.sep,
+    );
+    const allowed = allowedOutputDirs.some(base => resolved.startsWith(base));
+    if (!allowed) {
       return { success: false, error: 'Access denied' };
     }
     const content = await fs.promises.readFile(resolved, 'utf-8');

--- a/app/main.js
+++ b/app/main.js
@@ -1638,12 +1638,155 @@ ipcMain.handle('list-meetings', async () => {
   }
 });
 
+// Parse a legacy .md meeting file into the standard meeting dict. Mirrors
+// simple_recorder._parse_meeting_markdown so the detail page can render .md
+// meetings without a Python round-trip. Returns the FULL data (transcript
+// included) — the size-stripping that list-meetings does is intentionally
+// not applied here because the detail page needs the transcript.
+function parseMeetingMarkdown(content, mdPath) {
+  // Split frontmatter
+  const meta = {};
+  let body = content;
+  if (content.startsWith('---')) {
+    const parts = content.split('---');
+    // content.split('---', 2) in Python keeps the remainder; replicate by
+    // re-joining everything after the second delimiter.
+    if (parts.length >= 3) {
+      const fmText = parts[1].trim();
+      body = parts.slice(2).join('---').trim();
+      for (const line of fmText.split('\n')) {
+        const colon = line.indexOf(':');
+        if (colon === -1) continue;
+        const key = line.slice(0, colon).trim();
+        let value = line.slice(colon + 1).trim();
+        if (value.startsWith('"') && value.endsWith('"')) {
+          value = value.slice(1, -1).replace(/\\(.)/g, '$1');
+        } else if (value.startsWith('[')) {
+          try {
+            value = JSON.parse(value);
+          } catch (_) {
+            value = [];
+          }
+        } else if (value === 'null') {
+          value = null;
+        } else if (value === 'true') {
+          value = true;
+        } else if (value === 'false') {
+          value = false;
+        } else if (/^-?\d+$/.test(value)) {
+          value = parseInt(value, 10);
+        }
+        meta[key] = value;
+      }
+    }
+  }
+
+  // Parse markdown body into sections keyed by lowercased `## ` heading.
+  const sections = {};
+  let currentSection = null;
+  let currentLines = [];
+  for (const line of body.split('\n')) {
+    if (line.startsWith('## ')) {
+      if (currentSection) sections[currentSection] = currentLines.join('\n').trim();
+      currentSection = line.slice(3).trim().toLowerCase();
+      currentLines = [];
+    } else {
+      currentLines.push(line);
+    }
+  }
+  if (currentSection) sections[currentSection] = currentLines.join('\n').trim();
+
+  const participants = sections.participants
+    ? sections.participants.split(',').map((p) => p.trim()).filter(Boolean)
+    : [];
+
+  const keyPoints = [];
+  if (sections['key points']) {
+    for (let line of sections['key points'].split('\n')) {
+      line = line.trim();
+      if (line.startsWith('- ')) keyPoints.push(line.slice(2));
+    }
+  }
+
+  const actionItems = [];
+  if (sections['action items']) {
+    for (let line of sections['action items'].split('\n')) {
+      line = line.trim();
+      if (line.startsWith('- ')) actionItems.push(line.slice(2).replace('[ ] ', '').replace('[x] ', ''));
+    }
+  }
+
+  const discussionAreas = [];
+  if (sections['key topics']) {
+    let currentTopic = null;
+    let topicLines = [];
+    for (const line of sections['key topics'].split('\n')) {
+      if (line.startsWith('### ')) {
+        if (currentTopic) {
+          discussionAreas.push({ title: currentTopic, analysis: topicLines.join('\n').trim() });
+        }
+        currentTopic = line.slice(4).trim();
+        topicLines = [];
+      } else {
+        topicLines.push(line);
+      }
+    }
+    if (currentTopic) {
+      discussionAreas.push({ title: currentTopic, analysis: topicLines.join('\n').trim() });
+    }
+  }
+
+  const stem = path.basename(mdPath).replace(/\.md$/, '');
+  const sessionInfo = {
+    name: meta.title || stem,
+    processed_at: meta.date || '',
+    duration_seconds: meta.duration_seconds ?? null,
+    summary_file: mdPath,
+    output_language: meta.language ?? null,
+  };
+  if (meta.transcription_failed) {
+    sessionInfo.transcription_failed = true;
+    sessionInfo.reprocessable = Boolean(meta.reprocessable);
+    if (meta.audio_file) sessionInfo.audio_file = meta.audio_file;
+    if (meta.error) sessionInfo.error = meta.error;
+  }
+
+  return {
+    session_info: sessionInfo,
+    summary: sections.summary || '',
+    participants,
+    discussion_areas: discussionAreas,
+    key_points: keyPoints,
+    action_items: actionItems,
+    transcript: sections.transcript || '',
+    is_diarised: meta.is_diarised || false,
+    diarised_text: meta.is_diarised ? sections.transcript || '' : null,
+    user_notes: sections['user notes'] ?? null,
+    folders: meta.folders || [],
+  };
+}
+
 ipcMain.handle('get-meeting', async (_event, summaryFile) => {
   try {
-    if (!summaryFile || !summaryFile.endsWith('.json')) {
+    if (!summaryFile || (!summaryFile.endsWith('.json') && !summaryFile.endsWith('.md'))) {
       return { success: false, error: 'Invalid file path' };
     }
-    const content = await fs.promises.readFile(summaryFile, 'utf-8');
+    // Path containment: the resolved path must live under the user-data
+    // output dir. Without this a caller could pass an arbitrary path ending
+    // in .json/.md and read any file on disk.
+    const allowedBase = path.resolve(getUserDataDir(), 'output');
+    const resolved = path.resolve(summaryFile);
+    if (!resolved.startsWith(allowedBase)) {
+      return { success: false, error: 'Access denied' };
+    }
+    const content = await fs.promises.readFile(resolved, 'utf-8');
+    if (resolved.endsWith('.md')) {
+      // Legacy .md meetings are still listed by list-meetings, so their detail
+      // pages route through here. Unlike the list payload, the detail page
+      // needs the full data INCLUDING the transcript (for the AskBar /
+      // TranscriptPanel), so we return everything parseMeetingMarkdown yields.
+      return { success: true, meeting: parseMeetingMarkdown(content, resolved) };
+    }
     return { success: true, meeting: JSON.parse(content) };
   } catch (error) {
     return { success: false, error: error.message };

--- a/app/main.js
+++ b/app/main.js
@@ -2911,6 +2911,8 @@ async function processNextInQueue() {
             transcriptionFailedMsg = line.slice('TRANSCRIPTION_FAILED:'.length).trim();
             sendDebugLog(`Transcription failed (audio preserved): ${transcriptionFailedMsg}`);
             trackEvent('transcription_completed', { success: false });
+          } else if (line.startsWith('PROGRESS:')) {
+            mainWindow.webContents.send('processing-progress', { line });
           } else if (line.startsWith('HEARTBEAT:')) {
             // Liveness signal — its real job (resetting the watchdog) already
             // happened at the top of this handler. Throttle debug-log output

--- a/app/main.js
+++ b/app/main.js
@@ -1725,6 +1725,12 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
             if (mainWindow && !mainWindow.isDestroyed()) {
               mainWindow.webContents.send('processing-progress', { line });
             }
+          } else if (line.startsWith('STREAM_ERROR:')) {
+            const errMsg = line.slice('STREAM_ERROR:'.length);
+            sendDebugLog(`❌ Reprocess stream error: ${errMsg}`);
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('summary-complete', { success: false, sessionName });
+            }
           } else if (line.trim()) {
             sendDebugLog(line.trim());
           }
@@ -1754,6 +1760,14 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
           }
           resolve();
         } else {
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('processing-complete', {
+              success: false,
+              sessionName,
+              summaryFile,
+              message: `Reprocessing failed (exit ${code})`,
+            });
+          }
           reject(new Error(`reprocess exited with code ${code}: ${stderrBuf.slice(-500)}`));
         }
       });

--- a/app/main.js
+++ b/app/main.js
@@ -1638,6 +1638,18 @@ ipcMain.handle('list-meetings', async () => {
   }
 });
 
+ipcMain.handle('get-meeting', async (_event, summaryFile) => {
+  try {
+    if (!summaryFile || !summaryFile.endsWith('.json')) {
+      return { success: false, error: 'Invalid file path' };
+    }
+    const content = await fs.promises.readFile(summaryFile, 'utf-8');
+    return { success: true, meeting: JSON.parse(content) };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
 ipcMain.handle('clear-state', async () => {
   try {
     const result = await runPythonScript('simple_recorder.py', ['clear-state']);

--- a/app/preload.js
+++ b/app/preload.js
@@ -303,6 +303,7 @@ const stenoai = {
     summaryTitle: (cb) => subscribe('summary-title', cb),
     summaryComplete: (cb) => subscribe('summary-complete', cb),
     processingComplete: (cb) => subscribe('processing-complete', cb),
+    processingProgress: (cb) => subscribe('processing-progress', cb),
     queryChunk: (cb) => subscribe('query-chunk', cb),
     queryDone: (cb) => subscribe('query-done', cb),
     modelPullProgress: (cb) => subscribe('model-pull-progress', cb),

--- a/app/preload.js
+++ b/app/preload.js
@@ -136,6 +136,7 @@ const stenoai = {
 
   meetings: {
     list: () => invoke('list-meetings'),
+    get: (summaryFile) => invoke('get-meeting', summaryFile),
     update: (summaryFile, patch) => invoke('update-meeting', summaryFile, patch),
     revealFolder: (filePath) => invoke('reveal-meeting-folder', filePath),
     delete: (meeting) => invoke('delete-meeting', meeting),

--- a/app/renderer/src/hooks/meetingKeys.ts
+++ b/app/renderer/src/hooks/meetingKeys.ts
@@ -1,4 +1,6 @@
 export const meetingsKeys = {
   all: ['meetings'] as const,
   list: () => [...meetingsKeys.all, 'list'] as const,
+  detail: (summaryFile: string | null | undefined) =>
+    [...meetingsKeys.all, 'detail', summaryFile ?? null] as const,
 };

--- a/app/renderer/src/hooks/useMeetings.ts
+++ b/app/renderer/src/hooks/useMeetings.ts
@@ -117,15 +117,15 @@ function buildLiveMeeting(
 }
 
 export function useMeeting(summaryFile: string | null | undefined) {
-  const meetings = useMeetings();
-  const meeting = React.useMemo(
-    () =>
-      summaryFile
-        ? (meetings.data?.find((m) => m.session_info.summary_file === summaryFile) ?? null)
-        : null,
-    [meetings.data, summaryFile],
-  );
-  return { ...meetings, data: meeting };
+  return useQuery({
+    queryKey: meetingsKeys.detail(summaryFile),
+    queryFn: async () => {
+      if (!summaryFile) return null;
+      const res = await ipc().meetings.get(summaryFile);
+      return unwrap(res).meeting;
+    },
+    enabled: !!summaryFile,
+  });
 }
 
 export function useTranscript(summaryFile: string | null | undefined) {

--- a/app/renderer/src/hooks/useMeetings.ts
+++ b/app/renderer/src/hooks/useMeetings.ts
@@ -180,6 +180,11 @@ export function useDeleteMeeting() {
       qc.setQueryData<Meeting[]>(meetingsKeys.list(), (prev) =>
         prev?.filter((m) => m.session_info.summary_file !== deletedFile),
       );
+      // Drop the lazy-loaded detail cache for this meeting too. The list filter
+      // above only touches the list query; without this, the deleted meeting's
+      // detail payload (transcript etc.) stays served from cache if the detail
+      // route is revisited.
+      qc.removeQueries({ queryKey: meetingsKeys.detail(deletedFile) });
     },
   });
 }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -431,6 +431,9 @@ export type CheckForUpdatesResponse = Result<{
 }>;
 
 // ---------- event payloads ----------
+export interface ProcessingProgressEvent {
+  line: string;
+}
 export interface SummaryChunkEvent {
   chunk: string;
   sessionName: string;
@@ -798,6 +801,7 @@ export interface StenoaiBridge {
     summaryTitle: Subscribe<SummaryTitleEvent>;
     summaryComplete: Subscribe<SummaryCompleteEvent>;
     processingComplete: Subscribe<ProcessingCompleteEvent>;
+    processingProgress: Subscribe<ProcessingProgressEvent>;
     queryChunk: Subscribe<QueryChunkEvent>;
     queryDone: Subscribe<QueryDoneEvent>;
     modelPullProgress: Subscribe<ModelPullProgressEvent>;

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -434,6 +434,10 @@ export type CheckForUpdatesResponse = Result<{
 // ---------- event payloads ----------
 export interface ProcessingProgressEvent {
   line: string;
+  // The meeting's summary file — its unique key — so a detail view can ignore
+  // progress from a different meeting's concurrent reprocess. Uses the file path
+  // (not the display name, which two meetings can share) for an exact match.
+  summaryFile?: string;
 }
 export interface SummaryChunkEvent {
   chunk: string;

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -35,7 +35,7 @@ export interface Meeting {
   discussion_areas?: unknown[];
   key_points?: string[];
   action_items?: unknown[];
-  transcript: string;
+  transcript?: string;
   is_diarised?: boolean;
   diarised_text?: string | null;
   folders?: string[];
@@ -315,6 +315,7 @@ export type PickAudioFileResponse = Result<{ filePath: string }>;
 export type RecordingsDirResponse = Result<{ path: string }>;
 
 export type ListMeetingsResponse = Result<{ meetings: Meeting[] }>;
+export type GetMeetingResponse = Result<{ meeting: Meeting }>;
 export type UpdateMeetingResponse = Result<{ message: string; updatedData: Meeting }>;
 export type DeleteMeetingResponse = Result<{ message: string }>;
 export type SaveMeetingNotesResponse = Result<{ path: string }>;
@@ -645,6 +646,7 @@ export interface StenoaiBridge {
 
   meetings: {
     list: RequestFn<[], ListMeetingsResponse>;
+    get: RequestFn<[summaryFile: string], GetMeetingResponse>;
     update: RequestFn<[summaryFile: string, patch: UpdateMeetingPatch], UpdateMeetingResponse>;
     revealFolder: RequestFn<[filePath: string], Result<Record<string, never>>>;
     delete: RequestFn<[meeting: Meeting], DeleteMeetingResponse>;

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -264,6 +264,10 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
       }, 400);
     });
     const offProgress = ipc().on.processingProgress((e) => {
+      // Ignore progress from a different meeting's concurrent reprocess — without
+      // this scope check this view would render another meeting's map/reduce step.
+      // Scoped on summaryFile (unique) rather than the display name (shareable).
+      if (e.summaryFile !== summaryFile) return;
       const mapMatch = e.line.match(/^PROGRESS:summarize:(\d+)\/(\d+)$/);
       if (mapMatch) {
         setChunkProgress({ step: parseInt(mapMatch[1]), total: parseInt(mapMatch[2]) });

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -223,6 +223,8 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   const cached = streamCache.get(summaryFile);
   const [streamText, setStreamText] = React.useState(cached?.text ?? '');
   const [streamPhase, setStreamPhase] = React.useState<StreamPhase>(cached?.phase ?? 'idle');
+  const [chunkProgress, setChunkProgress] = React.useState<{ step: number; total: number } | null>(null);
+  const [reprocessFailed, setReprocessFailed] = React.useState(false);
   const qc = useQueryClient();
 
   React.useEffect(() => {
@@ -238,10 +240,22 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
     });
     const offComplete = ipc().on.summaryComplete((e) => {
       if (e.sessionName !== sessionName) return;
+      if (!e.success) {
+        setStreamPhase('idle');
+        setChunkProgress(null);
+        setReprocessFailed(true);
+        return;
+      }
       setStreamPhase('done');
     });
     const offProcessing = ipc().on.processingComplete((e) => {
       if (e.sessionName !== sessionName) return;
+      setChunkProgress(null);
+      if (!e.success) {
+        setStreamPhase('idle');
+        setReprocessFailed(true);
+        return;
+      }
       void qc.invalidateQueries({ queryKey: meetingsKeys.all });
       setTimeout(() => {
         setStreamText('');
@@ -249,10 +263,19 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
         streamCache.delete(summaryFile);
       }, 400);
     });
+    const offProgress = ipc().on.processingProgress((e) => {
+      const mapMatch = e.line.match(/^PROGRESS:summarize:(\d+)\/(\d+)$/);
+      if (mapMatch) {
+        setChunkProgress({ step: parseInt(mapMatch[1]), total: parseInt(mapMatch[2]) });
+      } else if (e.line === 'PROGRESS:summarize:reducing') {
+        setChunkProgress(null);
+      }
+    });
     return () => {
       offChunk();
       offComplete();
       offProcessing();
+      offProgress();
     };
   }, [info.name, summaryFile, qc]);
 
@@ -339,6 +362,8 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
                     onClick={() => {
                       setStreamText('');
                       setStreamPhase('analyzing');
+                      setChunkProgress(null);
+                      setReprocessFailed(false);
                       streamCache.set(summaryFile, { text: '', phase: 'analyzing' });
                       reprocess.mutate({ summaryFile, regenTitle: false, name: info.name });
                     }}
@@ -558,8 +583,21 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
         )}
       </header>
 
+      {reprocessFailed && (
+        <div
+          className="rounded-lg p-3 text-sm"
+          style={{
+            background: 'var(--surface-raised)',
+            border: '1px solid var(--border-subtle)',
+            color: 'var(--fg-2)',
+          }}
+        >
+          Summary generation failed — the model may have run out of memory or context.
+          Try switching to a smaller model like <strong style={{ color: 'var(--fg-1)' }}>Gemma 4 E2B</strong> in Settings.
+        </div>
+      )}
       {streamPhase !== 'idle' ? (
-        <StreamingView text={streamText} phase={streamPhase} />
+        <StreamingView text={streamText} phase={streamPhase} chunkProgress={chunkProgress} />
       ) : (
         <div className="flex flex-col gap-9">
           {transcriptionFailed ? (
@@ -826,7 +864,7 @@ function parseMarkdownBlocks(text: string): MarkdownBlock[] {
 const CHAR_TRANSITION = 'top 0.12s ease-out';
 const ROW_TRANSITION = 'top 0.35s cubic-bezier(0.45, 0, 0.55, 1)';
 
-function StreamingView({ text, phase }: { text: string; phase: StreamPhase }) {
+function StreamingView({ text, phase, chunkProgress }: { text: string; phase: StreamPhase; chunkProgress?: { step: number; total: number } | null }) {
   const blocks = parseMarkdownBlocks(text);
   const isStreaming = phase === 'analyzing' || phase === 'generating';
 
@@ -925,7 +963,11 @@ function StreamingView({ text, phase }: { text: string; phase: StreamPhase }) {
     if (rowTransitionTimerRef.current) clearTimeout(rowTransitionTimerRef.current);
   }, []);
 
-  const indicatorLabel = phase === 'analyzing' ? 'Analysing transcript' : 'Generating notes';
+  const indicatorLabel = chunkProgress
+    ? `Summarising part ${chunkProgress.step}/${chunkProgress.total}`
+    : phase === 'analyzing'
+      ? 'Analysing transcript'
+      : 'Generating notes';
 
   return (
     <div className="relative">

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -88,6 +88,20 @@ export function MeetingDetail({ summaryFile }: MeetingDetailProps) {
         <div className="flex min-h-[40vh] items-center justify-center text-[color:var(--fg-2)]">
           Loading meeting…
         </div>
+      ) : meeting.isError ? (
+        <div className="space-y-4 text-center">
+          <h1 className="mv-title">Couldn't load note.</h1>
+          <p className="text-[17px] leading-[1.55]" style={{ color: 'var(--fg-2)' }}>
+            {(meeting.error as Error)?.message ?? 'An error occurred loading this note.'}
+          </p>
+          <button
+            type="button"
+            className="mv-chip"
+            onClick={() => navigate('/meetings')}
+          >
+            Back to meetings
+          </button>
+        </div>
       ) : !meeting.data ? (
         <div className="space-y-4 text-center">
           <h1 className="mv-title">Note not found.</h1>

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -52,6 +52,7 @@ export function Processing() {
     : recording.elapsed;
 
   const [stage, setStage] = React.useState<ProcessingStage>('transcribing');
+  const [chunkProgress, setChunkProgress] = React.useState<string | null>(null);
   const [streamText, setStreamText] = React.useState('');
   const [streamedTitle, setStreamedTitle] = React.useState<string | null>(null);
 
@@ -109,6 +110,18 @@ export function Processing() {
           });
         }
       }),
+      ipc().on.processingProgress((e) => {
+        const raw = e.line.replace(/^PROGRESS:summarize:/, '');
+        if (raw === 'reducing') {
+          setChunkProgress('Merging summaries…');
+        } else {
+          const [step, total] = raw.split('/').map(Number);
+          if (!Number.isNaN(step) && !Number.isNaN(total)) {
+            setChunkProgress(`Summarizing part ${step} of ${total}…`);
+          }
+        }
+        setStage((s) => (s === 'transcribing' ? 'summarizing' : s));
+      }),
     ];
     return () => offs.forEach((fn) => fn());
   }, [activeSession, updateMeeting]);
@@ -160,7 +173,7 @@ export function Processing() {
         {stage === 'error' ? (
           <ErrorPanel onRetry={() => setStage('transcribing')} />
         ) : (
-          <StageCard stage={stage} streamText={streamText} />
+          <StageCard stage={stage} streamText={streamText} chunkProgress={chunkProgress} />
         )}
 
         {draft?.notes && (
@@ -199,9 +212,11 @@ const StreamMarkdown = React.memo(function StreamMarkdown({ text }: { text: stri
 function StageCard({
   stage,
   streamText,
+  chunkProgress,
 }: {
   stage: ProcessingStage;
   streamText: string;
+  chunkProgress: string | null;
 }) {
   // FLIP animation for the scanner bar. The bar is in normal flow under the
   // streaming markdown, so each token batch shifts it down by a discrete
@@ -285,7 +300,7 @@ function StageCard({
           className="text-[13px] transition-colors"
           style={{ color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
         >
-          {STAGE_LABEL[stage]}
+          {chunkProgress && stage === 'summarizing' ? chunkProgress : STAGE_LABEL[stage]}
         </span>
       </div>
     </div>

--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -22,10 +22,12 @@ const OLLAMA_PORT = 11434;
  * Start the mock Ollama on 11434.
  * @param {object} [opts]
  * @param {string} [opts.chatReply='ok'] assistant content returned by /api/chat.
- * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number, pullCalls: () => number }>}
+ * @param {string[]} [opts.chatReplyQueue=[]] queue of replies to dequeue per call; falls back to chatReply when exhausted.
+ * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number, pullCalls: () => number, remainingQueueLength: () => number }>}
  */
 function startMockOllama(opts = {}) {
   const chatReply = opts.chatReply ?? 'ok';
+  const chatReplyQueue = Array.isArray(opts.chatReplyQueue) ? [...opts.chatReplyQueue] : [];
   let lastChatPrompt = null;
   let chatCalls = 0;
   let pullCalls = 0;
@@ -79,21 +81,31 @@ function startMockOllama(opts = {}) {
         req.on('data', (c) => chunks.push(c));
         req.on('end', () => {
           chatCalls++;
+          let body = {};
           try {
-            const body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
-            const msgs = Array.isArray(body.messages) ? body.messages : [];
-            lastChatPrompt = msgs.length ? String(msgs[msgs.length - 1].content || '') : '';
-          } catch {
-            lastChatPrompt = '';
+            body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+          } catch { /* ignore */ }
+          const msgs = Array.isArray(body.messages) ? body.messages : [];
+          lastChatPrompt = msgs.length ? String(msgs[msgs.length - 1].content || '') : '';
+
+          // Dequeue reply or fall back to default
+          const reply = chatReplyQueue.length > 0 ? chatReplyQueue.shift() : chatReply;
+
+          if (body.stream === false) {
+            // Non-streaming (map call): return a single JSON object
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ message: { role: 'assistant', content: reply }, done: true }));
+          } else {
+            // Streaming (reduce call / legacy): return NDJSON
+            res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+            res.write(
+              JSON.stringify({ message: { role: 'assistant', content: reply }, done: false }) +
+                '\n',
+            );
+            res.end(
+              JSON.stringify({ message: { role: 'assistant', content: '' }, done: true }) + '\n',
+            );
           }
-          res.writeHead(200, { 'content-type': 'application/x-ndjson' });
-          res.write(
-            JSON.stringify({ message: { role: 'assistant', content: chatReply }, done: false }) +
-              '\n',
-          );
-          res.end(
-            JSON.stringify({ message: { role: 'assistant', content: '' }, done: true }) + '\n',
-          );
         });
         return;
       }
@@ -108,6 +120,7 @@ function startMockOllama(opts = {}) {
         lastChatPrompt: () => lastChatPrompt,
         chatCalls: () => chatCalls,
         pullCalls: () => pullCalls,
+        remainingQueueLength: () => chatReplyQueue.length,
       });
     });
   });

--- a/e2e/specs/map-reduce-chunking.t2.spec.ts
+++ b/e2e/specs/map-reduce-chunking.t2.spec.ts
@@ -15,9 +15,12 @@ import { readFileSync } from 'fs';
  * real model. Tagged @map-reduce; runs in the model-free t2 jobs.
  */
 
-// llama3.2:3b context=8192, budget factor ~0.8 → ~6554 tokens → ~26 214 chars.
-// 500 lines × ~80 chars = ~40 000 chars — comfortably over the threshold,
-// guaranteeing exactly 2 map chunks + 1 reduce = 3 chat calls.
+// Chunk math (llama3.2:3b, num_ctx=8192):
+//   needs_chunking threshold: estimated_tokens > num_ctx * 0.8
+//   chunk budget chars = (num_ctx - 300 - 600) * 2 = 14584 (content + overlap)
+//   overlap = floor(14584 * 0.05) = 729; content_budget = 13855
+// The 500-line transcript below is 44 390 chars → ceil(44390 / 13855) = 4 map
+// chunks, so 4 map calls + 1 reduce = 5 chat calls.
 const LONG_TRANSCRIPT = Array.from({ length: 500 }, (_, i) =>
   `Speaker A: This is utterance ${i} of a long planning meeting about the quarterly roadmap.\n`,
 ).join('');
@@ -49,10 +52,14 @@ test.describe('Map-reduce summarization @map-reduce', () => {
     });
 
     // Map calls get compact extraction replies; reduce call gets the full summary.
+    // One queued reply per map chunk (4), then the reduce call falls through to
+    // chatReply once the queue is exhausted.
     const ollama = await startMockOllama({
       chatReplyQueue: [
         'KEY POINTS\n- Planning session discussed roadmap.\n\nACTION ITEMS\n- Team to review Q3 budget.',
         'KEY POINTS\n- Team confirmed delivery timeline.\n\nACTION ITEMS\n- Alice to update tracker.',
+        'KEY POINTS\n- Risks reviewed for the rollout.\n\nACTION ITEMS\n- Bob to file mitigation plan.',
+        'KEY POINTS\n- Next steps and owners assigned.\n\nACTION ITEMS\n- Carol to schedule follow-up.',
       ],
       chatReply:
         '## Summary\nThis was a long planning meeting about the quarterly roadmap.\n\n## Key Points\n- Roadmap agreed\n\n## Action Items\n- Update tracker',
@@ -92,14 +99,16 @@ test.describe('Map-reduce summarization @map-reduce', () => {
 
       expect(completed).toBe(true);
 
-      // 2 map calls + 1 reduce call = 3 total.
-      expect(ollama.chatCalls()).toBe(3);
+      // 4 map calls + 1 reduce call = 5 total.
+      expect(ollama.chatCalls()).toBe(5);
 
       // PROGRESS: lines must arrive in order.
       const summarizeLines = progressLines.filter((l) => l.startsWith('PROGRESS:summarize:'));
       expect(summarizeLines).toEqual([
-        'PROGRESS:summarize:1/2',
-        'PROGRESS:summarize:2/2',
+        'PROGRESS:summarize:1/4',
+        'PROGRESS:summarize:2/4',
+        'PROGRESS:summarize:3/4',
+        'PROGRESS:summarize:4/4',
         'PROGRESS:summarize:reducing',
       ]);
 

--- a/e2e/specs/map-reduce-chunking.t2.spec.ts
+++ b/e2e/specs/map-reduce-chunking.t2.spec.ts
@@ -39,7 +39,7 @@ type StenoWindow = Window & {
 };
 
 test.describe('Map-reduce summarization @map-reduce', () => {
-  test('long transcript triggers N+1 chat calls (2 map + 1 reduce)', async ({
+  test('long transcript triggers N+1 chat calls (4 map + 1 reduce)', async ({
     launchApp,
     userDataDir,
   }) => {

--- a/e2e/specs/map-reduce-chunking.t2.spec.ts
+++ b/e2e/specs/map-reduce-chunking.t2.spec.ts
@@ -7,7 +7,7 @@ import { readFileSync } from 'fs';
  * T2 @map-reduce — end-to-end exercise of the map-reduce summarisation path.
  *
  * Drives `reprocess` through the real bundled backend + mock Ollama and asserts:
- *   1. A transcript > 26 214 chars (llama3.2:3b threshold) triggers N map calls
+ *   1. A transcript > 13 107 chars (llama3.2:3b threshold) triggers N map calls
  *      + 1 reduce call (N+1 total), emitting PROGRESS:summarize: lines in order.
  *   2. A short transcript still takes the direct 1-call path (regression guard).
  *
@@ -44,7 +44,7 @@ test.describe('Map-reduce summarization @map-reduce', () => {
     userDataDir,
   }) => {
     // Pin llama3.2:3b so the chunking threshold is predictable.
-    writeUserConfig(userDataDir, { ai_provider: 'local', ai_model: 'llama3.2:3b' });
+    writeUserConfig(userDataDir, { ai_provider: 'local', model: 'llama3.2:3b' });
     const summaryFile = writeMeetingSummary(userDataDir, 'long-meeting', {
       name: 'Long Planning Meeting',
       summary: 'stale',
@@ -112,9 +112,12 @@ test.describe('Map-reduce summarization @map-reduce', () => {
         'PROGRESS:summarize:reducing',
       ]);
 
-      // Final summary must be saved to disk with the expected shape.
+      // Final summary must be saved to disk with the expected shape. `summary`
+      // holds the parsed ## Summary body (the header is stripped by the backend's
+      // _parse_streamed_markdown; the other sections land in their own fields),
+      // so assert on the reduce reply's overview text rather than the header.
       const saved = JSON.parse(readFileSync(summaryFile, 'utf8'));
-      expect(saved.summary).toContain('## Summary');
+      expect(saved.summary).toContain('long planning meeting about the quarterly roadmap');
     } finally {
       await ollama.close();
     }
@@ -124,7 +127,7 @@ test.describe('Map-reduce summarization @map-reduce', () => {
     launchApp,
     userDataDir,
   }) => {
-    writeUserConfig(userDataDir, { ai_provider: 'local', ai_model: 'llama3.2:3b' });
+    writeUserConfig(userDataDir, { ai_provider: 'local', model: 'llama3.2:3b' });
     const summaryFile = writeMeetingSummary(userDataDir, 'short-meeting', {
       name: 'Short Meeting',
       summary: 'stale',

--- a/e2e/specs/map-reduce-chunking.t2.spec.ts
+++ b/e2e/specs/map-reduce-chunking.t2.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect } from '../fixtures/electron';
+import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { readFileSync } from 'fs';
+
+/**
+ * T2 @map-reduce — end-to-end exercise of the map-reduce summarisation path.
+ *
+ * Drives `reprocess` through the real bundled backend + mock Ollama and asserts:
+ *   1. A transcript > 26 214 chars (llama3.2:3b threshold) triggers N map calls
+ *      + 1 reduce call (N+1 total), emitting PROGRESS:summarize: lines in order.
+ *   2. A short transcript still takes the direct 1-call path (regression guard).
+ *
+ * Model-free: transcripts are pre-seeded and the LLM is the mock. No ASR, no
+ * real model. Tagged @map-reduce; runs in the model-free t2 jobs.
+ */
+
+// llama3.2:3b context=8192, budget factor ~0.8 → ~6554 tokens → ~26 214 chars.
+// 500 lines × ~80 chars = ~40 000 chars — comfortably over the threshold,
+// guaranteeing exactly 2 map chunks + 1 reduce = 3 chat calls.
+const LONG_TRANSCRIPT = Array.from({ length: 500 }, (_, i) =>
+  `Speaker A: This is utterance ${i} of a long planning meeting about the quarterly roadmap.\n`,
+).join('');
+
+type ReprocessResult = { success: boolean; error?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      reprocess: (summaryFile: string, regenTitle: boolean, name: string) => Promise<ReprocessResult>;
+    };
+    on: {
+      summaryComplete: (cb: (e: { success: boolean }) => void) => () => void;
+      processingProgress: (cb: (e: { line: string }) => void) => () => void;
+    };
+  };
+};
+
+test.describe('Map-reduce summarization @map-reduce', () => {
+  test('long transcript triggers N+1 chat calls (2 map + 1 reduce)', async ({
+    launchApp,
+    userDataDir,
+  }) => {
+    // Pin llama3.2:3b so the chunking threshold is predictable.
+    writeUserConfig(userDataDir, { ai_provider: 'local', ai_model: 'llama3.2:3b' });
+    const summaryFile = writeMeetingSummary(userDataDir, 'long-meeting', {
+      name: 'Long Planning Meeting',
+      summary: 'stale',
+      transcript: LONG_TRANSCRIPT,
+    });
+
+    // Map calls get compact extraction replies; reduce call gets the full summary.
+    const ollama = await startMockOllama({
+      chatReplyQueue: [
+        'KEY POINTS\n- Planning session discussed roadmap.\n\nACTION ITEMS\n- Team to review Q3 budget.',
+        'KEY POINTS\n- Team confirmed delivery timeline.\n\nACTION ITEMS\n- Alice to update tracker.',
+      ],
+      chatReply:
+        '## Summary\nThis was a long planning meeting about the quarterly roadmap.\n\n## Key Points\n- Roadmap agreed\n\n## Action Items\n- Update tracker',
+    });
+    try {
+      const { page } = await launchApp();
+
+      // Capture PROGRESS: events via the IPC bridge.
+      const progressLines: string[] = [];
+      await page.exposeFunction('captureProgress', (line: string) => {
+        progressLines.push(line);
+      });
+      await page.evaluate(() => {
+        const w = window as unknown as StenoWindow;
+        w.stenoai.on.processingProgress((e: { line: string }) => {
+          (window as any).captureProgress(e.line);
+        });
+      });
+
+      // Trigger reprocess and wait for completion.
+      const completed: boolean = await page.evaluate(
+        (f) =>
+          new Promise<boolean>((resolve) => {
+            const timer = setTimeout(() => resolve(false), 60_000);
+            const w = window as unknown as StenoWindow;
+            const off = w.stenoai.on.summaryComplete((e) => {
+              if (e && e.success) {
+                clearTimeout(timer);
+                off();
+                resolve(true);
+              }
+            });
+            w.stenoai.meetings.reprocess(f, false, 'Long Planning Meeting');
+          }),
+        summaryFile,
+      );
+
+      expect(completed).toBe(true);
+
+      // 2 map calls + 1 reduce call = 3 total.
+      expect(ollama.chatCalls()).toBe(3);
+
+      // PROGRESS: lines must arrive in order.
+      const summarizeLines = progressLines.filter((l) => l.startsWith('PROGRESS:summarize:'));
+      expect(summarizeLines).toEqual([
+        'PROGRESS:summarize:1/2',
+        'PROGRESS:summarize:2/2',
+        'PROGRESS:summarize:reducing',
+      ]);
+
+      // Final summary must be saved to disk with the expected shape.
+      const saved = JSON.parse(readFileSync(summaryFile, 'utf8'));
+      expect(saved.summary).toContain('## Summary');
+    } finally {
+      await ollama.close();
+    }
+  });
+
+  test('short transcript uses direct path (1 chat call)', async ({
+    launchApp,
+    userDataDir,
+  }) => {
+    writeUserConfig(userDataDir, { ai_provider: 'local', ai_model: 'llama3.2:3b' });
+    const summaryFile = writeMeetingSummary(userDataDir, 'short-meeting', {
+      name: 'Short Meeting',
+      summary: 'stale',
+      transcript: 'Speaker A: Hello, let us begin.\nSpeaker B: Agreed, let us proceed.\n',
+    });
+
+    const ollama = await startMockOllama({
+      chatReply:
+        '## Summary\nBrief meeting.\n\n## Key Points\n- Started well\n\n## Action Items\n- None',
+    });
+    try {
+      const { page } = await launchApp();
+
+      const completed: boolean = await page.evaluate(
+        (f) =>
+          new Promise<boolean>((resolve) => {
+            const timer = setTimeout(() => resolve(false), 60_000);
+            const w = window as unknown as StenoWindow;
+            const off = w.stenoai.on.summaryComplete((e) => {
+              if (e && e.success) {
+                clearTimeout(timer);
+                off();
+                resolve(true);
+              }
+            });
+            w.stenoai.meetings.reprocess(f, false, 'Short Meeting');
+          }),
+        summaryFile,
+      );
+
+      expect(completed).toBe(true);
+
+      // Short transcript takes the direct path: exactly 1 chat call.
+      expect(ollama.chatCalls()).toBe(1);
+    } finally {
+      await ollama.close();
+    }
+  });
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,10 @@ onnxruntime>=1.17
 # Parakeet can't speak (Chinese, Japanese, Korean, Arabic, Hindi, …).
 # Cross-platform — Windows wheels are published.
 pywhispercpp>=1.2.0
-ollama>=0.1.7
+# >=0.5.0: the chat() `think` param (used to disable reasoning channels for
+# summarization) was introduced in ollama-python 0.5.0; older versions raise
+# TypeError on it, which the streaming path would swallow into an empty summary.
+ollama>=0.5.0
 click>=8.1.0
 pydantic>=2.5.0
 python-dateutil>=2.8.0

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1892,8 +1892,16 @@ def list_meetings():
     for summary_file in summaries:
         try:
             if summary_file.suffix == '.md':
-                essential_meeting = _parse_meeting_markdown(summary_file)
-                sort_key = essential_meeting.get('session_info', {}).get('processed_at', '')
+                parsed = _parse_meeting_markdown(summary_file)
+                sort_key = parsed.get('session_info', {}).get('processed_at', '')
+                # Strip the transcript (and diarised copy) from the LIST payload
+                # to match the JSON path — the full text is fetched lazily by
+                # get-meeting for the detail page. Keep has_transcript so the UI
+                # still knows a transcript exists.
+                essential_meeting = parsed
+                essential_meeting['has_transcript'] = bool(parsed.get('transcript'))
+                essential_meeting.pop('transcript', None)
+                essential_meeting.pop('diarised_text', None)
             else:
                 with open(summary_file, 'r', encoding='utf-8') as f:
                     data = json.load(f)
@@ -2007,7 +2015,12 @@ def reprocess(summary_file, regenerate_title):
 
         if _stream_error is not None:
             logger.error(f"Summarization failed: {_stream_error}")
-            print(f"STREAM_ERROR:{_stream_error}", flush=True)
+            # The renderer's parser reads STREAM_ERROR line-by-line, so a
+            # message containing newlines (tracebacks can) would be truncated
+            # to its first line. Flatten newlines into spaces so the whole
+            # message survives on one line.
+            err_msg = str(_stream_error).replace('\n', ' ').replace('\r', ' ')
+            print(f"STREAM_ERROR:{err_msg}", flush=True)
             sys.exit(1)
 
         streamed_md = ''.join(streamed_chunks)

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1989,6 +1989,7 @@ def reprocess(summary_file, regenerate_title):
         # Same watchdog-liveness cover as process_streaming: model load +
         # prompt eval is silent until the first streamed token.
         summary_heartbeat = _start_summary_heartbeat()
+        _stream_error = None
         try:
             for chunk in recorder.summarizer.summarize_transcript_streaming(
                 transcript, duration_minutes, output_language, notes_text,
@@ -1999,8 +2000,16 @@ def reprocess(summary_file, regenerate_title):
                 sys.stdout.write(f"CHUNK:{encoded}\n")
                 sys.stdout.flush()
                 streamed_chunks.append(chunk)
+        except Exception as e:
+            _stream_error = e
         finally:
             summary_heartbeat.set()
+
+        if _stream_error is not None:
+            logger.error(f"Summarization failed: {_stream_error}")
+            print(f"STREAM_ERROR:{_stream_error}", flush=True)
+            sys.exit(1)
+
         streamed_md = ''.join(streamed_chunks)
 
         print("STREAM_COMPLETE", flush=True)

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -656,14 +656,24 @@ Transcript:
 
         print("🧠 Generating summary...", flush=True)
         streamed_chunks = []
-        for chunk in self.summarizer.summarize_transcript_streaming(
-            text_for_summary, duration_minutes, output_language, notes_text,
-            progress_callback=_emit_progress,
-        ):
-            encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
-            sys.stdout.write(f"CHUNK:{encoded}\n")
-            sys.stdout.flush()
-            streamed_chunks.append(chunk)
+        try:
+            for chunk in self.summarizer.summarize_transcript_streaming(
+                text_for_summary, duration_minutes, output_language, notes_text,
+                progress_callback=_emit_progress,
+            ):
+                encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
+                sys.stdout.write(f"CHUNK:{encoded}\n")
+                sys.stdout.flush()
+                streamed_chunks.append(chunk)
+        except Exception as e:
+            # Surface as STREAM_ERROR so the renderer shows the "try a smaller
+            # model" recommendation (same as reprocess) rather than a generic
+            # failure, then re-raise to preserve this method's existing error
+            # contract for its caller.
+            logger.error(f"Summarization failed: {e}")
+            err_msg = str(e).replace('\n', ' ').replace('\r', ' ')
+            print(f"STREAM_ERROR:{err_msg}", flush=True)
+            raise
         streamed_md = ''.join(streamed_chunks)
 
         print("STREAM_COMPLETE", flush=True)
@@ -857,6 +867,7 @@ def process_streaming(audio_file, name, notes):
         # silent stretch before the first streamed token. Stopped on the
         # first chunk; from then on the chunks themselves are the signal.
         summary_heartbeat = _start_summary_heartbeat()
+        _stream_error = None
         try:
             for chunk in recorder.summarizer.summarize_transcript_streaming(
                 text_for_summary, duration_minutes, output_language, notes_text,
@@ -867,8 +878,21 @@ def process_streaming(audio_file, name, notes):
                 sys.stdout.write(f"CHUNK:{encoded}\n")
                 sys.stdout.flush()
                 streamed_chunks.append(chunk)
+        except Exception as e:
+            _stream_error = e
         finally:
             summary_heartbeat.set()
+
+        # Surface a summarization failure (e.g. a long-meeting map-reduce that
+        # overflows context) as STREAM_ERROR so the renderer shows the same
+        # "try a smaller model" recommendation it shows for reprocess — instead
+        # of a generic processing failure with no guidance.
+        if _stream_error is not None:
+            logger.error(f"Summarization failed: {_stream_error}")
+            err_msg = str(_stream_error).replace('\n', ' ').replace('\r', ' ')
+            print(f"STREAM_ERROR:{err_msg}", flush=True)
+            sys.exit(1)
+
         streamed_md = ''.join(streamed_chunks)
 
         print("STREAM_COMPLETE", flush=True)

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1905,9 +1905,8 @@ def list_meetings():
                         "discussion_areas": data.get("discussion_areas", []),
                         "key_points": data.get("key_points", []),
                         "action_items": data.get("action_items", []),
-                        "transcript": data.get("transcript", ""),
+                        "has_transcript": bool(data.get("transcript")),
                         "is_diarised": data.get("is_diarised", False),
-                        "diarised_text": data.get("diarised_text"),
                         "folders": data.get("folders", [])
                     }
             meetings.append((sort_key, essential_meeting))

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -108,6 +108,16 @@ def _start_summary_heartbeat(label: str = "summarize", interval_s: int = 60, max
     return stop
 
 
+def _emit_progress(step: int, total: int) -> None:
+    """Emit a PROGRESS: line to stdout for the map-reduce summarization step."""
+    if step > total:
+        label = "reducing"
+    else:
+        label = f"{step}/{total}"
+    sys.stdout.write(f"PROGRESS:summarize:{label}\n")
+    sys.stdout.flush()
+
+
 def _render_frontmatter(meta: dict) -> list[str]:
     """Render a meeting .md YAML frontmatter block (including the enclosing
     ``---`` fences) from a flat dict, with the type-specific scalar
@@ -647,7 +657,8 @@ Transcript:
         print("🧠 Generating summary...", flush=True)
         streamed_chunks = []
         for chunk in self.summarizer.summarize_transcript_streaming(
-            text_for_summary, duration_minutes, output_language, notes_text
+            text_for_summary, duration_minutes, output_language, notes_text,
+            progress_callback=_emit_progress,
         ):
             encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
             sys.stdout.write(f"CHUNK:{encoded}\n")
@@ -848,7 +859,8 @@ def process_streaming(audio_file, name, notes):
         summary_heartbeat = _start_summary_heartbeat()
         try:
             for chunk in recorder.summarizer.summarize_transcript_streaming(
-                text_for_summary, duration_minutes, output_language, notes_text
+                text_for_summary, duration_minutes, output_language, notes_text,
+                progress_callback=_emit_progress,
             ):
                 summary_heartbeat.set()
                 encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
@@ -1980,7 +1992,8 @@ def reprocess(summary_file, regenerate_title):
         summary_heartbeat = _start_summary_heartbeat()
         try:
             for chunk in recorder.summarizer.summarize_transcript_streaming(
-                transcript, duration_minutes, output_language, notes_text
+                transcript, duration_minutes, output_language, notes_text,
+                progress_callback=_emit_progress,
             ):
                 summary_heartbeat.set()
                 encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')

--- a/src/config.py
+++ b/src/config.py
@@ -126,6 +126,14 @@ class Config:
             "speed": "fast",
             "quality": "good"
         },
+        "gemma4:4b": {
+            "name": "Gemma 4 E4B",
+            "size": "3.3GB",
+            "params": "4B",
+            "description": "Efficient 4B Gemma 4 — good balance of speed and quality",
+            "speed": "fast",
+            "quality": "good"
+        },
         "llama3.2:3b": {
             "name": "Llama 3.2 3B",
             "size": "2GB",

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -258,9 +258,15 @@ class OllamaSummarizer:
             scan_start = max(pos, end - content_budget // 5)
             split_pos = transcript.rfind('\n', scan_start, end + 1)
             if split_pos < scan_start:
-                split_pos = end  # no newline in scan window; hard cut
-            raw_chunks.append(transcript[pos:split_pos])
-            pos = split_pos + 1  # skip the \n itself
+                # No newline in scan window; hard cut at `end`. Advance to `end`
+                # exactly — the +1 below is only correct when we split ON a
+                # newline (to skip the \n itself); a hard cut has no separator
+                # char to skip, so +1 would drop a real character.
+                raw_chunks.append(transcript[pos:end])
+                pos = end
+            else:
+                raw_chunks.append(transcript[pos:split_pos])
+                pos = split_pos + 1  # skip the \n itself
 
         result: list[str] = []
         for i, raw in enumerate(raw_chunks):
@@ -419,20 +425,27 @@ class OllamaSummarizer:
         reduce_prompt = self._create_reduce_prompt(map_results, language, notes)
         if self.ai_provider != "remote":
             self._ensure_ollama_ready()
-        try:
-            response = self.client.chat(
-                model=self.model_name,
-                messages=[{"role": "user", "content": reduce_prompt}],
-                stream=True,
-                options=self._ollama_options(),
-            )
-            for chunk in response:
-                content = chunk.get("message", {}).get("content", "")
-                if content:
-                    yield content
-        except Exception as e:
-            logger.error(f"Ollama map-reduce reduce step failed: {e}")
-            return
+        # No try/except here: a reduce failure must propagate to the outer
+        # handler in simple_recorder.reprocess (`except Exception as e:
+        # _stream_error = e`) so it emits STREAM_ERROR + sys.exit(1). Swallowing
+        # it would yield nothing → caller joins [] into "" → empty summary saved.
+        response = self.client.chat(
+            model=self.model_name,
+            messages=[{"role": "user", "content": reduce_prompt}],
+            stream=True,
+            options=self._ollama_options(),
+        )
+        streamed_chunks = []
+        for chunk in response:
+            content = chunk.get("message", {}).get("content", "")
+            if content:
+                streamed_chunks.append(content)
+                yield content
+        # The model can complete without raising yet return nothing. Guard
+        # against silently saving an empty summary by routing through
+        # STREAM_ERROR instead.
+        if not streamed_chunks:
+            raise ValueError("Reduce step returned empty result")
 
     def _repair_json(self, json_text: str) -> Optional[str]:
         """

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -295,6 +295,55 @@ class OllamaSummarizer:
             f"TRANSCRIPT SEGMENT:\n{chunk}"
         )
 
+    def _chat_no_think(self, client, **kwargs):
+        """Non-streaming ``client.chat`` with ``think=False``, retrying once
+        WITHOUT ``think`` if the call fails.
+
+        The ``ollama>=0.5.0`` pin only governs the bundled client; in remote mode
+        the request hits the user's own Ollama server, which may be older and
+        reject the ``think`` parameter. On any first-attempt failure we retry
+        without it, then re-raise the ORIGINAL error if the retry also fails so a
+        genuine failure (OOM, model missing) isn't masked as a ``think`` problem.
+        """
+        try:
+            return client.chat(stream=False, think=False, **kwargs)
+        except Exception as original:
+            try:
+                return client.chat(stream=False, **kwargs)
+            except Exception:
+                raise original
+
+    def _chat_stream_no_think(self, client, **kwargs):
+        """Streaming counterpart of :meth:`_chat_no_think`.
+
+        A streaming ``chat`` issues its request lazily on first iteration, so a
+        ``think``-reject surfaces on the first token rather than on the call. We
+        guard the first token and, if it fails, restart the stream without
+        ``think`` — done before yielding anything, so no token is duplicated.
+        """
+        try:
+            stream = iter(client.chat(stream=True, think=False, **kwargs))
+            first = next(stream)
+        except StopIteration:
+            return
+        except Exception as original:
+            # Retry without `think`. Guard the retry's first token too — it is
+            # also issued lazily, so a failure there must re-raise the ORIGINAL
+            # error (not the retry's) to honour the fallback contract. Once the
+            # retry has yielded a token, later errors propagate as-is.
+            try:
+                stream = iter(client.chat(stream=True, **kwargs))
+                first = next(stream)
+            except StopIteration:
+                return
+            except Exception:
+                raise original
+            yield first
+            yield from stream
+            return
+        yield first
+        yield from stream
+
     def _summarize_chunk(self, chunk: str, chunk_num: int, total_chunks: int, _retry: bool = True) -> str:
         """Non-streaming Ollama call for one map chunk. Returns stripped text or raises."""
         import time
@@ -309,11 +358,12 @@ class OllamaSummarizer:
         # leave `message.content` empty -> empty-result retry -> ValueError ->
         # STREAM_ERROR. Extraction needs no reasoning, so disable it and give
         # the whole budget to the answer. No-op on non-thinking models.
-        response = self.client.chat(
+        # Routed through _chat_no_think so a remote server that rejects `think`
+        # falls back gracefully.
+        response = self._chat_no_think(
+            self.client,
             model=self.model_name,
             messages=[{"role": "user", "content": prompt}],
-            stream=False,
-            think=False,
             options=options,
         )
         result = (response.get("message", {}).get("content") or "").strip()
@@ -398,7 +448,7 @@ class OllamaSummarizer:
         estimated_tokens = (len(transcript) + len(notes or "")) / _CHUNK_SAFETY_CHARS_PER_TOKEN
         return estimated_tokens > num_ctx * 0.8
 
-    def _hierarchical_reduce(self, map_results: list[str], depth: int) -> list[str]:
+    def _hierarchical_reduce(self, map_results: list[str], depth: int, progress_callback=None) -> list[str]:
         """Re-chunk map results that are too large for a single reduce call (max depth 2)."""
         if depth > 2:
             raise ValueError(
@@ -408,11 +458,19 @@ class OllamaSummarizer:
         combined_text = "\n\n".join(map_results)
         chunks = self._split_into_chunks(combined_text)
         n = len(chunks)
-        new_results = [self._summarize_chunk(chunk, i + 1, n) for i, chunk in enumerate(chunks)]
+        # Emit progress for each intermediate-reduce chunk: this round is another
+        # batch of map-style calls, so without ticks the UI sits on "reducing"
+        # for the whole pass and can look hung on a slow CPU-only host (the calls
+        # can be minutes each). A moving counter shows the work is progressing.
+        new_results = []
+        for i, chunk in enumerate(chunks):
+            if progress_callback:
+                progress_callback(i + 1, n)
+            new_results.append(self._summarize_chunk(chunk, i + 1, n))
         num_ctx = resolve_num_ctx(self.model_name)
         combined_tokens = len("\n\n".join(new_results)) / CHARS_PER_TOKEN
         if combined_tokens > num_ctx * 0.7:
-            return self._hierarchical_reduce(new_results, depth + 1)
+            return self._hierarchical_reduce(new_results, depth + 1, progress_callback)
         return new_results
 
     def _map_reduce_streaming(
@@ -440,7 +498,7 @@ class OllamaSummarizer:
         num_ctx = resolve_num_ctx(self.model_name)
         combined_tokens = len("\n\n".join(map_results)) / CHARS_PER_TOKEN
         if combined_tokens > num_ctx * 0.7:
-            map_results = self._hierarchical_reduce(map_results, depth=1)
+            map_results = self._hierarchical_reduce(map_results, depth=1, progress_callback=progress_callback)
 
         reduce_prompt = self._create_reduce_prompt(map_results, language, notes)
         if self.ai_provider != "remote":
@@ -452,12 +510,12 @@ class OllamaSummarizer:
         # think=False for the same reason as the map step: the reduce prompt
         # demands direct markdown output, not reasoning, and thinking tokens
         # would only delay (and on a thinking model can risk) the first content
-        # token. See _summarize_chunk for the full rationale.
-        response = self.client.chat(
+        # token. See _summarize_chunk for the full rationale. Routed through
+        # _chat_stream_no_think for the remote-server `think` fallback.
+        response = self._chat_stream_no_think(
+            self.client,
             model=self.model_name,
             messages=[{"role": "user", "content": reduce_prompt}],
-            stream=True,
-            think=False,
             options=self._ollama_options(),
         )
         streamed_chunks = []
@@ -617,7 +675,7 @@ class OllamaSummarizer:
             # than forcing a (possibly offline) pull. Derived from the registry
             # so it can't drift out of sync with SUPPORTED_MODELS.
             from .config import Config
-            preferred = ["gemma4:e2b-it-qat", "llama3.2:3b", "qwen3.5:9b", "gemma4:12b"]
+            preferred = ["gemma4:e2b-it-qat", "llama3.2:3b", "gemma4:4b", "qwen3.5:9b", "gemma4:12b"]
             active = [
                 mid for mid, info in Config.SUPPORTED_MODELS.items()
                 if not info.get("deprecated")
@@ -1109,7 +1167,11 @@ Return ONLY the response in this exact JSON format:
                                 self._ensure_ollama_ready()
                                 self.client = ollama.Client()
 
-                        ollama_response = self.client.chat(
+                        # think=False: this JSON-summary path wants direct
+                        # structured output, not reasoning. See _summarize_chunk.
+                        # Via _chat_no_think for the remote-server `think` fallback.
+                        ollama_response = self._chat_no_think(
+                            self.client,
                             model=self.model_name,
                             messages=[
                                 {
@@ -1117,9 +1179,6 @@ Return ONLY the response in this exact JSON format:
                                     'content': prompt
                                 }
                             ],
-                            # think=False: this JSON-summary path wants direct
-                            # structured output, not reasoning. See _summarize_chunk.
-                            think=False,
                             options=self._ollama_options(),
                         )
                         break  # Success, exit retry loop
@@ -1385,12 +1444,12 @@ TRANSCRIPT:
                 # think=False: the markdown summary prompt wants direct output;
                 # a thinking model would otherwise spend tokens reasoning into a
                 # separate channel before the first content token. See
-                # _summarize_chunk for the full rationale.
-                response = self.client.chat(
+                # _summarize_chunk for the full rationale. Via _chat_stream_no_think
+                # for the remote-server `think` fallback.
+                response = self._chat_stream_no_think(
+                    self.client,
                     model=self.model_name,
                     messages=[{'role': 'user', 'content': prompt}],
-                    stream=True,
-                    think=False,
                     options=self._ollama_options(),
                 )
                 for chunk in response:
@@ -1539,12 +1598,13 @@ TITLE:"""
                     host=self.remote_url if self.ai_provider == "remote" else None,
                     timeout=90
                 )
-                ollama_response = title_client.chat(
+                # think=False: a 6-word title needs no reasoning; thinking would
+                # only burn tokens/latency before the title. See _summarize_chunk.
+                # Via _chat_no_think for the remote-server `think` fallback.
+                ollama_response = self._chat_no_think(
+                    title_client,
                     model=self.model_name,
                     messages=[{'role': 'user', 'content': prompt}],
-                    # think=False: a 6-word title needs no reasoning; thinking would
-                    # only burn tokens/latency before the title. See _summarize_chunk.
-                    think=False,
                     options=self._ollama_options(),
                 )
                 response_text = ollama_response['message']['content'].strip()

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -70,7 +70,8 @@ _OLLAMA_MODEL_NUM_CTX = {
 # Map-reduce summarization constants
 MAP_PROMPT_OVERHEAD_TOKENS = 300  # reserve for map prompt scaffolding
 MAP_OUTPUT_MAX_TOKENS = 600       # hard cap on each map call's output
-CHARS_PER_TOKEN = 4               # conservative estimate, safe for multilingual
+CHARS_PER_TOKEN = 4               # used for needs_chunking threshold (English baseline)
+_CHUNK_SAFETY_CHARS_PER_TOKEN = 3 # used for chunk budget: tighter for German/BPE variance
 _OVERLAP_RATIO = 0.05             # last 5% of previous chunk prepended to next
 
 
@@ -236,7 +237,7 @@ class OllamaSummarizer:
         """Total chars per chunk: content + overlap prefix, sized for the model."""
         num_ctx = resolve_num_ctx(self.model_name)
         content_tokens = num_ctx - MAP_PROMPT_OVERHEAD_TOKENS - MAP_OUTPUT_MAX_TOKENS
-        return int(content_tokens * CHARS_PER_TOKEN)
+        return int(content_tokens * _CHUNK_SAFETY_CHARS_PER_TOKEN)
 
     def _split_into_chunks(self, transcript: str) -> list[str]:
         """Split transcript into overlapping chunks that each fit within the model context."""

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -251,10 +251,13 @@ class OllamaSummarizer:
             if end >= len(transcript):
                 raw_chunks.append(transcript[pos:])
                 break
-            # Scan backward from budget boundary to nearest \n (never exceed budget)
-            split_pos = transcript.rfind('\n', pos, end + 1)
-            if split_pos <= pos:
-                split_pos = end  # no newline in range; hard cut
+            # Scan backward in the last 20% of the chunk for a clean \n break.
+            # Searching from pos would pick up an early header newline when the
+            # transcript body is one long line, producing a tiny first chunk.
+            scan_start = max(pos, end - content_budget // 5)
+            split_pos = transcript.rfind('\n', scan_start, end + 1)
+            if split_pos < scan_start:
+                split_pos = end  # no newline in scan window; hard cut
             raw_chunks.append(transcript[pos:split_pos])
             pos = split_pos + 1  # skip the \n itself
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -58,6 +58,9 @@ OLLAMA_NUM_CTX_DEFAULT = 32768
 OLLAMA_NUM_CTX_CEILING = 131072
 _OLLAMA_MODEL_NUM_CTX = {
     "gemma4:e2b-it-qat": 32768,
+    # gemma4:4b (E4B) advertises a large window like its siblings; capped to 32K
+    # — a meeting fits and the full window would be a large KV-cache allocation.
+    "gemma4:4b": 32768,
     # gemma4:12b advertises 256K; capped well under that — a meeting fits in 32K
     # and the full window would be a large KV-cache allocation.
     "gemma4:12b": 32768,
@@ -297,10 +300,18 @@ class OllamaSummarizer:
         if self.ai_provider != "remote":
             self._ensure_ollama_ready()
         options = {**self._ollama_options(), "num_predict": MAP_OUTPUT_MAX_TOKENS}
+        # think=False: thinking-capable models (gemma4:e2b-it-qat, gemma4:12b,
+        # gpt-oss) emit chain-of-thought into a separate `message.thinking`
+        # channel that still counts against num_predict. With output capped at
+        # MAP_OUTPUT_MAX_TOKENS, reasoning can consume the entire budget and
+        # leave `message.content` empty -> empty-result retry -> ValueError ->
+        # STREAM_ERROR. Extraction needs no reasoning, so disable it and give
+        # the whole budget to the answer. No-op on non-thinking models.
         response = self.client.chat(
             model=self.model_name,
             messages=[{"role": "user", "content": prompt}],
             stream=False,
+            think=False,
             options=options,
         )
         result = (response.get("message", {}).get("content") or "").strip()
@@ -429,10 +440,15 @@ class OllamaSummarizer:
         # handler in simple_recorder.reprocess (`except Exception as e:
         # _stream_error = e`) so it emits STREAM_ERROR + sys.exit(1). Swallowing
         # it would yield nothing → caller joins [] into "" → empty summary saved.
+        # think=False for the same reason as the map step: the reduce prompt
+        # demands direct markdown output, not reasoning, and thinking tokens
+        # would only delay (and on a thinking model can risk) the first content
+        # token. See _summarize_chunk for the full rationale.
         response = self.client.chat(
             model=self.model_name,
             messages=[{"role": "user", "content": reduce_prompt}],
             stream=True,
+            think=False,
             options=self._ollama_options(),
         )
         streamed_chunks = []
@@ -1092,6 +1108,9 @@ Return ONLY the response in this exact JSON format:
                                     'content': prompt
                                 }
                             ],
+                            # think=False: this JSON-summary path wants direct
+                            # structured output, not reasoning. See _summarize_chunk.
+                            think=False,
                             options=self._ollama_options(),
                         )
                         break  # Success, exit retry loop
@@ -1354,10 +1373,15 @@ TRANSCRIPT:
             try:
                 if self.ai_provider != "remote":
                     self._ensure_ollama_ready()
+                # think=False: the markdown summary prompt wants direct output;
+                # a thinking model would otherwise spend tokens reasoning into a
+                # separate channel before the first content token. See
+                # _summarize_chunk for the full rationale.
                 response = self.client.chat(
                     model=self.model_name,
                     messages=[{'role': 'user', 'content': prompt}],
                     stream=True,
+                    think=False,
                     options=self._ollama_options(),
                 )
                 for chunk in response:
@@ -1509,6 +1533,9 @@ TITLE:"""
                 ollama_response = title_client.chat(
                     model=self.model_name,
                     messages=[{'role': 'user', 'content': prompt}],
+                    # think=False: a 6-word title needs no reasoning; thinking would
+                    # only burn tokens/latency before the title. See _summarize_chunk.
+                    think=False,
                     options=self._ollama_options(),
                 )
                 response_text = ollama_response['message']['content'].strip()

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -86,7 +86,7 @@ def resolve_num_ctx(model_name: str) -> int:
 
 
 class OllamaSummarizer:
-    def __init__(self, model_name: Optional[str] = None, ai_provider: Optional[str] = None, config = None):
+    def __init__(self, model_name: Optional[str] = None, ai_provider: Optional[str] = None, config: Optional['Config'] = None):
         """
         Initialize the summarizer with automatic service management.
         Supports local Ollama, remote Ollama, and cloud API providers.
@@ -252,7 +252,7 @@ class OllamaSummarizer:
                 raw_chunks.append(transcript[pos:])
                 break
             # Scan backward from budget boundary to nearest \n (never exceed budget)
-            split_pos = transcript.rfind('\n', pos, end)
+            split_pos = transcript.rfind('\n', pos, end + 1)
             if split_pos <= pos:
                 split_pos = end  # no newline in range; hard cut
             raw_chunks.append(transcript[pos:split_pos])

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -284,8 +284,9 @@ class OllamaSummarizer:
             f"TRANSCRIPT SEGMENT:\n{chunk}"
         )
 
-    def _summarize_chunk(self, chunk: str, chunk_num: int, total_chunks: int) -> str:
+    def _summarize_chunk(self, chunk: str, chunk_num: int, total_chunks: int, _retry: bool = True) -> str:
         """Non-streaming Ollama call for one map chunk. Returns stripped text or raises."""
+        import time
         prompt = self._create_map_prompt(chunk, chunk_num, total_chunks)
         if self.ai_provider != "remote":
             self._ensure_ollama_ready()
@@ -298,9 +299,15 @@ class OllamaSummarizer:
         )
         result = (response.get("message", {}).get("content") or "").strip()
         if not result:
+            if _retry:
+                logger.warning(
+                    f"Chunk {chunk_num}/{total_chunks} returned empty result, retrying once…"
+                )
+                time.sleep(2)
+                return self._summarize_chunk(chunk, chunk_num, total_chunks, _retry=False)
             raise ValueError(
-                f"Chunk {chunk_num}/{total_chunks} returned an empty result — "
-                "aborting map-reduce summarization."
+                f"Chunk {chunk_num}/{total_chunks} returned an empty result after retry — "
+                "Ollama may have run out of context or memory."
             )
         return result
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -444,7 +444,7 @@ class OllamaSummarizer:
         # The model can complete without raising yet return nothing. Guard
         # against silently saving an empty summary by routing through
         # STREAM_ERROR instead.
-        if not streamed_chunks:
+        if not ''.join(streamed_chunks).strip():
             raise ValueError("Reduce step returned empty result")
 
     def _repair_json(self, json_text: str) -> Optional[str]:

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -353,6 +353,76 @@ class OllamaSummarizer:
             f"EXTRACTS:\n{combined}"
         )
 
+    def _needs_chunking(self, transcript: str, notes: str = None) -> bool:
+        """True iff transcript is too long for a single Ollama call on the configured model."""
+        if self.ai_provider not in ("local", "remote"):
+            return False
+        num_ctx = resolve_num_ctx(self.model_name)
+        estimated_tokens = (len(transcript) + len(notes or "")) / CHARS_PER_TOKEN
+        return estimated_tokens > num_ctx * 0.8
+
+    def _hierarchical_reduce(self, map_results: list[str], depth: int) -> list[str]:
+        """Re-chunk map results that are too large for a single reduce call (max depth 2)."""
+        if depth > 2:
+            raise ValueError(
+                "Meeting is too long to summarize even after chunking — "
+                "try a model with a larger context window."
+            )
+        combined_text = "\n\n".join(map_results)
+        chunks = self._split_into_chunks(combined_text)
+        n = len(chunks)
+        new_results = [self._summarize_chunk(chunk, i + 1, n) for i, chunk in enumerate(chunks)]
+        num_ctx = resolve_num_ctx(self.model_name)
+        combined_tokens = len("\n\n".join(new_results)) / CHARS_PER_TOKEN
+        if combined_tokens > num_ctx * 0.7:
+            return self._hierarchical_reduce(new_results, depth + 1)
+        return new_results
+
+    def _map_reduce_streaming(
+        self,
+        transcript: str,
+        language: str = "en",
+        notes: str = None,
+        progress_callback=None,
+    ):
+        """Map-reduce generator: chunks → parallel map → streaming reduce."""
+        chunks = self._split_into_chunks(transcript)
+        n = len(chunks)
+        map_results = []
+
+        for i, chunk in enumerate(chunks):
+            if progress_callback:
+                progress_callback(i + 1, n)
+            map_results.append(self._summarize_chunk(chunk, i + 1, n))
+
+        # Signal: now entering the reduce step (step > total is unambiguous)
+        if progress_callback:
+            progress_callback(n + 1, n)
+
+        # Check if combined map output fits in a single reduce call
+        num_ctx = resolve_num_ctx(self.model_name)
+        combined_tokens = len("\n\n".join(map_results)) / CHARS_PER_TOKEN
+        if combined_tokens > num_ctx * 0.7:
+            map_results = self._hierarchical_reduce(map_results, depth=1)
+
+        reduce_prompt = self._create_reduce_prompt(map_results, language, notes)
+        if self.ai_provider != "remote":
+            self._ensure_ollama_ready()
+        try:
+            response = self.client.chat(
+                model=self.model_name,
+                messages=[{"role": "user", "content": reduce_prompt}],
+                stream=True,
+                options=self._ollama_options(),
+            )
+            for chunk in response:
+                content = chunk.get("message", {}).get("content", "")
+                if content:
+                    yield content
+        except Exception as e:
+            logger.error(f"Ollama map-reduce reduce step failed: {e}")
+            return
+
     def _repair_json(self, json_text: str) -> Optional[str]:
         """
         Attempt to repair common JSON formatting issues.
@@ -1183,7 +1253,7 @@ Only include information explicitly discussed. Do not infer or assume.{language_
 TRANSCRIPT:
 {transcript}"""
 
-    def summarize_transcript_streaming(self, transcript: str, duration_minutes: int = 0, language: str = "en", notes: str = None):
+    def summarize_transcript_streaming(self, transcript: str, duration_minutes: int = 0, language: str = "en", notes: str = None, progress_callback=None):
         """Generator that yields markdown chunks from the LLM.
 
         Args:
@@ -1191,10 +1261,15 @@ TRANSCRIPT:
             duration_minutes: Duration of the meeting
             language: Language code for output
             notes: Optional user notes for context
+            progress_callback: Optional callable(step, total) for progress reporting
 
         Yields:
             str: Text chunks as they arrive from the LLM
         """
+        if self._needs_chunking(transcript, notes):
+            yield from self._map_reduce_streaming(transcript, language, notes, progress_callback)
+            return
+
         prompt = self._create_markdown_prompt(transcript, language, notes)
         logger.info(f"Starting streaming summary with {self.ai_provider} model: {self.model_name}")
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -71,7 +71,7 @@ _OLLAMA_MODEL_NUM_CTX = {
 MAP_PROMPT_OVERHEAD_TOKENS = 300  # reserve for map prompt scaffolding
 MAP_OUTPUT_MAX_TOKENS = 600       # hard cap on each map call's output
 CHARS_PER_TOKEN = 4               # used for needs_chunking threshold (English baseline)
-_CHUNK_SAFETY_CHARS_PER_TOKEN = 3 # used for chunk budget: tighter for German/BPE variance
+_CHUNK_SAFETY_CHARS_PER_TOKEN = 2 # used for chunk budget: worst-case German/BPE (2.0 c/t floor)
 _OVERLAP_RATIO = 0.05             # last 5% of previous chunk prepended to next
 
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -268,6 +268,38 @@ class OllamaSummarizer:
                 result.append(overlap + raw)
         return result
 
+    def _create_map_prompt(self, chunk: str, chunk_num: int, total_chunks: int) -> str:
+        """Compact extraction prompt for one transcript chunk (map step)."""
+        return (
+            f"This is part {chunk_num} of {total_chunks} of a meeting transcript.\n"
+            "Extract only what is explicitly stated. Be concise.\n\n"
+            "KEY POINTS\n- ...\n\n"
+            "DECISIONS\n- ...\n\n"
+            "ACTION ITEMS\n- [owner] action (deadline if mentioned)\n\n"
+            "OPEN QUESTIONS\n- ...\n\n"
+            f"TRANSCRIPT SEGMENT:\n{chunk}"
+        )
+
+    def _summarize_chunk(self, chunk: str, chunk_num: int, total_chunks: int) -> str:
+        """Non-streaming Ollama call for one map chunk. Returns stripped text or raises."""
+        prompt = self._create_map_prompt(chunk, chunk_num, total_chunks)
+        if self.ai_provider != "remote":
+            self._ensure_ollama_ready()
+        options = {**self._ollama_options(), "num_predict": MAP_OUTPUT_MAX_TOKENS}
+        response = self.client.chat(
+            model=self.model_name,
+            messages=[{"role": "user", "content": prompt}],
+            stream=False,
+            options=options,
+        )
+        result = (response.get("message", {}).get("content") or "").strip()
+        if not result:
+            raise ValueError(
+                f"Chunk {chunk_num}/{total_chunks} returned an empty result — "
+                "aborting map-reduce summarization."
+            )
+        return result
+
     def _repair_json(self, json_text: str) -> Optional[str]:
         """
         Attempt to repair common JSON formatting issues.

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -67,6 +67,12 @@ _OLLAMA_MODEL_NUM_CTX = {
     "gpt-oss:20b": 32768,
 }
 
+# Map-reduce summarization constants
+MAP_PROMPT_OVERHEAD_TOKENS = 300  # reserve for map prompt scaffolding
+MAP_OUTPUT_MAX_TOKENS = 600       # hard cap on each map call's output
+CHARS_PER_TOKEN = 4               # conservative estimate, safe for multilingual
+_OVERLAP_RATIO = 0.05             # last 5% of previous chunk prepended to next
+
 
 def resolve_num_ctx(model_name: str) -> int:
     """Context window (num_ctx) to request from Ollama for ``model_name``.
@@ -80,18 +86,21 @@ def resolve_num_ctx(model_name: str) -> int:
 
 
 class OllamaSummarizer:
-    def __init__(self, model_name: Optional[str] = None):
+    def __init__(self, model_name: Optional[str] = None, ai_provider: Optional[str] = None, config = None):
         """
         Initialize the summarizer with automatic service management.
         Supports local Ollama, remote Ollama, and cloud API providers.
 
         Args:
             model_name: Name of the model to use. If None, loads from config.
+            ai_provider: AI provider type (local, remote, cloud, adapter). If None, loads from config.
+            config: Config object. If None, loads from get_config().
         """
         from .config import get_config
-        config = get_config()
+        if config is None:
+            config = get_config()
 
-        self.ai_provider = config.get_ai_provider()
+        self.ai_provider = ai_provider or config.get_ai_provider()
         self.client = None
         self.cloud_client = None
         self.anthropic_client = None
@@ -222,7 +231,43 @@ class OllamaSummarizer:
         consistent and Ollama doesn't reload the model between calls.
         """
         return {"num_ctx": resolve_num_ctx(self.model_name)}
-    
+
+    def _chunk_budget_chars(self) -> int:
+        """Total chars per chunk: content + overlap prefix, sized for the model."""
+        num_ctx = resolve_num_ctx(self.model_name)
+        content_tokens = num_ctx - MAP_PROMPT_OVERHEAD_TOKENS - MAP_OUTPUT_MAX_TOKENS
+        return int(content_tokens * CHARS_PER_TOKEN)
+
+    def _split_into_chunks(self, transcript: str) -> list[str]:
+        """Split transcript into overlapping chunks that each fit within the model context."""
+        budget = self._chunk_budget_chars()
+        overlap_chars = int(budget * _OVERLAP_RATIO)
+        content_budget = budget - overlap_chars
+
+        raw_chunks: list[str] = []
+        pos = 0
+        while pos < len(transcript):
+            end = pos + content_budget
+            if end >= len(transcript):
+                raw_chunks.append(transcript[pos:])
+                break
+            # Scan backward from budget boundary to nearest \n (never exceed budget)
+            split_pos = transcript.rfind('\n', pos, end)
+            if split_pos <= pos:
+                split_pos = end  # no newline in range; hard cut
+            raw_chunks.append(transcript[pos:split_pos])
+            pos = split_pos + 1  # skip the \n itself
+
+        result: list[str] = []
+        for i, raw in enumerate(raw_chunks):
+            if i == 0:
+                result.append(raw)
+            else:
+                prev = raw_chunks[i - 1]
+                overlap = prev[-overlap_chars:] if len(prev) >= overlap_chars else prev
+                result.append(overlap + raw)
+        return result
+
     def _repair_json(self, json_text: str) -> Optional[str]:
         """
         Attempt to repair common JSON formatting issues.

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -300,6 +300,59 @@ class OllamaSummarizer:
             )
         return result
 
+    def _create_reduce_prompt(self, map_results: list[str], language: str = "en", notes: str = None) -> str:
+        """Reduce prompt: merge N map-extracted summaries into a single coherent note."""
+        n = len(map_results)
+
+        if language and language not in ("en", "auto"):
+            from .config import get_config
+            language_name = get_config().get_language_name(language)
+            if language_name != "Unknown":
+                language_instruction = (
+                    f"\n\nCRITICAL: Write all content (summary text, topic titles, "
+                    f"topic analysis, key points, action items) in {language_name}. "
+                    f"However, keep the markdown section headers exactly as shown in "
+                    f"English: '## Summary', '## Key Topics', '## Key Points', "
+                    f"'## Action Items'. Do not translate these four headers."
+                )
+            else:
+                language_instruction = ""
+        else:
+            language_instruction = ""
+
+        notes_context = ""
+        if notes and notes.strip():
+            notes_context = f"USER NOTES (written during the meeting):\n{notes.strip()}\n\n"
+
+        combined = "\n\n".join(
+            f"CHUNK {i + 1} OF {n}\n{result}"
+            for i, result in enumerate(map_results)
+        )
+
+        return (
+            f"{notes_context}"
+            f"The following are structured extracts from {n} segments of a long meeting.\n"
+            "Merge and deduplicate into a single coherent summary. "
+            "Do not refer to \"the extracts\" or \"the segments\" — "
+            "write as if summarising the original meeting directly.\n"
+            "Output ONLY the markdown below with no preamble. Start directly with ## Summary.\n\n"
+            "## Summary\n"
+            "A 1-3 sentence overview of the main topics and outcomes, written directly. "
+            "Do not open with phrases like \"The meeting discussed\" or \"This meeting\".\n\n"
+            "## Key Topics\n"
+            "### [Topic title]\n"
+            "Brief analysis of what was discussed about this topic.\n\n"
+            "(Repeat for each major topic)\n\n"
+            "## Key Points\n"
+            "- [Key point 1]\n"
+            "- [Key point 2]\n\n"
+            "## Action Items\n"
+            "- [Action item 1]\n"
+            "- [Action item 2]\n\n"
+            f"Only include information explicitly discussed. Do not infer or assume.{language_instruction}\n\n"
+            f"EXTRACTS:\n{combined}"
+        )
+
     def _repair_json(self, json_text: str) -> Optional[str]:
         """
         Attempt to repair common JSON formatting issues.

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -73,7 +73,9 @@ _OLLAMA_MODEL_NUM_CTX = {
 # Map-reduce summarization constants
 MAP_PROMPT_OVERHEAD_TOKENS = 300  # reserve for map prompt scaffolding
 MAP_OUTPUT_MAX_TOKENS = 600       # hard cap on each map call's output
-CHARS_PER_TOKEN = 4               # used for needs_chunking threshold (English baseline)
+CHARS_PER_TOKEN = 4               # English baseline; used for the reduce-fits size check
+                                  # (_map_reduce_streaming / _hierarchical_reduce). The
+                                  # needs_chunking gate uses the conservative floor below.
 _CHUNK_SAFETY_CHARS_PER_TOKEN = 2 # used for chunk budget: worst-case German/BPE (2.0 c/t floor)
 _OVERLAP_RATIO = 0.05             # last 5% of previous chunk prepended to next
 
@@ -382,11 +384,18 @@ class OllamaSummarizer:
         )
 
     def _needs_chunking(self, transcript: str, notes: str = None) -> bool:
-        """True iff transcript is too long for a single Ollama call on the configured model."""
+        """True iff transcript is too long for a single Ollama call on the configured model.
+
+        Uses the same conservative chars/token floor as the chunk budget
+        (_CHUNK_SAFETY_CHARS_PER_TOKEN, worst-case German/BPE density) rather than
+        the optimistic English baseline: an optimistic gate would let a token-dense
+        transcript take the single-call path and silently overflow num_ctx (the
+        truncated-formatting / empty-summary failure this whole path exists to avoid).
+        """
         if self.ai_provider not in ("local", "remote"):
             return False
         num_ctx = resolve_num_ctx(self.model_name)
-        estimated_tokens = (len(transcript) + len(notes or "")) / CHARS_PER_TOKEN
+        estimated_tokens = (len(transcript) + len(notes or "")) / _CHUNK_SAFETY_CHARS_PER_TOKEN
         return estimated_tokens > num_ctx * 0.8
 
     def _hierarchical_reduce(self, map_results: list[str], depth: int) -> list[str]:

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 
 from src.config import Config
-from src.summarizer import OllamaSummarizer, MAP_PROMPT_OVERHEAD_TOKENS, MAP_OUTPUT_MAX_TOKENS, CHARS_PER_TOKEN
+from src.summarizer import OllamaSummarizer, MAP_PROMPT_OVERHEAD_TOKENS, MAP_OUTPUT_MAX_TOKENS, CHARS_PER_TOKEN, _CHUNK_SAFETY_CHARS_PER_TOKEN
 
 
 def _make_summarizer(model_name="llama3.2:3b"):
@@ -15,8 +15,8 @@ def _make_summarizer(model_name="llama3.2:3b"):
 class ChunkBudgetTests(unittest.TestCase):
     def test_budget_uses_fixed_caps_not_ratio(self):
         s = _make_summarizer("llama3.2:3b")  # num_ctx = 8192
-        # content_tokens = 8192 - 300 - 600 = 7292; budget = 7292 * 4 = 29168
-        self.assertEqual(s._chunk_budget_chars(), 7292 * 4)
+        # content_tokens = 8192 - 300 - 600 = 7292; budget = 7292 * 3 = 21876
+        self.assertEqual(s._chunk_budget_chars(), 7292 * _CHUNK_SAFETY_CHARS_PER_TOKEN)
 
     def test_budget_scales_with_model_context(self):
         s_small = _make_summarizer("llama3.2:3b")   # 8192

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -1,0 +1,90 @@
+"""Unit tests for map-reduce summarization helpers in OllamaSummarizer."""
+
+import unittest
+from unittest import mock
+
+from src.config import Config
+from src.summarizer import OllamaSummarizer, MAP_PROMPT_OVERHEAD_TOKENS, MAP_OUTPUT_MAX_TOKENS, CHARS_PER_TOKEN
+
+
+def _make_summarizer(model_name="llama3.2:3b"):
+    cfg = Config()
+    return OllamaSummarizer(model_name=model_name, ai_provider="local", config=cfg)
+
+
+class ChunkBudgetTests(unittest.TestCase):
+    def test_budget_uses_fixed_caps_not_ratio(self):
+        s = _make_summarizer("llama3.2:3b")  # num_ctx = 8192
+        # content_tokens = 8192 - 300 - 600 = 7292; budget = 7292 * 4 = 29168
+        self.assertEqual(s._chunk_budget_chars(), 7292 * 4)
+
+    def test_budget_scales_with_model_context(self):
+        s_small = _make_summarizer("llama3.2:3b")   # 8192
+        s_large = _make_summarizer("gemma4:e2b-it-qat")  # 32768
+        self.assertLess(s_small._chunk_budget_chars(), s_large._chunk_budget_chars())
+
+
+class SplitIntoChunksTests(unittest.TestCase):
+    def test_short_transcript_returns_single_chunk(self):
+        s = _make_summarizer()
+        budget = s._chunk_budget_chars()
+        transcript = "Speaker A: hello world.\n" * 10
+        # Definitely shorter than budget
+        self.assertLess(len(transcript), budget)
+        chunks = s._split_into_chunks(transcript)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0], transcript)
+
+    def test_each_chunk_fits_within_budget(self):
+        s = _make_summarizer()
+        budget = s._chunk_budget_chars()
+        overlap_chars = int(budget * 0.05)
+        content_budget = budget - overlap_chars
+        # Build transcript 3x content_budget → guaranteed 3+ chunks
+        line = "Speaker A: some words here.\n"
+        n = (content_budget * 3) // len(line) + 1
+        transcript = line * n
+        chunks = s._split_into_chunks(transcript)
+        self.assertGreater(len(chunks), 1)
+        for i, chunk in enumerate(chunks):
+            self.assertLessEqual(
+                len(chunk), budget,
+                msg=f"chunk {i} of {len(chunks)} has {len(chunk)} chars > budget {budget}",
+            )
+
+    def test_overlap_prefix_from_previous_chunk(self):
+        s = _make_summarizer()
+        budget = s._chunk_budget_chars()
+        overlap_chars = int(budget * 0.05)
+        content_budget = budget - overlap_chars
+        # Make a transcript large enough for exactly 2 raw chunks
+        line = "x" * 80 + "\n"
+        n = (content_budget // len(line)) + 5
+        transcript = line * n
+        chunks = s._split_into_chunks(transcript)
+        self.assertGreaterEqual(len(chunks), 2, "need at least 2 chunks to test overlap")
+        # chunk[1] must start with the tail of chunk[0]
+        tail = chunks[0][-overlap_chars:]
+        self.assertTrue(
+            chunks[1].startswith(tail),
+            msg=f"chunk[1] does not start with last {overlap_chars} chars of chunk[0]",
+        )
+
+    def test_no_data_lost_across_chunks(self):
+        s = _make_summarizer()
+        budget = s._chunk_budget_chars()
+        overlap_chars = int(budget * 0.05)
+        content_budget = budget - overlap_chars
+        # Each line has a unique number so we can check coverage
+        line = "Speaker A: line {i}.\n"
+        n = (content_budget * 2) // len(line.format(i=9999)) + 1
+        lines = [line.format(i=i) for i in range(n)]
+        transcript = "".join(lines)
+        chunks = s._split_into_chunks(transcript)
+        combined = " ".join(chunks)
+        for i, ln in enumerate(lines):
+            self.assertIn(ln.strip(), combined, msg=f"line {i} not found in any chunk")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -142,6 +142,79 @@ class MapCallTests(unittest.TestCase):
         self.assertIs(call_kwargs.get('stream'), False)
 
 
+class ThinkingDisabledTests(unittest.TestCase):
+    """Regression for STREAM_ERROR "empty result after retry" on thinking-capable
+    models. gemma4:e2b-it-qat / gemma4:12b emit chain-of-thought into
+    message.thinking; the map step caps output at MAP_OUTPUT_MAX_TOKENS, so
+    reasoning tokens exhaust the budget and message.content comes back empty.
+    Summarization calls must pass think=False so the whole budget is answer text.
+    """
+
+    @staticmethod
+    def _chat_kwargs(mock_chat):
+        kw = dict(mock_chat.call_args.kwargs)
+        if not kw:
+            kw = dict(zip(['model', 'messages', 'stream', 'options'], mock_chat.call_args.args))
+        return kw
+
+    def _long_transcript(self, s):
+        budget = s._chunk_budget_chars()
+        overlap = int(budget * 0.05)
+        content_budget = budget - overlap
+        line = "b" * 80 + "\n"
+        n = (content_budget // len(line)) + 5
+        return line * n
+
+    def test_map_chunk_call_disables_thinking(self):
+        s = _make_summarizer()
+        fake_response = {"message": {"content": "result"}}
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat', return_value=fake_response) as mock_chat:
+                s._summarize_chunk("content", 1, 1)
+        self.assertIs(self._chat_kwargs(mock_chat).get('think'), False)
+
+    def test_reduce_call_disables_thinking(self):
+        s = _make_summarizer()
+        transcript = self._long_transcript(s)
+        with mock.patch.object(s, '_summarize_chunk', return_value="extracted"):
+            with mock.patch.object(s, '_ensure_ollama_ready'):
+                def fake_chat(**kwargs):
+                    return iter([{"message": {"content": "## Summary\nok\n"}}])
+                with mock.patch.object(s.client, 'chat', side_effect=fake_chat) as mock_chat:
+                    list(s._map_reduce_streaming(transcript))
+        self.assertIs(mock_chat.call_args.kwargs.get('think'), False)
+
+    def test_direct_streaming_summary_disables_thinking(self):
+        s = _make_summarizer()
+        short = "Speaker: hello.\n" * 5
+
+        def fake_chat(**kwargs):
+            return iter([{"message": {"content": "## Summary\nok\n"}}])
+
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat', side_effect=fake_chat) as mock_chat:
+                list(s.summarize_transcript_streaming(short))
+        self.assertIs(mock_chat.call_args.kwargs.get('think'), False)
+
+    def test_json_summary_path_disables_thinking(self):
+        s = _make_summarizer()
+        valid = ('{"overview":"o","key_points":[],"next_steps":[],'
+                 '"discussion_areas":[],"participants":[]}')
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat',
+                                   return_value={"message": {"content": valid}}) as mock_chat:
+                s.summarize_transcript("some transcript text", 10)
+        self.assertIs(self._chat_kwargs(mock_chat).get('think'), False)
+
+    def test_generate_title_disables_thinking(self):
+        s = _make_summarizer()
+        fake_client = mock.MagicMock()
+        fake_client.chat.return_value = {"message": {"content": "Project Kickoff"}}
+        with mock.patch('ollama.Client', return_value=fake_client):
+            s.generate_title("a summary", "a transcript")
+        self.assertIs(fake_client.chat.call_args.kwargs.get('think'), False)
+
+
 class ReducePromptTests(unittest.TestCase):
     def test_reduce_prompt_contains_chunk_headers(self):
         s = _make_summarizer()

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -215,6 +215,86 @@ class ThinkingDisabledTests(unittest.TestCase):
         self.assertIs(fake_client.chat.call_args.kwargs.get('think'), False)
 
 
+class ThinkFallbackTests(unittest.TestCase):
+    """The ollama>=0.5.0 pin governs only the bundled client; in remote mode the
+    request hits the user's own server, which may reject `think`. _chat_no_think
+    / _chat_stream_no_think must retry once without `think`, and re-raise the
+    ORIGINAL error if the retry also fails (so a genuine fault isn't masked)."""
+
+    def test_chat_no_think_retries_without_think_on_error(self):
+        s = _make_summarizer()
+        seen = []
+
+        def chat(**kwargs):
+            seen.append(kwargs)
+            if 'think' in kwargs:
+                raise Exception("unknown parameter: think")
+            return {"message": {"content": "ok"}}
+
+        client = mock.MagicMock()
+        client.chat.side_effect = chat
+        result = s._chat_no_think(client, model="m", messages=[])
+        self.assertEqual(result["message"]["content"], "ok")
+        self.assertEqual(len(seen), 2)
+        self.assertIs(seen[0].get('think'), False)   # first attempt requested think=False
+        self.assertNotIn('think', seen[1])           # retry dropped it
+
+    def test_chat_no_think_reraises_original_when_retry_also_fails(self):
+        s = _make_summarizer()
+
+        def chat(**kwargs):
+            raise RuntimeError("original" if 'think' in kwargs else "retry")
+
+        client = mock.MagicMock()
+        client.chat.side_effect = chat
+        with self.assertRaises(RuntimeError) as ctx:
+            s._chat_no_think(client, model="m", messages=[])
+        self.assertEqual(str(ctx.exception), "original")
+
+    def test_chat_no_think_passes_through_on_success(self):
+        s = _make_summarizer()
+        client = mock.MagicMock()
+        client.chat.return_value = {"message": {"content": "ok"}}
+        result = s._chat_no_think(client, model="m", messages=[])
+        self.assertEqual(result["message"]["content"], "ok")
+        self.assertEqual(client.chat.call_count, 1)
+        self.assertIs(client.chat.call_args.kwargs.get('think'), False)
+
+    def test_chat_stream_no_think_restarts_stream_without_think(self):
+        s = _make_summarizer()
+
+        def chat(**kwargs):
+            if 'think' in kwargs:
+                def boom():
+                    raise Exception("think rejected")
+                    yield  # pragma: no cover - makes this a generator
+                return boom()
+            return iter([{"message": {"content": "a"}}, {"message": {"content": "b"}}])
+
+        client = mock.MagicMock()
+        client.chat.side_effect = chat
+        out = list(s._chat_stream_no_think(client, model="m", messages=[]))
+        self.assertEqual([c["message"]["content"] for c in out], ["a", "b"])
+
+    def test_chat_stream_no_think_reraises_original_when_retry_stream_also_fails(self):
+        s = _make_summarizer()
+
+        def chat(**kwargs):
+            msg = "original" if 'think' in kwargs else "retry"
+
+            def boom():
+                raise RuntimeError(msg)
+                yield  # pragma: no cover - makes this a generator
+
+            return boom()
+
+        client = mock.MagicMock()
+        client.chat.side_effect = chat
+        with self.assertRaises(RuntimeError) as ctx:
+            list(s._chat_stream_no_think(client, model="m", messages=[]))
+        self.assertEqual(str(ctx.exception), "original")
+
+
 class ReducePromptTests(unittest.TestCase):
     def test_reduce_prompt_contains_chunk_headers(self):
         s = _make_summarizer()

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -1,6 +1,7 @@
 """Unit tests for map-reduce summarization helpers in OllamaSummarizer."""
 
 import unittest
+from unittest import mock
 
 from src.config import Config
 from src.summarizer import OllamaSummarizer, MAP_PROMPT_OVERHEAD_TOKENS, MAP_OUTPUT_MAX_TOKENS, CHARS_PER_TOKEN
@@ -83,6 +84,62 @@ class SplitIntoChunksTests(unittest.TestCase):
         combined = " ".join(chunks)
         for i, ln in enumerate(lines):
             self.assertIn(ln.strip(), combined, msg=f"line {i} not found in any chunk")
+
+
+class MapCallTests(unittest.TestCase):
+    def test_map_prompt_contains_chunk_position(self):
+        s = _make_summarizer()
+        prompt = s._create_map_prompt("hello world", 2, 5)
+        self.assertIn("part 2 of 5", prompt)
+        self.assertIn("hello world", prompt)
+
+    def test_map_prompt_contains_extraction_structure(self):
+        s = _make_summarizer()
+        prompt = s._create_map_prompt("some text", 1, 3)
+        self.assertIn("KEY POINTS", prompt)
+        self.assertIn("ACTION ITEMS", prompt)
+        self.assertIn("TRANSCRIPT SEGMENT:", prompt)
+
+    def test_summarize_chunk_raises_on_empty_llm_response(self):
+        s = _make_summarizer()
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat', return_value={"message": {"content": ""}}):
+                with self.assertRaises(ValueError) as ctx:
+                    s._summarize_chunk("some content", 1, 3)
+        self.assertIn("empty", str(ctx.exception).lower())
+
+    def test_summarize_chunk_returns_stripped_content(self):
+        s = _make_summarizer()
+        fake_response = {"message": {"content": "  KEY POINTS\n- item\n"}}
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat', return_value=fake_response):
+                result = s._summarize_chunk("some content", 1, 3)
+        self.assertEqual(result, "KEY POINTS\n- item")
+
+    def test_summarize_chunk_passes_num_predict_option(self):
+        s = _make_summarizer()
+        fake_response = {"message": {"content": "some result"}}
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat', return_value=fake_response) as mock_chat:
+                s._summarize_chunk("content", 1, 1)
+        call_kwargs = mock_chat.call_args
+        options = call_kwargs[1].get('options') or (call_kwargs[0][2] if len(call_kwargs[0]) > 2 else {})
+        # Extract options from however it was called
+        all_kwargs = mock_chat.call_args.kwargs if mock_chat.call_args.kwargs else {}
+        if not all_kwargs:
+            all_kwargs = dict(zip(['model', 'messages', 'stream', 'options'], mock_chat.call_args.args))
+        self.assertEqual(all_kwargs.get('options', {}).get('num_predict'), 600)
+
+    def test_summarize_chunk_uses_non_streaming(self):
+        s = _make_summarizer()
+        fake_response = {"message": {"content": "result"}}
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat', return_value=fake_response) as mock_chat:
+                s._summarize_chunk("content", 1, 1)
+        call_kwargs = mock_chat.call_args.kwargs if mock_chat.call_args.kwargs else {}
+        if not call_kwargs:
+            call_kwargs = dict(zip(['model', 'messages', 'stream', 'options'], mock_chat.call_args.args))
+        self.assertIs(call_kwargs.get('stream'), False)
 
 
 if __name__ == "__main__":

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -274,11 +274,11 @@ class NeedsChunkingTests(unittest.TestCase):
 
     def test_returns_false_for_short_transcript(self):
         s = _make_summarizer("llama3.2:3b")  # num_ctx = 8192
-        # 8192 * 0.8 * 4 = 26214 chars threshold; 1000 chars is well below
+        # 8192 * 0.8 * 2 = 13107 chars threshold; 1000 chars is well below
         self.assertFalse(s._needs_chunking("x" * 1000))
 
     def test_returns_true_for_long_transcript(self):
-        s = _make_summarizer("llama3.2:3b")  # threshold ~26214 chars
+        s = _make_summarizer("llama3.2:3b")  # threshold ~13107 chars
         long_transcript = "x" * 30000
         self.assertTrue(s._needs_chunking(long_transcript))
 

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -15,7 +15,7 @@ def _make_summarizer(model_name="llama3.2:3b"):
 class ChunkBudgetTests(unittest.TestCase):
     def test_budget_uses_fixed_caps_not_ratio(self):
         s = _make_summarizer("llama3.2:3b")  # num_ctx = 8192
-        # content_tokens = 8192 - 300 - 600 = 7292; budget = 7292 * 3 = 21876
+        # content_tokens = 8192 - 300 - 600 = 7292; budget = 7292 * 2 = 14584
         self.assertEqual(s._chunk_budget_chars(), 7292 * _CHUNK_SAFETY_CHARS_PER_TOKEN)
 
     def test_budget_scales_with_model_context(self):

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -1,7 +1,6 @@
 """Unit tests for map-reduce summarization helpers in OllamaSummarizer."""
 
 import unittest
-from unittest import mock
 
 from src.config import Config
 from src.summarizer import OllamaSummarizer, MAP_PROMPT_OVERHEAD_TOKENS, MAP_OUTPUT_MAX_TOKENS, CHARS_PER_TOKEN

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -142,5 +142,44 @@ class MapCallTests(unittest.TestCase):
         self.assertIs(call_kwargs.get('stream'), False)
 
 
+class ReducePromptTests(unittest.TestCase):
+    def test_reduce_prompt_contains_chunk_headers(self):
+        s = _make_summarizer()
+        results = ["KEY POINTS\n- item A", "KEY POINTS\n- item B"]
+        prompt = s._create_reduce_prompt(results)
+        self.assertIn("CHUNK 1 OF 2", prompt)
+        self.assertIn("CHUNK 2 OF 2", prompt)
+        self.assertIn("item A", prompt)
+        self.assertIn("item B", prompt)
+
+    def test_reduce_prompt_instructs_markdown_output(self):
+        s = _make_summarizer()
+        prompt = s._create_reduce_prompt(["result"])
+        self.assertIn("## Summary", prompt)
+        self.assertIn("## Key Topics", prompt)
+        self.assertIn("## Key Points", prompt)
+        self.assertIn("## Action Items", prompt)
+
+    def test_reduce_prompt_includes_notes_when_provided(self):
+        s = _make_summarizer()
+        prompt = s._create_reduce_prompt(["result"], notes="bring coffee")
+        self.assertIn("bring coffee", prompt)
+        self.assertIn("USER NOTES", prompt)
+
+    def test_reduce_prompt_no_notes_section_when_empty(self):
+        s = _make_summarizer()
+        prompt = s._create_reduce_prompt(["result"], notes=None)
+        self.assertNotIn("USER NOTES", prompt)
+
+    def test_reduce_prompt_does_not_say_summarise_this_transcript(self):
+        # Regression guard: the reduce step must NOT reuse _create_markdown_prompt's
+        # opening "Summarise this meeting transcript" because the input is already
+        # extracted bullet lists, not raw speech.
+        s = _make_summarizer()
+        prompt = s._create_reduce_prompt(["result"])
+        self.assertNotIn("Summarise this meeting transcript", prompt)
+        self.assertNotIn("TRANSCRIPT:\n", prompt)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -181,5 +181,127 @@ class ReducePromptTests(unittest.TestCase):
         self.assertNotIn("TRANSCRIPT:\n", prompt)
 
 
+class NeedsChunkingTests(unittest.TestCase):
+    def test_returns_false_for_cloud_provider(self):
+        cfg = Config()
+        with mock.patch.object(cfg, 'get_cloud_api_key', return_value="sk-fake"):
+            with mock.patch.object(cfg, 'get_cloud_provider', return_value="bedrock"):
+                with mock.patch.object(cfg, 'get_bedrock_region', return_value="us-east-1"):
+                    with mock.patch.object(cfg, 'get_bedrock_inference_profile', return_value=""):
+                        s = OllamaSummarizer(model_name="gpt-4o", ai_provider="cloud", config=cfg)
+        # Cloud provider: even with a giant transcript, chunking is not needed
+        self.assertFalse(s._needs_chunking("x" * 1_000_000))
+
+    def test_returns_false_for_adapter_provider(self):
+        cfg = Config()
+        with mock.patch.object(cfg, 'get_adapter_url', return_value="https://adapter.example.com"):
+            with mock.patch.object(cfg, 'get_adapter_token', return_value="fake-token"):
+                s = OllamaSummarizer(model_name="adapter-model", ai_provider="adapter", config=cfg)
+        self.assertFalse(s._needs_chunking("x" * 1_000_000))
+
+    def test_returns_false_for_short_transcript(self):
+        s = _make_summarizer("llama3.2:3b")  # num_ctx = 8192
+        # 8192 * 0.8 * 4 = 26214 chars threshold; 1000 chars is well below
+        self.assertFalse(s._needs_chunking("x" * 1000))
+
+    def test_returns_true_for_long_transcript(self):
+        s = _make_summarizer("llama3.2:3b")  # threshold ~26214 chars
+        long_transcript = "x" * 30000
+        self.assertTrue(s._needs_chunking(long_transcript))
+
+
+class MapReduceStreamingTests(unittest.TestCase):
+    def test_progress_callback_called_for_each_chunk_then_reducing(self):
+        s = _make_summarizer()
+        budget = s._chunk_budget_chars()
+        overlap = int(budget * 0.05)
+        content_budget = budget - overlap
+        # Force 2 raw chunks
+        line = "a" * 80 + "\n"
+        n = (content_budget // len(line)) + 5
+        transcript = line * n
+
+        progress_calls = []
+        with mock.patch.object(s, '_summarize_chunk', return_value="KEY POINTS\n- x"):
+            with mock.patch.object(s, '_ensure_ollama_ready'):
+                # Patch the Ollama streaming (reduce step)
+                def fake_chat(**kwargs):
+                    return iter([
+                        {"message": {"content": "## Summary\nok\n"}},
+                        {"message": {"content": ""}},
+                    ])
+                with mock.patch.object(s.client, 'chat', side_effect=fake_chat):
+                    chunks = list(s._map_reduce_streaming(
+                        transcript,
+                        progress_callback=lambda step, total: progress_calls.append((step, total)),
+                    ))
+
+        # Should have called progress once per map chunk, then once for reducing
+        n_chunks = len(s._split_into_chunks(transcript))
+        map_calls = [(i + 1, n_chunks) for i in range(n_chunks)]
+        reduce_signal = (n_chunks + 1, n_chunks)  # step > total = "reducing"
+        self.assertEqual(progress_calls[:-1], map_calls)
+        self.assertEqual(progress_calls[-1], reduce_signal)
+
+    def test_map_reduce_streaming_yields_reduce_content(self):
+        s = _make_summarizer()
+        budget = s._chunk_budget_chars()
+        overlap = int(budget * 0.05)
+        content_budget = budget - overlap
+        line = "b" * 80 + "\n"
+        n = (content_budget // len(line)) + 5
+        transcript = line * n
+
+        with mock.patch.object(s, '_summarize_chunk', return_value="extracted"):
+            with mock.patch.object(s, '_ensure_ollama_ready'):
+                def fake_chat(**kwargs):
+                    return iter([
+                        {"message": {"content": "## Summary\ntest result\n"}},
+                        {"message": {"content": ""}},
+                    ])
+                with mock.patch.object(s.client, 'chat', side_effect=fake_chat):
+                    result = "".join(s._map_reduce_streaming(transcript))
+        self.assertIn("## Summary", result)
+        self.assertIn("test result", result)
+
+
+class SummarizeTranscriptStreamingForkTests(unittest.TestCase):
+    def test_short_transcript_uses_direct_path(self):
+        """Short transcripts must NOT trigger map-reduce (1 chat call, not N+1)."""
+        s = _make_summarizer()
+        short = "Speaker: hello.\n" * 5
+
+        def fake_chat(**kwargs):
+            return iter([{"message": {"content": "## Summary\nok\n"}}])
+
+        with mock.patch.object(s, '_ensure_ollama_ready'):
+            with mock.patch.object(s.client, 'chat', side_effect=fake_chat) as mock_chat:
+                list(s.summarize_transcript_streaming(short))
+        # Direct path: exactly 1 chat call
+        self.assertEqual(mock_chat.call_count, 1)
+
+    def test_long_transcript_routes_to_map_reduce(self):
+        """A transcript over threshold must call _map_reduce_streaming, not direct."""
+        s = _make_summarizer("llama3.2:3b")
+        long_transcript = "Speaker: words.\n" * 3000  # definitely over 26k chars
+
+        with mock.patch.object(s, '_map_reduce_streaming', return_value=iter(["ok"])) as mock_mr:
+            with mock.patch.object(s, '_ensure_ollama_ready'):
+                list(s.summarize_transcript_streaming(long_transcript))
+        mock_mr.assert_called_once()
+
+    def test_no_valueerror_for_long_transcript(self):
+        """The PR #246 ValueError must be gone — long transcripts must not raise."""
+        s = _make_summarizer("llama3.2:3b")
+        long_transcript = "x" * 40000  # over threshold
+
+        with mock.patch.object(s, '_map_reduce_streaming', return_value=iter(["## Summary\nok"])):
+            with mock.patch.object(s, '_ensure_ollama_ready'):
+                try:
+                    list(s.summarize_transcript_streaming(long_transcript))
+                except ValueError as e:
+                    self.fail(f"summarize_transcript_streaming raised ValueError for long transcript: {e}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Long meetings overflow the model's usable context. Ollama silently truncates the transcript before the model sees it, so long meetings get partial or empty summaries — and on thinking-capable models the failure surfaces as a `STREAM_ERROR` mid-summary.

## What this does

Adds **map-reduce summarization** for transcripts that exceed the model's context, and surfaces failures clearly instead of silently saving an empty summary.

- **Chunking**: split the transcript into overlapping chunks sized to the model's real `num_ctx`, with a German/BPE-aware budget (2 chars/token worst case) and a newline-aware splitter that avoids tiny header-only first chunks.
- **Map**: extract key points / decisions / action items / open questions per chunk (non-streaming, output-capped).
- **Reduce**: merge + deduplicate the per-chunk extracts into one coherent markdown summary (streaming), with a hierarchical second pass if the combined extracts are themselves too large.
- **Progress**: `PROGRESS:summarize:N/M` (and a reducing signal) streamed via stdout → Electron IPC → a "Summarising part N/M" label in the renderer.
- **Errors**: a failed/empty reduce routes through `STREAM_ERROR` with a model-recommendation banner, instead of writing an empty summary. Replaces the prior #246 context-overflow `ValueError` with a short/long fork.

### Bundled fix: empty summaries on thinking-capable models

`gemma4:e2b-it-qat` / `gemma4:12b` emit chain-of-thought into a separate `message.thinking` channel whose tokens still count against `num_predict`. With the map step capped at 600 output tokens, reasoning could consume the whole budget and return empty `content` → "empty result after retry" → `STREAM_ERROR` (deterministic, not the suspected post-OOM Ollama state). All summary-generation calls now pass `think=False`; it is a no-op on non-thinking models.

## Tests

- Unit: chunk budget/splitter, map/reduce prompt construction, the short/long fork, and `think=False` on every summary call site.
- E2E: a T2 spec drives the real bundled backend through the map-reduce path via a non-streaming mock-ollama.

Implements #188.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add map‑reduce summarization for long meetings to prevent context overflow and empty notes, with per‑meeting progress and clearer failure handling. Lazily load transcripts to keep the app responsive. Implements #188.

- New Features
  - Map‑reduce summarization: chunking sized to model `num_ctx`, per‑chunk extracts (non‑streaming), streamed reduce with hierarchical fallback; shows “Summarising part N/M” and “Merging summaries…” via `processing-progress` IPC, scoped to the meeting (hierarchical rounds tick progress too).
  - Lazy transcript loading: `meetings.get` fetches the full note on demand; meeting list omits transcripts and only flags `has_transcript`; legacy `.md` notes parsed in `main.js`.
  - Model: add `gemma4:4b` as a fast, sensible fallback.

- Bug Fixes
  - Prevent empty summaries: pass `think=false` on all summary calls and retry without `think` if a remote `ollama` rejects it; requires `ollama>=0.5.0`.
  - Avoid context overflow on dense text: conservative 2 chars/token gate aligned with the chunk budget, newline‑aware splitter, and a short/long fork instead of raising.
  - Robustness/security: surface `STREAM_ERROR` in both record→summarize and reprocess flows, send `processing-complete { success:false }`, scope progress to the meeting, harden `get-meeting` path checks with `realpath`, and drop cached detail on delete.

<sup>Written for commit 20f18245361039a856451b803096e8fe183f1f4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

