### PR TITLE
feat: switch E4B and 12B summary models to QAT builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu)
 
 **Summarization Models** (Ollama):
 - `gemma4:e2b-it-qat` (4.3GB): Lightest Gemma 4, quantization-aware, with a real 128K context **(default)**
+- `gemma4:e4b-it-qat` (6.1GB): Quantization-aware E4B — higher quality than E2B at a modest footprint
 - `qwen3.5:9b` (6.6GB): Excellent at structured output and action items
-- `gemma4:12b` (7.6GB): Gemma 4 with a 256K context — best for long meetings
+- `gemma4:12b-it-qat` (7.2GB): Gemma 4 (quantization-aware) with a 256K context — best for long meetings
 - `gpt-oss:20b` (14GB): OpenAI open-weight model with reasoning capabilities
 
 ## Future Roadmap

--- a/src/config.py
+++ b/src/config.py
@@ -126,13 +126,13 @@ class Config:
             "speed": "fast",
             "quality": "good"
         },
-        "gemma4:4b": {
-            "name": "Gemma 4 E4B",
-            "size": "3.3GB",
+        "gemma4:e4b-it-qat": {
+            "name": "Gemma 4 E4B (QAT)",
+            "size": "6.1GB",
             "params": "4B",
-            "description": "Efficient 4B Gemma 4 — good balance of speed and quality",
-            "speed": "fast",
-            "quality": "good"
+            "description": "Quantization-aware E4B — higher quality than E2B at a modest footprint",
+            "speed": "medium",
+            "quality": "excellent"
         },
         "llama3.2:3b": {
             "name": "Llama 3.2 3B",
@@ -151,11 +151,11 @@ class Config:
             "speed": "medium",
             "quality": "excellent"
         },
-        "gemma4:12b": {
-            "name": "Gemma 4 12B",
-            "size": "7.6GB",
+        "gemma4:12b-it-qat": {
+            "name": "Gemma 4 12B (QAT)",
+            "size": "7.2GB",
             "params": "12B",
-            "description": "Large 256K context - best for long meetings",
+            "description": "Large 256K context, quantization-aware - best for long meetings",
             "speed": "medium",
             "quality": "excellent"
         },
@@ -298,6 +298,15 @@ class Config:
         self._config["whisper_model"] = "large-v3-turbo"
         self._save()
 
+    # Summary-model ids we renamed in place — a user pinned to the old tag is
+    # moved to the equivalent, better-quantized build so they keep the model
+    # they chose (rather than being dropped to the default). The new tag is a
+    # different Ollama model, so the next summarisation pulls it on demand.
+    _RENAMED_SUMMARY_MODELS = {
+        "gemma4:4b": "gemma4:e4b-it-qat",
+        "gemma4:12b": "gemma4:12b-it-qat",
+    }
+
     # Curated models we retired — a user pinned to one is migrated to the
     # default on load. Deliberately a specific allow-list, NOT "anything not in
     # SUPPORTED_MODELS": set_model intentionally allows arbitrary user-pulled
@@ -305,16 +314,22 @@ class Config:
     _RETIRED_SUMMARY_MODELS = {"gemma3:4b", "deepseek-r1:14b"}
 
     def _migrate_summary_model(self) -> None:
-        """Reset a retired summary model to the default.
+        """Migrate a renamed or retired summary model on load.
 
-        gemma3:4b / deepseek-r1:14b were removed from SUPPORTED_MODELS; a user
-        pinned to one would otherwise stay on a model the app no longer surfaces.
-        Only those specific ids migrate — custom/self-pulled models and the
+        Renamed ids (gemma4:4b -> gemma4:e4b-it-qat, gemma4:12b ->
+        gemma4:12b-it-qat) move to the equivalent quantization-aware build, so
+        the user keeps their chosen model; the new tag is pulled on demand.
+        Retired ids (gemma3:4b, deepseek-r1:14b) reset to the default. Only
+        these specific ids migrate — custom/self-pulled models and the
         deprecated-but-kept llama3.2:3b are left alone.
         """
         if self._load_failed:
             return  # never persist defaults over a corrupt-but-recoverable file
-        if self._config.get("model") in self._RETIRED_SUMMARY_MODELS:
+        current = self._config.get("model")
+        if current in self._RENAMED_SUMMARY_MODELS:
+            self._config["model"] = self._RENAMED_SUMMARY_MODELS[current]
+            self._save()
+        elif current in self._RETIRED_SUMMARY_MODELS:
             self._config["model"] = self.DEFAULT_MODEL
             self._save()
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -58,12 +58,12 @@ OLLAMA_NUM_CTX_DEFAULT = 32768
 OLLAMA_NUM_CTX_CEILING = 131072
 _OLLAMA_MODEL_NUM_CTX = {
     "gemma4:e2b-it-qat": 32768,
-    # gemma4:4b (E4B) advertises a large window like its siblings; capped to 32K
-    # — a meeting fits and the full window would be a large KV-cache allocation.
-    "gemma4:4b": 32768,
-    # gemma4:12b advertises 256K; capped well under that — a meeting fits in 32K
-    # and the full window would be a large KV-cache allocation.
-    "gemma4:12b": 32768,
+    # gemma4:e4b-it-qat (E4B) advertises a large window like its siblings; capped
+    # to 32K — a meeting fits and the full window would be a large KV-cache alloc.
+    "gemma4:e4b-it-qat": 32768,
+    # gemma4:12b-it-qat advertises 256K; capped well under that — a meeting fits
+    # in 32K and the full window would be a large KV-cache allocation.
+    "gemma4:12b-it-qat": 32768,
     # llama3.2:3b's quantized build effectively caps ~8K despite the headline 128K
     "llama3.2:3b": 8192,
     "qwen3.5:9b": 32768,
@@ -351,7 +351,7 @@ class OllamaSummarizer:
         if self.ai_provider != "remote":
             self._ensure_ollama_ready()
         options = {**self._ollama_options(), "num_predict": MAP_OUTPUT_MAX_TOKENS}
-        # think=False: thinking-capable models (gemma4:e2b-it-qat, gemma4:12b,
+        # think=False: thinking-capable models (gemma4:e2b-it-qat, gemma4:12b-it-qat,
         # gpt-oss) emit chain-of-thought into a separate `message.thinking`
         # channel that still counts against num_predict. With output capped at
         # MAP_OUTPUT_MAX_TOKENS, reasoning can consume the entire budget and
@@ -675,7 +675,7 @@ class OllamaSummarizer:
             # than forcing a (possibly offline) pull. Derived from the registry
             # so it can't drift out of sync with SUPPORTED_MODELS.
             from .config import Config
-            preferred = ["gemma4:e2b-it-qat", "llama3.2:3b", "gemma4:4b", "qwen3.5:9b", "gemma4:12b"]
+            preferred = ["gemma4:e2b-it-qat", "llama3.2:3b", "qwen3.5:9b", "gemma4:e4b-it-qat", "gemma4:12b-it-qat"]
             active = [
                 mid for mid, info in Config.SUPPORTED_MODELS.items()
                 if not info.get("deprecated")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,6 +123,21 @@ class ConfigSummaryModelTests(unittest.TestCase):
             # Persisted so the migration doesn't re-run forever.
             self.assertEqual(json.loads(path.read_text())["model"], "gemma4:e2b-it-qat")
 
+    def test_renamed_model_migrates_to_qat_build(self):
+        # A user pinned to a renamed tag (gemma4:12b / gemma4:4b) is moved to
+        # the equivalent quantization-aware build, preserving their model choice
+        # rather than dropping them to the default.
+        for old, new in (("gemma4:12b", "gemma4:12b-it-qat"),
+                         ("gemma4:4b", "gemma4:e4b-it-qat")):
+            with self.subTest(old=old):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    path = Path(tmp_dir) / "config.json"
+                    path.write_text(json.dumps({"model": old}))
+                    config = Config(config_path=path)
+                    self.assertEqual(config.get_model(), new)
+                    # Persisted so the migration doesn't re-run forever.
+                    self.assertEqual(json.loads(path.read_text())["model"], new)
+
     def test_custom_pulled_model_is_not_migrated(self):
         # set_model intentionally allows arbitrary user-pulled Ollama models
         # (not in SUPPORTED_MODELS). The migration must only touch the specific

--- a/tests/test_setup_model_reuse.py
+++ b/tests/test_setup_model_reuse.py
@@ -20,8 +20,9 @@ from simple_recorder import pick_installed_supported_model
 SUPPORTED = [
     "llama3.2:3b",
     "gemma4:e2b-it-qat",
+    "gemma4:e4b-it-qat",
     "qwen3.5:9b",
-    "gemma4:12b",
+    "gemma4:12b-it-qat",
     "gpt-oss:20b",
     "gemma3:4b",        # deprecated
     "deepseek-r1:14b",  # deprecated
@@ -70,7 +71,7 @@ class PickInstalledSupportedModelTests(unittest.TestCase):
         # headline: existing llama3.2:3b means no pull).
         self.assertEqual(
             pick_installed_supported_model(
-                installed_names={"llama3.2:3b", "gemma4:12b"},
+                installed_names={"llama3.2:3b", "gemma4:12b-it-qat"},
                 preferred=["gpt-oss:20b", DEFAULT],
                 supported_order=SUPPORTED,
                 deprecated=DEPRECATED,
@@ -83,7 +84,7 @@ class PickInstalledSupportedModelTests(unittest.TestCase):
         # non-deprecated id in registry order.
         self.assertEqual(
             pick_installed_supported_model(
-                installed_names={"gemma4:12b", "qwen3.5:9b"},
+                installed_names={"gemma4:12b-it-qat", "qwen3.5:9b"},
                 preferred=["gpt-oss:20b", DEFAULT],
                 supported_order=SUPPORTED,
                 deprecated=DEPRECATED,
@@ -96,12 +97,12 @@ class PickInstalledSupportedModelTests(unittest.TestCase):
         # installed -- a live model always beats a retired one.
         self.assertEqual(
             pick_installed_supported_model(
-                installed_names={"gemma3:4b", "gemma4:12b"},
+                installed_names={"gemma3:4b", "gemma4:12b-it-qat"},
                 preferred=["gpt-oss:20b", DEFAULT],
                 supported_order=SUPPORTED,
                 deprecated=DEPRECATED,
             ),
-            "gemma4:12b",
+            "gemma4:12b-it-qat",
         )
         # ...but a deprecated model is still better than pulling fresh.
         self.assertEqual(

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -144,7 +144,7 @@ class MapCallTests(unittest.TestCase):
 
 class ThinkingDisabledTests(unittest.TestCase):
     """Regression for STREAM_ERROR "empty result after retry" on thinking-capable
-    models. gemma4:e2b-it-qat / gemma4:12b emit chain-of-thought into
+    models. gemma4:e2b-it-qat / gemma4:12b-it-qat emit chain-of-thought into
     message.thinking; the map step caps output at MAP_OUTPUT_MAX_TOKENS, so
     reasoning tokens exhaust the budget and message.content comes back empty.
     Summarization calls must pass think=False so the whole budget is answer text.

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -196,7 +196,7 @@ export function Hero() {
           <div className="mt-3 flex items-center gap-1.5 text-fg-muted text-[12px]">
             <Cpu size={12} aria-hidden="true" />
             Summarized locally with{" "}
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>gemma4:12b</code>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>gemma4:12b-it-qat</code>
           </div>
         </Motion.div>
 

--- a/website/src/sections/Models.jsx
+++ b/website/src/sections/Models.jsx
@@ -4,9 +4,10 @@ import { motion as Motion } from "framer-motion";
 
 const models = [
   { id: "gemma4:e2b-it-qat",  label: "Gemma 4 E2B", detail: "2B · Light" },
+  { id: "gemma4:e4b-it-qat",  label: "Gemma 4 E4B", detail: "4B · Balanced" },
   { id: "llama3.2:3b",        label: "Llama 3.2",   detail: "3B · Fast" },
   { id: "qwen3.5:9b",         label: "Qwen 3.5",    detail: "9B · Smart" },
-  { id: "gemma4:12b",         label: "Gemma 4",     detail: "12B · Long meetings" },
+  { id: "gemma4:12b-it-qat",  label: "Gemma 4",     detail: "12B · Long meetings" },
   { id: "gpt-oss:20b",        label: "GPT-OSS",     detail: "20B · Capable" },
 ];
 


### PR DESCRIPTION
> **Stacked on #250.** This branch is based on `feat/map-reduce-summarization-188`, so until #250 merges the diff below also includes #250's commits. The change specific to this PR is the single top commit (`switch E4B and 12B summary models to QAT builds`). Please review/merge after #250.

## What this does

Fixes a mislabeled model in the registry and moves both Gemma 4 large models to their quantization-aware (QAT) builds.

- The registry's "Gemma 4 E4B" pointed at `gemma4:4b` (3.3GB), which is **not** an E4B build — the real E4B tags are 6.1GB (QAT) / 9.6GB (standard). Now points at `gemma4:e4b-it-qat` (6.1GB): E4B capacity with QAT quality retention, a better quality/footprint balance than the E2B default for machines with the headroom.
- `gemma4:12b` → `gemma4:12b-it-qat` (7.6 → 7.2GB).

Updated everywhere: the model registry, the `num_ctx` map, the fallback preference list, and the README/website references.

## Migration

A user already pinned to an old tag is migrated in place to the equivalent QAT build (`gemma4:4b` → `gemma4:e4b-it-qat`, `gemma4:12b` → `gemma4:12b-it-qat`) so they keep the model they chose; the new tag is pulled on demand. Without this they'd be stuck on a tag the registry no longer surfaces.

## Notes

Tags/sizes verified against the official Ollama registry. Both new builds run on Apple Silicon; a quick local check on a 123k-char German meeting showed `e4b-it-qat` producing a noticeably better-structured summary than `e2b-it-qat` (cleaner topic segmentation, richer action items) at ~2.3GB more RAM. E2B stays the default; E4B-QAT is the quality tier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Gemma 4 E4B/12B to quantization‑aware builds (fixes the mislabeled E4B tag) and ship chunked map‑reduce summarization with progress and better failure handling. The app now uses `gemma4:e4b-it-qat` (6.1GB) and `gemma4:12b-it-qat` (7.2GB), shows “Summarising part N/M” / “Merging summaries…”, lazy‑loads note details, and disables Ollama thinking for summaries (requires `ollama>=0.5.0`).

- **New Features**
  - Long‑meeting summarization (Linear #188): overlapping chunking, hierarchical reduce when needed, and progress via `processing-progress`.
  - Reliability: surfaces stream errors, resets spinners, scopes progress per note, retries once on empty chunk, and falls back if a remote Ollama rejects `think`; UI shows a clear retry suggestion.
  - Performance: meeting list omits transcripts; new `meetings.get` loads full note on demand to avoid startup freezes.

- **Migration**
  - Auto‑migrates `gemma4:4b`/`gemma4:12b` to `gemma4:e4b-it-qat`/`gemma4:12b-it-qat`; new tags pull on first use.

<sup>Written for commit 3a2803f602c14c1dcb70519307f2ade250924cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

