### PR TITLE
feat(ui): hide reasoning blocks before rendering markdown

### DIFF
--- a/app/renderer/src/lib/markdown.test.ts
+++ b/app/renderer/src/lib/markdown.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest';
+import { stripReasoning } from '@/lib/markdown';
+
+/**
+ * Unit coverage for stripReasoning — the guard that removes `<think>` /
+ * `<thought>` reasoning blocks emitted by some local models before the text is
+ * handed to the markdown renderer. The streaming case (an unclosed tag at the
+ * end of a chunk) is the load-bearing edge: a half-streamed reasoning block
+ * must not flash into the rendered summary.
+ */
+describe('stripReasoning', () => {
+  test('strips a closed reasoning block and trims leading whitespace', () => {
+    const input = '<think>deliberating about the summary</think>\n\n## Summary\nHello';
+    expect(stripReasoning(input)).toBe('## Summary\nHello');
+  });
+
+  test('strips an unclosed reasoning block to the end of a streaming chunk', () => {
+    const input = 'visible intro\n<think>still thinking and the chunk cut off here';
+    // The closing tag never arrives, so everything from <think> onward is dropped
+    // (only the trailing newline before the tag survives — strip trims leading,
+    // not trailing, whitespace).
+    const result = stripReasoning(input);
+    expect(result).toBe('visible intro\n');
+    expect(result).not.toContain('still thinking');
+  });
+
+  test('passes through text with no reasoning tags unchanged', () => {
+    const input = '## Summary\nNo reasoning here, just content.';
+    expect(stripReasoning(input)).toBe(input);
+  });
+
+  test('returns falsy/empty for empty input', () => {
+    expect(stripReasoning('')).toBeFalsy();
+    expect(stripReasoning('')).toBe('');
+  });
+});

--- a/app/renderer/src/lib/markdown.tsx
+++ b/app/renderer/src/lib/markdown.tsx
@@ -8,8 +8,14 @@ import { cn } from '@/lib/utils';
 // zero deps, predictable output, and safe-by-default React text rendering
 // (no innerHTML).
 
+export function stripReasoning(text: string): string {
+  if (!text) return text;
+  return text.replace(/<(think|thought)>[\s\S]*?(?:<\/\1>|$)/gi, '').trimStart();
+}
+
 export function renderMarkdown(text: string): React.ReactNode {
   if (!text) return null;
+  text = stripReasoning(text);
 
   // Strip trailing \r so CRLF input doesn't leave ghost characters at the end
   // of every line — that breaks regex anchors and table cell parsing.

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -75,6 +75,7 @@ import { buildTranscriptBundle, defaultExportFilename } from '@/lib/transcriptBu
 import { unwrap } from '@/lib/result';
 import { cn } from '@/lib/utils';
 import { navigate } from '@/lib/router';
+import { stripReasoning } from '@/lib/markdown';
 import {
   pendingTitleRegens,
   streamCache,
@@ -853,7 +854,7 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
             <section className="flex flex-col gap-3">
               <SectionTitle>Summary</SectionTitle>
               <div data-testid="tab-summary-content">
-                {summary.split(/\n{2,}/).map((para, i) => (
+                {stripReasoning(summary).split(/\n{2,}/).map((para, i) => (
                   <p
                     key={i}
                     className="text-[15.5px] leading-[1.65]"
@@ -1248,7 +1249,7 @@ const CHAR_TRANSITION = 'top 0.12s ease-out';
 const ROW_TRANSITION = 'top 0.35s cubic-bezier(0.45, 0, 0.55, 1)';
 
 function StreamingView({ text, phase, chunkProgress }: { text: string; phase: StreamPhase; chunkProgress?: { step: number; total: number } | null }) {
-  const blocks = parseMarkdownBlocks(text);
+  const blocks = parseMarkdownBlocks(stripReasoning(text));
   const isStreaming = phase === 'analyzing' || phase === 'generating';
 
   const prevBlockCountRef = React.useRef(blocks.length);

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -13,6 +13,7 @@ import { useRecording } from '@/hooks/useRecording';
 import { useUpdateMeeting } from '@/hooks/useMeetings';
 import { getLiveDraft, useLiveDraftStore } from '@/hooks/liveDraftStore';
 import { ipc } from '@/lib/ipc';
+import { stripReasoning } from '@/lib/markdown';
 
 type ProcessingStage = 'transcribing' | 'summarizing' | 'finalizing' | 'error';
 
@@ -211,7 +212,7 @@ export function Processing() {
 // this it'd re-render on every parent re-render (stage transitions, draft
 // updates, etc.) and re-walk the markdown tree unnecessarily.
 const StreamMarkdown = React.memo(function StreamMarkdown({ text }: { text: string }) {
-  return <ReactMarkdown>{text}</ReactMarkdown>;
+  return <ReactMarkdown>{stripReasoning(text)}</ReactMarkdown>;
 });
 
 function StageCard({

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -70,6 +70,15 @@ _AUTO_NAMED_PATTERN = re.compile(
     r'|.+ — \d{4}-\d{2}-\d{2} \d{2}:\d{2})$'
 )
 
+# Regex to normalize markdown headers that incorrectly start on the same line as
+# the closing tag of a reasoning block (e.g. `</thought>## Summary`). This ensures
+# the parser correctly splits and identifies sections.
+_REASONING_TAG_HEADER_PATTERN = re.compile(r'(</?[a-zA-Z0-9_-]+>)\s*(#{1,6}\s)')
+
+def _normalize_markdown_for_parsing(md_text: str) -> str:
+    """Ensure headers immediately following HTML-like tags start on a new line."""
+    return _REASONING_TAG_HEADER_PATTERN.sub(r'\1\n\2', md_text)
+
 # Shared atomic JSON writer (tempfile + os.replace + Windows PermissionError
 # retry). One implementation for recorder_state.json, the summary JSON, and
 # config.json — re-exported here so existing imports keep working. The
@@ -241,6 +250,8 @@ Summary output language: {config.get_language_name(output_language)}
     @staticmethod
     def _parse_streamed_markdown(md_text: str) -> dict:
         """Parse streamed markdown summary into structured fields."""
+        md_text = _normalize_markdown_for_parsing(md_text)
+
         summary_parts = []
         participants = []
         discussion_areas = []
@@ -1962,6 +1973,8 @@ def _parse_meeting_markdown(md_path):
                             pass
                     meta[key.strip()] = value
             body = parts[2].strip()
+
+    body = _normalize_markdown_for_parsing(body)
 
     # Parse markdown body into sections
     sections = {}

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -72,11 +72,14 @@ _AUTO_NAMED_PATTERN = re.compile(
 
 # Regex to normalize markdown headers that incorrectly start on the same line as
 # the closing tag of a reasoning block (e.g. `</thought>## Summary`). This ensures
-# the parser correctly splits and identifies sections.
-_REASONING_TAG_HEADER_PATTERN = re.compile(r'(</?[a-zA-Z0-9_-]+>)\s*(#{1,6}\s)')
+# the parser correctly splits and identifies sections. Scoped to think/thought
+# tags specifically (not any HTML-like tag) so unrelated inline markup in the
+# model's output can't be mistaken for a reasoning block and get a spurious
+# section break inserted ahead of it.
+_REASONING_TAG_HEADER_PATTERN = re.compile(r'(</(?:think|thought)>)\s*(#{1,6}\s)', re.IGNORECASE)
 
 def _normalize_markdown_for_parsing(md_text: str) -> str:
-    """Ensure headers immediately following HTML-like tags start on a new line."""
+    """Ensure headers immediately following a reasoning tag start on a new line."""
     return _REASONING_TAG_HEADER_PATTERN.sub(r'\1\n\2', md_text)
 
 # Shared atomic JSON writer (tempfile + os.replace + Windows PermissionError

--- a/tests/test_markdown_normalize.py
+++ b/tests/test_markdown_normalize.py
@@ -1,0 +1,35 @@
+"""Unit coverage for _normalize_markdown_for_parsing.
+
+Some local models emit a reasoning block whose closing tag runs straight into
+the first real header on the same line (e.g. `</thought>## Summary`). Without a
+newline between the tag and the `#`, the section parser never recognises the
+header and the whole summary collapses into one blob. The normaliser inserts
+that missing newline before parsing.
+"""
+
+import unittest
+
+from simple_recorder import _normalize_markdown_for_parsing
+
+
+class NormalizeMarkdownForParsingTests(unittest.TestCase):
+    def test_header_adjacent_to_closing_tag_gets_its_own_line(self):
+        normalized = _normalize_markdown_for_parsing("</thought>## Summary\ntext")
+        self.assertEqual(normalized, "</thought>\n## Summary\ntext")
+        # The header now starts a line of its own.
+        self.assertIn("\n## Summary", normalized)
+
+    def test_text_without_tag_adjacent_header_is_unchanged(self):
+        original = "## Summary\n\nSome discussion text with no reasoning tags."
+        self.assertEqual(_normalize_markdown_for_parsing(original), original)
+
+    def test_unrelated_html_like_tag_before_header_is_unchanged(self):
+        # Only </think>/</thought> are reasoning-block closers. Any other
+        # HTML-like tag the model happens to emit right before a header
+        # (e.g. </span>, </div>) must NOT get a spurious section break.
+        original = "</span>## Summary\ntext"
+        self.assertEqual(_normalize_markdown_for_parsing(original), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
Hides LLM reasoning blocks (`<think>`, `<thought>`) from the UI across all markdown rendering paths without modifying the backend or raw text files.

## Changes
- Added `stripReasoning` regex helper to `app/renderer/src/lib/markdown.tsx`
- Applied helper to `renderMarkdown` (Chat, Shared, AskBar)
- Applied helper to `StreamMarkdown` (`Processing.tsx`)
- Applied helper to `parseMarkdownBlocks` & static summary (`MeetingDetail.tsx`)

## Testing
- [x] CLI functionality works
- [x] Electron app starts
- [x] No breaking changes to existing functionality
- [x] Ran renderer typecheck and lint

I have read the CLA Document and I hereby sign the CLA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide LLM reasoning tags (<think>, <thought>) before rendering markdown across the app, and fix parsing so headers after closing tags are recognized. Internal thoughts no longer flash during streaming.

- **New Features**
  - Added `stripReasoning` and applied across `renderMarkdown`, streaming markdown, block parsing, and Meeting Summary.

- **Bug Fixes**
  - Normalize headers that follow `</think>`/`</thought>` (e.g., `</thought>##`) so sections parse correctly, and tighten the regex to only affect reasoning tags.

<sup>Written for commit 50f8f2354018aca89d8350b2650c6a58d9cd6753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

