### PR TITLE
feat: report templates + per-meeting report generation, versions & sidecar storage

### DIFF
--- a/app/docs/ipc-contract.md
+++ b/app/docs/ipc-contract.md
@@ -219,7 +219,7 @@ interface ProcessingCompleteEvent {
 
 Emitted during map-reduce summarization of long meetings to update the processing-row badge.
 
-**Payload:** `{ line: string }` — e.g. `"PROGRESS:summarize:2/5"` or `"PROGRESS:summarize:reducing"`
+**Payload:** `{ line: string; summaryFile?: string }` — e.g. `{ line: "PROGRESS:summarize:2/5", summaryFile: "/path/to/meeting.md" }` or `{ line: "PROGRESS:summarize:reducing", summaryFile }`. `summaryFile` scopes the progress to a meeting so a concurrent reprocess can't leak its stage into another meeting's view (see `MeetingDetail.tsx`).
 
 **Renderer:** `ipc().on.processingProgress(cb)` → updates Processing.tsx label to *"Summarizing part 2 of 5…"* or *"Merging summaries…"*.
 

--- a/app/main.js
+++ b/app/main.js
@@ -5061,7 +5061,50 @@ ipcMain.handle('set-model', async (event, modelName) => {
   }
 });
 
+ipcMain.handle('list-templates', async () => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['list-templates']);
+    return { success: true, ...JSON.parse(out) };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
 
+ipcMain.handle('save-template', async (_e, template) => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['save-template', JSON.stringify(template)]);
+    return JSON.parse(out);
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('delete-template', async (_e, id) => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['delete-template', id]);
+    return JSON.parse(out);
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('set-default-template', async (_e, id) => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['set-default-template', id]);
+    return JSON.parse(out);
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('reset-template', async (_e, id) => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['reset-template', id]);
+    return JSON.parse(out);
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
 
 ipcMain.handle('get-transcription-engine', async () => {
   try {

--- a/app/main.js
+++ b/app/main.js
@@ -1648,6 +1648,26 @@ ipcMain.handle('list-meetings', async () => {
 // meetings without a Python round-trip. Returns the FULL data (transcript
 // included) — the size-stripping that list-meetings does is intentionally
 // not applied here because the detail page needs the transcript.
+async function readReportsSidecar(meetingPath) {
+  // Derive sidecar path: <stem>_summary.(md|json) → <stem>_reports.json
+  const ext = path.extname(meetingPath); // '.md' or '.json'
+  const base = path.basename(meetingPath, ext); // e.g. '20240101_120000_summary'
+  const dir = path.dirname(meetingPath);
+  // Strip trailing '_summary' if present (handles both naming conventions)
+  const stem = base.endsWith('_summary') ? base.slice(0, -'_summary'.length) : base;
+  const sidecarPath = path.join(dir, `${stem}_reports.json`);
+  try {
+    const raw = await fs.promises.readFile(sidecarPath, 'utf-8');
+    const data = JSON.parse(raw);
+    return {
+      reports: Array.isArray(data.reports) ? data.reports : [],
+      active_report: data.active_report ?? null,
+    };
+  } catch {
+    return { reports: [], active_report: null };
+  }
+}
+
 function parseMeetingMarkdown(content, mdPath) {
   // Split frontmatter
   const meta = {};
@@ -1809,9 +1829,13 @@ ipcMain.handle('get-meeting', async (_event, summaryFile) => {
       // pages route through here. Unlike the list payload, the detail page
       // needs the full data INCLUDING the transcript (for the AskBar /
       // TranscriptPanel), so we return everything parseMeetingMarkdown yields.
-      return { success: true, meeting: parseMeetingMarkdown(content, realResolved) };
+      const mdMeeting = parseMeetingMarkdown(content, realResolved);
+      const mdSidecar = await readReportsSidecar(realResolved);
+      return { success: true, meeting: { ...mdMeeting, reports: mdSidecar.reports, active_report: mdSidecar.active_report } };
     }
-    return { success: true, meeting: JSON.parse(content) };
+    const jsonMeeting = JSON.parse(content);
+    const jsonSidecar = await readReportsSidecar(realResolved);
+    return { success: true, meeting: { ...jsonMeeting, reports: jsonSidecar.reports, active_report: jsonSidecar.active_report } };
   } catch (error) {
     return { success: false, error: error.message };
   }

--- a/app/main.js
+++ b/app/main.js
@@ -2042,7 +2042,7 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
             }
           } else if (line === 'STREAM_COMPLETE') {
             if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('summary-complete', { success: true, sessionName, summaryFile });
+              mainWindow.webContents.send('summary-complete', { success: true, sessionName, summaryFile, report: true });
             }
           } else if (line.startsWith('PROGRESS:')) {
             if (mainWindow && !mainWindow.isDestroyed()) {
@@ -2052,7 +2052,7 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
             const errMsg = line.slice('STREAM_ERROR:'.length);
             sendDebugLog(`❌ Report generation stream error: ${errMsg}`);
             if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('summary-complete', { success: false, sessionName, summaryFile });
+              mainWindow.webContents.send('summary-complete', { success: false, sessionName, summaryFile, report: true });
             }
           } else if (line.startsWith('SAVED:')) {
             sendDebugLog(`Report saved: ${line.slice(6).trim()}`);
@@ -2080,6 +2080,7 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
               success: true,
               sessionName,
               summaryFile,
+              report: true,
               message: 'Report generation completed successfully'
             });
           }
@@ -2090,6 +2091,7 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
               success: false,
               sessionName,
               summaryFile,
+              report: true,
               message: `Report generation failed (exit ${code})`,
             });
           }

--- a/app/main.js
+++ b/app/main.js
@@ -2073,6 +2073,20 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
   }
 });
 
+ipcMain.handle('set-active-report', async (_e, summaryFile, reportId) => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['set-active-report', summaryFile, reportId]);
+    return JSON.parse(out);
+  } catch (error) { return { success: false, error: error.message }; }
+});
+
+ipcMain.handle('delete-report', async (_e, summaryFile, reportId) => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['delete-report', summaryFile, reportId]);
+    return JSON.parse(out);
+  } catch (error) { return { success: false, error: error.message }; }
+});
+
 ipcMain.handle('regen-meeting-title', async (event, summaryFile, sessionName) => {
   try {
     const aiEnv = getAiEnv();

--- a/app/main.js
+++ b/app/main.js
@@ -1950,6 +1950,129 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
   }
 });
 
+ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId) => {
+  // Resolve the sessionName from the meeting JSON so streaming events carry the
+  // same key as the reprocess flow (keyed by sessionName, disambiguated by summaryFile).
+  let sessionName = null;
+  try {
+    const fs = require('fs');
+    const data = JSON.parse(fs.readFileSync(summaryFile, 'utf-8'));
+    sessionName = data?.session_info?.name || null;
+  } catch (_) { /* non-fatal — sessionName stays null */ }
+
+  try {
+    const args = ['generate-report', summaryFile, templateId];
+
+    sendDebugLog(`📄 Generating report for: ${summaryFile} (template: ${templateId})`);
+    sendDebugLog(`$ stenoai ${args.join(' ')}`);
+
+    activeReprocessJobs.set(summaryFile, { summaryFile, sessionName });
+
+    const aiEnv = getAiEnv();
+    const reportEnv = Object.keys(aiEnv).length > 0 ? { ...require('process').env, ...aiEnv } : undefined;
+
+    await new Promise((resolve, reject) => {
+      const proc = spawn(getBackendPath(), args, {
+        cwd: getBackendCwd(),
+        env: reportEnv
+      });
+
+      let stderrBuf = '';
+
+      const watchdog = makeInactivityWatchdog(proc, TRANSCRIBE_INACTIVITY_MS, 'generate-report');
+
+      proc.on('error', (err) => {
+        watchdog.clear();
+        reject(new Error(`generate-report spawn error: ${err.message}`));
+      });
+
+      proc.stdout.on('data', (data) => {
+        watchdog.reset();
+        const text = data.toString();
+        // CRLF-tolerant: Windows stdout is \r\n; exact-match lines (STREAM_COMPLETE)
+        // would otherwise carry a trailing \r and never match.
+        text.split(/\r?\n/).forEach(line => {
+          if (line.startsWith('CHUNK:')) {
+            try {
+              const encoded = line.slice(6);
+              const chunk = Buffer.from(encoded, 'base64').toString('utf-8');
+              if (mainWindow && !mainWindow.isDestroyed()) {
+                mainWindow.webContents.send('summary-chunk', { chunk, sessionName });
+              }
+            } catch (e) { console.log('CHUNK decode error:', e.message); }
+          } else if (line.startsWith('TITLE:')) {
+            const title = line.slice(6);
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('summary-title', { title, sessionName });
+            }
+          } else if (line === 'STREAM_COMPLETE') {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('summary-complete', { success: true, sessionName });
+            }
+          } else if (line.startsWith('PROGRESS:')) {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('processing-progress', { line, summaryFile });
+            }
+          } else if (line.startsWith('STREAM_ERROR:')) {
+            const errMsg = line.slice('STREAM_ERROR:'.length);
+            sendDebugLog(`❌ Report generation stream error: ${errMsg}`);
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('summary-complete', { success: false, sessionName });
+            }
+          } else if (line.startsWith('SAVED:')) {
+            sendDebugLog(`Report saved: ${line.slice(6).trim()}`);
+          } else if (line.trim()) {
+            sendDebugLog(line.trim());
+          }
+        });
+      });
+
+      proc.stderr.on('data', (data) => {
+        watchdog.reset();
+        const msg = data.toString().trim();
+        if (msg) {
+          stderrBuf += msg + '\n';
+          sendDebugLog(`STDERR: ${msg}`);
+        }
+      });
+
+      proc.on('close', (code) => {
+        watchdog.clear();
+        if (code === 0) {
+          console.log(`✅ Completed report generation: ${sessionName}`);
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('processing-complete', {
+              success: true,
+              sessionName,
+              summaryFile,
+              message: 'Report generation completed successfully'
+            });
+          }
+          resolve();
+        } else {
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('processing-complete', {
+              success: false,
+              sessionName,
+              summaryFile,
+              message: `Report generation failed (exit ${code})`,
+            });
+          }
+          reject(new Error(`generate-report exited with code ${code}: ${stderrBuf.slice(-500)}`));
+        }
+      });
+    });
+
+    sendDebugLog('✅ Report generated successfully');
+    return { success: true };
+  } catch (error) {
+    sendDebugLog(`❌ Report generation failed: ${error.message}`);
+    return { success: false, error: error.message };
+  } finally {
+    activeReprocessJobs.delete(summaryFile);
+  }
+});
+
 ipcMain.handle('regen-meeting-title', async (event, summaryFile, sessionName) => {
   try {
     const aiEnv = getAiEnv();

--- a/app/main.js
+++ b/app/main.js
@@ -1876,7 +1876,7 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
               const encoded = line.slice(6);
               const chunk = Buffer.from(encoded, 'base64').toString('utf-8');
               if (mainWindow && !mainWindow.isDestroyed()) {
-                mainWindow.webContents.send('summary-chunk', { chunk, sessionName });
+                mainWindow.webContents.send('summary-chunk', { chunk, sessionName, summaryFile });
               }
             } catch (e) { console.log('CHUNK decode error:', e.message); }
           } else if (line.startsWith('TITLE:')) {
@@ -1886,7 +1886,7 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
             }
           } else if (line === 'STREAM_COMPLETE') {
             if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('summary-complete', { success: true, sessionName });
+              mainWindow.webContents.send('summary-complete', { success: true, sessionName, summaryFile });
             }
           } else if (line.startsWith('PROGRESS:')) {
             if (mainWindow && !mainWindow.isDestroyed()) {
@@ -1896,7 +1896,7 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
             const errMsg = line.slice('STREAM_ERROR:'.length);
             sendDebugLog(`❌ Reprocess stream error: ${errMsg}`);
             if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('summary-complete', { success: false, sessionName });
+              mainWindow.webContents.send('summary-complete', { success: false, sessionName, summaryFile });
             }
           } else if (line.trim()) {
             sendDebugLog(line.trim());
@@ -1997,7 +1997,7 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
               const encoded = line.slice(6);
               const chunk = Buffer.from(encoded, 'base64').toString('utf-8');
               if (mainWindow && !mainWindow.isDestroyed()) {
-                mainWindow.webContents.send('summary-chunk', { chunk, sessionName });
+                mainWindow.webContents.send('summary-chunk', { chunk, sessionName, summaryFile });
               }
             } catch (e) { console.log('CHUNK decode error:', e.message); }
           } else if (line.startsWith('TITLE:')) {
@@ -2007,7 +2007,7 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
             }
           } else if (line === 'STREAM_COMPLETE') {
             if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('summary-complete', { success: true, sessionName });
+              mainWindow.webContents.send('summary-complete', { success: true, sessionName, summaryFile });
             }
           } else if (line.startsWith('PROGRESS:')) {
             if (mainWindow && !mainWindow.isDestroyed()) {
@@ -2017,7 +2017,7 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
             const errMsg = line.slice('STREAM_ERROR:'.length);
             sendDebugLog(`❌ Report generation stream error: ${errMsg}`);
             if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send('summary-complete', { success: false, sessionName });
+              mainWindow.webContents.send('summary-complete', { success: false, sessionName, summaryFile });
             }
           } else if (line.startsWith('SAVED:')) {
             sendDebugLog(`Report saved: ${line.slice(6).trim()}`);

--- a/app/main.js
+++ b/app/main.js
@@ -1648,7 +1648,7 @@ ipcMain.handle('list-meetings', async () => {
 // meetings without a Python round-trip. Returns the FULL data (transcript
 // included) — the size-stripping that list-meetings does is intentionally
 // not applied here because the detail page needs the transcript.
-async function readReportsSidecar(meetingPath) {
+async function readReportsSidecar(meetingPath, allowedOutputDirs) {
   // Derive sidecar path: <stem>_summary.(md|json) → <stem>_reports.json
   const ext = path.extname(meetingPath); // '.md' or '.json'
   const base = path.basename(meetingPath, ext); // e.g. '20240101_120000_summary'
@@ -1657,7 +1657,18 @@ async function readReportsSidecar(meetingPath) {
   const stem = base.endsWith('_summary') ? base.slice(0, -'_summary'.length) : base;
   const sidecarPath = path.join(dir, `${stem}_reports.json`);
   try {
-    const raw = await fs.promises.readFile(sidecarPath, 'utf-8');
+    // Path containment (mirrors get-meeting): the derived '_reports.json' is
+    // read directly, so a symlinked sidecar could otherwise escape the allowed
+    // output tree. Resolve its REAL path and require it to live under one of the
+    // same allowed output dirs the meeting passed. realpath needs the file to
+    // exist; a missing sidecar -> caught below -> empty result.
+    const realSidecar = await fs.promises.realpath(path.resolve(sidecarPath));
+    const allowed = Array.isArray(allowedOutputDirs)
+      && allowedOutputDirs.some(b => b && realSidecar.startsWith(b));
+    if (!allowed) {
+      return { reports: [], active_report: null };
+    }
+    const raw = await fs.promises.readFile(realSidecar, 'utf-8');
     const data = JSON.parse(raw);
     return {
       reports: Array.isArray(data.reports) ? data.reports : [],
@@ -1830,11 +1841,11 @@ ipcMain.handle('get-meeting', async (_event, summaryFile) => {
       // needs the full data INCLUDING the transcript (for the AskBar /
       // TranscriptPanel), so we return everything parseMeetingMarkdown yields.
       const mdMeeting = parseMeetingMarkdown(content, realResolved);
-      const mdSidecar = await readReportsSidecar(realResolved);
+      const mdSidecar = await readReportsSidecar(realResolved, allowedOutputDirs);
       return { success: true, meeting: { ...mdMeeting, reports: mdSidecar.reports, active_report: mdSidecar.active_report } };
     }
     const jsonMeeting = JSON.parse(content);
-    const jsonSidecar = await readReportsSidecar(realResolved);
+    const jsonSidecar = await readReportsSidecar(realResolved, allowedOutputDirs);
     return { success: true, meeting: { ...jsonMeeting, reports: jsonSidecar.reports, active_report: jsonSidecar.active_report } };
   } catch (error) {
     return { success: false, error: error.message };

--- a/app/preload.js
+++ b/app/preload.js
@@ -168,6 +168,14 @@ const stenoai = {
     removeMeeting: (summaryFile, folderId) => invoke('remove-meeting-from-folder', summaryFile, folderId),
   },
 
+  templates: {
+    list: () => invoke('list-templates'),
+    save: (template) => invoke('save-template', template),
+    remove: (id) => invoke('delete-template', id),
+    setDefault: (id) => invoke('set-default-template', id),
+    reset: (id) => invoke('reset-template', id),
+  },
+
   models: {
     checkOllama: () => invoke('check-ollama-installed'),
     list: () => invoke('list-models'),

--- a/app/preload.js
+++ b/app/preload.js
@@ -143,6 +143,7 @@ const stenoai = {
     reprocess: (summaryFile, regenTitle, name) => invoke('reprocess-meeting', summaryFile, regenTitle, name),
     regenTitle: (summaryFile, name) => invoke('regen-meeting-title', summaryFile, name),
     saveNotes: (name, notes) => invoke('save-meeting-notes', name, notes),
+    generateReport: (summaryFile, templateId) => invoke('generate-report-meeting', summaryFile, templateId),
   },
 
   query: {

--- a/app/preload.js
+++ b/app/preload.js
@@ -144,6 +144,8 @@ const stenoai = {
     regenTitle: (summaryFile, name) => invoke('regen-meeting-title', summaryFile, name),
     saveNotes: (name, notes) => invoke('save-meeting-notes', name, notes),
     generateReport: (summaryFile, templateId) => invoke('generate-report-meeting', summaryFile, templateId),
+    setActiveReport: (summaryFile, reportId) => invoke('set-active-report', summaryFile, reportId),
+    deleteReport: (summaryFile, reportId) => invoke('delete-report', summaryFile, reportId),
   },
 
   query: {

--- a/app/renderer/src/components/ui/input.tsx
+++ b/app/renderer/src/components/ui/input.tsx
@@ -97,8 +97,12 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         rows={rows}
         onInput={handleInput}
         className={cn(
-          inputVariants({ variant, size: 'default', className }),
-          'min-h-[36px] resize-none py-2',
+          // size 'default' brings horizontal padding; drop its fixed h-9 with
+          // h-auto so `rows` (and any caller min-h) drive the height instead of
+          // clamping the textarea to a single line.
+          inputVariants({ variant, size: 'default' }),
+          'h-auto min-h-[36px] resize-none py-2',
+          className,
         )}
         {...props}
       />

--- a/app/renderer/src/hooks/useMeetings.ts
+++ b/app/renderer/src/hooks/useMeetings.ts
@@ -214,3 +214,21 @@ export function useSaveMeetingNotes() {
       unwrap(await ipc().meetings.saveNotes(args.name, args.notes)),
   });
 }
+
+export const useSetActiveReport = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (a: { summaryFile: string; reportId: string }) =>
+      unwrap(await ipc().meetings.setActiveReport(a.summaryFile, a.reportId)),
+    onSuccess: (_d, a) => qc.invalidateQueries({ queryKey: meetingsKeys.detail(a.summaryFile) }),
+  });
+};
+
+export const useDeleteReport = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (a: { summaryFile: string; reportId: string }) =>
+      unwrap(await ipc().meetings.deleteReport(a.summaryFile, a.reportId)),
+    onSuccess: (_d, a) => qc.invalidateQueries({ queryKey: meetingsKeys.detail(a.summaryFile) }),
+  });
+};

--- a/app/renderer/src/hooks/useMeetings.ts
+++ b/app/renderer/src/hooks/useMeetings.ts
@@ -198,6 +198,16 @@ export function useReprocessMeeting() {
   });
 }
 
+export function useGenerateReport() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (args: { summaryFile: string; templateId: string }) =>
+      unwrap(await ipc().meetings.generateReport(args.summaryFile, args.templateId)),
+    onSuccess: (_data, args) =>
+      qc.invalidateQueries({ queryKey: meetingsKeys.detail(args.summaryFile) }),
+  });
+}
+
 export function useSaveMeetingNotes() {
   return useMutation({
     mutationFn: async (args: { name: string; notes: string }) =>

--- a/app/renderer/src/hooks/useTemplates.ts
+++ b/app/renderer/src/hooks/useTemplates.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ipc, type Template } from '@/lib/ipc';
+import { unwrap } from '@/lib/result';
+
+export const templatesKeys = {
+  all: ['templates'] as const,
+  list: () => [...templatesKeys.all, 'list'] as const,
+};
+
+export function useTemplates() {
+  const q = useQuery({
+    queryKey: templatesKeys.list(),
+    queryFn: async () => unwrap(await ipc().templates.list()),
+  });
+  return {
+    templates: (q.data?.templates ?? []) as Template[],
+    defaultId: q.data?.default_template_id ?? 'standard',
+    isLoading: q.isLoading,
+  };
+}
+
+function useTemplateMutation<TArgs>(fn: (a: TArgs) => Promise<unknown>) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: fn,
+    onSuccess: () => qc.invalidateQueries({ queryKey: templatesKeys.all }),
+  });
+}
+
+export const useSaveTemplate = () =>
+  useTemplateMutation(async (t: Partial<Template>) => unwrap(await ipc().templates.save(t)));
+export const useDeleteTemplate = () =>
+  useTemplateMutation(async (id: string) => unwrap(await ipc().templates.remove(id)));
+export const useSetDefaultTemplate = () =>
+  useTemplateMutation(async (id: string) => unwrap(await ipc().templates.setDefault(id)));
+export const useResetTemplate = () =>
+  useTemplateMutation(async (id: string) => unwrap(await ipc().templates.reset(id)));

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -469,6 +469,7 @@ export interface ProcessingProgressEvent {
 export interface SummaryChunkEvent {
   chunk: string;
   sessionName: string;
+  summaryFile?: string;
 }
 export interface SummaryTitleEvent {
   title: string;
@@ -477,6 +478,7 @@ export interface SummaryTitleEvent {
 export interface SummaryCompleteEvent {
   success: boolean;
   sessionName: string;
+  summaryFile?: string;
 }
 export interface ProcessingCompleteEvent {
   success: boolean;

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -690,6 +690,8 @@ export interface StenoaiBridge {
     saveNotes: RequestFn<[name: string, notes: string], SaveMeetingNotesResponse>;
     regenTitle: RequestFn<[summaryFile: string, name: string], Result<Record<string, never>>>;
     generateReport: RequestFn<[summaryFile: string, templateId: string], Result<{ message: string }>>;
+    setActiveReport: RequestFn<[summaryFile: string, reportId: string], Result<Record<string, never>>>;
+    deleteReport: RequestFn<[summaryFile: string, reportId: string], Result<Record<string, never>>>;
   };
 
   query: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -328,6 +328,22 @@ export type CreateFolderResponse = Result<{ folder: Folder }>;
 
 export type CheckOllamaResponse = Result<{ installed: boolean; path?: string }>;
 export type CheckModelInstalledResponse = Result<{ installed: boolean }>;
+export interface Template {
+  id: string;
+  name: string;
+  icon: string;
+  prompt: string;
+  language: string;
+  format: 'structured' | 'markdown';
+  builtin: boolean;
+  locked: boolean;
+}
+export type ListTemplatesResponse = Result<{
+  templates: Template[];
+  default_template_id: string;
+}>;
+export type SaveTemplateResponse = Result<{ template: Template }>;
+
 export interface RawSupportedModel {
   name?: string;
   size?: string;
@@ -689,6 +705,14 @@ export interface StenoaiBridge {
       [summaryFile: string, folderId: string],
       Result<Record<string, never>>
     >;
+  };
+
+  templates: {
+    list: RequestFn<[], ListTemplatesResponse>;
+    save: RequestFn<[t: Partial<Template>], SaveTemplateResponse>;
+    remove: RequestFn<[id: string], Result<Record<string, never>>>;
+    setDefault: RequestFn<[id: string], Result<Record<string, never>>>;
+    reset: RequestFn<[id: string], Result<Record<string, never>>>;
   };
 
   models: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -40,6 +40,8 @@ export interface Meeting {
   diarised_text?: string | null;
   folders?: string[];
   notes?: string;
+  reports?: Report[];
+  active_report?: string;
   /** Synthetic flag set by the renderer for the in-progress recording. Never sent by backend. */
   is_recording?: boolean;
   /** Synthetic flag set by the renderer when a recording is in the processing pipeline (post-stop, pre-summary). */
@@ -343,6 +345,15 @@ export type ListTemplatesResponse = Result<{
   default_template_id: string;
 }>;
 export type SaveTemplateResponse = Result<{ template: Template }>;
+
+export interface Report {
+  id: string;
+  template_id: string;
+  template_name: string;
+  model: string;
+  content: string;
+  created_at: string;
+}
 
 export interface RawSupportedModel {
   name?: string;
@@ -676,6 +687,7 @@ export interface StenoaiBridge {
     >;
     saveNotes: RequestFn<[name: string, notes: string], SaveMeetingNotesResponse>;
     regenTitle: RequestFn<[summaryFile: string, name: string], Result<Record<string, never>>>;
+    generateReport: RequestFn<[summaryFile: string, templateId: string], Result<{ message: string }>>;
   };
 
   query: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -479,6 +479,10 @@ export interface SummaryCompleteEvent {
   success: boolean;
   sessionName: string;
   summaryFile?: string;
+  /** True when this completion belongs to a template report generation rather
+   *  than a reprocess. Lets the renderer suppress the reprocess/model-memory
+   *  failure banner for report failures, independent of event ordering. */
+  report?: boolean;
 }
 export interface ProcessingCompleteEvent {
   success: boolean;
@@ -496,6 +500,11 @@ export interface ProcessingCompleteEvent {
    *  the failure honestly rather than treat it as a normal note. */
   transcriptionFailed?: boolean;
   transcriptionError?: string;
+  /** True when this is the terminal event of a template report generation
+   *  (not a reprocess). The renderer rolls the stream back without the
+   *  reprocess banner regardless of whether STREAM_ERROR or a non-zero exit
+   *  ended it. */
+  report?: boolean;
 }
 export interface QueryChunkEvent {
   queryId: string;

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -282,8 +282,16 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
       if (!e.success) {
         setStreamPhase('idle');
         setChunkProgress(null);
-        setReprocessFailed(true);
-        generatingReportRef.current = false;
+        if (e.report) {
+          // A failed report generation is not a reprocess/model-memory failure.
+          // Keyed on the event's `report` flag (not the local ref) so it's
+          // correct regardless of summary-complete vs processing-complete order.
+          generatingReportRef.current = false;
+          setStreamText('');
+          streamCache.delete(summaryFile);
+        } else {
+          setReprocessFailed(true);
+        }
         return;
       }
       setStreamPhase('done');
@@ -311,7 +319,15 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
       setChunkProgress(null);
       if (!e.success) {
         setStreamPhase('idle');
-        setReprocessFailed(true);
+        if (e.report) {
+          // Terminal event of a failed report generation (e.g. non-zero exit
+          // with no STREAM_ERROR). Roll back without the reprocess banner.
+          generatingReportRef.current = false;
+          setStreamText('');
+          streamCache.delete(summaryFile);
+        } else {
+          setReprocessFailed(true);
+        }
         return;
       }
       void qc.invalidateQueries({ queryKey: meetingsKeys.all });
@@ -352,7 +368,21 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
     setReprocessFailed(false);
     generatingReportRef.current = true;
     streamCache.set(summaryFile, { text: '', phase: 'analyzing' });
-    generateReport.mutate({ summaryFile, templateId });
+    generateReport.mutate(
+      { summaryFile, templateId },
+      {
+        // Failures before the first stream event (e.g. the backend never starts
+        // streaming) won't emit summary-complete, so roll the UI back here instead
+        // of stranding it in the analyzing state.
+        onError: () => {
+          generatingReportRef.current = false;
+          setStreamPhase('idle');
+          setStreamText('');
+          setChunkProgress(null);
+          streamCache.delete(summaryFile);
+        },
+      },
+    );
   };
 
   // Persist the choice so it survives navigation (B1 review: active_report not

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -1013,7 +1013,6 @@ function ReportSwitch({
                   onGenerate(t.id);
                 }}
               >
-                {t.icon && <span aria-hidden>{t.icon}</span>}
                 <span className="truncate">{t.name}</span>
               </button>
             ))}

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -253,6 +253,12 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   const activeReport = activeReportId
     ? reports.find((r) => r.id === activeReportId) ?? null
     : null;
+  // meeting.active_report is the source of truth (the switch persists it). Re-sync
+  // local state whenever it changes so a reprocess (backend clears it to null)
+  // can't leave the UI showing a stale report. Idempotent for user clicks.
+  React.useEffect(() => {
+    setActiveReportId(meeting.active_report ?? null);
+  }, [meeting.active_report]);
   // When a report generation finishes, summaryComplete fires for THIS meeting
   // and we want to land on the freshly-created report. The IPC stream doesn't
   // carry the new report id, so we flag "the active stream is a report" and,

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -262,12 +262,12 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   React.useEffect(() => {
     const sessionName = info.name;
     const offChunk = ipc().on.summaryChunk((e) => {
-      if (e.sessionName !== sessionName) return;
+      if (e.summaryFile !== summaryFile) return;
       setStreamPhase((prev) => (prev === 'analyzing' ? 'generating' : prev));
       setStreamText((prev) => prev + e.chunk);
     });
     const offComplete = ipc().on.summaryComplete((e) => {
-      if (e.sessionName !== sessionName) return;
+      if (e.summaryFile !== summaryFile) return;
       if (!e.success) {
         setStreamPhase('idle');
         setChunkProgress(null);

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
+import ReactMarkdown from 'react-markdown';
 import {
   Calendar as CalendarIcon,
   Check,
+  ChevronDown,
   ChevronLeft,
   Clock,
   CloudOff,
   Copy,
+  FileText,
   Folder as FolderIcon,
   Globe,
   MoreHorizontal,
@@ -27,7 +30,14 @@ import {
   SelectItem,
   SelectSeparator,
 } from '@/components/ui/select';
-import { useMeeting, useReprocessMeeting, useDeleteMeeting, meetingsKeys } from '@/hooks/useMeetings';
+import {
+  useMeeting,
+  useReprocessMeeting,
+  useDeleteMeeting,
+  useGenerateReport,
+  meetingsKeys,
+} from '@/hooks/useMeetings';
+import { useTemplates } from '@/hooks/useTemplates';
 import {
   useOrgSession,
   useShareToOrg,
@@ -56,7 +66,7 @@ import {
   useCreateFolder,
 } from '@/hooks/useFolders';
 import { useActiveMeeting } from '@/lib/askBarContext';
-import { ipc, type Meeting } from '@/lib/ipc';
+import { ipc, type Meeting, type Report, type Template } from '@/lib/ipc';
 import { unwrap } from '@/lib/result';
 import { cn } from '@/lib/utils';
 import { navigate } from '@/lib/router';
@@ -132,6 +142,8 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   const [deleteOpen, setDeleteOpen] = React.useState(false);
   const deleteMeeting = useDeleteMeeting();
   const reprocess = useReprocessMeeting();
+  const generateReport = useGenerateReport();
+  const { templates } = useTemplates();
   const orgSession = useOrgSession();
   const shareToOrg = useShareToOrg();
   const backupState = useOrgBackupState(orgSession.data?.signedIn ? summaryFile : null);
@@ -227,6 +239,22 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   const [reprocessFailed, setReprocessFailed] = React.useState(false);
   const qc = useQueryClient();
 
+  // Report switch: null = the structured Standard summary, otherwise the id of
+  // a generated report in meeting.reports. Seeded from the meeting's persisted
+  // active_report so reopening a note lands on whatever was last viewed.
+  const reports = meeting.reports ?? [];
+  const [activeReportId, setActiveReportId] = React.useState<string | null>(
+    meeting.active_report ?? null,
+  );
+  const activeReport = activeReportId
+    ? reports.find((r) => r.id === activeReportId) ?? null
+    : null;
+  // When a report generation finishes, summaryComplete fires for THIS meeting
+  // and we want to land on the freshly-created report. The IPC stream doesn't
+  // carry the new report id, so we flag "the active stream is a report" and,
+  // on complete, refetch + adopt the meeting's refreshed active_report.
+  const generatingReportRef = React.useRef(false);
+
   React.useEffect(() => {
     streamCache.set(summaryFile, { text: streamText, phase: streamPhase });
   }, [summaryFile, streamText, streamPhase]);
@@ -244,9 +272,28 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
         setStreamPhase('idle');
         setChunkProgress(null);
         setReprocessFailed(true);
+        generatingReportRef.current = false;
         return;
       }
       setStreamPhase('done');
+      // Report generation reuses the summary stream. On success, refetch this
+      // meeting so reports[]/active_report refresh, then land on the new report
+      // (the backend marks it active) once the fresh detail payload arrives.
+      if (generatingReportRef.current) {
+        generatingReportRef.current = false;
+        void qc
+          .invalidateQueries({ queryKey: meetingsKeys.detail(summaryFile) })
+          .then(() => {
+            const fresh = qc.getQueryData<Meeting>(meetingsKeys.detail(summaryFile));
+            if (fresh?.active_report) setActiveReportId(fresh.active_report);
+          });
+        setChunkProgress(null);
+        setTimeout(() => {
+          setStreamText('');
+          setStreamPhase('idle');
+          streamCache.delete(summaryFile);
+        }, 400);
+      }
     });
     const offProcessing = ipc().on.processingComplete((e) => {
       if (e.sessionName !== sessionName) return;
@@ -282,6 +329,20 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
       offProgress();
     };
   }, [info.name, summaryFile, qc]);
+
+  // Non-Standard templates only — the locked `standard` template drives the
+  // structured summary, not an on-demand report.
+  const reportTemplates = templates.filter((t) => !t.locked);
+
+  const onGenerateReport = (templateId: string) => {
+    setStreamText('');
+    setStreamPhase('analyzing');
+    setChunkProgress(null);
+    setReprocessFailed(false);
+    generatingReportRef.current = true;
+    streamCache.set(summaryFile, { text: '', phase: 'analyzing' });
+    generateReport.mutate({ summaryFile, templateId });
+  };
 
   const copyNotes = () => {
     const lines: string[] = [info.name];
@@ -587,6 +648,16 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
         )}
       </header>
 
+      {streamPhase === 'idle' && (reports.length > 0 || reportTemplates.length > 0) && (
+        <ReportSwitch
+          reports={reports}
+          activeReportId={activeReportId}
+          onSelect={setActiveReportId}
+          templates={reportTemplates}
+          onGenerate={onGenerateReport}
+          generating={generateReport.isPending}
+        />
+      )}
       {reprocessFailed && (
         <div
           className="rounded-lg p-3 text-sm"
@@ -602,6 +673,14 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
       )}
       {streamPhase !== 'idle' ? (
         <StreamingView text={streamText} phase={streamPhase} chunkProgress={chunkProgress} />
+      ) : activeReport ? (
+        <section
+          className="stream-markdown"
+          data-testid="report-content"
+          style={{ color: 'var(--fg-1)', maxWidth: '72ch' }}
+        >
+          <ReactMarkdown>{activeReport.content}</ReactMarkdown>
+        </section>
       ) : (
         <div className="flex flex-col gap-9">
           {transcriptionFailed ? (
@@ -824,6 +903,112 @@ const ActionIconButton = React.forwardRef<
     </button>
   );
 });
+
+// ---------------------------------------------------------------------------
+// Report switch — segmented pills (Standard + one per generated report) plus a
+// "Generate report" dropdown of the non-Standard templates. Controls which
+// body the detail view renders; generation reuses the summary stream.
+// ---------------------------------------------------------------------------
+
+interface ReportSwitchProps {
+  reports: Report[];
+  activeReportId: string | null;
+  onSelect: (id: string | null) => void;
+  templates: Template[];
+  onGenerate: (templateId: string) => void;
+  generating: boolean;
+}
+
+function ReportSwitch({
+  reports,
+  activeReportId,
+  onSelect,
+  templates,
+  onGenerate,
+  generating,
+}: ReportSwitchProps) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="flex flex-wrap items-center gap-1.5" data-testid="report-switch">
+      <ReportPill active={activeReportId === null} onClick={() => onSelect(null)}>
+        Standard
+      </ReportPill>
+      {reports.map((r) => (
+        <ReportPill
+          key={r.id}
+          active={activeReportId === r.id}
+          onClick={() => onSelect(r.id)}
+        >
+          {r.template_name}
+        </ReportPill>
+      ))}
+      {templates.length > 0 && (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              data-testid="generate-report-trigger"
+              disabled={generating}
+              className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[12.5px] transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50"
+              style={{
+                color: 'var(--fg-2)',
+                border: '1px solid var(--border-subtle)',
+              }}
+            >
+              <FileText className="size-[12px]" />
+              {generating ? 'Generating…' : 'Generate report'}
+              <ChevronDown className="size-[12px]" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-56 p-1">
+            {templates.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-[color:var(--surface-hover)]"
+                style={{ color: 'var(--fg-1)' }}
+                onClick={() => {
+                  setOpen(false);
+                  onGenerate(t.id);
+                }}
+              >
+                {t.icon && <span aria-hidden>{t.icon}</span>}
+                <span className="truncate">{t.name}</span>
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}
+
+function ReportPill({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className="inline-flex items-center rounded-full px-3 py-1 text-[12.5px] transition-colors"
+      style={{
+        color: active ? 'var(--fg-1)' : 'var(--fg-2)',
+        background: active ? 'var(--surface-raised)' : 'transparent',
+        border: '1px solid var(--border-subtle)',
+        fontWeight: active ? 600 : 400,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Streaming view (kept in this file because StreamingView's pinned-indicator

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -35,6 +35,8 @@ import {
   useReprocessMeeting,
   useDeleteMeeting,
   useGenerateReport,
+  useSetActiveReport,
+  useDeleteReport,
   meetingsKeys,
 } from '@/hooks/useMeetings';
 import { useTemplates } from '@/hooks/useTemplates';
@@ -143,6 +145,8 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   const deleteMeeting = useDeleteMeeting();
   const reprocess = useReprocessMeeting();
   const generateReport = useGenerateReport();
+  const setActiveReport = useSetActiveReport();
+  const deleteReport = useDeleteReport();
   const { templates } = useTemplates();
   const orgSession = useOrgSession();
   const shareToOrg = useShareToOrg();
@@ -342,6 +346,18 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
     generatingReportRef.current = true;
     streamCache.set(summaryFile, { text: '', phase: 'analyzing' });
     generateReport.mutate({ summaryFile, templateId });
+  };
+
+  // Persist the choice so it survives navigation (B1 review: active_report not
+  // persisted). `null` selects the structured Standard summary → 'standard'.
+  const onSelectReport = (id: string | null) => {
+    setActiveReportId(id);
+    setActiveReport.mutate({ summaryFile, reportId: id ?? 'standard' });
+  };
+
+  const onDeleteReport = (reportId: string) => {
+    if (activeReportId === reportId) setActiveReportId(null);
+    deleteReport.mutate({ summaryFile, reportId });
   };
 
   const copyNotes = () => {
@@ -652,7 +668,8 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
         <ReportSwitch
           reports={reports}
           activeReportId={activeReportId}
-          onSelect={setActiveReportId}
+          onSelect={onSelectReport}
+          onDelete={onDeleteReport}
           templates={reportTemplates}
           onGenerate={onGenerateReport}
           generating={generateReport.isPending}
@@ -914,6 +931,7 @@ interface ReportSwitchProps {
   reports: Report[];
   activeReportId: string | null;
   onSelect: (id: string | null) => void;
+  onDelete: (reportId: string) => void;
   templates: Template[];
   onGenerate: (templateId: string) => void;
   generating: boolean;
@@ -923,6 +941,7 @@ function ReportSwitch({
   reports,
   activeReportId,
   onSelect,
+  onDelete,
   templates,
   onGenerate,
   generating,
@@ -933,15 +952,31 @@ function ReportSwitch({
       <ReportPill active={activeReportId === null} onClick={() => onSelect(null)}>
         Standard
       </ReportPill>
-      {reports.map((r) => (
-        <ReportPill
-          key={r.id}
-          active={activeReportId === r.id}
-          onClick={() => onSelect(r.id)}
-        >
-          {r.template_name}
-        </ReportPill>
-      ))}
+      {reports.map((r) => {
+        const when = formatReportDate(r.created_at);
+        const meta = [r.model, when].filter(Boolean).join(' · ');
+        return (
+          <ReportPill
+            key={r.id}
+            active={activeReportId === r.id}
+            onClick={() => onSelect(r.id)}
+            onDelete={() => onDelete(r.id)}
+            title={meta || undefined}
+          >
+            <span className="flex flex-col items-start leading-tight">
+              <span>{r.template_name}</span>
+              {meta && (
+                <span
+                  className="text-[10.5px]"
+                  style={{ color: 'var(--fg-2)', fontWeight: 400 }}
+                >
+                  {meta}
+                </span>
+              )}
+            </span>
+          </ReportPill>
+        );
+      })}
       {templates.length > 0 && (
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
@@ -986,18 +1021,19 @@ function ReportSwitch({
 function ReportPill({
   active,
   onClick,
+  onDelete,
+  title,
   children,
 }: {
   active: boolean;
   onClick: () => void;
+  onDelete?: () => void;
+  title?: string;
   children: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className="inline-flex items-center rounded-full px-3 py-1 text-[12.5px] transition-colors"
+    <span
+      className="inline-flex items-center rounded-full transition-colors"
       style={{
         color: active ? 'var(--fg-1)' : 'var(--fg-2)',
         background: active ? 'var(--surface-raised)' : 'transparent',
@@ -1005,8 +1041,32 @@ function ReportPill({
         fontWeight: active ? 600 : 400,
       }}
     >
-      {children}
-    </button>
+      <button
+        type="button"
+        onClick={onClick}
+        title={title}
+        aria-pressed={active}
+        className="inline-flex items-center rounded-full py-1 pl-3 text-[12.5px]"
+        style={{ paddingRight: onDelete ? '0.375rem' : '0.75rem' }}
+      >
+        {children}
+      </button>
+      {onDelete && (
+        <button
+          type="button"
+          aria-label="Delete report"
+          title="Delete report"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          className="mr-1.5 inline-flex items-center rounded-full p-0.5 transition-colors hover:bg-[color:var(--surface-hover)]"
+          style={{ color: 'var(--fg-2)' }}
+        >
+          <Trash2 className="size-[11px]" />
+        </button>
+      )}
+    </span>
   );
 }
 
@@ -1367,6 +1427,15 @@ function formatDetailDate(info: { processed_at?: string; updated_at?: string }):
     hour: 'numeric',
     minute: '2-digit',
   });
+}
+
+// Compact date for the report-pill secondary line (e.g. "Jun 23"). Kept
+// terser than formatDetailDate so the pill stays small.
+function formatReportDate(raw?: string): string | undefined {
+  if (!raw) return undefined;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
 function formatDuration(seconds?: number): string | undefined {

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -56,6 +56,7 @@ import {
   DialogClose,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   Tooltip,
   TooltipTrigger,
@@ -953,6 +954,8 @@ function ReportSwitch({
   generating,
 }: ReportSwitchProps) {
   const [open, setOpen] = React.useState(false);
+  // Report pending deletion → drives the confirmation dialog.
+  const [deleteTarget, setDeleteTarget] = React.useState<Report | null>(null);
   return (
     <div className="flex flex-wrap items-center gap-1.5" data-testid="report-switch">
       <ReportPill active={activeReportId === null} onClick={() => onSelect(null)}>
@@ -966,7 +969,7 @@ function ReportSwitch({
             key={r.id}
             active={activeReportId === r.id}
             onClick={() => onSelect(r.id)}
-            onDelete={() => onDelete(r.id)}
+            onDelete={() => setDeleteTarget(r)}
             title={meta || undefined}
           >
             <span className="flex flex-col items-start leading-tight">
@@ -1019,6 +1022,22 @@ function ReportSwitch({
           </PopoverContent>
         </Popover>
       )}
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title={
+          deleteTarget ? `Delete report "${deleteTarget.template_name}"?` : ''
+        }
+        description="This permanently deletes this generated report. The transcript and other reports are not affected."
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => {
+          if (!deleteTarget) return;
+          onDelete(deleteTarget.id);
+          setDeleteTarget(null);
+        }}
+      />
     </div>
   );
 }
@@ -1065,8 +1084,7 @@ function ReportPill({
             e.stopPropagation();
             onDelete();
           }}
-          className="mr-1.5 inline-flex items-center rounded-full p-0.5 transition-colors hover:bg-[color:var(--surface-hover)]"
-          style={{ color: 'var(--fg-2)' }}
+          className="mr-1.5 inline-flex items-center rounded-full p-0.5 text-[color:var(--fg-2)] transition-colors hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]"
         >
           <Trash2 className="size-[11px]" />
         </button>

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -111,6 +111,11 @@ export function Processing() {
         }
       }),
       ipc().on.processingProgress((e) => {
+        // This screen shows the fresh-recording queue job, which emits bare
+        // {line} progress (no summaryFile). A concurrent reprocess/report of a
+        // DIFFERENT meeting emits summaryFile-scoped progress — ignore those so
+        // another meeting's "Summarizing part N" can't hijack this screen's stage.
+        if (e.summaryFile) return;
         const raw = e.line.replace(/^PROGRESS:summarize:/, '');
         if (raw === 'reducing') {
           setChunkProgress('Merging summaries…');

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input, Textarea } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import {
@@ -1011,6 +1012,8 @@ function TemplatesTab() {
 
   // null = editor closed; a Template = edit existing; {} = new template.
   const [editing, setEditing] = React.useState<Partial<Template> | null>(null);
+  // Template pending deletion → drives the confirmation dialog.
+  const [deleteTarget, setDeleteTarget] = React.useState<Template | null>(null);
 
   return (
     <section data-settings-tab="templates">
@@ -1119,9 +1122,11 @@ function TemplatesTab() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  className={COMPACT_BTN}
-                  disabled={del.isPending}
-                  onClick={() => del.mutate(t.id)}
+                  className={cn(
+                    COMPACT_BTN,
+                    'text-[color:var(--fg-2)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
+                  )}
+                  onClick={() => setDeleteTarget(t)}
                   aria-label={`Delete ${t.name}`}
                 >
                   <Trash2 size={14} />
@@ -1148,6 +1153,21 @@ function TemplatesTab() {
           New Template
         </Button>
       )}
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title={deleteTarget ? `Delete template "${deleteTarget.name}"?` : ''}
+        description="This permanently deletes the template. Reports already generated from it are not affected."
+        confirmLabel="Delete"
+        destructive
+        isPending={del.isPending}
+        onConfirm={async () => {
+          if (!deleteTarget) return;
+          await del.mutateAsync(deleteTarget.id);
+          setDeleteTarget(null);
+        }}
+      />
     </section>
   );
 }

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1003,19 +1003,6 @@ function AiTab() {
 // transcript / global setting.
 const TEMPLATE_LANGUAGES: LangOption[] = LANGUAGES_WHISPER;
 
-// Fixed icon palette for custom templates. Keys are stored verbatim on the
-// template; the renderer that shows summaries maps them to glyphs. We keep
-// the picker small and curated rather than a free-text field so authored
-// templates stay visually consistent with the built-ins.
-const TEMPLATE_ICONS: { value: string; label: string }[] = [
-  { value: 'doc', label: 'Document' },
-  { value: 'people', label: 'People' },
-  { value: 'calendar', label: 'Calendar' },
-  { value: 'lightbulb', label: 'Idea' },
-  { value: 'phone', label: 'Call' },
-  { value: 'megaphone', label: 'Announcement' },
-];
-
 function TemplatesTab() {
   const { templates, defaultId, isLoading } = useTemplates();
   const setDefault = useSetDefaultTemplate();
@@ -1179,13 +1166,12 @@ function TemplateEditor({
   const [name, setName] = React.useState(editing?.name ?? '');
   const [prompt, setPrompt] = React.useState(editing?.prompt ?? '');
   const [language, setLanguage] = React.useState(editing?.language ?? 'auto');
-  const [icon, setIcon] = React.useState(editing?.icon ?? 'doc');
   const [error, setError] = React.useState<string | null>(null);
 
   const onSave = () => {
     setError(null);
     save.mutate(
-      { id: editing?.id, name, icon, prompt, language },
+      { id: editing?.id, name, prompt, language },
       {
         onSuccess: () => onClose(),
         onError: (e) => setError(e instanceof Error ? e.message : 'Save failed'),
@@ -1226,21 +1212,6 @@ function TemplateEditor({
             {TEMPLATE_LANGUAGES.map((l) => (
               <SelectItem key={l.value} value={l.value}>
                 {l.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </SettingRow>
-
-      <SettingRow label="Icon">
-        <Select value={icon} onValueChange={setIcon}>
-          <SelectTrigger className={cn(COMPACT_TRIGGER, 'min-w-[180px]')}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {TEMPLATE_ICONS.map((i) => (
-              <SelectItem key={i.value} value={i.value}>
-                {i.label}
               </SelectItem>
             ))}
           </SelectContent>

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -7,10 +7,13 @@ import {
   Copy,
   ExternalLink,
   Loader2,
+  Lock,
+  Plus,
+  Trash2,
   X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { Input, Textarea } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import {
   Select,
@@ -92,7 +95,14 @@ import {
   useGoogleCalendarAuth,
   useOutlookCalendarAuth,
 } from '@/hooks/useCalendarEvents';
-import type { AiProvider, CloudProvider, OrgStatusResponse } from '@/lib/ipc';
+import {
+  useTemplates,
+  useSaveTemplate,
+  useDeleteTemplate,
+  useSetDefaultTemplate,
+  useResetTemplate,
+} from '@/hooks/useTemplates';
+import type { AiProvider, CloudProvider, OrgStatusResponse, Template } from '@/lib/ipc';
 import {
   useOrgAutoBackup,
   useOrgLogin,
@@ -144,6 +154,7 @@ const TABS = [
   { id: 'general', label: 'General' },
   { id: 'transcription', label: 'Transcribe' },
   { id: 'ai', label: 'AI' },
+  { id: 'templates', label: 'Templates' },
   { id: 'organisation', label: 'Organisation' },
   { id: 'advanced', label: 'Advanced' },
   { id: 'developer', label: 'Developer' },
@@ -541,6 +552,7 @@ export function Settings() {
             {tab === 'general' && <GeneralTab />}
             {tab === 'transcription' && <TranscriptionTab />}
             {tab === 'ai' && <AiTab />}
+            {tab === 'templates' && <TemplatesTab />}
             {tab === 'organisation' && <OrganisationTab />}
             {tab === 'advanced' && <AdvancedTab />}
             {tab === 'developer' && <DeveloperTab />}
@@ -973,6 +985,311 @@ function AiTab() {
         </>
       )}
     </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Templates tab — manage summary report templates (CRUD + default pick).
+// This is management UI only; it does not change how summaries are
+// generated. The backend (Task 4) owns merging built-ins with user edits,
+// so the renderer just lists what `templates.list()` returns and routes
+// edits/resets/deletes back through the typed bridge.
+// ---------------------------------------------------------------------------
+
+// Template language picker. Built from LANGUAGES_WHISPER so the codes line
+// up with Config.SUPPORTED_LANGUAGES (the 11 curated codes) plus 'auto',
+// and we reuse its human labels rather than hardcoding a second list. A
+// template's language pins the summary output language; 'auto' follows the
+// transcript / global setting.
+const TEMPLATE_LANGUAGES: LangOption[] = LANGUAGES_WHISPER;
+
+// Fixed icon palette for custom templates. Keys are stored verbatim on the
+// template; the renderer that shows summaries maps them to glyphs. We keep
+// the picker small and curated rather than a free-text field so authored
+// templates stay visually consistent with the built-ins.
+const TEMPLATE_ICONS: { value: string; label: string }[] = [
+  { value: 'doc', label: 'Document' },
+  { value: 'people', label: 'People' },
+  { value: 'calendar', label: 'Calendar' },
+  { value: 'lightbulb', label: 'Idea' },
+  { value: 'phone', label: 'Call' },
+  { value: 'megaphone', label: 'Announcement' },
+];
+
+function TemplatesTab() {
+  const { templates, defaultId, isLoading } = useTemplates();
+  const setDefault = useSetDefaultTemplate();
+  const reset = useResetTemplate();
+  const del = useDeleteTemplate();
+
+  // null = editor closed; a Template = edit existing; {} = new template.
+  const [editing, setEditing] = React.useState<Partial<Template> | null>(null);
+
+  return (
+    <section data-settings-tab="templates">
+      <SettingRow
+        label="Default template"
+        description="The template used for new summaries unless you pick another."
+      >
+        <Select
+          value={defaultId}
+          onValueChange={(v) => setDefault.mutate(v)}
+          disabled={isLoading || templates.length === 0}
+        >
+          <SelectTrigger className={cn(COMPACT_TRIGGER, 'min-w-[180px]')}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="w-64">
+            {templates.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingRow>
+
+      <SectionHeading>Templates</SectionHeading>
+
+      {templates.map((t) => (
+        <div
+          key={t.id}
+          className="mb-1.5 flex items-center gap-4 rounded-[8px] px-4 py-[13px]"
+          style={{
+            border: '1px solid var(--border-subtle)',
+            background:
+              t.id === defaultId ? 'var(--surface-raised)' : 'transparent',
+          }}
+        >
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span
+                className="truncate text-[13px] font-medium"
+                style={{ color: 'var(--fg-1)' }}
+              >
+                {t.name}
+              </span>
+              {t.locked && (
+                <span
+                  className="inline-flex items-center gap-1 text-[11px]"
+                  style={{ color: 'var(--fg-muted)' }}
+                  title="Built-in template — protected from editing and deletion"
+                >
+                  <Lock size={11} aria-hidden="true" />
+                  Locked
+                </span>
+              )}
+              {t.builtin && !t.locked && (
+                <span
+                  className="rounded-[3px] px-1.5 py-px text-[11px]"
+                  style={{
+                    color: 'var(--fg-muted)',
+                    border: '1px solid var(--border-subtle)',
+                  }}
+                >
+                  Built-in
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {t.builtin ? (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={COMPACT_BTN}
+                  disabled={reset.isPending}
+                  onClick={() => reset.mutate(t.id)}
+                >
+                  Reset
+                </Button>
+                {!t.locked && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className={COMPACT_BTN}
+                    onClick={() => setEditing(t)}
+                  >
+                    Edit
+                  </Button>
+                )}
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={COMPACT_BTN}
+                  onClick={() => setEditing(t)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={COMPACT_BTN}
+                  disabled={del.isPending}
+                  onClick={() => del.mutate(t.id)}
+                  aria-label={`Delete ${t.name}`}
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      ))}
+
+      {editing ? (
+        <TemplateEditor
+          editing={editing.id ? editing : null}
+          onClose={() => setEditing(null)}
+        />
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn(COMPACT_BTN, 'mt-3')}
+          onClick={() => setEditing({})}
+        >
+          <Plus size={14} className="mr-1.5" />
+          New Template
+        </Button>
+      )}
+    </section>
+  );
+}
+
+/** Inline editor for creating or editing a template. Surfaces backend
+ *  validation/save errors inline rather than throwing — the save handler
+ *  is the verbatim spec from the task brief. */
+function TemplateEditor({
+  editing,
+  onClose,
+}: {
+  editing: Partial<Template> | null;
+  onClose: () => void;
+}) {
+  const save = useSaveTemplate();
+  const [name, setName] = React.useState(editing?.name ?? '');
+  const [prompt, setPrompt] = React.useState(editing?.prompt ?? '');
+  const [language, setLanguage] = React.useState(editing?.language ?? 'auto');
+  const [icon, setIcon] = React.useState(editing?.icon ?? 'doc');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const onSave = () => {
+    setError(null);
+    save.mutate(
+      { id: editing?.id, name, icon, prompt, language },
+      {
+        onSuccess: () => onClose(),
+        onError: (e) => setError(e instanceof Error ? e.message : 'Save failed'),
+      },
+    );
+  };
+
+  return (
+    <div
+      className="mt-3 rounded-[8px] p-4"
+      style={{
+        border: '1px solid var(--border-subtle)',
+        background: 'var(--surface-raised)',
+      }}
+    >
+      <div
+        className="mb-3 text-[13px] font-medium"
+        style={{ color: 'var(--fg-1)' }}
+      >
+        {editing ? 'Edit template' : 'New template'}
+      </div>
+
+      <SettingRow label="Name">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Weekly sync"
+          className="h-[30px] w-[220px] text-[13px]"
+        />
+      </SettingRow>
+
+      <SettingRow label="Language" description="Output language for the summary.">
+        <Select value={language} onValueChange={setLanguage}>
+          <SelectTrigger className={cn(COMPACT_TRIGGER, 'min-w-[180px]')}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TEMPLATE_LANGUAGES.map((l) => (
+              <SelectItem key={l.value} value={l.value}>
+                {l.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingRow>
+
+      <SettingRow label="Icon">
+        <Select value={icon} onValueChange={setIcon}>
+          <SelectTrigger className={cn(COMPACT_TRIGGER, 'min-w-[180px]')}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TEMPLATE_ICONS.map((i) => (
+              <SelectItem key={i.value} value={i.value}>
+                {i.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingRow>
+
+      <SettingRow label="Prompt" align="start" noBorder>
+        <Textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Summarise the meeting as…"
+          rows={6}
+          className="w-[320px] text-[13px]"
+        />
+      </SettingRow>
+
+      {error && (
+        <div
+          className="mt-2 text-[12px]"
+          style={{ color: 'var(--accent-danger, var(--fg-1))' }}
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="mt-3 flex justify-end gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className={COMPACT_BTN}
+          onClick={onClose}
+          disabled={save.isPending}
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          className={COMPACT_BTN}
+          onClick={onSave}
+          disabled={save.isPending || !name.trim()}
+        >
+          {save.isPending ? (
+            <>
+              <Loader2 className="mr-1.5 size-3 animate-spin" />
+              Saving…
+            </>
+          ) : (
+            'Save'
+          )}
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1094,17 +1094,21 @@ function TemplatesTab() {
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {t.builtin ? (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={COMPACT_BTN}
-                  disabled={reset.isPending}
-                  onClick={() => reset.mutate(t.id)}
-                >
-                  Reset
-                </Button>
-                {!t.locked && (
+              // A locked built-in (Standard) can't be edited, so there is no
+              // override to reset and nothing to edit — show no actions (the
+              // "Locked" badge above already conveys its state). Only an
+              // editable built-in offers Reset + Edit.
+              !t.locked && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={COMPACT_BTN}
+                    disabled={reset.isPending}
+                    onClick={() => reset.mutate(t.id)}
+                  >
+                    Reset
+                  </Button>
                   <Button
                     variant="outline"
                     size="sm"
@@ -1113,8 +1117,8 @@ function TemplatesTab() {
                   >
                     Edit
                   </Button>
-                )}
-              </>
+                </>
+              )
             ) : (
               <>
                 <Button
@@ -1243,15 +1247,21 @@ function TemplateEditor({
         </Select>
       </SettingRow>
 
-      <SettingRow label="Prompt" align="start" noBorder>
+      <div className="pt-3">
+        <div
+          className="mb-2 text-[13px] font-medium"
+          style={{ color: 'var(--fg-1)' }}
+        >
+          Prompt
+        </div>
         <Textarea
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="Summarise the meeting as…"
-          rows={6}
-          className="w-[320px] text-[13px]"
+          rows={10}
+          className="w-full min-h-[200px] text-[13px] leading-relaxed"
         />
-      </SettingRow>
+      </div>
 
       {error && (
         <div

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1139,6 +1139,7 @@ function TemplatesTab() {
 
       {editing ? (
         <TemplateEditor
+          key={editing.id ?? 'new'}
           editing={editing.id ? editing : null}
           onClose={() => setEditing(null)}
         />

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -96,3 +96,72 @@ export function writeMeetingSummary(
   writeFileSync(summaryFile, JSON.stringify(data, null, 2));
   return summaryFile;
 }
+
+export interface FixtureMeetingMarkdown {
+  name: string;
+  summaryMarkdown: string;
+  transcript: string;
+  notes?: string;
+}
+
+/**
+ * Write a deterministic `<stem>_summary.md` into <userDataDir>/output so the
+ * real backend's `list-meetings` (which globs get_data_dirs()['output']) finds
+ * it.  The format mirrors `simple_recorder._render_frontmatter` + the section
+ * layout produced by `process_recording_streaming`:
+ *
+ *   ---
+ *   title: "…"
+ *   date: "…"
+ *   duration_seconds: 0
+ *   language: "en"
+ *   is_diarised: false
+ *   ---
+ *
+ *   <summaryMarkdown>
+ *
+ *   ## Transcript
+ *
+ *   <transcript>
+ *
+ *   ## User Notes        ← only when `notes` is provided
+ *
+ *   <notes>
+ *
+ * Returns the absolute path of the written summary file.
+ */
+export function writeMeetingMarkdown(
+  userDataDir: string,
+  stem: string,
+  meeting: FixtureMeetingMarkdown,
+): string {
+  const outputDir = path.join(userDataDir, 'output');
+  mkdirSync(outputDir, { recursive: true });
+  const summaryFile = path.join(outputDir, `${stem}_summary.md`);
+  const now = new Date().toISOString();
+
+  const escapeYaml = (s: string) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+  const lines: string[] = [
+    '---',
+    `title: "${escapeYaml(meeting.name)}"`,
+    `date: "${now}"`,
+    `duration_seconds: 0`,
+    `language: "en"`,
+    `is_diarised: false`,
+    '---',
+    '',
+    meeting.summaryMarkdown,
+    '',
+    '## Transcript',
+    '',
+    meeting.transcript,
+  ];
+
+  if (meeting.notes) {
+    lines.push('', '## User Notes', '', meeting.notes);
+  }
+
+  writeFileSync(summaryFile, lines.join('\n'));
+  return summaryFile;
+}

--- a/e2e/specs/generate-report.t2.spec.ts
+++ b/e2e/specs/generate-report.t2.spec.ts
@@ -2,14 +2,15 @@ import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
 import { startMockOllama } from '../fixtures/mock-ollama';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
 
 /**
  * T2 — generate-report persists into reports[] and sets active_report. Drives
  * the real `generate-report` path (NO ASR, NO real model) with a capturing mock
  * Ollama and asserts the two sides of the generate-report contract:
  *   1. The markdown returned by the mock LLM is stored verbatim in
- *      `reports[0].content` in the meeting `_summary.json`.
+ *      `reports[0].content` in the sidecar `<stem>_reports.json`.
  *   2. `active_report` is set to `reports[0].id` and `reports[0].template_id`
  *      matches the template used.
  *
@@ -43,7 +44,22 @@ type StenoWindow = Window & {
 
 const readSummary = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
 
-test('generate-report appends to reports[] and sets active_report in the meeting JSON', async ({
+type Report = { id: string; template_id: string; content: string };
+
+const readSidecar = (sidecarPath: string): { reports: Report[]; active_report: string | null } => {
+  if (!existsSync(sidecarPath)) return { reports: [], active_report: null };
+  return JSON.parse(readFileSync(sidecarPath, 'utf8'));
+};
+
+/** Derive the sidecar path from a `*_summary.json` path. */
+const sidecarFor = (summaryFile: string): string => {
+  const dir = path.dirname(summaryFile);
+  const base = path.basename(summaryFile, '.json'); // e.g. 'report-gen_summary'
+  const stem = base.endsWith('_summary') ? base.slice(0, -'_summary'.length) : base;
+  return path.join(dir, `${stem}_reports.json`);
+};
+
+test('generate-report appends to reports[] and sets active_report in the sidecar', async ({
   launchApp,
   userDataDir,
 }) => {
@@ -56,6 +72,7 @@ test('generate-report appends to reports[] and sets active_report in the meeting
     summary: 'Existing summary',
     transcript: TRANSCRIPT,
   });
+  const sidecarPath = sidecarFor(summaryFile);
 
   const ollama = await startMockOllama({ chatReply: REPORT_REPLY });
   try {
@@ -94,18 +111,18 @@ test('generate-report appends to reports[] and sets active_report in the meeting
 
     expect(completed).toBe(true);
 
-    // Wait for the file to be written (STREAM_COMPLETE fires before _atomic_write_json).
+    // Wait for the sidecar to be written (STREAM_COMPLETE fires before atomic write).
     await expect
-      .poll(() => readSummary(summaryFile).reports?.length, { timeout: 15_000 })
+      .poll(() => readSidecar(sidecarPath).reports.length, { timeout: 15_000 })
       .toBe(1);
 
-    // Assert the on-disk JSON: reports[] appended, content verbatim, active_report set.
-    const updated = readSummary(summaryFile);
-    expect(updated.reports).toHaveLength(1);
-    expect(updated.reports[0].content).toContain('did the thing');
-    expect(updated.reports[0].content).toContain('Q2 up 15%');
-    expect(updated.reports[0].template_id).toBe(templateId);
-    expect(updated.active_report).toBe(updated.reports[0].id);
+    // Assert the sidecar on disk: reports[] appended, content verbatim, active_report set.
+    const sidecar = readSidecar(sidecarPath);
+    expect(sidecar.reports).toHaveLength(1);
+    expect(sidecar.reports[0].content).toContain('did the thing');
+    expect(sidecar.reports[0].content).toContain('Q2 up 15%');
+    expect(sidecar.reports[0].template_id).toBe(templateId);
+    expect(sidecar.active_report).toBe(sidecar.reports[0].id);
 
     // Keystone: the real user-data dir is byte-for-byte untouched.
     expect(fileSig(realUserDataDir())).toBe(realDirBefore);
@@ -126,6 +143,7 @@ test('generate-report with an unknown template surfaces failure and persists no 
     summary: 'Existing summary',
     transcript: TRANSCRIPT,
   });
+  const sidecarPath = sidecarFor(summaryFile);
 
   // Mock Ollama is started but should never be reached — the unknown-template
   // guard fails before any model call.
@@ -155,10 +173,10 @@ test('generate-report with an unknown template surfaces failure and persists no 
     expect(result.completed).toBe(true);
     expect(result.success).toBe(false);
 
-    // No report was persisted to the meeting JSON.
-    const updated = readSummary(summaryFile);
-    expect(updated.reports ?? []).toHaveLength(0);
-    expect(updated.active_report ?? null).toBeNull();
+    // No report was persisted to the sidecar (sidecar absent or empty).
+    const sidecar = readSidecar(sidecarPath);
+    expect(sidecar.reports).toHaveLength(0);
+    expect(sidecar.active_report).toBeNull();
 
     // Keystone: the real user-data dir is byte-for-byte untouched.
     expect(fileSig(realUserDataDir())).toBe(realDirBefore);

--- a/e2e/specs/generate-report.t2.spec.ts
+++ b/e2e/specs/generate-report.t2.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { readFileSync } from 'fs';
+
+/**
+ * T2 — generate-report persists into reports[] and sets active_report. Drives
+ * the real `generate-report` path (NO ASR, NO real model) with a capturing mock
+ * Ollama and asserts the two sides of the generate-report contract:
+ *   1. The markdown returned by the mock LLM is stored verbatim in
+ *      `reports[0].content` in the meeting `_summary.json`.
+ *   2. `active_report` is set to `reports[0].id` and `reports[0].template_id`
+ *      matches the template used.
+ *
+ * Model-free: the transcript is pre-seeded and the LLM is the mock, so no model
+ * loads. The isolation keystone (STENOAI_USER_DATA_DIR) prevents any write to the
+ * real ~/Library/Application Support/stenoai.
+ */
+
+const TRANSCRIPT =
+  'Alice: Q2 sales are up 15 percent. Bob: we need to hire two engineers.';
+
+// A fixed assistant reply: free-form markdown (no required section headers —
+// generate-report stores the content verbatim, no parse into sub-fields).
+const REPORT_REPLY = '## Status\n- did the thing\n- Q2 up 15%\n\n## Hires\n- 2 engineers needed';
+
+type GenerateReportResult = { success: boolean; error?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      generateReport: (summaryFile: string, templateId: string) => Promise<GenerateReportResult>;
+    };
+    templates: {
+      save: (template: Record<string, unknown>) => Promise<{ success: boolean; template?: { id: string } }>;
+      list: () => Promise<{ success: boolean; templates?: Array<{ id: string }> }>;
+    };
+    on: {
+      summaryComplete: (cb: (e: { success: boolean }) => void) => () => void;
+    };
+  };
+};
+
+const readSummary = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
+
+test('generate-report appends to reports[] and sets active_report in the meeting JSON', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Local provider so the summarizer talks to the mock Ollama on 11434.
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  const summaryFile = writeMeetingSummary(userDataDir, 'report-gen', {
+    name: 'Report Gen Meeting',
+    summary: 'Existing summary',
+    transcript: TRANSCRIPT,
+  });
+
+  const ollama = await startMockOllama({ chatReply: REPORT_REPLY });
+  try {
+    const { page } = await launchApp();
+
+    // Create a custom template via the bridge and read back its generated id.
+    const saveRes = await page.evaluate(
+      () =>
+        (window as StenoWindow).stenoai.templates.save({
+          name: 'Test Status Template',
+          prompt: 'Write a concise status report covering key outcomes and next steps.',
+          language: 'auto',
+        }),
+    );
+    expect(saveRes.success).toBe(true);
+    const templateId = saveRes.template?.id;
+    expect(templateId).toBeTruthy();
+
+    // Drive generate-report and wait for summaryComplete.
+    const completed: boolean = await page.evaluate(
+      ([f, tid]) =>
+        new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(false), 30_000);
+          const w = window as unknown as StenoWindow;
+          const off = w.stenoai.on.summaryComplete((e) => {
+            if (e && e.success) {
+              clearTimeout(timer);
+              off();
+              resolve(true);
+            }
+          });
+          w.stenoai.meetings.generateReport(f, tid);
+        }),
+      [summaryFile, templateId] as [string, string],
+    );
+
+    expect(completed).toBe(true);
+
+    // Wait for the file to be written (STREAM_COMPLETE fires before _atomic_write_json).
+    await expect
+      .poll(() => readSummary(summaryFile).reports?.length, { timeout: 15_000 })
+      .toBe(1);
+
+    // Assert the on-disk JSON: reports[] appended, content verbatim, active_report set.
+    const updated = readSummary(summaryFile);
+    expect(updated.reports).toHaveLength(1);
+    expect(updated.reports[0].content).toContain('did the thing');
+    expect(updated.reports[0].content).toContain('Q2 up 15%');
+    expect(updated.reports[0].template_id).toBe(templateId);
+    expect(updated.active_report).toBe(updated.reports[0].id);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});

--- a/e2e/specs/generate-report.t2.spec.ts
+++ b/e2e/specs/generate-report.t2.spec.ts
@@ -113,3 +113,56 @@ test('generate-report appends to reports[] and sets active_report in the meeting
     await ollama.close();
   }
 });
+
+test('generate-report with an unknown template surfaces failure and persists no report', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  const summaryFile = writeMeetingSummary(userDataDir, 'report-gen-fail', {
+    name: 'Report Gen Fail Meeting',
+    summary: 'Existing summary',
+    transcript: TRANSCRIPT,
+  });
+
+  // Mock Ollama is started but should never be reached — the unknown-template
+  // guard fails before any model call.
+  const ollama = await startMockOllama({ chatReply: REPORT_REPLY });
+  try {
+    const { page } = await launchApp();
+
+    // Drive generate-report with a template id that does not exist and wait for
+    // the completion event. It must arrive with success:false (mirroring the
+    // first spec's summaryComplete listener), not silently succeed.
+    const result: { completed: boolean; success: boolean } = await page.evaluate(
+      ([f]) =>
+        new Promise<{ completed: boolean; success: boolean }>((resolve) => {
+          const timer = setTimeout(() => resolve({ completed: false, success: false }), 30_000);
+          const w = window as unknown as StenoWindow;
+          const off = w.stenoai.on.summaryComplete((e) => {
+            clearTimeout(timer);
+            off();
+            resolve({ completed: true, success: !!(e && e.success) });
+          });
+          w.stenoai.meetings.generateReport(f, 'does-not-exist');
+        }),
+      [summaryFile] as [string],
+    );
+
+    // The completion event arrived and reported failure (not silent success).
+    expect(result.completed).toBe(true);
+    expect(result.success).toBe(false);
+
+    // No report was persisted to the meeting JSON.
+    const updated = readSummary(summaryFile);
+    expect(updated.reports ?? []).toHaveLength(0);
+    expect(updated.active_report ?? null).toBeNull();
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});

--- a/e2e/specs/report-md.t2.spec.ts
+++ b/e2e/specs/report-md.t2.spec.ts
@@ -43,6 +43,7 @@ type StenoWindow = Window & {
       get: (summaryFile: string) => Promise<{ success: boolean; meeting?: Meeting }>;
       setActiveReport: (summaryFile: string, reportId: string) => Promise<{ success: boolean }>;
       deleteReport: (summaryFile: string, reportId: string) => Promise<{ success: boolean }>;
+      reprocess: (summaryFile: string, regenTitle: boolean, name: string) => Promise<{ success: boolean; error?: string }>;
     };
     templates: {
       save: (template: Record<string, unknown>) => Promise<{ success: boolean; template?: { id: string } }>;
@@ -185,6 +186,86 @@ test('generate-report on a .md meeting writes the sidecar and get-meeting merges
     expect(getAfterDelete.success).toBe(true);
     expect(getAfterDelete.meeting?.reports ?? []).toHaveLength(0);
     expect(getAfterDelete.meeting?.active_report ?? null).toBeNull();
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});
+
+/**
+ * Fix 1 (#249) — reprocessing a REAL `.md` meeting must snapshot the prior
+ * Standard note into the sidecar as a `standard-backup`. Before the fix the
+ * snapshot lived only in the `.json` branch, so a `.md` reprocess silently lost
+ * the previous summary. Model-free: mock-ollama returns a new summary markdown.
+ */
+
+// Mock LLM reply that becomes the new live `.md` summary on reprocess.
+const MD_REPROCESS_REPLY = [
+  '## Summary',
+  'Regenerated Q2 summary.',
+  '',
+  '## Key Points',
+  '- Reprocessed',
+].join('\n');
+
+test('reprocessing a .md meeting backs up the prior Standard note into the sidecar', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  const summaryFile = writeMeetingMarkdown(userDataDir, 'md-reprocess-backup', {
+    name: 'MD Reprocess Backup Meeting',
+    summaryMarkdown: SUMMARY_MARKDOWN,
+    transcript: TRANSCRIPT,
+  });
+  const sidecarPath = sidecarFor(summaryFile);
+
+  const ollama = await startMockOllama({ chatReply: MD_REPROCESS_REPLY });
+  try {
+    const { page } = await launchApp();
+
+    const completed: boolean = await page.evaluate(
+      ([f, name]) =>
+        new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(false), 30_000);
+          const w = window as unknown as StenoWindow;
+          const off = w.stenoai.on.summaryComplete((e) => {
+            if (e && e.success) {
+              clearTimeout(timer);
+              off();
+              resolve(true);
+            }
+          });
+          w.stenoai.meetings.reprocess(f, false, name);
+        }),
+      [summaryFile, 'MD Reprocess Backup Meeting'] as [string, string],
+    );
+    expect(completed).toBe(true);
+
+    // The `.md` file is rewritten with the new summary.
+    await expect
+      .poll(() => readFileSync(summaryFile, 'utf8').includes('Regenerated Q2 summary.'), {
+        timeout: 15_000,
+      })
+      .toBe(true);
+
+    // A standard-backup of the PRIOR note now lands in the sidecar.
+    await expect
+      .poll(() => readSidecar(sidecarPath).reports.length, { timeout: 15_000 })
+      .toBe(1);
+
+    const sidecar = readSidecar(sidecarPath);
+    const backup = sidecar.reports[0];
+    expect(backup.template_id).toBe('standard-backup');
+    // The backup captured the prior summary markdown, not the new one.
+    expect(backup.content).toContain('Pipeline strong');
+    expect(backup.content).not.toContain('Regenerated Q2 summary.');
+    // active_report stays null so the live (regenerated) note is the default view.
+    expect(sidecar.active_report ?? null).toBeNull();
 
     // Keystone: the real user-data dir is byte-for-byte untouched.
     expect(fileSig(realUserDataDir())).toBe(realDirBefore);

--- a/e2e/specs/report-md.t2.spec.ts
+++ b/e2e/specs/report-md.t2.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig, writeMeetingMarkdown } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — generate-report on a REAL `.md` meeting writes a sidecar (`_reports.json`)
+ * and get-meeting merges it back. This is the bug class the `.json`-seeded spec
+ * missed: the old path stored reports in the meeting JSON itself; the new path
+ * uses a `<stem>_reports.json` sidecar alongside the `.md` file.
+ *
+ * Test contract:
+ *  1. `generateReport(mdFile, templateId)` writes `<stem>_reports.json` next to
+ *     the `.md` file (NOT inline in the `.md`).
+ *  2. `get-meeting(mdFile)` returns `reports` (length 1) and `active_report`
+ *     from the sidecar.
+ *  3. `setActiveReport` + `deleteReport` each mutate only the sidecar.
+ *
+ * Model-free: mock-ollama replies with a fixed string; no ASR.
+ */
+
+const TRANSCRIPT =
+  'Alice: Q2 pipeline looks strong. Bob: we should hire three engineers by Q3.';
+
+const SUMMARY_MARKDOWN =
+  '## Summary\n\nQ2 pipeline reviewed. Hiring plans discussed.\n\n## Key Points\n\n- Pipeline strong\n- 3 hires planned';
+
+const REPORT_REPLY =
+  '## Status Report\n- Pipeline healthy\n- 3 engineers needed by Q3\n\n## Next Steps\n- Open reqs ASAP';
+
+type GenerateReportResult = { success: boolean; error?: string };
+type Report = { id: string; template_id: string; content: string };
+type Meeting = {
+  reports?: Report[];
+  active_report?: string | null;
+};
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      generateReport: (summaryFile: string, templateId: string) => Promise<GenerateReportResult>;
+      get: (summaryFile: string) => Promise<{ success: boolean; meeting?: Meeting }>;
+      setActiveReport: (summaryFile: string, reportId: string) => Promise<{ success: boolean }>;
+      deleteReport: (summaryFile: string, reportId: string) => Promise<{ success: boolean }>;
+    };
+    templates: {
+      save: (template: Record<string, unknown>) => Promise<{ success: boolean; template?: { id: string } }>;
+      list: () => Promise<{ success: boolean; templates?: Array<{ id: string; name: string }> }>;
+    };
+    on: {
+      summaryComplete: (cb: (e: { success: boolean }) => void) => () => void;
+    };
+  };
+};
+
+const readSidecar = (sidecarPath: string): { reports: Report[]; active_report: string | null } => {
+  if (!existsSync(sidecarPath)) return { reports: [], active_report: null };
+  return JSON.parse(readFileSync(sidecarPath, 'utf8'));
+};
+
+/** Derive the sidecar path from a `*_summary.md` path. */
+const sidecarFor = (summaryFile: string): string => {
+  const dir = path.dirname(summaryFile);
+  const base = path.basename(summaryFile, '.md'); // e.g. 'meeting_summary'
+  const stem = base.endsWith('_summary') ? base.slice(0, -'_summary'.length) : base;
+  return path.join(dir, `${stem}_reports.json`);
+};
+
+test('generate-report on a .md meeting writes the sidecar and get-meeting merges it', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  const summaryFile = writeMeetingMarkdown(userDataDir, 'md-report-gen', {
+    name: 'MD Report Gen Meeting',
+    summaryMarkdown: SUMMARY_MARKDOWN,
+    transcript: TRANSCRIPT,
+  });
+  const sidecarPath = sidecarFor(summaryFile);
+
+  const ollama = await startMockOllama({ chatReply: REPORT_REPLY });
+  try {
+    const { page } = await launchApp();
+
+    // Create a template so we have a valid templateId.
+    const saveRes = await page.evaluate(
+      () =>
+        (window as StenoWindow).stenoai.templates.save({
+          name: 'MD Status Template',
+          prompt: 'Write a concise status report covering key outcomes and next steps.',
+          language: 'auto',
+        }),
+    );
+    expect(saveRes.success).toBe(true);
+    const templateId = saveRes.template?.id;
+    expect(templateId).toBeTruthy();
+
+    // Drive generate-report and wait for summaryComplete.
+    const completed: boolean = await page.evaluate(
+      ([f, tid]) =>
+        new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(false), 30_000);
+          const w = window as unknown as StenoWindow;
+          const off = w.stenoai.on.summaryComplete((e) => {
+            if (e && e.success) {
+              clearTimeout(timer);
+              off();
+              resolve(true);
+            }
+          });
+          w.stenoai.meetings.generateReport(f, tid);
+        }),
+      [summaryFile, templateId] as [string, string],
+    );
+
+    expect(completed).toBe(true);
+
+    // Wait for the sidecar to appear on disk (STREAM_COMPLETE fires before atomic write).
+    await expect
+      .poll(() => readSidecar(sidecarPath).reports.length, { timeout: 15_000 })
+      .toBe(1);
+
+    // ── Assertion 1: sidecar on disk is correct ────────────────────────────
+    const sidecar = readSidecar(sidecarPath);
+    expect(sidecar.reports).toHaveLength(1);
+    expect(sidecar.reports[0].content).toContain('Pipeline healthy');
+    expect(sidecar.reports[0].content).toContain('3 engineers needed');
+    expect(sidecar.reports[0].template_id).toBe(templateId);
+    expect(sidecar.active_report).toBe(sidecar.reports[0].id);
+    const reportId = sidecar.reports[0].id;
+
+    // ── Assertion 2: the .md file itself is NOT modified ──────────────────
+    const mdContent = readFileSync(summaryFile, 'utf8');
+    expect(mdContent).not.toContain('reports');
+    expect(mdContent).not.toContain(reportId);
+
+    // ── Assertion 3: get-meeting merges the sidecar ───────────────────────
+    const getRes = await page.evaluate(
+      ([f]) => (window as unknown as StenoWindow).stenoai.meetings.get(f),
+      [summaryFile] as [string],
+    );
+    expect(getRes.success).toBe(true);
+    expect(getRes.meeting?.reports).toHaveLength(1);
+    expect(getRes.meeting?.reports?.[0].content).toContain('Pipeline healthy');
+    expect(getRes.meeting?.active_report).toBe(reportId);
+
+    // ── Assertion 4: setActiveReport mutates the sidecar ─────────────────
+    // 'standard' is not a real id in this meeting; calling set-active-report
+    // with a non-existent id should fail gracefully (the backend returns
+    // success:false). We instead call with the real reportId to prove a round-
+    // trip that leaves the sidecar consistent, then verify.
+    const setRes = await page.evaluate(
+      ([f, rid]) => (window as unknown as StenoWindow).stenoai.meetings.setActiveReport(f, rid),
+      [summaryFile, reportId] as [string, string],
+    );
+    expect(setRes.success).toBe(true);
+
+    await expect
+      .poll(() => readSidecar(sidecarPath).active_report, { timeout: 5_000 })
+      .toBe(reportId);
+
+    // ── Assertion 5: deleteReport removes the report from the sidecar ─────
+    const delRes = await page.evaluate(
+      ([f, rid]) => (window as unknown as StenoWindow).stenoai.meetings.deleteReport(f, rid),
+      [summaryFile, reportId] as [string, string],
+    );
+    expect(delRes.success).toBe(true);
+
+    await expect
+      .poll(() => readSidecar(sidecarPath).reports.length, { timeout: 5_000 })
+      .toBe(0);
+
+    const afterDelete = readSidecar(sidecarPath);
+    expect(afterDelete.reports).toHaveLength(0);
+    expect(afterDelete.active_report).toBeNull();
+
+    // ── Final: get-meeting reflects the deletion ──────────────────────────
+    const getAfterDelete = await page.evaluate(
+      ([f]) => (window as unknown as StenoWindow).stenoai.meetings.get(f),
+      [summaryFile] as [string],
+    );
+    expect(getAfterDelete.success).toBe(true);
+    expect(getAfterDelete.meeting?.reports ?? []).toHaveLength(0);
+    expect(getAfterDelete.meeting?.active_report ?? null).toBeNull();
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});

--- a/e2e/specs/report-versions.t2.spec.ts
+++ b/e2e/specs/report-versions.t2.spec.ts
@@ -2,17 +2,18 @@ import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
 import { startMockOllama } from '../fixtures/mock-ollama';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
 
 /**
  * T2 — report-versions round-trip. Drives `reprocess` (NO ASR, NO real model)
  * with a capturing mock Ollama and asserts the full versions contract:
- *   1. reprocess snapshots the prior Standard note into `reports[]` as a backup
- *      (template_id 'standard-backup', non-empty content) and writes the new
- *      mock LLM output as the live summary.
- *   2. setActiveReport(backupId) → active_report === backupId on disk.
- *   3. setActiveReport('standard') → active_report === null on disk.
- *   4. deleteReport(backupId) → reports[] is empty on disk.
+ *   1. reprocess snapshots the prior Standard note into the sidecar (`<stem>_reports.json`)
+ *      as a backup (template_id 'standard-backup', non-empty content) and writes the new
+ *      mock LLM output as the live summary in the meeting JSON.
+ *   2. setActiveReport(backupId) → active_report === backupId in the sidecar.
+ *   3. setActiveReport('standard') → active_report === null in the sidecar.
+ *   4. deleteReport(backupId) → reports[] is empty in the sidecar.
  *
  * Model-free: the transcript is pre-seeded and the LLM is the mock.
  * The isolation keystone (STENOAI_USER_DATA_DIR) prevents writes to the real
@@ -53,6 +54,21 @@ type StenoWindow = Window & {
 
 const readSummary = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
 
+type Report = { id: string; template_id: string; content: string };
+
+const readSidecar = (sidecarPath: string): { reports: Report[]; active_report: string | null } => {
+  if (!existsSync(sidecarPath)) return { reports: [], active_report: null };
+  return JSON.parse(readFileSync(sidecarPath, 'utf8'));
+};
+
+/** Derive the sidecar path from a `*_summary.json` path. */
+const sidecarFor = (summaryFile: string): string => {
+  const dir = path.dirname(summaryFile);
+  const base = path.basename(summaryFile, '.json'); // e.g. 'report-versions_summary'
+  const stem = base.endsWith('_summary') ? base.slice(0, -'_summary'.length) : base;
+  return path.join(dir, `${stem}_reports.json`);
+};
+
 test('reprocess backup + set-active + delete round-trip', async ({
   launchApp,
   userDataDir,
@@ -66,6 +82,7 @@ test('reprocess backup + set-active + delete round-trip', async ({
     summary: SEEDED_SUMMARY,
     transcript: TRANSCRIPT,
   });
+  const sidecarPath = sidecarFor(summaryFile);
 
   const ollama = await startMockOllama({ chatReply: REPROCESS_REPLY });
   try {
@@ -91,23 +108,27 @@ test('reprocess backup + set-active + delete round-trip', async ({
 
     expect(completed).toBe(true);
 
-    // Poll until the file reflects the new live summary (written after STREAM_COMPLETE).
+    // Poll until the meeting JSON reflects the new live summary (written after STREAM_COMPLETE).
     await expect
       .poll(() => readSummary(summaryFile).summary, { timeout: 15_000 })
       .toBe('new summary');
 
-    // Assert backup: exactly one entry with template_id 'standard-backup' and
-    // non-empty content (the pre-existing summary was captured as markdown).
-    const afterReprocess = readSummary(summaryFile);
-    expect(afterReprocess.reports).toHaveLength(1);
-    const backup = afterReprocess.reports[0];
+    // Assert backup in the sidecar: exactly one entry with template_id 'standard-backup'
+    // and non-empty content (the pre-existing summary was captured as markdown).
+    await expect
+      .poll(() => readSidecar(sidecarPath).reports.length, { timeout: 10_000 })
+      .toBe(1);
+
+    const sidecarAfterReprocess = readSidecar(sidecarPath);
+    expect(sidecarAfterReprocess.reports).toHaveLength(1);
+    const backup = sidecarAfterReprocess.reports[0];
     expect(backup.template_id).toBe('standard-backup');
     expect(backup.content.trim()).not.toBe('');
     // The backup content is derived from the seeded summary.
     expect(backup.content).toContain('Old Q2 summary');
 
     // active_report is null after reprocess (live Standard note is the default view).
-    expect(afterReprocess.active_report ?? null).toBeNull();
+    expect(sidecarAfterReprocess.active_report ?? null).toBeNull();
 
     const backupId = backup.id as string;
     expect(backupId).toBeTruthy();
@@ -119,9 +140,9 @@ test('reprocess backup + set-active + delete round-trip', async ({
     );
     expect(setRes.success).toBe(true);
 
-    // Poll until active_report is the backup id on disk.
+    // Poll until active_report is the backup id in the sidecar.
     await expect
-      .poll(() => readSummary(summaryFile).active_report, { timeout: 10_000 })
+      .poll(() => readSidecar(sidecarPath).active_report, { timeout: 10_000 })
       .toBe(backupId);
 
     // --- Step 3: setActiveReport back to 'standard' ---
@@ -131,9 +152,9 @@ test('reprocess backup + set-active + delete round-trip', async ({
     );
     expect(clearRes.success).toBe(true);
 
-    // Poll until active_report is null on disk.
+    // Poll until active_report is null in the sidecar.
     await expect
-      .poll(() => readSummary(summaryFile).active_report ?? null, { timeout: 10_000 })
+      .poll(() => readSidecar(sidecarPath).active_report ?? null, { timeout: 10_000 })
       .toBeNull();
 
     // --- Step 4: deleteReport ---
@@ -143,9 +164,9 @@ test('reprocess backup + set-active + delete round-trip', async ({
     );
     expect(delRes.success).toBe(true);
 
-    // Poll until reports[] is empty on disk.
+    // Poll until reports[] is empty in the sidecar.
     await expect
-      .poll(() => readSummary(summaryFile).reports?.length ?? 0, { timeout: 10_000 })
+      .poll(() => readSidecar(sidecarPath).reports.length, { timeout: 10_000 })
       .toBe(0);
 
     // Keystone: the real user-data dir is byte-for-byte untouched.

--- a/e2e/specs/report-versions.t2.spec.ts
+++ b/e2e/specs/report-versions.t2.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { readFileSync } from 'fs';
+
+/**
+ * T2 — report-versions round-trip. Drives `reprocess` (NO ASR, NO real model)
+ * with a capturing mock Ollama and asserts the full versions contract:
+ *   1. reprocess snapshots the prior Standard note into `reports[]` as a backup
+ *      (template_id 'standard-backup', non-empty content) and writes the new
+ *      mock LLM output as the live summary.
+ *   2. setActiveReport(backupId) → active_report === backupId on disk.
+ *   3. setActiveReport('standard') → active_report === null on disk.
+ *   4. deleteReport(backupId) → reports[] is empty on disk.
+ *
+ * Model-free: the transcript is pre-seeded and the LLM is the mock.
+ * The isolation keystone (STENOAI_USER_DATA_DIR) prevents writes to the real
+ * ~/Library/Application Support/stenoai.
+ */
+
+const TRANSCRIPT =
+  'Alice: Q2 sales are up 15 percent. Bob: we need to hire two engineers.';
+
+// Pre-existing summary that will become the backup content.
+const SEEDED_SUMMARY = 'Old Q2 summary that will be snapshotted as backup.';
+
+// Mock LLM reply in the format _parse_streamed_markdown keys on.
+const REPROCESS_REPLY = [
+  '## Summary',
+  'new summary',
+  '',
+  '## Key Points',
+  '- kp',
+  '',
+].join('\n');
+
+type ReprocessResult = { success: boolean; error?: string };
+type SetActiveResult = { success: boolean; error?: string };
+type DeleteResult = { success: boolean; error?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      reprocess: (summaryFile: string, regenTitle: boolean, name: string) => Promise<ReprocessResult>;
+      setActiveReport: (summaryFile: string, reportId: string) => Promise<SetActiveResult>;
+      deleteReport: (summaryFile: string, reportId: string) => Promise<DeleteResult>;
+    };
+    on: {
+      summaryComplete: (cb: (e: { success: boolean }) => void) => () => void;
+    };
+  };
+};
+
+const readSummary = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
+
+test('reprocess backup + set-active + delete round-trip', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Local provider so the summarizer talks to mock Ollama on 11434.
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  const summaryFile = writeMeetingSummary(userDataDir, 'report-versions', {
+    name: 'Report Versions Meeting',
+    summary: SEEDED_SUMMARY,
+    transcript: TRANSCRIPT,
+  });
+
+  const ollama = await startMockOllama({ chatReply: REPROCESS_REPLY });
+  try {
+    const { page } = await launchApp();
+
+    // --- Step 1: reprocess and wait for summaryComplete ---
+    const completed: boolean = await page.evaluate(
+      ([f, name]) =>
+        new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(false), 30_000);
+          const w = window as unknown as StenoWindow;
+          const off = w.stenoai.on.summaryComplete((e) => {
+            if (e && e.success) {
+              clearTimeout(timer);
+              off();
+              resolve(true);
+            }
+          });
+          w.stenoai.meetings.reprocess(f, false, name);
+        }),
+      [summaryFile, 'Report Versions Meeting'] as [string, string],
+    );
+
+    expect(completed).toBe(true);
+
+    // Poll until the file reflects the new live summary (written after STREAM_COMPLETE).
+    await expect
+      .poll(() => readSummary(summaryFile).summary, { timeout: 15_000 })
+      .toBe('new summary');
+
+    // Assert backup: exactly one entry with template_id 'standard-backup' and
+    // non-empty content (the pre-existing summary was captured as markdown).
+    const afterReprocess = readSummary(summaryFile);
+    expect(afterReprocess.reports).toHaveLength(1);
+    const backup = afterReprocess.reports[0];
+    expect(backup.template_id).toBe('standard-backup');
+    expect(backup.content.trim()).not.toBe('');
+    // The backup content is derived from the seeded summary.
+    expect(backup.content).toContain('Old Q2 summary');
+
+    // active_report is null after reprocess (live Standard note is the default view).
+    expect(afterReprocess.active_report ?? null).toBeNull();
+
+    const backupId = backup.id as string;
+    expect(backupId).toBeTruthy();
+
+    // --- Step 2: setActiveReport to the backup ---
+    const setRes = await page.evaluate(
+      ([f, id]) => (window as unknown as StenoWindow).stenoai.meetings.setActiveReport(f, id),
+      [summaryFile, backupId] as [string, string],
+    );
+    expect(setRes.success).toBe(true);
+
+    // Poll until active_report is the backup id on disk.
+    await expect
+      .poll(() => readSummary(summaryFile).active_report, { timeout: 10_000 })
+      .toBe(backupId);
+
+    // --- Step 3: setActiveReport back to 'standard' ---
+    const clearRes = await page.evaluate(
+      ([f]) => (window as unknown as StenoWindow).stenoai.meetings.setActiveReport(f, 'standard'),
+      [summaryFile] as [string],
+    );
+    expect(clearRes.success).toBe(true);
+
+    // Poll until active_report is null on disk.
+    await expect
+      .poll(() => readSummary(summaryFile).active_report ?? null, { timeout: 10_000 })
+      .toBeNull();
+
+    // --- Step 4: deleteReport ---
+    const delRes = await page.evaluate(
+      ([f, id]) => (window as unknown as StenoWindow).stenoai.meetings.deleteReport(f, id),
+      [summaryFile, backupId] as [string, string],
+    );
+    expect(delRes.success).toBe(true);
+
+    // Poll until reports[] is empty on disk.
+    await expect
+      .poll(() => readSummary(summaryFile).reports?.length ?? 0, { timeout: 10_000 })
+      .toBe(0);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});

--- a/e2e/specs/templates-crud.t2.spec.ts
+++ b/e2e/specs/templates-crud.t2.spec.ts
@@ -1,0 +1,75 @@
+// e2e/specs/templates-crud.t2.spec.ts
+import { test, expect } from '../fixtures/electron';
+import { readUserConfig } from '../fixtures/user-config';
+
+type Tmpl = { id: string; name: string; builtin: boolean; locked: boolean };
+type ListResult = { success: boolean; templates: Tmpl[]; default_template_id: string };
+type SaveResult = { success: boolean; template?: { id: string }; error?: string };
+type Result = { success?: boolean };
+
+type StenoWindow = Window & {
+  stenoai: {
+    templates: {
+      list: () => Promise<ListResult>;
+      save: (t: Record<string, unknown>) => Promise<SaveResult>;
+      remove: (id: string) => Promise<Result>;
+      setDefault: (id: string) => Promise<Result>;
+      reset: (id: string) => Promise<Result>;
+    };
+  };
+};
+
+test('templates: list ships Standard + seeded sample; default is Standard', async ({
+  launchApp, userDataDir,
+}) => {
+  const { page } = await launchApp();
+  const data = await page.evaluate(() =>
+    (window as unknown as StenoWindow).stenoai.templates.list());
+  expect(data.success).toBe(true);
+  const ids = data.templates.map((t) => t.id);
+  expect(ids).toContain('standard');
+  expect(ids).toContain('shareable-summary');
+  expect(data.default_template_id).toBe('standard');
+  // standard is a locked built-in
+  expect(data.templates.find((t) => t.id === 'standard')?.locked).toBe(true);
+});
+
+test('templates: create custom, set default, delete; persisted to config.json', async ({
+  launchApp, userDataDir,
+}) => {
+  const { page } = await launchApp();
+  const win = () => (window as unknown as StenoWindow).stenoai.templates;
+
+  const saved = await page.evaluate(() =>
+    (window as unknown as StenoWindow).stenoai.templates.save({
+      name: 'Leitung', prompt: 'kurz halten', language: 'de',
+    }));
+  expect(saved.success).toBe(true);
+  const id = saved.template!.id;
+
+  await page.evaluate((tid) =>
+    (window as unknown as StenoWindow).stenoai.templates.setDefault(tid), id);
+
+  await expect.poll(() => readUserConfig(userDataDir).default_template_id).toBe(id);
+  expect(readUserConfig(userDataDir).custom_templates).toEqual(
+    expect.arrayContaining([expect.objectContaining({ id, prompt: 'kurz halten' })]),
+  );
+
+  await page.evaluate((tid) =>
+    (window as unknown as StenoWindow).stenoai.templates.remove(tid), id);
+  await expect
+    .poll(() => (readUserConfig(userDataDir).custom_templates as Tmpl[]).map((t) => t.id))
+    .not.toContain(id);
+  // deleting the default falls back to standard
+  await expect.poll(() => readUserConfig(userDataDir).default_template_id).toBe('standard');
+});
+
+test('templates: locked Standard rejects an edit', async ({ launchApp }) => {
+  const { page } = await launchApp();
+  const res = await page.evaluate(() =>
+    (window as unknown as StenoWindow).stenoai.templates.save({
+      id: 'standard', name: 'X', prompt: 'hack', language: 'auto',
+    }));
+  expect(res.success).toBe(false);
+  expect((res.error ?? '').toLowerCase()).toContain('locked');
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2177,12 +2177,11 @@ def delete_report(summary_file, report_id):
 @click.argument('summary_file', required=True)
 @click.argument('template_id', required=True)
 def generate_report(summary_file, template_id):
-    """Generate a template-based report and append it to the meeting JSON."""
-    import json
+    """Generate a template-based report and write it to the meeting sidecar."""
     import base64
-    import src.reports
-
+    from src import report_store, reports as _rpts
     from src.config import get_config
+
     recorder = MeetingPipeline()
     summary_path = Path(summary_file)
 
@@ -2191,8 +2190,7 @@ def generate_report(summary_file, template_id):
         sys.exit(1)
 
     try:
-        with open(summary_path, 'r') as f:
-            existing_data = json.load(f)
+        meeting = report_store.read_meeting(summary_path)
     except Exception as e:
         print(f"ERROR: Failed to load summary file: {e}")
         sys.exit(1)
@@ -2205,31 +2203,22 @@ def generate_report(summary_file, template_id):
         print("STREAM_ERROR:Unknown template", flush=True)
         sys.exit(1)
 
-    transcript = existing_data.get('transcript', '')
+    transcript = meeting["transcript"]
     if not transcript:
         print("ERROR: No transcript found in summary file")
         sys.exit(1)
 
-    duration_minutes = existing_data.get('session_info', {}).get('duration_minutes', 10)
-    if duration_minutes is None:
-        ds = existing_data.get('session_info', {}).get('duration_seconds')
-        duration_minutes = int(ds / 60) if ds else 10
-
-    notes_text = existing_data.get('user_notes')
+    duration_minutes = meeting["duration_minutes"] or 10
+    notes_text = meeting["notes"]
 
     # Resolve output language: template language takes precedence over "auto"
     if tmpl.get("language") and tmpl["language"] != "auto":
         output_language = tmpl["language"]
     else:
-        existing_session_info = existing_data.get("session_info", {})
-        output_language = existing_session_info.get("output_language")
+        output_language = meeting["language"]
         if not output_language:
-            configured_language = existing_session_info.get("configured_language")
-            if not configured_language:
-                configured_language = config.get_language()
             output_language = recorder._resolve_output_language(
-                configured_language,
-                existing_session_info.get("detected_language")
+                config.get_language(), None
             )
 
     if recorder.summarizer is None:
@@ -2269,15 +2258,16 @@ def generate_report(summary_file, template_id):
         print("STREAM_ERROR:Model returned an empty report", flush=True)
         sys.exit(1)
 
-    # Write the meeting JSON BEFORE emitting STREAM_COMPLETE so the renderer's
+    # Write the sidecar BEFORE emitting STREAM_COMPLETE so the renderer's
     # refetch (triggered by the completion event) never reads stale data.
-    report = src.reports.make_report(
+    sidecar = report_store.load_sidecar(summary_path)
+    report = _rpts.make_report(
         template_id, tmpl["name"], recorder.summarizer.model_name, streamed_md
     )
-    src.reports.append_report(existing_data, report)
-    _atomic_write_json(summary_path, existing_data)
+    _rpts.append_report(sidecar, report)
+    report_store.save_sidecar(summary_path, sidecar)
     print("STREAM_COMPLETE", flush=True)
-    print(f"SAVED:{summary_path}")
+    print(f"SAVED:{report_store.sidecar_path(summary_path)}")
 
 
 @cli.command('regen-title')

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -745,6 +745,41 @@ Transcript:
         }
 
 
+def generate_default_template_report(summary_path, transcript, notes, language,
+                                     duration_minutes, config, summarizer):
+    """Best-effort: if the configured default template is not 'standard', generate
+    its report into the meeting's sidecar and make it active. Additive — the
+    Standard note is untouched. Never raises (a new recording must not fail because
+    of the extra report)."""
+    from src import reports as _reports
+    from src import report_store as _store
+    try:
+        tid = config.get_default_template_id()
+        if not tid or tid == "standard":
+            return None
+        tmpl = config.get_template(tid)
+        if not tmpl or not (tmpl.get("prompt") or "").strip():
+            return None
+        report_language = tmpl["language"] if tmpl.get("language") and tmpl["language"] != "auto" else language
+        chunks = []
+        for chunk in summarizer.summarize_transcript_streaming(
+            transcript, duration_minutes, report_language, notes,
+            template_prompt=tmpl["prompt"],
+        ):
+            chunks.append(chunk)
+        content = "".join(chunks).strip()
+        if not content:
+            return None
+        sidecar = _store.load_sidecar(summary_path)
+        report = _reports.make_report(tid, tmpl["name"], summarizer.model_name, content)
+        _reports.append_report(sidecar, report)
+        _store.save_sidecar(summary_path, sidecar)
+        return report
+    except Exception as e:
+        logger.warning(f"Default-template report generation skipped: {e}")
+        return None
+
+
 # CLI Commands for Electron
 @click.group()
 def cli():
@@ -950,6 +985,14 @@ def process_streaming(audio_file, name, notes):
                 pass
 
         print(f"SAVED:{summary_path}", flush=True)
+
+        # B3: if a non-Standard default template is configured, additionally
+        # generate its report into the sidecar (best-effort; the Standard note
+        # is already saved above).
+        generate_default_template_report(
+            summary_path, text_for_summary, notes_text, output_language,
+            duration_minutes, config, recorder.summarizer,
+        )
 
     asyncio.run(run())
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2208,6 +2208,9 @@ def reprocess(summary_file, regenerate_title):
 def set_active_report(summary_file, report_id):
     """Persist which report version is shown (report_id 'standard' clears it)."""
     from src import report_store, reports as _reports
+    if not Path(summary_file).exists():
+        print(json.dumps({"success": False, "error": "Summary file not found"}))
+        sys.exit(1)
     sidecar = report_store.load_sidecar(summary_file)
     ok = _reports.set_active(sidecar, report_id)
     if ok:
@@ -2223,6 +2226,9 @@ def set_active_report(summary_file, report_id):
 def delete_report(summary_file, report_id):
     """Delete a saved report version from a meeting."""
     from src import report_store, reports as _reports
+    if not Path(summary_file).exists():
+        print(json.dumps({"success": False, "error": "Summary file not found"}))
+        sys.exit(1)
     sidecar = report_store.load_sidecar(summary_file)
     ok = _reports.remove_report(sidecar, report_id)
     if ok:

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2123,6 +2123,106 @@ def reprocess(summary_file, regenerate_title):
         sys.exit(1)
 
 
+@cli.command(name='generate-report')
+@click.argument('summary_file', required=True)
+@click.argument('template_id', required=True)
+def generate_report(summary_file, template_id):
+    """Generate a template-based report and append it to the meeting JSON."""
+    import json
+    import base64
+    import src.reports
+
+    from src.config import get_config
+    recorder = MeetingPipeline()
+    summary_path = Path(summary_file)
+
+    if not summary_path.exists():
+        print(f"ERROR: Summary file not found: {summary_file}")
+        sys.exit(1)
+
+    try:
+        with open(summary_path, 'r') as f:
+            existing_data = json.load(f)
+    except Exception as e:
+        print(f"ERROR: Failed to load summary file: {e}")
+        sys.exit(1)
+
+    # Unknown template → IPC contract: exit 0 with JSON error
+    config = get_config()
+    tmpl = config.get_template(template_id)
+    if tmpl is None:
+        print(json.dumps({"success": False, "error": "Unknown template"}))
+        return
+
+    transcript = existing_data.get('transcript', '')
+    if not transcript:
+        print("ERROR: No transcript found in summary file")
+        sys.exit(1)
+
+    duration_minutes = existing_data.get('session_info', {}).get('duration_minutes', 10)
+    if duration_minutes is None:
+        ds = existing_data.get('session_info', {}).get('duration_seconds')
+        duration_minutes = int(ds / 60) if ds else 10
+
+    notes_text = existing_data.get('user_notes')
+
+    # Resolve output language: template language takes precedence over "auto"
+    if tmpl.get("language") and tmpl["language"] != "auto":
+        output_language = tmpl["language"]
+    else:
+        existing_session_info = existing_data.get("session_info", {})
+        output_language = existing_session_info.get("output_language")
+        if not output_language:
+            configured_language = existing_session_info.get("configured_language")
+            if not configured_language:
+                configured_language = config.get_language()
+            output_language = recorder._resolve_output_language(
+                configured_language,
+                existing_session_info.get("detected_language")
+            )
+
+    if recorder.summarizer is None:
+        from src.summarizer import OllamaSummarizer
+        recorder.summarizer = OllamaSummarizer()
+
+    print("Generating report...", flush=True)
+    streamed_chunks = []
+    summary_heartbeat = _start_summary_heartbeat()
+    _stream_error = None
+    try:
+        for chunk in recorder.summarizer.summarize_transcript_streaming(
+            transcript, duration_minutes, output_language, notes_text,
+            progress_callback=_emit_progress,
+            template_prompt=tmpl["prompt"],
+        ):
+            summary_heartbeat.set()
+            encoded = base64.b64encode(chunk.encode('utf-8')).decode('ascii')
+            sys.stdout.write(f"CHUNK:{encoded}\n")
+            sys.stdout.flush()
+            streamed_chunks.append(chunk)
+    except Exception as e:
+        _stream_error = e
+    finally:
+        summary_heartbeat.set()
+
+    if _stream_error is not None:
+        logger.error(f"Report generation failed: {_stream_error}")
+        err_msg = str(_stream_error).replace('\n', ' ').replace('\r', ' ')
+        print(f"STREAM_ERROR:{err_msg}", flush=True)
+        sys.exit(1)
+
+    streamed_md = ''.join(streamed_chunks)
+
+    print("STREAM_COMPLETE", flush=True)
+
+    report = src.reports.make_report(
+        template_id, tmpl["name"], recorder.summarizer.model_name, streamed_md
+    )
+    src.reports.append_report(existing_data, report)
+    _atomic_write_json(summary_path, existing_data)
+    print(f"SAVED:{summary_path}")
+
+
 @cli.command('regen-title')
 @click.argument('summary_file', required=True)
 def regen_title(summary_file):

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2109,23 +2109,21 @@ def reprocess(summary_file, regenerate_title):
             # #249: snapshot the prior Standard note as a switchable backup before
             # we overwrite it, so a regenerate never loses the previous summary.
             from src import reports as _reports
-            _prev_summary = existing_data.get("summary", "")
-            if (_prev_summary or "").strip():
-                _backup_md = _reports.structured_to_markdown(
-                    _prev_summary,
-                    existing_data.get("discussion_areas", []),
-                    existing_data.get("key_points", []),
-                    existing_data.get("action_items", []),
-                )
-                if _backup_md.strip():
-                    _stamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-                    _reports.append_report(existing_data, _reports.make_report(
-                        "standard-backup", f"Standard · {_stamp}",
-                        existing_data.get("session_info", {}).get("model")
-                        or recorder.summarizer.model_name, _backup_md))
-                    # append_report sets active_report to the backup; the live note
-                    # should stay the default view after regenerate, so clear it:
-                    existing_data["active_report"] = None
+            _backup_md = _reports.structured_to_markdown(
+                existing_data.get("summary", ""),
+                existing_data.get("discussion_areas", []),
+                existing_data.get("key_points", []),
+                existing_data.get("action_items", []),
+            )
+            if _backup_md.strip():
+                _stamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+                _reports.append_report(existing_data, _reports.make_report(
+                    "standard-backup", f"Standard · {_stamp}",
+                    existing_data.get("session_info", {}).get("model")
+                    or recorder.summarizer.model_name, _backup_md))
+                # append_report sets active_report to the backup; the live note
+                # should stay the default view after regenerate, so clear it:
+                existing_data["active_report"] = None
             existing_data.update({
                 "summary": parsed.get("summary", "") or "",
                 "participants": parsed.get("participants", []) or [],

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2100,8 +2100,6 @@ def reprocess(summary_file, regenerate_title):
 
         streamed_md = ''.join(streamed_chunks)
 
-        print("STREAM_COMPLETE", flush=True)
-
         # Regenerate title if requested
         if regenerate_title:
             try:
@@ -2187,6 +2185,15 @@ def reprocess(summary_file, regenerate_title):
             })
             with open(summary_path, 'w') as f:
                 json.dump(existing_data, f, indent=2)
+
+        # Signal completion only AFTER the note file is fully written. The
+        # renderer reads the note the instant it sees STREAM_COMPLETE, so
+        # emitting it before the write above is a write-after-complete race
+        # (the #249 backup widened the window). It surfaced as a stale read on
+        # Windows CI — map-reduce-chunking.t2 saw the pre-reprocess summary —
+        # while macOS happened to win the race. Mirrors process_streaming's
+        # write-before-complete intent.
+        print("STREAM_COMPLETE", flush=True)
 
         print(f"Summary reprocessed successfully: {summary_path}")
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2108,22 +2108,19 @@ def reprocess(summary_file, regenerate_title):
             parsed = recorder._parse_streamed_markdown(streamed_md)
             # #249: snapshot the prior Standard note as a switchable backup before
             # we overwrite it, so a regenerate never loses the previous summary.
-            from src import reports as _reports
-            _backup_md = _reports.structured_to_markdown(
-                existing_data.get("summary", ""),
-                existing_data.get("discussion_areas", []),
-                existing_data.get("key_points", []),
-                existing_data.get("action_items", []),
-            )
+            from src import report_store, reports as _reports
+            _backup_md = report_store.read_meeting(summary_path)["summary_markdown"]
             if _backup_md.strip():
                 _stamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-                _reports.append_report(existing_data, _reports.make_report(
+                _sidecar = report_store.load_sidecar(summary_path)
+                _reports.append_report(_sidecar, _reports.make_report(
                     "standard-backup", f"Standard · {_stamp}",
                     existing_data.get("session_info", {}).get("model")
                     or recorder.summarizer.model_name, _backup_md))
                 # append_report sets active_report to the backup; the live note
                 # should stay the default view after regenerate, so clear it:
-                existing_data["active_report"] = None
+                _sidecar["active_report"] = None
+                report_store.save_sidecar(summary_path, _sidecar)
             existing_data.update({
                 "summary": parsed.get("summary", "") or "",
                 "participants": parsed.get("participants", []) or [],
@@ -2146,12 +2143,11 @@ def reprocess(summary_file, regenerate_title):
 @click.argument('report_id')
 def set_active_report(summary_file, report_id):
     """Persist which report version is shown (report_id 'standard' clears it)."""
-    from src import reports as _reports
-    path = Path(summary_file)
-    data = json.loads(path.read_text(encoding='utf-8'))
-    ok = _reports.set_active(data, report_id)
+    from src import report_store, reports as _reports
+    sidecar = report_store.load_sidecar(summary_file)
+    ok = _reports.set_active(sidecar, report_id)
     if ok:
-        _atomic_write_json(path, data)
+        report_store.save_sidecar(summary_file, sidecar)
     print(json.dumps({"success": ok} if ok else {"success": False, "error": "Unknown report"}))
     if not ok:
         sys.exit(1)
@@ -2162,12 +2158,11 @@ def set_active_report(summary_file, report_id):
 @click.argument('report_id')
 def delete_report(summary_file, report_id):
     """Delete a saved report version from a meeting."""
-    from src import reports as _reports
-    path = Path(summary_file)
-    data = json.loads(path.read_text(encoding='utf-8'))
-    ok = _reports.remove_report(data, report_id)
+    from src import report_store, reports as _reports
+    sidecar = report_store.load_sidecar(summary_file)
+    ok = _reports.remove_report(sidecar, report_id)
     if ok:
-        _atomic_write_json(path, data)
+        report_store.save_sidecar(summary_file, sidecar)
     print(json.dumps({"success": ok} if ok else {"success": False, "error": "Unknown report"}))
     if not ok:
         sys.exit(1)

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -751,9 +751,9 @@ def generate_default_template_report(summary_path, transcript, notes, language,
     its report into the meeting's sidecar and make it active. Additive — the
     Standard note is untouched. Never raises (a new recording must not fail because
     of the extra report)."""
-    from src import reports as _reports
-    from src import report_store as _store
     try:
+        from src import reports as _reports
+        from src import report_store as _store
         tid = config.get_default_template_id()
         if not tid or tid == "standard":
             return None
@@ -761,12 +761,20 @@ def generate_default_template_report(summary_path, transcript, notes, language,
         if not tmpl or not (tmpl.get("prompt") or "").strip():
             return None
         report_language = tmpl["language"] if tmpl.get("language") and tmpl["language"] != "auto" else language
-        chunks = []
-        for chunk in summarizer.summarize_transcript_streaming(
-            transcript, duration_minutes, report_language, notes,
-            template_prompt=tmpl["prompt"],
-        ):
-            chunks.append(chunk)
+        # This generation produces NO CHUNK:/PROGRESS: output, so the main-process
+        # inactivity watchdog would otherwise fire on a slow model and FAIL the
+        # recording AFTER the Standard note was already saved. Heartbeat keeps it
+        # alive; a distinct label avoids polluting the parsed summary stream.
+        heartbeat = _start_summary_heartbeat(label="default-report")
+        try:
+            chunks = []
+            for chunk in summarizer.summarize_transcript_streaming(
+                transcript, duration_minutes, report_language, notes,
+                template_prompt=tmpl["prompt"],
+            ):
+                chunks.append(chunk)
+        finally:
+            heartbeat.set()
         content = "".join(chunks).strip()
         if not content:
             return None

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2892,6 +2892,68 @@ def set_model(model_name):
         sys.exit(1)
 
 
+@cli.command(name='list-templates')
+def list_templates():
+    """List all report templates (built-in + custom) and the default id."""
+    from src.config import get_config
+    config = get_config()
+    print(json.dumps({
+        "templates": config.get_templates(),
+        "default_template_id": config.get_default_template_id(),
+    }))
+
+
+@cli.command(name='save-template')
+@click.argument('template_json')
+def save_template(template_json):
+    """Create or update a template from a JSON object."""
+    from src.config import get_config
+    try:
+        payload = json.loads(template_json)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"success": False, "error": f"Invalid JSON: {e}"}))
+        sys.exit(1)
+    ok, err, saved = get_config().save_template(payload)
+    print(json.dumps({"success": ok, "template": saved} if ok
+                     else {"success": False, "error": err}))
+    if not ok:
+        sys.exit(1)
+
+
+@cli.command(name='delete-template')
+@click.argument('template_id')
+def delete_template(template_id):
+    """Delete a custom template by id."""
+    from src.config import get_config
+    ok = get_config().delete_template(template_id)
+    print(json.dumps({"success": ok}))
+    if not ok:
+        sys.exit(1)
+
+
+@cli.command(name='set-default-template')
+@click.argument('template_id')
+def set_default_template(template_id):
+    """Set the default template used for auto-generation."""
+    from src.config import get_config
+    ok = get_config().set_default_template(template_id)
+    print(json.dumps({"success": ok} if ok
+                     else {"success": False, "error": "Failed to save config"}))
+    if not ok:
+        sys.exit(1)
+
+
+@cli.command(name='reset-template')
+@click.argument('template_id')
+def reset_template(template_id):
+    """Reset a built-in template to its shipped default (drops the override)."""
+    from src.config import get_config
+    ok = get_config().reset_template(template_id)
+    print(json.dumps({"success": ok}))
+    if not ok:
+        sys.exit(1)
+
+
 @cli.command()
 def get_notifications():
     """Get the current notification preference"""

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2106,6 +2106,26 @@ def reprocess(summary_file, regenerate_title):
         else:
             # JSON format: parse streamed markdown into structured fields
             parsed = recorder._parse_streamed_markdown(streamed_md)
+            # #249: snapshot the prior Standard note as a switchable backup before
+            # we overwrite it, so a regenerate never loses the previous summary.
+            from src import reports as _reports
+            _prev_summary = existing_data.get("summary", "")
+            if (_prev_summary or "").strip():
+                _backup_md = _reports.structured_to_markdown(
+                    _prev_summary,
+                    existing_data.get("discussion_areas", []),
+                    existing_data.get("key_points", []),
+                    existing_data.get("action_items", []),
+                )
+                if _backup_md.strip():
+                    _stamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+                    _reports.append_report(existing_data, _reports.make_report(
+                        "standard-backup", f"Standard · {_stamp}",
+                        existing_data.get("session_info", {}).get("model")
+                        or recorder.summarizer.model_name, _backup_md))
+                    # append_report sets active_report to the backup; the live note
+                    # should stay the default view after regenerate, so clear it:
+                    existing_data["active_report"] = None
             existing_data.update({
                 "summary": parsed.get("summary", "") or "",
                 "participants": parsed.get("participants", []) or [],
@@ -2120,6 +2140,38 @@ def reprocess(summary_file, regenerate_title):
 
     except Exception as e:
         print(f"ERROR: Failed to reprocess summary: {e}")
+        sys.exit(1)
+
+
+@cli.command(name='set-active-report')
+@click.argument('summary_file')
+@click.argument('report_id')
+def set_active_report(summary_file, report_id):
+    """Persist which report version is shown (report_id 'standard' clears it)."""
+    from src import reports as _reports
+    path = Path(summary_file)
+    data = json.loads(path.read_text(encoding='utf-8'))
+    ok = _reports.set_active(data, report_id)
+    if ok:
+        _atomic_write_json(path, data)
+    print(json.dumps({"success": ok} if ok else {"success": False, "error": "Unknown report"}))
+    if not ok:
+        sys.exit(1)
+
+
+@cli.command(name='delete-report')
+@click.argument('summary_file')
+@click.argument('report_id')
+def delete_report(summary_file, report_id):
+    """Delete a saved report version from a meeting."""
+    from src import reports as _reports
+    path = Path(summary_file)
+    data = json.loads(path.read_text(encoding='utf-8'))
+    ok = _reports.remove_report(data, report_id)
+    if ok:
+        _atomic_write_json(path, data)
+    print(json.dumps({"success": ok} if ok else {"success": False, "error": "Unknown report"}))
+    if not ok:
         sys.exit(1)
 
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2914,10 +2914,11 @@ def save_template(template_json):
         print(json.dumps({"success": False, "error": f"Invalid JSON: {e}"}))
         sys.exit(1)
     ok, err, saved = get_config().save_template(payload)
+    # Exit 0 regardless: the JSON on stdout IS the result. The IPC handler parses
+    # it directly; non-zero exit would cause runPythonScript to reject and throw
+    # away the structured error message (returning raw stderr instead).
     print(json.dumps({"success": ok, "template": saved} if ok
                      else {"success": False, "error": err}))
-    if not ok:
-        sys.exit(1)
 
 
 @cli.command(name='delete-template')

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2147,12 +2147,13 @@ def generate_report(summary_file, template_id):
         print(f"ERROR: Failed to load summary file: {e}")
         sys.exit(1)
 
-    # Unknown template → IPC contract: exit 0 with JSON error
+    # Unknown template → surface as a stream error so the IPC handler (which only
+    # watches the streaming protocol) reports failure instead of silent success.
     config = get_config()
     tmpl = config.get_template(template_id)
     if tmpl is None:
-        print(json.dumps({"success": False, "error": "Unknown template"}))
-        return
+        print("STREAM_ERROR:Unknown template", flush=True)
+        sys.exit(1)
 
     transcript = existing_data.get('transcript', '')
     if not transcript:
@@ -2213,13 +2214,19 @@ def generate_report(summary_file, template_id):
 
     streamed_md = ''.join(streamed_chunks)
 
-    print("STREAM_COMPLETE", flush=True)
+    # Do NOT persist an empty report — surface a stream error instead.
+    if not streamed_md.strip():
+        print("STREAM_ERROR:Model returned an empty report", flush=True)
+        sys.exit(1)
 
+    # Write the meeting JSON BEFORE emitting STREAM_COMPLETE so the renderer's
+    # refetch (triggered by the completion event) never reads stale data.
     report = src.reports.make_report(
         template_id, tmpl["name"], recorder.summarizer.model_name, streamed_md
     )
     src.reports.append_report(existing_data, report)
     _atomic_write_json(summary_path, existing_data)
+    print("STREAM_COMPLETE", flush=True)
     print(f"SAVED:{summary_path}")
 
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2068,6 +2068,27 @@ def reprocess(summary_file, regenerate_title):
         # Add reprocess timestamp
         existing_data["session_info"]["reprocessed_at"] = datetime.now().isoformat()
 
+        # #249: snapshot the prior Standard note as a switchable backup BEFORE we
+        # overwrite the note file, so a regenerate never loses the previous
+        # summary. read_meeting + the sidecar are format-agnostic, so this runs
+        # once for BOTH .md and .json meetings (above the format branch below).
+        # Only snapshot an existing file — a brand-new meeting has nothing to
+        # back up.
+        if summary_path.exists():
+            from src import report_store, reports as _reports
+            _backup_md = report_store.read_meeting(summary_path)["summary_markdown"]
+            if _backup_md.strip():
+                _stamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+                _sidecar = report_store.load_sidecar(summary_path)
+                _reports.append_report(_sidecar, _reports.make_report(
+                    "standard-backup", f"Standard · {_stamp}",
+                    existing_data.get("session_info", {}).get("model")
+                    or recorder.summarizer.model_name, _backup_md))
+                # append_report sets active_report to the backup; the live note
+                # should stay the default view after regenerate, so clear it:
+                _sidecar["active_report"] = None
+                report_store.save_sidecar(summary_path, _sidecar)
+
         # Save updated summary
         if summary_path.suffix == '.md':
             session_name = existing_data.get('session_info', {}).get('name', 'Reprocessed')
@@ -2106,21 +2127,6 @@ def reprocess(summary_file, regenerate_title):
         else:
             # JSON format: parse streamed markdown into structured fields
             parsed = recorder._parse_streamed_markdown(streamed_md)
-            # #249: snapshot the prior Standard note as a switchable backup before
-            # we overwrite it, so a regenerate never loses the previous summary.
-            from src import report_store, reports as _reports
-            _backup_md = report_store.read_meeting(summary_path)["summary_markdown"]
-            if _backup_md.strip():
-                _stamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-                _sidecar = report_store.load_sidecar(summary_path)
-                _reports.append_report(_sidecar, _reports.make_report(
-                    "standard-backup", f"Standard · {_stamp}",
-                    existing_data.get("session_info", {}).get("model")
-                    or recorder.summarizer.model_name, _backup_md))
-                # append_report sets active_report to the backup; the live note
-                # should stay the default view after regenerate, so clear it:
-                _sidecar["active_report"] = None
-                report_store.save_sidecar(summary_path, _sidecar)
             existing_data.update({
                 "summary": parsed.get("summary", "") or "",
                 "participants": parsed.get("participants", []) or [],

--- a/src/config.py
+++ b/src/config.py
@@ -265,6 +265,7 @@ class Config:
         self._migrate_whisper_model()
         self._migrate_summary_model()
         self._migrate_transcription_engine()
+        self._normalize_templates()
         self._seed_sample_template()
 
     def _migrate_transcription_engine(self) -> None:
@@ -488,20 +489,43 @@ class Config:
         return self._save()
 
     # --- Report templates ---------------------------------------------------
+    def _normalize_templates(self) -> None:
+        """Coerce persisted template state into the shapes the CRUD/merge code
+        assumes — on EVERY load, not gated behind `templates_seeded`.
+
+        A malformed-but-parseable config (`custom_templates` as a non-list or a
+        list with non-dict entries, or `template_overrides` as a non-dict) would
+        otherwise survive past first-run seeding and crash later template reads
+        (`merge_templates`) and writes (`save_template`/`delete_template`). The
+        repair is in-memory; it persists on the next `_save()`.
+        """
+        if self._load_failed:
+            return
+        custom_raw = self._config.get("custom_templates", [])
+        self._config["custom_templates"] = (
+            [t for t in custom_raw if isinstance(t, dict)]
+            if isinstance(custom_raw, list)
+            else []
+        )
+        overrides_raw = self._config.get("template_overrides")
+        self._config["template_overrides"] = (
+            {k: v for k, v in overrides_raw.items() if isinstance(v, dict)}
+            if isinstance(overrides_raw, dict)
+            else {}
+        )
+
     def _seed_sample_template(self) -> None:
         """Seed the editable 'Shareable summary' sample once, on fresh configs.
 
         Guarded by `templates_seeded` so deleting the sample doesn't re-add it.
+        Assumes `_normalize_templates` has already coerced `custom_templates`
+        into a list of dicts.
         """
         if self._load_failed:
             return
         if self._config.get("templates_seeded"):
             return
-        # Normalize defensively: a malformed-but-parseable config (e.g. a non-list
-        # or a list with non-dict entries) must not crash startup seeding.
-        custom_raw = self._config.setdefault("custom_templates", [])
-        custom = [t for t in custom_raw if isinstance(t, dict)] if isinstance(custom_raw, list) else []
-        self._config["custom_templates"] = custom
+        custom = self._config.setdefault("custom_templates", [])
         if not any(t.get("id") == _templates.SAMPLE_TEMPLATE["id"] for t in custom):
             custom.append(dict(_templates.SAMPLE_TEMPLATE))
         self._config["templates_seeded"] = True

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 
 from src.whisper_models import SUPPORTED_WHISPER_MODELS as _WHISPER_REGISTRY
+from src import templates as _templates
 
 logger = logging.getLogger(__name__)
 
@@ -264,6 +265,7 @@ class Config:
         self._migrate_whisper_model()
         self._migrate_summary_model()
         self._migrate_transcription_engine()
+        self._seed_sample_template()
 
     def _migrate_transcription_engine(self) -> None:
         """Decide the active ASR engine on first launch of a version that has
@@ -483,6 +485,97 @@ class Config:
             logger.warning(f"Model {model_name} not in supported list, but allowing anyway")
 
         self._config["model"] = model_name
+        return self._save()
+
+    # --- Report templates ---------------------------------------------------
+    def _seed_sample_template(self) -> None:
+        """Seed the editable 'Shareable summary' sample once, on fresh configs.
+
+        Guarded by `templates_seeded` so deleting the sample doesn't re-add it.
+        """
+        if self._load_failed:
+            return
+        if self._config.get("templates_seeded"):
+            return
+        custom = self._config.setdefault("custom_templates", [])
+        if not any(t.get("id") == _templates.SAMPLE_TEMPLATE["id"] for t in custom):
+            custom.append(dict(_templates.SAMPLE_TEMPLATE))
+        self._config["templates_seeded"] = True
+        self._save()
+
+    def get_templates(self) -> list:
+        """Merged template list: built-ins (with overrides) then custom."""
+        return _templates.merge_templates(
+            overrides=self._config.get("template_overrides", {}) or {},
+            custom=self._config.get("custom_templates", []) or [],
+        )
+
+    def get_default_template_id(self) -> str:
+        return self._config.get("default_template_id", _templates.STANDARD_TEMPLATE_ID)
+
+    def set_default_template(self, template_id: str) -> bool:
+        if template_id not in {t["id"] for t in self.get_templates()}:
+            logger.error(f"Unknown template id: {template_id}")
+            return False
+        self._config["default_template_id"] = template_id
+        return self._save()
+
+    def save_template(self, t: dict) -> tuple:
+        """Upsert a template. Returns (ok, error, saved_template)."""
+        valid_langs = set(self.SUPPORTED_LANGUAGES.keys()) | {"auto"}
+        ok, err = _templates.validate_template(t, valid_langs)
+        if not ok:
+            return False, err, {}
+
+        tid = t.get("id")
+        # Built-in id -> store as an override (Standard is locked: no prompt edit).
+        if tid in _templates.BUILTIN_TEMPLATES:
+            if _templates.BUILTIN_TEMPLATES[tid].get("locked"):
+                return False, "This template is locked and cannot be edited", {}
+            overrides = self._config.setdefault("template_overrides", {})
+            overrides[tid] = {k: t[k] for k in ("name", "icon", "prompt", "language") if k in t}
+            if not self._save():
+                return False, "Failed to save config", {}
+            return True, "", {**_templates.BUILTIN_TEMPLATES[tid], **overrides[tid]}
+
+        custom = self._config.setdefault("custom_templates", [])
+        existing = next((c for c in custom if c.get("id") == tid), None)
+        if existing is not None:
+            existing.update({k: t[k] for k in ("name", "icon", "prompt", "language", "format")
+                             if k in t})
+            saved = dict(existing)
+        else:
+            new_id = _templates.new_template_id(
+                t["name"], {c.get("id") for c in custom} | set(_templates.BUILTIN_TEMPLATES)
+            )
+            saved = {
+                "id": new_id,
+                "name": t["name"],
+                "icon": t.get("icon", "doc"),
+                "prompt": t["prompt"],
+                "language": t.get("language", "auto"),
+                "format": t.get("format", "markdown"),
+            }
+            custom.append(saved)
+        if not self._save():
+            return False, "Failed to save config", {}
+        return True, "", dict(saved)
+
+    def delete_template(self, template_id: str) -> bool:
+        custom = self._config.get("custom_templates", [])
+        remaining = [c for c in custom if c.get("id") != template_id]
+        if len(remaining) == len(custom):
+            return False  # not a custom template (or doesn't exist)
+        self._config["custom_templates"] = remaining
+        if self._config.get("default_template_id") == template_id:
+            self._config["default_template_id"] = _templates.STANDARD_TEMPLATE_ID
+        return self._save()
+
+    def reset_template(self, template_id: str) -> bool:
+        overrides = self._config.get("template_overrides", {})
+        if template_id not in overrides:
+            return True  # already at shipped default — no-op success
+        del overrides[template_id]
         return self._save()
 
     def get_model_info(self, model_name: str) -> Optional[Dict[str, str]]:

--- a/src/config.py
+++ b/src/config.py
@@ -497,7 +497,11 @@ class Config:
             return
         if self._config.get("templates_seeded"):
             return
-        custom = self._config.setdefault("custom_templates", [])
+        # Normalize defensively: a malformed-but-parseable config (e.g. a non-list
+        # or a list with non-dict entries) must not crash startup seeding.
+        custom_raw = self._config.setdefault("custom_templates", [])
+        custom = [t for t in custom_raw if isinstance(t, dict)] if isinstance(custom_raw, list) else []
+        self._config["custom_templates"] = custom
         if not any(t.get("id") == _templates.SAMPLE_TEMPLATE["id"] for t in custom):
             custom.append(dict(_templates.SAMPLE_TEMPLATE))
         self._config["templates_seeded"] = True

--- a/src/config.py
+++ b/src/config.py
@@ -522,6 +522,8 @@ class Config:
 
     def save_template(self, t: dict) -> tuple:
         """Upsert a template. Returns (ok, error, saved_template)."""
+        if not isinstance(t, dict):
+            return False, "Invalid template payload", {}
         valid_langs = set(self.SUPPORTED_LANGUAGES.keys()) | {"auto"}
         ok, err = _templates.validate_template(t, valid_langs)
         if not ok:

--- a/src/config.py
+++ b/src/config.py
@@ -510,6 +510,10 @@ class Config:
             custom=self._config.get("custom_templates", []) or [],
         )
 
+    def get_template(self, template_id: str) -> Optional[dict]:
+        """Return the template with the given id, or None if not found."""
+        return next((t for t in self.get_templates() if t["id"] == template_id), None)
+
     def get_default_template_id(self) -> str:
         return self._config.get("default_template_id", _templates.STANDARD_TEMPLATE_ID)
 

--- a/src/report_store.py
+++ b/src/report_store.py
@@ -26,8 +26,14 @@ def load_sidecar(meeting_path) -> dict:
         try:
             data = json.loads(sp.read_text(encoding="utf-8"))
             if isinstance(data, dict):
-                data.setdefault("reports", [])
-                data.setdefault("active_report", None)
+                # Normalize TYPES, not just presence: a hand-edited or
+                # partially-written sidecar could carry a non-list `reports` or a
+                # non-string `active_report`, which would break iteration/append
+                # downstream. setdefault only fills missing keys, so coerce here.
+                reports = data.get("reports")
+                data["reports"] = reports if isinstance(reports, list) else []
+                active = data.get("active_report")
+                data["active_report"] = active if isinstance(active, str) else None
                 return data
         except Exception:
             pass

--- a/src/report_store.py
+++ b/src/report_store.py
@@ -1,0 +1,102 @@
+# src/report_store.py
+"""Per-meeting report storage independent of the note's on-disk format.
+
+Real meetings are saved as `<stem>_summary.md` (markdown + YAML frontmatter);
+older/reprocessed ones may be `<stem>_summary.json`. Generated template reports
+and the active-report pointer live in a SIDECAR `<stem>_reports.json`, so the
+report feature works on both formats without touching the canonical note file.
+"""
+import json
+from pathlib import Path
+
+
+def sidecar_path(meeting_path) -> Path:
+    p = Path(meeting_path)
+    name = p.name
+    for suf in ("_summary.md", "_summary.json"):
+        if name.endswith(suf):
+            return p.with_name(name[: -len(suf)] + "_reports.json")
+    # Fallback: strip extension only.
+    return p.with_name(p.stem + "_reports.json")
+
+
+def load_sidecar(meeting_path) -> dict:
+    sp = sidecar_path(meeting_path)
+    if sp.exists():
+        try:
+            data = json.loads(sp.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                data.setdefault("reports", [])
+                data.setdefault("active_report", None)
+                return data
+        except Exception:
+            pass
+    return {"reports": [], "active_report": None}
+
+
+def save_sidecar(meeting_path, sidecar: dict) -> None:
+    from src.config import _atomic_write_json
+    _atomic_write_json(sidecar_path(meeting_path), sidecar)
+
+
+def _split_frontmatter(text: str):
+    """Return (frontmatter_dict, body). Frontmatter is the first --- ... --- block."""
+    fm = {}
+    body = text
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            block = text[3:end].strip("\n")
+            body = text[end + 4:].lstrip("\n")
+            for line in block.splitlines():
+                if ":" in line:
+                    k, _, v = line.partition(":")
+                    fm[k.strip()] = v.strip().strip('"')
+    return fm, body
+
+
+def _split_md_sections(body: str):
+    """Return (summary_markdown, transcript, notes) from a meeting .md body."""
+    notes = None
+    if "## User Notes" in body:
+        body, _, notes_part = body.partition("## User Notes")
+        notes = notes_part.strip() or None
+    transcript = ""
+    if "## Transcript" in body:
+        summary_part, _, transcript_part = body.partition("## Transcript")
+        transcript = transcript_part.strip()
+    else:
+        summary_part = body
+    return summary_part.strip(), transcript, notes
+
+
+def read_meeting(meeting_path) -> dict:
+    """Format-agnostic view used by report generation."""
+    p = Path(meeting_path)
+    text = p.read_text(encoding="utf-8")
+    if p.suffix == ".json":
+        d = json.loads(text)
+        from src import reports as _reports
+        summary_md = _reports.structured_to_markdown(
+            d.get("summary", ""), d.get("discussion_areas", []),
+            d.get("key_points", []), d.get("action_items", []),
+        )
+        si = d.get("session_info", {}) or {}
+        ds = si.get("duration_seconds")
+        return {
+            "transcript": d.get("transcript", "") or d.get("diarised_text", "") or "",
+            "notes": d.get("user_notes"),
+            "language": si.get("output_language") or si.get("language"),
+            "duration_minutes": si.get("duration_minutes") or (int(ds / 60) if ds else None),
+            "summary_markdown": summary_md,
+        }
+    fm, body = _split_frontmatter(text)
+    summary_md, transcript, notes = _split_md_sections(body)
+    ds = fm.get("duration_seconds")
+    return {
+        "transcript": transcript,
+        "notes": notes,
+        "language": fm.get("language"),
+        "duration_minutes": (int(ds) // 60) if (ds and str(ds).isdigit()) else None,
+        "summary_markdown": summary_md,
+    }

--- a/src/report_store.py
+++ b/src/report_store.py
@@ -55,18 +55,32 @@ def _split_frontmatter(text: str):
     return fm, body
 
 
+def _split_on_heading(body: str, heading: str):
+    """Split `body` at the first line that IS `heading` (after stripping).
+
+    Mirrors how the meeting writer emits section headers on their own line, so
+    the literal heading text appearing inside transcript/summary prose does NOT
+    trigger a split. Returns (before, after) where `after` is None if the
+    heading line is absent.
+    """
+    lines = body.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.strip() == heading:
+            before = "".join(lines[:i])
+            after = "".join(lines[i + 1:])
+            return before, after
+    return body, None
+
+
 def _split_md_sections(body: str):
     """Return (summary_markdown, transcript, notes) from a meeting .md body."""
     notes = None
-    if "## User Notes" in body:
-        body, _, notes_part = body.partition("## User Notes")
+    before_notes, notes_part = _split_on_heading(body, "## User Notes")
+    if notes_part is not None:
+        body = before_notes
         notes = notes_part.strip() or None
-    transcript = ""
-    if "## Transcript" in body:
-        summary_part, _, transcript_part = body.partition("## Transcript")
-        transcript = transcript_part.strip()
-    else:
-        summary_part = body
+    summary_part, transcript_part = _split_on_heading(body, "## Transcript")
+    transcript = transcript_part.strip() if transcript_part is not None else ""
     return summary_part.strip(), transcript, notes
 
 

--- a/src/reports.py
+++ b/src/reports.py
@@ -1,0 +1,30 @@
+"""Pure helpers for the per-meeting `reports[]` model (no I/O).
+
+A meeting's `_summary.json` gains an additive `reports` list of generated
+template reports and an `active_report` pointer. The existing top-level summary
+fields remain the canonical "Standard" report; `active_report` absent/None means
+"show the Standard note".
+"""
+import uuid
+from datetime import datetime
+
+
+def new_report_id() -> str:
+    return f"rep_{uuid.uuid4().hex[:12]}"
+
+
+def make_report(template_id: str, template_name: str, model: str, content: str) -> dict:
+    return {
+        "id": new_report_id(),
+        "template_id": template_id,
+        "template_name": template_name,
+        "model": model,
+        "content": content,
+        "created_at": datetime.now().isoformat(),
+    }
+
+
+def append_report(meeting: dict, report: dict) -> dict:
+    meeting.setdefault("reports", []).append(report)
+    meeting["active_report"] = report["id"]
+    return report

--- a/src/reports.py
+++ b/src/reports.py
@@ -28,3 +28,57 @@ def append_report(meeting: dict, report: dict) -> dict:
     meeting.setdefault("reports", []).append(report)
     meeting["active_report"] = report["id"]
     return report
+
+
+def _item_text(item, *keys) -> str:
+    if isinstance(item, dict):
+        for k in keys:
+            v = item.get(k)
+            if v:
+                return str(v)
+        return ""
+    return str(item)
+
+
+def structured_to_markdown(summary, discussion_areas, key_points, action_items) -> str:
+    """Reconstruct a structured note's markdown (for a read-only backup)."""
+    parts = []
+    if (summary or "").strip():
+        parts.append(f"## Summary\n{summary.strip()}")
+    topics = []
+    for a in discussion_areas or []:
+        title = _item_text(a, "title")
+        analysis = _item_text(a, "analysis")
+        if title or analysis:
+            topics.append(f"### {title}\n{analysis}".strip())
+    if topics:
+        parts.append("## Key Topics\n" + "\n\n".join(topics))
+    kps = [f"- {_item_text(k, 'decision', 'point')}" for k in (key_points or []) if _item_text(k, 'decision', 'point')]
+    if kps:
+        parts.append("## Key Points\n" + "\n".join(kps))
+    ais = [f"- {_item_text(a, 'description')}" for a in (action_items or []) if _item_text(a, 'description')]
+    if ais:
+        parts.append("## Action Items\n" + "\n".join(ais))
+    return "\n\n".join(parts)
+
+
+def set_active(meeting: dict, report_id) -> bool:
+    """Set active_report. report_id None or 'standard' clears it (show Standard)."""
+    if report_id in (None, "standard"):
+        meeting["active_report"] = None
+        return True
+    if any(r.get("id") == report_id for r in meeting.get("reports", [])):
+        meeting["active_report"] = report_id
+        return True
+    return False
+
+
+def remove_report(meeting: dict, report_id: str) -> bool:
+    reports = meeting.get("reports", [])
+    kept = [r for r in reports if r.get("id") != report_id]
+    if len(kept) == len(reports):
+        return False
+    meeting["reports"] = kept
+    if meeting.get("active_report") == report_id:
+        meeting["active_report"] = None
+    return True

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1364,7 +1364,62 @@ Only include information explicitly discussed. Do not infer or assume.{language_
 TRANSCRIPT:
 {transcript}"""
 
-    def summarize_transcript_streaming(self, transcript: str, duration_minutes: int = 0, language: str = "en", notes: str = None, progress_callback=None):
+    def _create_template_report_prompt(self, transcript: str, template_prompt: str,
+                                       language: str = "en", notes: str = None) -> str:
+        """Free-form report prompt: the user's template instructions over the
+        transcript. Unlike _create_markdown_prompt there is NO fixed section
+        schema — the template decides the shape. Output is raw markdown."""
+        if language and language not in ("en", "auto"):
+            from .config import get_config
+            language_name = get_config().get_language_name(language)
+            language_instruction = (
+                f"\n\nCRITICAL: Write the report in {language_name}."
+                if language_name != "Unknown" else ""
+            )
+        else:
+            language_instruction = ""
+        notes_context = ""
+        if notes and notes.strip():
+            notes_context = f"USER NOTES (written during the meeting):\n{notes.strip()}\n\n"
+        diarisation_note = ""
+        if "[You]" in transcript and "[Others]" in transcript:
+            diarisation_note = "NOTE: [You] is the recorder, [Others] are remote participants.\n\n"
+        return (
+            f"{diarisation_note}{notes_context}{template_prompt.strip()}\n\n"
+            "Base the report only on what was explicitly discussed; do not infer. "
+            "Output the report as markdown with no preamble."
+            f"{language_instruction}\n\nTRANSCRIPT:\n{transcript}"
+        )
+
+    def _stream_direct(self, prompt: str):
+        """Stream a single non-chunked completion for ``prompt`` via local/remote
+        Ollama, yielding content chunks. ``think=False`` so a thinking-capable
+        model emits answer text directly instead of spending tokens reasoning
+        into a separate channel before the first content token (see
+        _summarize_chunk for the full rationale).
+
+        Cloud/adapter providers keep their own inline streaming in
+        ``summarize_transcript_streaming`` and never reach here — this is the
+        minimal extraction of just the local/remote Ollama path, shared by the
+        markdown and free-form template routes.
+        """
+        if self.ai_provider != "remote":
+            self._ensure_ollama_ready()
+        # Via _chat_stream_no_think so a remote server that rejects `think`
+        # falls back gracefully (the ollama>=0.5.0 pin governs only the bundled
+        # client). Shared by the markdown and free-form template routes.
+        response = self._chat_stream_no_think(
+            self.client,
+            model=self.model_name,
+            messages=[{'role': 'user', 'content': prompt}],
+            options=self._ollama_options(),
+        )
+        for chunk in response:
+            content = chunk.get('message', {}).get('content', '')
+            if content:
+                yield content
+
+    def summarize_transcript_streaming(self, transcript: str, duration_minutes: int = 0, language: str = "en", notes: str = None, progress_callback=None, template_prompt: Optional[str] = None):
         """Generator that yields markdown chunks from the LLM.
 
         Args:
@@ -1373,10 +1428,21 @@ TRANSCRIPT:
             language: Language code for output
             notes: Optional user notes for context
             progress_callback: Optional callable(step, total) for progress reporting
+            template_prompt: Optional free-form report instructions. When set,
+                the report is generated via the DIRECT path (no chunking, no
+                map-reduce — the map/reduce prompts are summary-schema specific
+                and don't apply to a free-form template).
 
         Yields:
             str: Text chunks as they arrive from the LLM
         """
+        if template_prompt:
+            # Free-form template report: always the direct path (the map/reduce
+            # prompts are summary-schema specific and don't apply here).
+            prompt = self._create_template_report_prompt(transcript, template_prompt, language, notes)
+            yield from self._stream_direct(prompt)
+            return
+
         if self._needs_chunking(transcript, notes):
             yield from self._map_reduce_streaming(transcript, language, notes, progress_callback)
             return
@@ -1437,25 +1503,9 @@ TRANSCRIPT:
                     logger.error(f"OpenAI streaming failed: {e}")
                     return
         else:
-            # Ollama (local or remote)
+            # Ollama (local or remote) — shared with the free-form template path.
             try:
-                if self.ai_provider != "remote":
-                    self._ensure_ollama_ready()
-                # think=False: the markdown summary prompt wants direct output;
-                # a thinking model would otherwise spend tokens reasoning into a
-                # separate channel before the first content token. See
-                # _summarize_chunk for the full rationale. Via _chat_stream_no_think
-                # for the remote-server `think` fallback.
-                response = self._chat_stream_no_think(
-                    self.client,
-                    model=self.model_name,
-                    messages=[{'role': 'user', 'content': prompt}],
-                    options=self._ollama_options(),
-                )
-                for chunk in response:
-                    content = chunk.get('message', {}).get('content', '')
-                    if content:
-                        yield content
+                yield from self._stream_direct(prompt)
             except Exception as e:
                 logger.error(f"Ollama streaming failed: {e}")
                 return

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1419,35 +1419,13 @@ TRANSCRIPT:
             if content:
                 yield content
 
-    def summarize_transcript_streaming(self, transcript: str, duration_minutes: int = 0, language: str = "en", notes: str = None, progress_callback=None, template_prompt: Optional[str] = None):
-        """Generator that yields markdown chunks from the LLM.
-
-        Args:
-            transcript: Meeting transcript text
-            duration_minutes: Duration of the meeting
-            language: Language code for output
-            notes: Optional user notes for context
-            progress_callback: Optional callable(step, total) for progress reporting
-            template_prompt: Optional free-form report instructions. When set,
-                the report is generated via the DIRECT path (no chunking, no
-                map-reduce — the map/reduce prompts are summary-schema specific
-                and don't apply to a free-form template).
-
-        Yields:
-            str: Text chunks as they arrive from the LLM
+    def _stream_completion(self, prompt: str):
+        """Stream a single completion for ``prompt`` through whichever provider is
+        active: adapter, cloud (anthropic / bedrock / openai-compatible), or local/
+        remote Ollama. Shared by the free-form template path and the markdown
+        summary path so a provider only has to be wired up in one place. Bedrock has
+        no eventstream parser yet, so it yields the whole answer as a single chunk.
         """
-        if template_prompt:
-            # Free-form template report: always the direct path (the map/reduce
-            # prompts are summary-schema specific and don't apply here).
-            prompt = self._create_template_report_prompt(transcript, template_prompt, language, notes)
-            yield from self._stream_direct(prompt)
-            return
-
-        if self._needs_chunking(transcript, notes):
-            yield from self._map_reduce_streaming(transcript, language, notes, progress_callback)
-            return
-
-        prompt = self._create_markdown_prompt(transcript, language, notes)
         logger.info(f"Starting streaming summary with {self.ai_provider} model: {self.model_name}")
 
         if self.ai_provider == "adapter":
@@ -1502,13 +1480,47 @@ TRANSCRIPT:
                 except Exception as e:
                     logger.error(f"OpenAI streaming failed: {e}")
                     return
-        else:
-            # Ollama (local or remote) — shared with the free-form template path.
-            try:
-                yield from self._stream_direct(prompt)
-            except Exception as e:
-                logger.error(f"Ollama streaming failed: {e}")
-                return
+            return
+
+        # Ollama (local or remote) — shared with the free-form template path.
+        try:
+            yield from self._stream_direct(prompt)
+        except Exception as e:
+            logger.error(f"Ollama streaming failed: {e}")
+            return
+
+    def summarize_transcript_streaming(self, transcript: str, duration_minutes: int = 0, language: str = "en", notes: str = None, progress_callback=None, template_prompt: Optional[str] = None):
+        """Generator that yields markdown chunks from the LLM.
+
+        Args:
+            transcript: Meeting transcript text
+            duration_minutes: Duration of the meeting
+            language: Language code for output
+            notes: Optional user notes for context
+            progress_callback: Optional callable(step, total) for progress reporting
+            template_prompt: Optional free-form report instructions. When set,
+                the report streams through the active provider without chunking or
+                map-reduce (those prompts are summary-schema specific and don't
+                apply to a free-form template).
+
+        Yields:
+            str: Text chunks as they arrive from the LLM
+        """
+        if template_prompt:
+            # Free-form template report: no chunking/map-reduce (those prompts are
+            # summary-schema specific and don't apply here). Stream through the
+            # ACTIVE provider — not straight to Ollama, which has no client and
+            # would crash in cloud/adapter mode.
+            prompt = self._create_template_report_prompt(transcript, template_prompt, language, notes)
+            yield from self._stream_completion(prompt)
+            return
+
+        if self._needs_chunking(transcript, notes):
+            yield from self._map_reduce_streaming(transcript, language, notes, progress_callback)
+            return
+
+        prompt = self._create_markdown_prompt(transcript, language, notes)
+        yield from self._stream_completion(prompt)
 
     def test_connection(self) -> bool:
         """

--- a/src/templates.py
+++ b/src/templates.py
@@ -15,6 +15,11 @@ import re
 
 STANDARD_TEMPLATE_ID = "standard"
 
+MAX_NAME_LEN = 200
+MAX_PROMPT_LEN = 8000
+MAX_ICON_LEN = 64
+VALID_FORMATS = {"structured", "markdown"}
+
 # Only STANDARD is a built-in. Locked + structured: its "prompt" is empty
 # because it routes through the existing JSON-schema summary path, not a
 # free-form prompt. PR B reads `format` to pick the render/generation path.
@@ -34,7 +39,7 @@ BUILTIN_TEMPLATES = {
 SAMPLE_TEMPLATE = {
     "id": "shareable-summary",
     "name": "Shareable summary",
-    "icon": "send",
+    "icon": "megaphone",
     "prompt": (
         "Write a clear, plain-language summary I can forward to a colleague or "
         "manager: the key points, decisions, and any next steps. Write in the "
@@ -58,14 +63,47 @@ def new_template_id(name: str, existing_ids: set) -> str:
 
 
 def validate_template(t: dict, valid_languages: set) -> tuple:
-    """Return (ok, error_message) for a template dict (name/prompt/language)."""
-    if not (t.get("name") or "").strip():
+    """Return (ok, error_message) for a template dict.
+
+    Defensive at the Python trust boundary: `t` arrives from the renderer as
+    decoded JSON and may be malformed. This never raises — it always returns
+    (False, "<message>") on bad input.
+    """
+    if not isinstance(t, dict):
+        return False, "Invalid template payload"
+
+    name = t.get("name")
+    if not isinstance(name, str):
         return False, "Template name is required"
-    if not (t.get("prompt") or "").strip():
+    name = name.strip()
+    if not name:
+        return False, "Template name is required"
+    if len(name) > MAX_NAME_LEN:
+        return False, f"Template name is too long (max {MAX_NAME_LEN} characters)"
+
+    prompt = t.get("prompt")
+    if not isinstance(prompt, str):
         return False, "Template prompt is required"
+    if not prompt.strip():
+        return False, "Template prompt is required"
+    if len(prompt) > MAX_PROMPT_LEN:
+        return False, f"Template prompt is too long (max {MAX_PROMPT_LEN} characters)"
+
     lang = t.get("language", "auto")
-    if lang not in valid_languages:
+    if not isinstance(lang, str) or lang not in valid_languages:
         return False, f"Unsupported language: {lang}"
+
+    fmt = t.get("format")
+    if fmt is not None and fmt not in VALID_FORMATS:
+        return False, f"Unsupported format: {fmt}"
+
+    icon = t.get("icon")
+    if icon is not None:
+        if not isinstance(icon, str):
+            return False, "Invalid template icon"
+        if len(icon) > MAX_ICON_LEN:
+            return False, "Template icon is too long"
+
     return True, ""
 
 

--- a/src/templates.py
+++ b/src/templates.py
@@ -1,0 +1,86 @@
+# src/templates.py
+"""Built-in report templates + pure template helpers.
+
+A template shapes how a meeting report is generated/exported. The shipped
+lineup is intentionally minimal: STANDARD is the only built-in (locked, drives
+today's structured note). One editable SAMPLE custom template is pre-seeded by
+Config on first run; everything else is user-created. Built-in definitions live
+here (source of truth, like whisper_models.py); custom templates, built-in
+overrides, the seed flag, and the default id live in config.json.
+
+This module is pure — no I/O — so it is unit-testable without a running app.
+"""
+
+import re
+
+STANDARD_TEMPLATE_ID = "standard"
+
+# Only STANDARD is a built-in. Locked + structured: its "prompt" is empty
+# because it routes through the existing JSON-schema summary path, not a
+# free-form prompt. PR B reads `format` to pick the render/generation path.
+BUILTIN_TEMPLATES = {
+    "standard": {
+        "id": "standard",
+        "name": "Standard",
+        "icon": "doc",
+        "prompt": "",
+        "language": "auto",
+        "format": "structured",
+        "locked": True,
+    },
+}
+
+# Pre-seeded once into the user's custom templates (editable + deletable).
+SAMPLE_TEMPLATE = {
+    "id": "shareable-summary",
+    "name": "Shareable summary",
+    "icon": "send",
+    "prompt": (
+        "Write a clear, plain-language summary I can forward to a colleague or "
+        "manager: the key points, decisions, and any next steps. Write in the "
+        "language of the meeting."
+    ),
+    "language": "auto",
+    "format": "markdown",
+}
+
+
+def new_template_id(name: str, existing_ids: set) -> str:
+    """A stable slug id from a display name, de-duped against existing ids."""
+    base = re.sub(r"[^a-z0-9]+", "-", (name or "").strip().lower()).strip("-")
+    base = base or "template"
+    if base not in existing_ids:
+        return base
+    n = 2
+    while f"{base}-{n}" in existing_ids:
+        n += 1
+    return f"{base}-{n}"
+
+
+def validate_template(t: dict, valid_languages: set) -> tuple:
+    """Return (ok, error_message) for a template dict (name/prompt/language)."""
+    if not (t.get("name") or "").strip():
+        return False, "Template name is required"
+    if not (t.get("prompt") or "").strip():
+        return False, "Template prompt is required"
+    lang = t.get("language", "auto")
+    if lang not in valid_languages:
+        return False, f"Unsupported language: {lang}"
+    return True, ""
+
+
+def merge_templates(overrides: dict, custom: list) -> list:
+    """Built-ins (with overrides applied) first, then custom templates.
+
+    Each entry is tagged `builtin` (and `locked` for STANDARD) so the UI knows
+    which controls (Reset vs Edit/Delete) to show.
+    """
+    result = []
+    for tid, base in BUILTIN_TEMPLATES.items():
+        merged = {**base, **(overrides.get(tid) or {})}
+        merged["builtin"] = True
+        merged["locked"] = bool(base.get("locked"))
+        result.append(merged)
+    for c in custom:
+        result.append({**c, "builtin": False, "locked": False})
+    return result

--- a/src/templates.py
+++ b/src/templates.py
@@ -94,7 +94,7 @@ def validate_template(t: dict, valid_languages: set) -> tuple:
         return False, f"Unsupported language: {lang}"
 
     fmt = t.get("format")
-    if fmt is not None and fmt not in VALID_FORMATS:
+    if fmt is not None and (not isinstance(fmt, str) or fmt not in VALID_FORMATS):
         return False, f"Unsupported format: {fmt}"
 
     icon = t.get("icon")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -314,5 +314,27 @@ class ConfigBedrockSettingsTests(unittest.TestCase):
             )
 
 
+class ConfigTemplateSeedingResilienceTests(unittest.TestCase):
+    def _config_with(self, custom_templates):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / "config.json"
+        path.write_text(
+            json.dumps({"custom_templates": custom_templates}), encoding="utf-8"
+        )
+        # Construction runs _seed_sample_template(); must not raise on bad data.
+        return Config(config_path=path)
+
+    def test_seeding_survives_non_list_custom_templates(self):
+        config = self._config_with({"oops": "not a list"})
+        self.assertIsInstance(config._config["custom_templates"], list)
+
+    def test_seeding_drops_non_dict_entries(self):
+        config = self._config_with(["nope", 42, None, {"id": "keep", "name": "K"}])
+        ids = [t.get("id") for t in config._config["custom_templates"]]
+        self.assertIn("keep", ids)
+        self.assertNotIn("nope", ids)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_templates.py
+++ b/tests/test_config_templates.py
@@ -85,6 +85,30 @@ class TemplateCrudTests(unittest.TestCase):
             ok, err, _ = c.save_template({"name": " ", "prompt": "x", "language": "auto"})
             self.assertFalse(ok)
 
+    def test_save_does_not_crash_on_non_dict_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            ok, err, saved = c.save_template([])
+            self.assertFalse(ok)
+            self.assertTrue(err)
+            self.assertEqual(saved, {})
+
+    def test_save_rejects_over_long_prompt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            ok, _, _ = c.save_template(
+                {"name": "X", "prompt": "x" * 8001, "language": "auto"}
+            )
+            self.assertFalse(ok)
+
+    def test_reset_template_noop_and_unknown_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            # standard is locked → no override exists → reset is a no-op success
+            self.assertTrue(c.reset_template(STANDARD_TEMPLATE_ID))
+            # an id with no override returns True too
+            self.assertTrue(c.reset_template("does-not-exist"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_templates.py
+++ b/tests/test_config_templates.py
@@ -110,5 +110,77 @@ class TemplateCrudTests(unittest.TestCase):
             self.assertTrue(c.reset_template("does-not-exist"))
 
 
+class AlreadySeededMalformedConfigTests(unittest.TestCase):
+    """A malformed-but-parseable config that is ALREADY seeded must still be
+    repaired on load — the normalization can't be gated behind the one-time
+    `templates_seeded` flag, or template reads/writes crash on the junk."""
+
+    def _write(self, tmp, config: dict) -> Path:
+        path = Path(tmp) / "config.json"
+        path.write_text(json.dumps(config))
+        return path
+
+    def test_non_list_custom_templates_does_not_crash_reads_or_writes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Already seeded, but custom_templates got clobbered to a non-list.
+            path = self._write(
+                tmp, {"templates_seeded": True, "custom_templates": "oops"}
+            )
+            c = Config(config_path=path)
+            # Reads merge cleanly (built-ins only; the junk is dropped).
+            ids = [t["id"] for t in c.get_templates()]
+            self.assertIn(STANDARD_TEMPLATE_ID, ids)
+            # Writes still succeed against the repaired list.
+            ok, _, saved = c.save_template(
+                {"name": "Brief", "prompt": "p", "language": "auto"}
+            )
+            self.assertTrue(ok)
+            self.assertTrue(c.delete_template(saved["id"]))
+
+    def test_list_with_non_dict_entries_is_filtered_on_load(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(
+                tmp,
+                {
+                    "templates_seeded": True,
+                    "custom_templates": [
+                        "junk",
+                        None,
+                        {"id": "keep", "name": "Keep", "prompt": "p", "language": "auto"},
+                    ],
+                },
+            )
+            c = Config(config_path=path)
+            ids = [t["id"] for t in c.get_templates()]
+            self.assertIn(STANDARD_TEMPLATE_ID, ids)
+            self.assertIn("keep", ids)
+            # The non-dict entries are gone, so CRUD that iterates the list is safe.
+            self.assertTrue(c.delete_template("keep"))
+
+    def test_non_dict_template_overrides_does_not_crash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(
+                tmp, {"templates_seeded": True, "template_overrides": "nope"}
+            )
+            c = Config(config_path=path)
+            ids = [t["id"] for t in c.get_templates()]
+            self.assertIn(STANDARD_TEMPLATE_ID, ids)
+
+    def test_malformed_per_template_override_value_is_dropped(self):
+        # template_overrides is a dict, but a per-template value is junk —
+        # merge_templates would still crash on `{**base, **value}` without this.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(
+                tmp,
+                {
+                    "templates_seeded": True,
+                    "template_overrides": {STANDARD_TEMPLATE_ID: "oops"},
+                },
+            )
+            c = Config(config_path=path)
+            ids = [t["id"] for t in c.get_templates()]
+            self.assertIn(STANDARD_TEMPLATE_ID, ids)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_templates.py
+++ b/tests/test_config_templates.py
@@ -1,0 +1,90 @@
+# tests/test_config_templates.py
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.config import Config
+from src.templates import STANDARD_TEMPLATE_ID
+
+
+def _cfg(tmp):
+    return Config(config_path=Path(tmp) / "config.json")
+
+
+class TemplateSeedTests(unittest.TestCase):
+    def test_sample_is_seeded_once_on_fresh_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            ids = [t["id"] for t in c.get_templates()]
+            self.assertIn(STANDARD_TEMPLATE_ID, ids)
+            self.assertIn("shareable-summary", ids)
+
+    def test_deleting_the_sample_does_not_reseed_on_reload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            c = Config(config_path=path)
+            self.assertTrue(c.delete_template("shareable-summary"))
+            reloaded = Config(config_path=path)
+            ids = [t["id"] for t in reloaded.get_templates()]
+            self.assertNotIn("shareable-summary", ids)
+
+
+class TemplateCrudTests(unittest.TestCase):
+    def test_default_is_standard_then_settable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            self.assertEqual(c.get_default_template_id(), STANDARD_TEMPLATE_ID)
+            self.assertTrue(c.set_default_template("shareable-summary"))
+            self.assertEqual(c.get_default_template_id(), "shareable-summary")
+
+    def test_set_default_rejects_unknown_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            self.assertFalse(c.set_default_template("does-not-exist"))
+
+    def test_save_new_custom_assigns_id_and_persists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            c = Config(config_path=path)
+            ok, err, saved = c.save_template(
+                {"name": "Leitung", "prompt": "kurz", "language": "de", "icon": "doc"}
+            )
+            self.assertTrue(ok, err)
+            self.assertEqual(saved["id"], "leitung")
+            reloaded = [t for t in Config(config_path=path).get_templates() if t["id"] == "leitung"]
+            self.assertEqual(reloaded[0]["prompt"], "kurz")
+            self.assertFalse(reloaded[0]["builtin"])
+
+    def test_editing_a_custom_template_updates_in_place(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            _, _, saved = c.save_template({"name": "X", "prompt": "a", "language": "auto"})
+            ok, _, _ = c.save_template({**saved, "prompt": "b"})
+            self.assertTrue(ok)
+            again = [t for t in c.get_templates() if t["id"] == saved["id"]]
+            self.assertEqual(again[0]["prompt"], "b")
+
+    def test_locked_standard_prompt_cannot_be_overridden(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            ok, err, _ = c.save_template(
+                {"id": "standard", "name": "Renamed", "prompt": "hacked", "language": "auto"}
+            )
+            self.assertFalse(ok)
+            self.assertIn("locked", err.lower())
+
+    def test_delete_only_removes_custom(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            self.assertFalse(c.delete_template("standard"))  # built-in: not deletable
+
+    def test_save_validates_blank_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = _cfg(tmp)
+            ok, err, _ = c.save_template({"name": " ", "prompt": "x", "language": "auto"})
+            self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_default_template_report.py
+++ b/tests/test_default_template_report.py
@@ -76,6 +76,26 @@ class DefaultTemplateReportTests(unittest.TestCase):
                 mp, "T: hi", None, "en", 1, c, _FakeSummarizer(["x"]))
             self.assertIsNone(out)
 
+    def test_swallows_exceptions_writes_nothing(self):
+        class _BoomSummarizer:
+            model_name = "llama3.2:3b"
+            def summarize_transcript_streaming(self, transcript, duration_minutes=0,
+                                               language="en", notes=None,
+                                               progress_callback=None, template_prompt=None):
+                yield "## partial"
+                raise RuntimeError("model exploded mid-stream")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            c, _ = _cfg(tmp, "custom")
+            mp = Path(tmp) / "m_summary.md"
+            mp.write_text("---\n---\n\n## Summary\nx\n", encoding="utf-8")
+            # Must not propagate: a new recording must never fail because of
+            # the extra report.
+            out = simple_recorder.generate_default_template_report(
+                mp, "T: hi", None, "en", 1, c, _BoomSummarizer())
+            self.assertIsNone(out)
+            self.assertFalse((Path(tmp) / "m_reports.json").exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_default_template_report.py
+++ b/tests/test_default_template_report.py
@@ -1,0 +1,81 @@
+# tests/test_default_template_report.py
+import json, tempfile, unittest
+from pathlib import Path
+from unittest import mock
+from src.config import Config
+import simple_recorder
+from src import report_store
+
+
+class _FakeSummarizer:
+    model_name = "llama3.2:3b"
+    def __init__(self, chunks):
+        self._chunks = chunks
+    def summarize_transcript_streaming(self, transcript, duration_minutes=0, language="en",
+                                       notes=None, progress_callback=None, template_prompt=None):
+        # assert the template prompt is threaded through
+        assert template_prompt, "expected a template prompt"
+        for c in self._chunks:
+            yield c
+
+
+def _cfg(tmp, default_id):
+    c = Config(config_path=Path(tmp) / "config.json")
+    # seed a custom template + set it default
+    ok, _, saved = c.save_template({"name": "Leitung", "prompt": "Kurz für den Chef.",
+                                    "language": "auto"})
+    assert ok
+    if default_id == "custom":
+        c.set_default_template(saved["id"])
+        return c, saved["id"]
+    return c, "standard"
+
+
+class DefaultTemplateReportTests(unittest.TestCase):
+    def test_noop_when_default_is_standard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c, _ = _cfg(tmp, "standard")
+            mp = Path(tmp) / "m_summary.md"
+            mp.write_text("---\n---\n\n## Summary\nx\n", encoding="utf-8")
+            out = simple_recorder.generate_default_template_report(
+                mp, "T: hi", None, "en", 1, c, _FakeSummarizer(["ignored"]))
+            self.assertIsNone(out)
+            self.assertFalse((Path(tmp) / "m_reports.json").exists())
+
+    def test_generates_and_writes_sidecar_for_custom_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c, tid = _cfg(tmp, "custom")
+            mp = Path(tmp) / "m_summary.md"
+            mp.write_text("---\n---\n\n## Summary\nx\n", encoding="utf-8")
+            out = simple_recorder.generate_default_template_report(
+                mp, "T: hi", None, "en", 1, c, _FakeSummarizer(["## Report\n- ok"]))
+            self.assertIsNotNone(out)
+            sc = report_store.load_sidecar(mp)
+            self.assertEqual(len(sc["reports"]), 1)
+            self.assertEqual(sc["reports"][0]["template_id"], tid)
+            self.assertIn("## Report", sc["reports"][0]["content"])
+            self.assertEqual(sc["active_report"], sc["reports"][0]["id"])
+
+    def test_empty_generation_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c, _ = _cfg(tmp, "custom")
+            mp = Path(tmp) / "m_summary.md"
+            mp.write_text("---\n---\n\n## Summary\nx\n", encoding="utf-8")
+            out = simple_recorder.generate_default_template_report(
+                mp, "T: hi", None, "en", 1, c, _FakeSummarizer(["  ", "\n"]))
+            self.assertIsNone(out)
+            self.assertFalse((Path(tmp) / "m_reports.json").exists())
+
+    def test_unknown_default_is_safe_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c, _ = _cfg(tmp, "standard")
+            c._config["default_template_id"] = "ghost"  # points at nothing
+            mp = Path(tmp) / "m_summary.md"
+            mp.write_text("---\n---\n\n## Summary\nx\n", encoding="utf-8")
+            out = simple_recorder.generate_default_template_report(
+                mp, "T: hi", None, "en", 1, c, _FakeSummarizer(["x"]))
+            self.assertIsNone(out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_report_cli.py
+++ b/tests/test_generate_report_cli.py
@@ -1,0 +1,90 @@
+# tests/test_generate_report_cli.py
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+from unittest import mock
+
+import simple_recorder
+from src.config import Config
+
+
+def _write_summary(tmp, transcript="Alice: hi. Bob: bye."):
+    p = Path(tmp) / "meeting_summary.json"
+    p.write_text(json.dumps({
+        "summary": "Existing summary",
+        "transcript": transcript,
+        "session_info": {"name": "Test", "duration_minutes": 10},
+    }))
+    return p
+
+
+class GenerateReportCliTests(unittest.TestCase):
+    def test_unknown_template_emits_stream_error_and_nonzero_exit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = _write_summary(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            with mock.patch("src.config.get_config", return_value=cfg):
+                res = CliRunner().invoke(
+                    simple_recorder.generate_report,
+                    [str(summary), "does-not-exist"],
+                )
+            self.assertNotEqual(res.exit_code, 0)
+            self.assertIn("STREAM_ERROR", res.output)
+            # No report persisted.
+            data = json.loads(summary.read_text())
+            self.assertFalse(data.get("reports"))
+
+    def test_empty_stream_emits_stream_error_and_nonzero_exit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = _write_summary(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+
+            fake_summarizer = mock.MagicMock()
+            fake_summarizer.model_name = "llama3.2:3b"
+            # Stream yields only whitespace → must be treated as empty.
+            fake_summarizer.summarize_transcript_streaming.return_value = iter(["   ", "\n"])
+
+            with mock.patch("src.config.get_config", return_value=cfg), \
+                 mock.patch("src.summarizer.OllamaSummarizer", return_value=fake_summarizer):
+                res = CliRunner().invoke(
+                    simple_recorder.generate_report,
+                    [str(summary), "standard"],
+                )
+            self.assertNotEqual(res.exit_code, 0)
+            self.assertIn("STREAM_ERROR", res.output)
+            self.assertIn("empty report", res.output)
+            data = json.loads(summary.read_text())
+            self.assertFalse(data.get("reports"))
+
+    def test_valid_stream_writes_before_stream_complete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = _write_summary(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+
+            fake_summarizer = mock.MagicMock()
+            fake_summarizer.model_name = "llama3.2:3b"
+            fake_summarizer.summarize_transcript_streaming.return_value = iter(
+                ["## Report\n", "- body"]
+            )
+
+            with mock.patch("src.config.get_config", return_value=cfg), \
+                 mock.patch("src.summarizer.OllamaSummarizer", return_value=fake_summarizer):
+                res = CliRunner().invoke(
+                    simple_recorder.generate_report,
+                    [str(summary), "standard"],
+                )
+            self.assertEqual(res.exit_code, 0, res.output)
+            # Ordering: the file is written before STREAM_COMPLETE is emitted.
+            saved_idx = res.output.find("STREAM_COMPLETE")
+            self.assertNotEqual(saved_idx, -1)
+            data = json.loads(summary.read_text())
+            self.assertEqual(len(data["reports"]), 1)
+            self.assertIn("body", data["reports"][0]["content"])
+            self.assertEqual(data["active_report"], data["reports"][0]["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_report_cli.py
+++ b/tests/test_generate_report_cli.py
@@ -8,16 +8,27 @@ from click.testing import CliRunner
 from unittest import mock
 
 import simple_recorder
+from src import report_store
 from src.config import Config
+
+_MD_TEMPLATE = """\
+---
+language: en
+duration_seconds: 600
+---
+## Summary
+
+Existing summary
+
+## Transcript
+
+{transcript}
+"""
 
 
 def _write_summary(tmp, transcript="Alice: hi. Bob: bye."):
-    p = Path(tmp) / "meeting_summary.json"
-    p.write_text(json.dumps({
-        "summary": "Existing summary",
-        "transcript": transcript,
-        "session_info": {"name": "Test", "duration_minutes": 10},
-    }))
+    p = Path(tmp) / "meeting_summary.md"
+    p.write_text(_MD_TEMPLATE.format(transcript=transcript))
     return p
 
 
@@ -33,9 +44,9 @@ class GenerateReportCliTests(unittest.TestCase):
                 )
             self.assertNotEqual(res.exit_code, 0)
             self.assertIn("STREAM_ERROR", res.output)
-            # No report persisted.
-            data = json.loads(summary.read_text())
-            self.assertFalse(data.get("reports"))
+            # No sidecar written.
+            sidecar_p = report_store.sidecar_path(summary)
+            self.assertFalse(sidecar_p.exists())
 
     def test_empty_stream_emits_stream_error_and_nonzero_exit(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -56,8 +67,9 @@ class GenerateReportCliTests(unittest.TestCase):
             self.assertNotEqual(res.exit_code, 0)
             self.assertIn("STREAM_ERROR", res.output)
             self.assertIn("empty report", res.output)
-            data = json.loads(summary.read_text())
-            self.assertFalse(data.get("reports"))
+            # No sidecar written.
+            sidecar_p = report_store.sidecar_path(summary)
+            self.assertFalse(sidecar_p.exists())
 
     def test_valid_stream_writes_before_stream_complete(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -77,13 +89,17 @@ class GenerateReportCliTests(unittest.TestCase):
                     [str(summary), "standard"],
                 )
             self.assertEqual(res.exit_code, 0, res.output)
-            # Ordering: the file is written before STREAM_COMPLETE is emitted.
-            saved_idx = res.output.find("STREAM_COMPLETE")
-            self.assertNotEqual(saved_idx, -1)
-            data = json.loads(summary.read_text())
-            self.assertEqual(len(data["reports"]), 1)
-            self.assertIn("body", data["reports"][0]["content"])
-            self.assertEqual(data["active_report"], data["reports"][0]["id"])
+            # Ordering: the sidecar is written before STREAM_COMPLETE is emitted.
+            self.assertIn("STREAM_COMPLETE", res.output)
+            # Report landed in the sidecar, NOT the meeting file.
+            sidecar_p = report_store.sidecar_path(summary)
+            self.assertTrue(sidecar_p.exists(), "sidecar file should exist")
+            sidecar = json.loads(sidecar_p.read_text())
+            self.assertEqual(len(sidecar["reports"]), 1)
+            self.assertIn("body", sidecar["reports"][0]["content"])
+            self.assertEqual(sidecar["active_report"], sidecar["reports"][0]["id"])
+            # Meeting file itself must NOT be modified (it's still a .md).
+            self.assertTrue(summary.read_text().startswith("---"))
 
 
 if __name__ == "__main__":

--- a/tests/test_report_store.py
+++ b/tests/test_report_store.py
@@ -85,7 +85,7 @@ class ReadMeetingTests(unittest.TestCase):
             mp.write_text(MD.split("## User Notes")[0], encoding="utf-8")
             m = S.read_meeting(mp)
             self.assertIn("Speaker A: hello.", m["transcript"])
-            self.assertIn(m["notes"] or "", ("", None))
+            self.assertIsNone(m["notes"])
 
     def test_transcript_text_containing_heading_literal_not_truncated(self):
         # A transcript whose TEXT contains the literal '## Transcript' (e.g. a
@@ -106,7 +106,7 @@ class ReadMeetingTests(unittest.TestCase):
             self.assertIn("written ## Transcript on its own line.", m["transcript"])
             self.assertIn("## User Notes inline like this.", m["transcript"])
             # Notes were NOT split out from the inline mention.
-            self.assertIn(m["notes"] or "", ("", None))
+            self.assertIsNone(m["notes"])
             # Summary stays clean.
             self.assertIn("Discussed the markdown spec.", m["summary_markdown"])
             self.assertNotIn("Speaker A", m["summary_markdown"])

--- a/tests/test_report_store.py
+++ b/tests/test_report_store.py
@@ -1,0 +1,92 @@
+# tests/test_report_store.py
+import json, tempfile, unittest
+from pathlib import Path
+from src import report_store as S
+
+
+MD = '''---
+title: "Note"
+date: "2026-06-14T08:43:37"
+duration_seconds: 120
+language: "de"
+is_diarised: false
+---
+
+## Summary
+An overview.
+
+## Key Points
+- one
+
+## Transcript
+
+Speaker A: hello.
+Speaker B: hi.
+
+## User Notes
+
+remember coffee
+'''
+
+
+class SidecarPathTests(unittest.TestCase):
+    def test_md_and_json_map_to_same_sidecar(self):
+        self.assertEqual(S.sidecar_path("/x/abc_summary.md").name, "abc_reports.json")
+        self.assertEqual(S.sidecar_path("/x/abc_summary.json").name, "abc_reports.json")
+
+
+class LoadSaveSidecarTests(unittest.TestCase):
+    def test_missing_returns_empty(self):
+        with tempfile.TemporaryDirectory() as t:
+            sc = S.load_sidecar(Path(t) / "m_summary.md")
+            self.assertEqual(sc, {"reports": [], "active_report": None})
+
+    def test_save_then_load_roundtrip(self):
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.md"
+            S.save_sidecar(mp, {"reports": [{"id": "r1"}], "active_report": "r1"})
+            self.assertEqual(S.load_sidecar(mp)["active_report"], "r1")
+            self.assertTrue((Path(t) / "m_reports.json").exists())
+
+
+class ReadMeetingTests(unittest.TestCase):
+    def test_reads_md_transcript_notes_summary(self):
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.md"
+            mp.write_text(MD, encoding="utf-8")
+            m = S.read_meeting(mp)
+            self.assertIn("Speaker A: hello.", m["transcript"])
+            self.assertIn("Speaker B: hi.", m["transcript"])
+            self.assertNotIn("## Transcript", m["transcript"])
+            self.assertEqual(m["notes"].strip(), "remember coffee")
+            self.assertIn("## Summary", m["summary_markdown"])
+            self.assertIn("An overview.", m["summary_markdown"])
+            self.assertNotIn("## Transcript", m["summary_markdown"])
+            self.assertEqual(m["language"], "de")
+            self.assertEqual(m["duration_minutes"], 2)
+
+    def test_reads_json_meeting(self):
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.json"
+            mp.write_text(json.dumps({
+                "transcript": "T: hi", "user_notes": "n",
+                "summary": "ov", "key_points": ["kp"], "discussion_areas": [], "action_items": [],
+                "session_info": {"duration_seconds": 180, "output_language": "en"},
+            }), encoding="utf-8")
+            m = S.read_meeting(mp)
+            self.assertEqual(m["transcript"], "T: hi")
+            self.assertEqual(m["language"], "en")
+            self.assertEqual(m["duration_minutes"], 3)
+            self.assertIn("ov", m["summary_markdown"])
+
+    def test_md_without_notes_section(self):
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.md"
+            mp.write_text(MD.split("## User Notes")[0], encoding="utf-8")
+            m = S.read_meeting(mp)
+            self.assertIn("Speaker A: hello.", m["transcript"])
+            self.assertIn(m["notes"] or "", ("", None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_store.py
+++ b/tests/test_report_store.py
@@ -87,6 +87,46 @@ class ReadMeetingTests(unittest.TestCase):
             self.assertIn("Speaker A: hello.", m["transcript"])
             self.assertIn(m["notes"] or "", ("", None))
 
+    def test_transcript_text_containing_heading_literal_not_truncated(self):
+        # A transcript whose TEXT contains the literal '## Transcript' (e.g. a
+        # speaker reading a markdown heading aloud) must not split the section
+        # early / misclassify content. Only a real heading line splits.
+        md = (
+            "---\ntitle: \"N\"\nduration_seconds: 60\nlanguage: \"en\"\n---\n\n"
+            "## Summary\nDiscussed the markdown spec.\n\n"
+            "## Transcript\n\n"
+            "Speaker A: the heading is written ## Transcript on its own line.\n"
+            "Speaker B: and notes use ## User Notes inline like this.\n"
+        )
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.md"
+            mp.write_text(md, encoding="utf-8")
+            m = S.read_meeting(mp)
+            # The whole transcript survives, including the literal heading text.
+            self.assertIn("written ## Transcript on its own line.", m["transcript"])
+            self.assertIn("## User Notes inline like this.", m["transcript"])
+            # Notes were NOT split out from the inline mention.
+            self.assertIn(m["notes"] or "", ("", None))
+            # Summary stays clean.
+            self.assertIn("Discussed the markdown spec.", m["summary_markdown"])
+            self.assertNotIn("Speaker A", m["summary_markdown"])
+
+    def test_summary_text_containing_heading_literal_not_split(self):
+        # The summary body mentioning '## Transcript' inline must not be treated
+        # as the section boundary.
+        md = (
+            "---\ntitle: \"N\"\nduration_seconds: 60\nlanguage: \"en\"\n---\n\n"
+            "## Summary\nWe agreed the note format uses ## Transcript as a header.\n\n"
+            "## Transcript\n\n"
+            "Speaker A: hello.\n"
+        )
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.md"
+            mp.write_text(md, encoding="utf-8")
+            m = S.read_meeting(mp)
+            self.assertIn("uses ## Transcript as a header.", m["summary_markdown"])
+            self.assertEqual(m["transcript"].strip(), "Speaker A: hello.")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_report_store.py
+++ b/tests/test_report_store.py
@@ -48,6 +48,20 @@ class LoadSaveSidecarTests(unittest.TestCase):
             self.assertEqual(S.load_sidecar(mp)["active_report"], "r1")
             self.assertTrue((Path(t) / "m_reports.json").exists())
 
+    def test_malformed_types_are_normalized(self):
+        # A hand-edited / partially-written sidecar with wrong-typed keys must
+        # not propagate: reports coerces to a list, active_report to None,
+        # so downstream iteration/append can't blow up.
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.md"
+            (Path(t) / "m_reports.json").write_text(
+                json.dumps({"reports": "oops", "active_report": {"bad": 1}}),
+                encoding="utf-8",
+            )
+            sc = S.load_sidecar(mp)
+            self.assertEqual(sc["reports"], [])
+            self.assertIsNone(sc["active_report"])
+
 
 class ReadMeetingTests(unittest.TestCase):
     def test_reads_md_transcript_notes_summary(self):

--- a/tests/test_report_versions_cli.py
+++ b/tests/test_report_versions_cli.py
@@ -3,51 +3,88 @@ import json, tempfile, unittest
 from pathlib import Path
 from click.testing import CliRunner
 import simple_recorder
+from src import report_store
 
 
 def _last_json(out):
     return json.loads([l for l in out.splitlines() if l.strip().startswith("{")][-1])
 
 
-def _seed(tmp, meeting):
+def _seed(tmp, meeting, sidecar=None):
+    """Write a meeting JSON and optionally a sidecar. Returns the meeting path."""
     p = Path(tmp) / "m_summary.json"
     p.write_text(json.dumps(meeting))
+    if sidecar is not None:
+        sp = report_store.sidecar_path(p)
+        sp.write_text(json.dumps(sidecar))
     return p
+
+
+def _read_sidecar(meeting_path):
+    return json.loads(report_store.sidecar_path(meeting_path).read_text())
 
 
 class SetActiveDeleteCliTests(unittest.TestCase):
     def _meeting(self):
+        """Minimal meeting JSON — no reports/active_report in the meeting file."""
         return {"session_info": {"name": "M", "summary_file": "m_summary.json"},
-                "summary": "s", "discussion_areas": [], "key_points": [], "action_items": [],
-                "reports": [{"id": "rep_1", "template_id": "t", "template_name": "T",
-                             "model": "m", "content": "c", "created_at": "2026-01-01T00:00:00"}],
+                "summary": "s", "discussion_areas": [], "key_points": [], "action_items": []}
+
+    def _sidecar(self):
+        """Sidecar with one report pre-seeded."""
+        return {"reports": [{"id": "rep_1", "template_id": "t", "template_name": "T",
+                              "model": "m", "content": "c", "created_at": "2026-01-01T00:00:00"}],
                 "active_report": None}
 
-    def test_set_active_persists(self):
+    def test_set_active_persists_to_sidecar(self):
+        """set-active-report must write active_report to the SIDECAR, not the meeting file."""
         with tempfile.TemporaryDirectory() as tmp:
-            p = _seed(tmp, self._meeting())
+            p = _seed(tmp, self._meeting(), self._sidecar())
             res = CliRunner().invoke(simple_recorder.set_active_report, [str(p), "rep_1"])
             self.assertTrue(_last_json(res.output)["success"])
-            self.assertEqual(json.loads(p.read_text())["active_report"], "rep_1")
+            # Sidecar is updated
+            sidecar = _read_sidecar(p)
+            self.assertEqual(sidecar["active_report"], "rep_1")
+            # Meeting file is untouched (no active_report key injected)
+            meeting = json.loads(p.read_text())
+            self.assertNotIn("active_report", meeting)
 
-    def test_set_active_standard_clears(self):
+    def test_set_active_standard_clears_in_sidecar(self):
+        """'standard' clears active_report in the sidecar."""
         with tempfile.TemporaryDirectory() as tmp:
-            m = self._meeting(); m["active_report"] = "rep_1"
-            p = _seed(tmp, m)
+            sc = self._sidecar()
+            sc["active_report"] = "rep_1"
+            p = _seed(tmp, self._meeting(), sc)
             CliRunner().invoke(simple_recorder.set_active_report, [str(p), "standard"])
-            self.assertIsNone(json.loads(p.read_text())["active_report"])
+            sidecar = _read_sidecar(p)
+            self.assertIsNone(sidecar["active_report"])
+            meeting = json.loads(p.read_text())
+            self.assertNotIn("active_report", meeting)
 
-    def test_delete_report_removes(self):
+    def test_delete_report_removes_from_sidecar(self):
+        """delete-report must remove the entry from the SIDECAR."""
         with tempfile.TemporaryDirectory() as tmp:
-            p = _seed(tmp, self._meeting())
+            p = _seed(tmp, self._meeting(), self._sidecar())
             res = CliRunner().invoke(simple_recorder.delete_report, [str(p), "rep_1"])
             self.assertTrue(_last_json(res.output)["success"])
-            self.assertEqual(json.loads(p.read_text())["reports"], [])
+            sidecar = _read_sidecar(p)
+            self.assertEqual(sidecar["reports"], [])
+            # Meeting file is untouched
+            meeting = json.loads(p.read_text())
+            self.assertNotIn("reports", meeting)
 
     def test_set_active_unknown_exits_nonzero(self):
+        """Unknown report_id must produce non-zero exit."""
         with tempfile.TemporaryDirectory() as tmp:
-            p = _seed(tmp, self._meeting())
+            p = _seed(tmp, self._meeting(), self._sidecar())
             res = CliRunner().invoke(simple_recorder.set_active_report, [str(p), "nope"])
+            self.assertNotEqual(res.exit_code, 0)
+
+    def test_delete_unknown_exits_nonzero(self):
+        """Unknown report_id in delete-report must produce non-zero exit."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _seed(tmp, self._meeting(), self._sidecar())
+            res = CliRunner().invoke(simple_recorder.delete_report, [str(p), "nope"])
             self.assertNotEqual(res.exit_code, 0)
 
 

--- a/tests/test_report_versions_cli.py
+++ b/tests/test_report_versions_cli.py
@@ -1,0 +1,55 @@
+# tests/test_report_versions_cli.py
+import json, tempfile, unittest
+from pathlib import Path
+from click.testing import CliRunner
+import simple_recorder
+
+
+def _last_json(out):
+    return json.loads([l for l in out.splitlines() if l.strip().startswith("{")][-1])
+
+
+def _seed(tmp, meeting):
+    p = Path(tmp) / "m_summary.json"
+    p.write_text(json.dumps(meeting))
+    return p
+
+
+class SetActiveDeleteCliTests(unittest.TestCase):
+    def _meeting(self):
+        return {"session_info": {"name": "M", "summary_file": "m_summary.json"},
+                "summary": "s", "discussion_areas": [], "key_points": [], "action_items": [],
+                "reports": [{"id": "rep_1", "template_id": "t", "template_name": "T",
+                             "model": "m", "content": "c", "created_at": "2026-01-01T00:00:00"}],
+                "active_report": None}
+
+    def test_set_active_persists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _seed(tmp, self._meeting())
+            res = CliRunner().invoke(simple_recorder.set_active_report, [str(p), "rep_1"])
+            self.assertTrue(_last_json(res.output)["success"])
+            self.assertEqual(json.loads(p.read_text())["active_report"], "rep_1")
+
+    def test_set_active_standard_clears(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = self._meeting(); m["active_report"] = "rep_1"
+            p = _seed(tmp, m)
+            CliRunner().invoke(simple_recorder.set_active_report, [str(p), "standard"])
+            self.assertIsNone(json.loads(p.read_text())["active_report"])
+
+    def test_delete_report_removes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _seed(tmp, self._meeting())
+            res = CliRunner().invoke(simple_recorder.delete_report, [str(p), "rep_1"])
+            self.assertTrue(_last_json(res.output)["success"])
+            self.assertEqual(json.loads(p.read_text())["reports"], [])
+
+    def test_set_active_unknown_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _seed(tmp, self._meeting())
+            res = CliRunner().invoke(simple_recorder.set_active_report, [str(p), "nope"])
+            self.assertNotEqual(res.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,30 @@
+# tests/test_reports.py
+import json, tempfile, unittest
+from pathlib import Path
+from src import reports as R
+from src.config import Config
+
+
+class ReportHelpersTests(unittest.TestCase):
+    def test_append_sets_active_and_appends(self):
+        m = {"summary": "x"}
+        rep = {"id": "rep_1", "template_id": "t", "template_name": "T",
+               "model": "llama3.2:3b", "content": "## R\nbody", "created_at": "2026-01-01T00:00:00"}
+        R.append_report(m, rep)
+        self.assertEqual(m["reports"][0]["content"], "## R\nbody")
+        self.assertEqual(m["active_report"], "rep_1")
+
+    def test_ids_are_unique(self):
+        self.assertNotEqual(R.new_report_id(), R.new_report_id())
+
+
+class GetTemplateTests(unittest.TestCase):
+    def test_get_template_returns_standard_and_none_for_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            c = Config(config_path=Path(tmp) / "config.json")
+            self.assertEqual(c.get_template("standard")["id"], "standard")
+            self.assertIsNone(c.get_template("nope"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reports_versions.py
+++ b/tests/test_reports_versions.py
@@ -1,0 +1,71 @@
+# tests/test_reports_versions.py
+import unittest
+from src import reports as R
+
+
+class StructuredToMarkdownTests(unittest.TestCase):
+    def test_renders_all_sections_present(self):
+        md = R.structured_to_markdown(
+            "An overview.",
+            [{"title": "Topic A", "analysis": "did A"}],
+            ["point one"],
+            ["do the thing"],
+        )
+        self.assertIn("## Summary", md)
+        self.assertIn("An overview.", md)
+        self.assertIn("### Topic A", md)
+        self.assertIn("did A", md)
+        self.assertIn("- point one", md)
+        self.assertIn("- do the thing", md)
+
+    def test_skips_empty_sections(self):
+        md = R.structured_to_markdown("Only overview.", [], [], [])
+        self.assertIn("Only overview.", md)
+        self.assertNotIn("## Key Points", md)
+        self.assertNotIn("## Action Items", md)
+
+    def test_tolerates_string_or_dict_items(self):
+        md = R.structured_to_markdown(
+            "o", [], [{"decision": "kp dict"}, "kp str"], [{"description": "ai dict"}, "ai str"]
+        )
+        self.assertIn("- kp dict", md)
+        self.assertIn("- kp str", md)
+        self.assertIn("- ai dict", md)
+        self.assertIn("- ai str", md)
+
+
+class SetActiveRemoveTests(unittest.TestCase):
+    def _meeting(self):
+        return {"reports": [
+            {"id": "rep_1", "template_id": "t", "template_name": "T", "model": "m",
+             "content": "c", "created_at": "2026-01-01T00:00:00"}],
+            "active_report": "rep_1"}
+
+    def test_set_active_to_standard_clears_pointer(self):
+        m = self._meeting()
+        self.assertTrue(R.set_active(m, "standard"))
+        self.assertIsNone(m.get("active_report"))
+
+    def test_set_active_to_known_report(self):
+        m = self._meeting()
+        m["active_report"] = None
+        self.assertTrue(R.set_active(m, "rep_1"))
+        self.assertEqual(m["active_report"], "rep_1")
+
+    def test_set_active_unknown_returns_false(self):
+        m = self._meeting()
+        self.assertFalse(R.set_active(m, "nope"))
+
+    def test_remove_drops_entry_and_clears_active(self):
+        m = self._meeting()
+        self.assertTrue(R.remove_report(m, "rep_1"))
+        self.assertEqual(m["reports"], [])
+        self.assertIsNone(m.get("active_report"))
+
+    def test_remove_unknown_returns_false(self):
+        m = self._meeting()
+        self.assertFalse(R.remove_report(m, "nope"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reports_versions.py
+++ b/tests/test_reports_versions.py
@@ -24,6 +24,29 @@ class StructuredToMarkdownTests(unittest.TestCase):
         self.assertNotIn("## Key Points", md)
         self.assertNotIn("## Action Items", md)
 
+    def test_empty_summary_with_sections_still_nonempty(self):
+        # Fix B2 (HIGH): a prior note with empty `summary` but populated
+        # discussion_areas/key_points/action_items must still reconstruct to a
+        # non-empty backup markdown, so the reprocess #249 snapshot fires and the
+        # old version isn't lost. The gate is `_backup_md.strip()`, so prove it
+        # is truthy here.
+        md = R.structured_to_markdown(
+            "",
+            [{"title": "Topic A", "analysis": "did A"}],
+            ["a key point"],
+            ["an action item"],
+        )
+        self.assertTrue(md.strip(), "expected non-empty backup md for empty-summary note")
+        self.assertNotIn("## Summary", md)
+        self.assertIn("### Topic A", md)
+        self.assertIn("- a key point", md)
+        self.assertIn("- an action item", md)
+
+    def test_all_fields_empty_yields_empty(self):
+        # The gate must NOT fire when there's genuinely nothing to back up.
+        md = R.structured_to_markdown("", [], [], [])
+        self.assertFalse(md.strip(), "expected empty md when every field is empty")
+
     def test_tolerates_string_or_dict_items(self):
         md = R.structured_to_markdown(
             "o", [], [{"decision": "kp dict"}, "kp str"], [{"description": "ai dict"}, "ai str"]

--- a/tests/test_summarizer_template.py
+++ b/tests/test_summarizer_template.py
@@ -5,7 +5,11 @@ from src.summarizer import OllamaSummarizer
 
 
 def _s(model="llama3.2:3b"):
-    return OllamaSummarizer(model_name=model, ai_provider="local", config=Config())
+    # Construct under a mocked readiness check: __init__ calls _ensure_ollama_ready()
+    # for the local provider, so without this the tests would try to start Ollama at
+    # construction time (non-hermetic — fails on any machine without Ollama).
+    with mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready", return_value=True):
+        return OllamaSummarizer(model_name=model, ai_provider="local", config=Config())
 
 
 class TemplatePromptTests(unittest.TestCase):

--- a/tests/test_summarizer_template.py
+++ b/tests/test_summarizer_template.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest import mock
+from src.config import Config
+from src.summarizer import OllamaSummarizer
+
+
+def _s(model="llama3.2:3b"):
+    return OllamaSummarizer(model_name=model, ai_provider="local", config=Config())
+
+
+class TemplatePromptTests(unittest.TestCase):
+    def test_prompt_embeds_template_instructions_and_transcript(self):
+        s = _s()
+        p = s._create_template_report_prompt("ALICE: hi BOB: ok",
+                                             "Write a status update.", language="en")
+        self.assertIn("Write a status update.", p)
+        self.assertIn("ALICE: hi BOB: ok", p)
+
+    def test_prompt_adds_language_instruction_when_pinned(self):
+        s = _s()
+        p = s._create_template_report_prompt("t", "Summarise.", language="de")
+        self.assertIn("German", p)
+
+    def test_prompt_no_language_instruction_for_auto(self):
+        s = _s()
+        p = s._create_template_report_prompt("t", "Summarise.", language="auto")
+        self.assertNotIn("CRITICAL: Write", p)
+
+    def test_streaming_with_template_uses_direct_path_and_template_prompt(self):
+        s = _s()
+        long_t = "Speaker: words.\n" * 4000  # would chunk on the summary path
+        seen = {}
+
+        def fake_chat(**kwargs):
+            seen["content"] = kwargs["messages"][0]["content"]
+            seen["think"] = kwargs.get("think")
+            return iter([{"message": {"content": "## Status\nok\n"}}])
+
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with mock.patch.object(s.client, "chat", side_effect=fake_chat) as mock_chat:
+                out = "".join(s.summarize_transcript_streaming(
+                    long_t, 0, "en", None, template_prompt="Write a status update."))
+        # one direct chat call (NOT N+1 map-reduce), template prompt used, think disabled
+        self.assertEqual(mock_chat.call_count, 1)
+        self.assertIn("Write a status update.", seen["content"])
+        self.assertIs(seen["think"], False)
+        self.assertIn("## Status", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarizer_template.py
+++ b/tests/test_summarizer_template.py
@@ -46,6 +46,48 @@ class TemplatePromptTests(unittest.TestCase):
         self.assertIs(seen["think"], False)
         self.assertIn("## Status", out)
 
+    def test_streaming_with_template_uses_active_cloud_provider_not_ollama(self):
+        # Regression: the free-form template path must honour the active provider.
+        # In cloud mode self.client (Ollama) is None, so routing a template report
+        # through _stream_direct would crash. It must go through the cloud client.
+        s = _s()
+        s.ai_provider = "cloud"
+        s.cloud_provider = "openai"
+        s.client = None  # cloud mode has no Ollama client
+
+        captured = {}
+
+        class _Delta:
+            def __init__(self, c):
+                self.content = c
+
+        class _Choice:
+            def __init__(self, c):
+                self.delta = _Delta(c)
+
+        class _Chunk:
+            def __init__(self, c):
+                self.choices = [_Choice(c)]
+
+        def fake_create(**kwargs):
+            captured["content"] = kwargs["messages"][0]["content"]
+            captured["stream"] = kwargs.get("stream")
+            return iter([_Chunk("## Status\n"), _Chunk("ok\n")])
+
+        s.cloud_client = mock.Mock()
+        s.cloud_client.chat.completions.create.side_effect = fake_create
+
+        # Patch _ensure_ollama_ready so the buggy (pre-fix) path fails fast on the
+        # None client instead of trying to spin up Ollama in cloud mode.
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            out = "".join(s.summarize_transcript_streaming(
+                "Speaker: hi.", 0, "en", None, template_prompt="Write a status update."))
+
+        self.assertEqual(s.cloud_client.chat.completions.create.call_count, 1)
+        self.assertIn("Write a status update.", captured["content"])
+        self.assertTrue(captured["stream"])
+        self.assertIn("## Status", out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,58 @@
+# tests/test_templates.py
+import unittest
+from src import templates as T
+
+
+class BuiltinRegistryTests(unittest.TestCase):
+    def test_standard_is_the_only_builtin_and_is_locked_structured(self):
+        self.assertEqual(list(T.BUILTIN_TEMPLATES), ["standard"])
+        std = T.BUILTIN_TEMPLATES["standard"]
+        self.assertEqual(std["id"], T.STANDARD_TEMPLATE_ID)
+        self.assertTrue(std["locked"])
+        self.assertEqual(std["format"], "structured")
+
+    def test_sample_is_an_editable_markdown_custom_template(self):
+        s = T.SAMPLE_TEMPLATE
+        self.assertEqual(s["id"], "shareable-summary")
+        self.assertEqual(s["format"], "markdown")
+        self.assertTrue(s["prompt"].strip())
+        self.assertNotIn("locked", s)  # custom: not locked
+
+    def test_new_template_id_slugifies_and_dedupes(self):
+        self.assertEqual(T.new_template_id("Sprint Planning", set()), "sprint-planning")
+        self.assertEqual(
+            T.new_template_id("Sprint Planning", {"sprint-planning"}),
+            "sprint-planning-2",
+        )
+
+    def test_validate_rejects_blank_name_and_bad_language(self):
+        ok, _ = T.validate_template(
+            {"name": "", "prompt": "x", "language": "auto"}, {"auto", "de"}
+        )
+        self.assertFalse(ok)
+        ok, _ = T.validate_template(
+            {"name": "X", "prompt": "x", "language": "xx"}, {"auto", "de"}
+        )
+        self.assertFalse(ok)
+        ok, _ = T.validate_template(
+            {"name": "X", "prompt": "x", "language": "de"}, {"auto", "de"}
+        )
+        self.assertTrue(ok)
+
+    def test_merge_applies_overrides_and_tags_builtin(self):
+        merged = T.merge_templates(
+            overrides={"standard": {"name": "Default note"}},
+            custom=[{"id": "leitung", "name": "Leitung", "prompt": "p", "language": "de",
+                     "format": "markdown"}],
+        )
+        std = next(m for m in merged if m["id"] == "standard")
+        self.assertEqual(std["name"], "Default note")   # override applied
+        self.assertTrue(std["builtin"] and std["locked"])
+        custom = next(m for m in merged if m["id"] == "leitung")
+        self.assertFalse(custom["builtin"])
+        # built-ins come first
+        self.assertEqual(merged[0]["id"], "standard")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -64,11 +64,14 @@ class BuiltinRegistryTests(unittest.TestCase):
                 {"name": "X", "prompt": "p", "language": bad_lang}, langs
             )
             self.assertFalse(ok)
-        # format: present but invalid
-        ok, _ = T.validate_template(
-            {"name": "X", "prompt": "p", "language": "auto", "format": "weird"}, langs
-        )
-        self.assertFalse(ok)
+        # format: present but invalid — including non-string/unhashable payloads
+        # that would raise on a naive `fmt in VALID_FORMATS` membership check.
+        for bad_fmt in ("weird", ["markdown"], {"k": "v"}, 5):
+            ok, msg = T.validate_template(
+                {"name": "X", "prompt": "p", "language": "auto", "format": bad_fmt}, langs
+            )
+            self.assertFalse(ok)
+            self.assertTrue(msg)
         # icon: present but not a str
         ok, _ = T.validate_template(
             {"name": "X", "prompt": "p", "language": "auto", "icon": 5}, langs

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -39,6 +39,54 @@ class BuiltinRegistryTests(unittest.TestCase):
         )
         self.assertTrue(ok)
 
+    def test_validate_is_defensive_at_the_trust_boundary(self):
+        langs = {"auto", "de"}
+        # Non-dict payloads must return (False, msg), never raise.
+        for bad in ([], None, 42):
+            ok, msg = T.validate_template(bad, langs)
+            self.assertFalse(ok)
+            self.assertTrue(msg)
+        # name: numeric / blank / over-long
+        for bad_name in (123, "", "   ", "x" * (T.MAX_NAME_LEN + 1)):
+            ok, _ = T.validate_template(
+                {"name": bad_name, "prompt": "p", "language": "auto"}, langs
+            )
+            self.assertFalse(ok)
+        # prompt: missing / blank / over-long / numeric
+        for bad_prompt in (None, "", "   ", 123, "x" * (T.MAX_PROMPT_LEN + 1)):
+            ok, _ = T.validate_template(
+                {"name": "X", "prompt": bad_prompt, "language": "auto"}, langs
+            )
+            self.assertFalse(ok)
+        # language: array / unknown
+        for bad_lang in (["de"], "xx"):
+            ok, _ = T.validate_template(
+                {"name": "X", "prompt": "p", "language": bad_lang}, langs
+            )
+            self.assertFalse(ok)
+        # format: present but invalid
+        ok, _ = T.validate_template(
+            {"name": "X", "prompt": "p", "language": "auto", "format": "weird"}, langs
+        )
+        self.assertFalse(ok)
+        # icon: present but not a str
+        ok, _ = T.validate_template(
+            {"name": "X", "prompt": "p", "language": "auto", "icon": 5}, langs
+        )
+        self.assertFalse(ok)
+        # A fully valid dict still passes.
+        ok, msg = T.validate_template(
+            {"name": "X", "prompt": "p", "language": "de",
+             "format": "markdown", "icon": "doc"},
+            langs,
+        )
+        self.assertTrue(ok, msg)
+
+    def test_sample_icon_is_a_valid_editor_key(self):
+        editor_keys = {"doc", "people", "calendar", "lightbulb", "phone", "megaphone"}
+        self.assertEqual(T.SAMPLE_TEMPLATE["icon"], "megaphone")
+        self.assertIn(T.SAMPLE_TEMPLATE["icon"], editor_keys)
+
     def test_merge_applies_overrides_and_tags_builtin(self):
         merged = T.merge_templates(
             overrides={"standard": {"name": "Default note"}},

--- a/tests/test_templates_cli.py
+++ b/tests/test_templates_cli.py
@@ -1,0 +1,53 @@
+# tests/test_templates_cli.py
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+from unittest import mock
+
+import simple_recorder
+from src.config import Config
+
+
+def _last_json(output):
+    line = [ln for ln in output.splitlines() if ln.strip().startswith("{")][-1]
+    return json.loads(line)
+
+
+class TemplatesCliTests(unittest.TestCase):
+    def _run(self, cmd, args, tmp):
+        cfg = Config(config_path=Path(tmp) / "config.json")
+        with mock.patch("src.config.get_config", return_value=cfg):
+            return CliRunner().invoke(cmd, args), cfg
+
+    def test_list_templates_includes_standard_and_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            res, _ = self._run(simple_recorder.list_templates, [], tmp)
+            data = _last_json(res.output)
+            ids = [t["id"] for t in data["templates"]]
+            self.assertIn("standard", ids)
+            self.assertEqual(data["default_template_id"], "standard")
+
+    def test_save_template_creates_custom(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = json.dumps({"name": "Leitung", "prompt": "kurz", "language": "de"})
+            res, cfg = self._run(simple_recorder.save_template, [payload], tmp)
+            data = _last_json(res.output)
+            self.assertTrue(data["success"])
+            self.assertEqual(data["template"]["id"], "leitung")
+
+    def test_set_default_template_persists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            res, cfg = self._run(simple_recorder.set_default_template, ["shareable-summary"], tmp)
+            self.assertTrue(_last_json(res.output)["success"])
+
+    def test_set_default_unknown_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            res, _ = self._run(simple_recorder.set_default_template, ["nope"], tmp)
+            self.assertNotEqual(res.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked on #250.** This branch is based on `feat/map-reduce-summarization-188`, so until #250 merges the diff below also includes #250's commits. The work specific to this PR is the report-storage-sidecar + templates + reports commits on top. Please review/merge after #250.

## What this does

Adds user-defined **report templates** and **per-meeting report generation/versioning**, persisted via a meeting **sidecar** — so a meeting can have more than one summary (the structured Standard plus any number of template-driven reports), switchable in the UI.

### Templates
- Built-in registry + pure template helpers; a locked **Standard** template plus a one-time seeded sample.
- Config storage with full **CRUD**, a configurable **default template**, and hardened `validate_template` (type + size limits, language-code validation).
- **CLI**: `list-templates` / `save-template` / `delete-template` / `set-default-template` / `reset-template`.
- **IPC bridge** (main handlers + preload + typed group) and a **Settings → Templates** tab with a `useTemplates` hook.
- Full-width, taller **prompt editor** (the shared `Textarea` no longer inherits the single-line input height, so `rows`/`min-h` apply).

### Reports
- Free-form template-generation path in the summarizer; `generate-report` CLI + IPC + `reports[]` model.
- **Report switcher** in MeetingDetail: generate from any template, switch between versions (shows model + date), set-active, delete; markdown render.
- **Versions + #249 snapshot**: reprocess snapshots the prior Standard report instead of overwriting it; note backed up with any content.
- **Sidecar storage** (`.md` + `.json`) with a format-agnostic meeting reader; `get-meeting` merges the sidecar.
- **Auto-generate** the default template's report for new recordings (heartbeated; never raises on import).
- Edge cases surfaced cleanly: unknown template / empty report → `STREAM_ERROR` (no phantom success).

## Tests

- **T2 e2e** (model-free, in CI): template CRUD + default + locked-Standard round-trips; `generate-report` persists into `reports[]` and sets active; generate/switch/delete on a real `.md` meeting via the sidecar; reprocess backup + set-active + delete round-trip.
- Renderer `typecheck` + `lint` green.
- Manual (macOS): Templates tab create/edit/delete + default; per-recording auto-report; report switcher generate/switch/delete; reprocess snapshot; sidecar files on disk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds report templates and per‑meeting report generation with versioning, stored in a `_reports.json` sidecar and switchable in the UI. Also ships a Templates settings tab + CLI, provider‑agnostic template streaming, scoped progress, auto‑generation of a default report for new recordings, and stronger validation/error handling.

- **New Features**
  - Templates: built‑in locked Standard + one‑time seeded sample; full CRUD in Settings and CLI (delete confirmation, reset, set default); hardened validation and on‑load normalization/repair; editor remounts per template and the prompt textarea now grows; CLI surfaces structured errors for locked templates.
  - Reporting: generate from any template with provider‑agnostic streaming (local or cloud); versions with switch/set‑active/delete (confirmations) and Markdown render; previous Standard snapshot is saved on reprocess; failures are tagged as report events and surfaced separately; `STREAM_COMPLETE` fires after saving to prevent stale reads.
  - Storage/IO: `_reports.json` sidecar for both `.md` and `.json` meetings; `get-meeting` merges the sidecar; reads are path‑contained; sidecar loads normalize key types and handle malformed data; set‑active/delete require the meeting to exist.
  - UX/Processing: progress events include `summaryFile` to scope map‑reduce status; the Processing screen ignores scoped progress from other meetings; unknown/empty results emit `STREAM_ERROR` with safe retry; summarization disables reasoning (`think=false`) with a one‑time fallback; meetings list omits transcripts for speed; Meeting detail lazy‑loads via a secure `get-meeting`; default‑template report auto‑generates for new recordings without blocking import.

- **Dependencies**
  - Require Python `ollama` >= `0.5.0` (enables `think=false`; older servers auto‑retry without it) and add support for `gemma4:4b`.

<sup>Written for commit 1e59188aa18d9715d8956a62005075782bc4cc94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

