### PR TITLE
feat(home): dynamic hero status from recording + calendar state (supersedes #147)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -7537,6 +7537,14 @@ ipcMain.handle('get-calendar-events', async () => {
 });
 
 // Pick the calendar event most likely to be the one the user is joining now.
+// INTENTIONAL DUPLICATION: this algorithm is kept in lockstep with
+// `app/renderer/src/lib/calendar.ts` → `pickInProgressEvent` (same
+// constants, filters, and tie-break order). The two
+// surfaces (auto-detect-meeting notification here + hero copy in the
+// renderer) keep their own copy because main and renderer can't share
+// ESM modules. If you change the constants or matching rules, update
+// BOTH or the notification and the hero will disagree about what counts
+// as "in a meeting now".
 // Match window:
 //   - opens 5 min before the scheduled start (early-join grace)
 //   - closes at the scheduled end, OR 10 min after start, whichever is later

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -339,8 +339,15 @@
     letter-spacing: -0.025em;
     color: var(--fg-1);
     font-weight: 400;
+    /* Headline copy reacts to recording + calendar state; soften the
+       theme/colour swap so light/dark mode toggle isn't a hard pop. The
+       text content swap itself still pops — CSS can't tween text. */
+    transition: color var(--dur-fast) var(--ease);
   }
-  .home-hello .faint { color: var(--fg-2); }
+  .home-hello .faint {
+    color: var(--fg-2);
+    transition: color var(--dur-fast) var(--ease);
+  }
 
   /* Upcoming card — 3-column grid */
   .upcoming-card {

--- a/app/renderer/src/lib/calendar.test.ts
+++ b/app/renderer/src/lib/calendar.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'vitest';
+import type { CalendarEvent } from '@/lib/ipc';
+import { pickInProgressEvent } from '@/lib/calendar';
+
+// Coverage for the renderer's calendar-matching helper (#147), which is kept
+// in lockstep with main.js → pickCurrentCalendarEvent. These tests pin the
+// match window (5-min early grace, 10-min late floor), the filters (all-day,
+// declined, malformed), and the priority order so a future edit to either
+// copy that drifts from the documented rules fails here.
+// NOTE: a true cross-impl equivalence test (renderer port vs the main.js copy)
+// is a tracked follow-up — it needs the main.js function extracted into a
+// shared CommonJS module first.
+
+const NOW = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+const NOW_MS = NOW.getTime();
+const MIN = 60_000;
+
+function ev(
+  startOffsetMs: number,
+  endOffsetMs: number,
+  extra: Partial<CalendarEvent> = {},
+): CalendarEvent {
+  return {
+    id: extra.id ?? 'e',
+    title: extra.title ?? 'Meeting',
+    start: new Date(NOW_MS + startOffsetMs).toISOString(),
+    end: new Date(NOW_MS + endOffsetMs).toISOString(),
+    ...extra,
+  };
+}
+
+describe('pickInProgressEvent', () => {
+  test('returns null for empty / nullish input', () => {
+    expect(pickInProgressEvent([], NOW)).toBeNull();
+    expect(pickInProgressEvent(null, NOW)).toBeNull();
+    expect(pickInProgressEvent(undefined, NOW)).toBeNull();
+  });
+
+  test('a genuinely in-progress event is picked over an upcoming one', () => {
+    const inProgress = ev(-5 * MIN, 25 * MIN, { id: 'now' });
+    const upcoming = ev(3 * MIN, 30 * MIN, { id: 'soon' });
+    expect(pickInProgressEvent([upcoming, inProgress], NOW)?.id).toBe('now');
+  });
+
+  test('early-join grace: an event starting in <5 min matches; >5 min does not', () => {
+    expect(pickInProgressEvent([ev(4 * MIN, 30 * MIN, { id: 'grace' })], NOW)?.id).toBe('grace');
+    expect(pickInProgressEvent([ev(6 * MIN, 30 * MIN, { id: 'tooEarly' })], NOW)).toBeNull();
+  });
+
+  test('late floor: a short meeting still matches within 10 min of its start', () => {
+    // 2-min meeting that started 4 min ago: real end passed, but the 10-min
+    // floor (start+10) keeps it matchable for a late joiner.
+    expect(pickInProgressEvent([ev(-4 * MIN, -2 * MIN, { id: 'late' })], NOW)?.id).toBe('late');
+    // ...but once past start+10 it drops off.
+    expect(pickInProgressEvent([ev(-12 * MIN, -10 * MIN, { id: 'gone' })], NOW)).toBeNull();
+  });
+
+  test('all-day events are skipped (date-only and the explicit is_all_day flag)', () => {
+    const dateOnly: CalendarEvent = { id: 'allday', title: 'OOO', start: '2026-01-15', end: '2026-01-16' };
+    expect(pickInProgressEvent([dateOnly], NOW)).toBeNull();
+    const flagged = ev(-5 * MIN, 25 * MIN, { id: 'flag', is_all_day: true });
+    expect(pickInProgressEvent([flagged], NOW)).toBeNull();
+  });
+
+  test('declined and malformed events are skipped', () => {
+    expect(pickInProgressEvent([ev(-5 * MIN, 25 * MIN, { id: 'no', response_status: 'declined' })], NOW)).toBeNull();
+    const bad = { id: 'bad', title: 'x', start: 'not-a-date', end: 'also-bad' } as CalendarEvent;
+    expect(pickInProgressEvent([bad], NOW)).toBeNull();
+  });
+
+  test('in-progress tie-break: the latest-starting overlapping event wins', () => {
+    const early = ev(-30 * MIN, 30 * MIN, { id: 'early' });
+    const later = ev(-5 * MIN, 25 * MIN, { id: 'later' });
+    expect(pickInProgressEvent([early, later], NOW)?.id).toBe('later');
+  });
+
+  test('upcoming tie-break: the soonest-starting event wins', () => {
+    const soon = ev(2 * MIN, 30 * MIN, { id: 'soon' });
+    const later = ev(4 * MIN, 30 * MIN, { id: 'later' });
+    expect(pickInProgressEvent([later, soon], NOW)?.id).toBe('soon');
+  });
+
+  test('recently-ended fallback: most-recently-ended within the floor wins when nothing is live or upcoming', () => {
+    const endedEarlier = ev(-9 * MIN, -6 * MIN, { id: 'earlier' });
+    const endedLater = ev(-8 * MIN, -3 * MIN, { id: 'later' });
+    expect(pickInProgressEvent([endedEarlier, endedLater], NOW)?.id).toBe('later');
+  });
+});

--- a/app/renderer/src/lib/calendar.ts
+++ b/app/renderer/src/lib/calendar.ts
@@ -1,0 +1,78 @@
+import type { CalendarEvent } from '@/lib/ipc';
+
+const EARLY_GRACE_MS = 5 * 60 * 1000;
+const LATE_FLOOR_MS = 10 * 60 * 1000;
+
+/**
+ * Find the calendar event the user is most likely "in" right now.
+ *
+ * INTENTIONAL DUPLICATION: this algorithm is kept in lockstep with
+ * `app/main.js` → `pickCurrentCalendarEvent` (same constants, filters, and
+ * tie-break order). The main process can't
+ * import renderer ESM modules and the renderer can't import from main,
+ * so the two surfaces (hero copy here + auto-detect-meeting
+ * notification there) keep their own copy. If you change the constants
+ * (EARLY_GRACE_MS, LATE_FLOOR_MS) or the matching/tie-break rules,
+ * update BOTH or the hero and the notification will disagree about
+ * what counts as "in a meeting now".
+ *
+ *   - opens 5 min before the scheduled start (early-join grace)
+ *   - closes at the scheduled end, OR 10 min after start, whichever is later
+ *
+ * Priority when multiple events match the window:
+ *   1. Truly in-progress (now ∈ [start, end))   — latest-starting wins
+ *   2. Upcoming (start > now)                   — soonest wins
+ *   3. Recently ended but inside the late-floor — most recently ended wins
+ *
+ * All-day events are skipped (date-only `start` / `end` with no `T`
+ * separator) — they span midnight to midnight and would falsely match
+ * every recording all day.
+ */
+export function pickInProgressEvent(
+  events: CalendarEvent[] | null | undefined,
+  now: Date = new Date(),
+): CalendarEvent | null {
+  if (!events || events.length === 0) return null;
+
+  const nowMs = now.getTime();
+  type Candidate = { event: CalendarEvent; startMs: number; endMs: number };
+  const candidates: Candidate[] = [];
+
+  for (const e of events) {
+    if (!e || typeof e.start !== 'string' || typeof e.end !== 'string') continue;
+    if (!e.start.includes('T') || !e.end.includes('T')) continue;
+    // Match main.js's pickCurrentCalendarEvent: an all-day block spans
+    // midnight→midnight and would mistag every recording all day, and a
+    // declined meeting is one the user said no to. The 'T' guard above only
+    // catches date-only all-day events (Google); Outlook emits all-day with a
+    // T00:00:00 datetime, so the explicit is_all_day flag is load-bearing.
+    if (e.is_all_day === true) continue;
+    if (e.response_status === 'declined') continue;
+    const startMs = new Date(e.start).getTime();
+    const endMs = new Date(e.end).getTime();
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) continue;
+    const closesAt = Math.max(endMs, startMs + LATE_FLOOR_MS);
+    if (nowMs >= startMs - EARLY_GRACE_MS && nowMs < closesAt) {
+      candidates.push({ event: e, startMs, endMs });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  const inProgress = candidates.filter(
+    (c) => c.startMs <= nowMs && nowMs < c.endMs,
+  );
+  if (inProgress.length > 0) {
+    inProgress.sort((a, b) => b.startMs - a.startMs);
+    return inProgress[0].event;
+  }
+
+  const upcoming = candidates.filter((c) => c.startMs > nowMs);
+  if (upcoming.length > 0) {
+    upcoming.sort((a, b) => a.startMs - b.startMs);
+    return upcoming[0].event;
+  }
+
+  candidates.sort((a, b) => b.endMs - a.endMs);
+  return candidates[0].event;
+}

--- a/app/renderer/src/lib/hero.test.ts
+++ b/app/renderer/src/lib/hero.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect } from 'vitest';
+import type { CalendarEvent } from '@/lib/ipc';
+import { heroHeadline, heroSubtitle, type HeroState } from '@/lib/hero';
+
+// Pure-function coverage for the Home hero copy (#147). Asserts the full
+// state matrix: recording state wins over calendar state, the present-tense
+// "In a meeting now" only fires once the meeting has truly started (not in
+// the early-join grace), and the minute/hour wording flips at the same
+// threshold in both the headline and subtitle.
+
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0); // fixed clock for deterministic deltas
+const MIN = 60_000;
+
+function ev(
+  startOffsetMs: number,
+  endOffsetMs: number,
+  extra: Partial<CalendarEvent> = {},
+): CalendarEvent {
+  return {
+    id: extra.id ?? 'e1',
+    title: extra.title ?? 'Sprint Planning',
+    start: new Date(NOW + startOffsetMs).toISOString(),
+    end: new Date(NOW + endOffsetMs).toISOString(),
+    ...extra,
+  };
+}
+
+function state(overrides: Partial<HeroState> = {}): HeroState {
+  return {
+    status: 'idle',
+    sessionName: null,
+    inProgressEvent: null,
+    nextSoonEvent: null,
+    tomorrowPreview: null,
+    calendarConnected: false,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('heroHeadline', () => {
+  test('recording / paused / processing status wins over everything', () => {
+    // Even with a meeting in progress, status copy takes precedence.
+    const inMeeting = ev(-5 * MIN, 25 * MIN);
+    expect(heroHeadline(state({ status: 'recording', inProgressEvent: inMeeting }))).toBe('Recording');
+    expect(heroHeadline(state({ status: 'paused', inProgressEvent: inMeeting }))).toBe('Recording paused');
+    expect(heroHeadline(state({ status: 'processing', inProgressEvent: inMeeting }))).toBe('Processing your note');
+  });
+
+  test('"In a meeting now" only when the meeting has truly started', () => {
+    const started = ev(-5 * MIN, 25 * MIN); // now ∈ [start, end)
+    expect(heroHeadline(state({ inProgressEvent: started }))).toBe('In a meeting now');
+  });
+
+  test('early-join grace does NOT claim "In a meeting now" — falls through to countdown', () => {
+    // pickInProgressEvent returns events up to 5 min before start, but the
+    // headline must not say the user is "in" a meeting that hasn't begun.
+    const soon = ev(4 * MIN, 34 * MIN);
+    const s = state({ inProgressEvent: soon, nextSoonEvent: soon });
+    expect(heroHeadline(s)).toBe('Next meeting in 4 mins');
+  });
+
+  test('upcoming countdown: minutes, singular minute, and the 60-min → hour flip', () => {
+    expect(heroHeadline(state({ nextSoonEvent: ev(30 * MIN, 60 * MIN) }))).toBe('Next meeting in 30 mins');
+    expect(heroHeadline(state({ nextSoonEvent: ev(1 * MIN, 31 * MIN) }))).toBe('Next meeting in 1 min');
+    // 59.5 min rounds up to 60, which reads unnaturally → "1 hr" instead.
+    expect(heroHeadline(state({ nextSoonEvent: ev(59.5 * MIN, 120 * MIN) }))).toBe('Next meeting in 1 hr');
+    expect(heroHeadline(state({ nextSoonEvent: ev(120 * MIN, 180 * MIN) }))).toBe('Next meeting in 2 hrs');
+  });
+
+  test('idle fallbacks distinguish a connected clear day from no calendar', () => {
+    expect(heroHeadline(state({ calendarConnected: true }))).toBe('Clear day ahead');
+    expect(heroHeadline(state({ calendarConnected: false }))).toBe('Ready to capture beautiful notes');
+  });
+});
+
+describe('heroSubtitle', () => {
+  test('recording subtitle prefers the active session name', () => {
+    const sub = heroSubtitle(state({ status: 'recording', sessionName: 'Q3 Roadmap', inProgressEvent: ev(-5 * MIN, 25 * MIN, { title: 'Other Meeting' }) }));
+    expect(sub).toContain('Q3 Roadmap');
+    expect(sub).toContain('to stop');
+  });
+
+  test('recording subtitle falls back to event title then a generic label', () => {
+    expect(heroSubtitle(state({ status: 'recording', inProgressEvent: ev(-5 * MIN, 25 * MIN, { title: 'Standup' }) }))).toContain('Standup');
+    expect(heroSubtitle(state({ status: 'recording' }))).toContain('In progress');
+  });
+
+  test('paused and processing have their own copy', () => {
+    expect(heroSubtitle(state({ status: 'paused' }))).toBe('Recording paused. Tap resume on the bar below to continue.');
+    expect(heroSubtitle(state({ status: 'processing' }))).toBe(`We'll have your note ready in a moment.`);
+  });
+
+  test('upcoming-soon subtitle names the meeting and its start time', () => {
+    const sub = heroSubtitle(state({ nextSoonEvent: ev(20 * MIN, 50 * MIN, { title: 'Design Review' }) }));
+    expect(sub).toContain('Design Review');
+    expect(sub).toContain('at');
+    expect(sub).toContain("when you're ready");
+  });
+
+  test('tomorrow preview when nothing is on today', () => {
+    const sub = heroSubtitle(state({ tomorrowPreview: ev(24 * 60 * MIN, 24 * 60 * MIN + 30 * MIN, { title: 'Kickoff' }) }));
+    expect(sub).toContain('Next up:');
+    expect(sub).toContain('Kickoff');
+    expect(sub).toContain('tomorrow at');
+  });
+
+  test('idle with no events falls back to the recording hint', () => {
+    expect(heroSubtitle(state())).toContain('Start recording');
+  });
+});

--- a/app/renderer/src/lib/hero.ts
+++ b/app/renderer/src/lib/hero.ts
@@ -1,0 +1,138 @@
+import { type CalendarEvent } from '@/lib/ipc';
+import { shortcut } from '@/lib/utils';
+
+// Pure copy logic for the Home hero. Extracted from Home.tsx so the
+// headline/subtitle string-building can be unit-tested without mounting the
+// React route. Recording state always wins over calendar state.
+
+// Default subtitle — also used as the empty/idle fallback. Cached so it
+// renders the same string each call without rebuilding the shortcut.
+const RECORD_SHORTCUT = shortcut('⌘⇧R', 'Ctrl+Shift+R');
+const RECORDING_HINT = `Start recording from the top-right, or from anywhere with ${RECORD_SHORTCUT}.`;
+
+// Cached at module load to avoid rebuilding on every render. We don't
+// react to system-locale changes mid-session — that would require a full
+// app relaunch on macOS anyway, and creating an Intl.DateTimeFormat per
+// render isn't free. If we ever start supporting in-app locale toggles
+// we'd need to move this inside the function.
+const HERO_TIME_FMT = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: '2-digit',
+});
+
+const HOUR_MS = 60 * 60 * 1000;
+const MIN_MS = 60 * 1000;
+
+export interface HeroState {
+  status: 'idle' | 'recording' | 'paused' | 'processing';
+  sessionName: string | null;
+  inProgressEvent: CalendarEvent | null;
+  nextSoonEvent: CalendarEvent | null;
+  tomorrowPreview: CalendarEvent | null;
+  calendarConnected: boolean;
+  now: number;
+}
+
+// True only when `now` is inside the event's real [start, end) — i.e. the
+// meeting has actually started. `pickInProgressEvent` also returns events in
+// the 5-min early-join grace and the late-join floor, which are the right
+// targets for the "start recording" CTA but must NOT drive present-tense
+// copy like "In a meeting now" (the meeting may not have begun yet).
+function eventIsNow(e: CalendarEvent, nowMs: number): boolean {
+  const startMs = new Date(e.start).getTime();
+  const endMs = new Date(e.end).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return false;
+  return startMs <= nowMs && nowMs < endMs;
+}
+
+// Headline. Recording state always wins over calendar state — when the
+// user is recording / paused / processing they want status, not a
+// schedule. Idle falls through to the calendar-driven copy.
+export function heroHeadline(s: HeroState): string {
+  switch (s.status) {
+    case 'recording':
+      return 'Recording';
+    case 'paused':
+      return 'Recording paused';
+    case 'processing':
+      return 'Processing your note';
+  }
+  // Only present-tense when the meeting has truly started — not during the
+  // early-join grace, which would tell the user they're "in" a meeting that
+  // hasn't begun. The pre-start case falls through to "Next meeting in N min".
+  if (s.inProgressEvent && eventIsNow(s.inProgressEvent, s.now)) {
+    return 'In a meeting now';
+  }
+  if (s.nextSoonEvent) {
+    const startMs = new Date(s.nextSoonEvent.start).getTime();
+    if (!Number.isNaN(startMs)) {
+      const deltaMs = startMs - s.now;
+      // Compute mins first and gate on the rounded value: Math.ceil rounds
+      // anything in (59 min, 60 min) up to 60, and "60 mins" reads
+      // unnaturally — fall straight through to "1 hr" instead. The
+      // Math.max(1) keeps the headline non-zero in the last 30 seconds
+      // before start.
+      const mins = Math.max(1, Math.ceil(deltaMs / MIN_MS));
+      if (mins < 60) return `Next meeting in ${mins} min${mins === 1 ? '' : 's'}`;
+      const hrs = Math.max(1, Math.round(deltaMs / HOUR_MS));
+      return `Next meeting in ${hrs} hr${hrs === 1 ? '' : 's'}`;
+    }
+  }
+  // Reaching here means nothing is live or upcoming today. Only call the day
+  // "clear" when the calendar is actually connected — otherwise we don't know,
+  // so keep the neutral invitation.
+  if (s.calendarConnected) return 'Clear day ahead';
+  return 'Ready to capture beautiful notes';
+}
+
+// Subtitle. Mirrors the headline cases. Keeps the recording shortcut hint
+// as the default fallback so the page always tells the user how to act.
+export function heroSubtitle(s: HeroState): string {
+  if (s.status === 'recording') {
+    // Source of truth for "what we're capturing" is the active session
+    // name — the user may have started a recording titled after one
+    // event while a different calendar event is also concurrently in
+    // progress, and the subtitle should reflect what they actually hit
+    // record on. ⌘⇧R is a record-toggle per main.js's global shortcut
+    // so "to stop" is accurate when already recording.
+    const title =
+      s.sessionName?.trim() || s.inProgressEvent?.title?.trim() || 'In progress';
+    return `${title} · ${RECORD_SHORTCUT} to stop`;
+  }
+  if (s.status === 'paused') {
+    // ⌘⇧R is a record-toggle: while paused it STOPS (finalizes) the recording
+    // rather than resuming. Resume is a click-only action on the bottom bar,
+    // so point there instead of advertising a shortcut that would end the note.
+    return 'Recording paused. Tap resume on the bar below to continue.';
+  }
+  if (s.status === 'processing') {
+    return `We'll have your note ready in a moment.`;
+  }
+  // Only when the meeting has truly started (mirrors the headline gate) — the
+  // pre-start grace falls through to the timed "starts at …" line below.
+  if (s.inProgressEvent && eventIsNow(s.inProgressEvent, s.now)) {
+    return `Press ${RECORD_SHORTCUT} to start recording — or tap a meeting card below.`;
+  }
+  if (s.nextSoonEvent) {
+    const startMs = new Date(s.nextSoonEvent.start).getTime();
+    if (!Number.isNaN(startMs)) {
+      // Mirror the headline's `mins < 60` threshold (Math.ceil-based) so the
+      // title-at-time line and the "Next meeting in N min" headline flip to
+      // the hours wording at the same instant.
+      const mins = Math.max(1, Math.ceil((startMs - s.now) / MIN_MS));
+      if (mins < 60) {
+        const at = HERO_TIME_FMT.format(new Date(startMs));
+        return `${s.nextSoonEvent.title} at ${at} — ${RECORD_SHORTCUT} when you're ready.`;
+      }
+    }
+    return RECORDING_HINT;
+  }
+  if (s.tomorrowPreview) {
+    const startMs = new Date(s.tomorrowPreview.start).getTime();
+    if (!Number.isNaN(startMs)) {
+      const at = HERO_TIME_FMT.format(new Date(startMs));
+      return `Next up: ${s.tomorrowPreview.title} tomorrow at ${at}.`;
+    }
+  }
+  return RECORDING_HINT;
+}

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Calendar, ChevronLeft, ChevronRight, PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
-import { isMac, shortcut } from '@/lib/utils';
+import { isMac } from '@/lib/utils';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import { UpcomingCard } from '@/components/home/UpcomingCard';
 import { PreviousRow } from '@/components/home/PreviousRow';
@@ -16,6 +16,8 @@ import {
 } from '@/hooks/useCalendarEvents';
 import { useFolders } from '@/hooks/useFolders';
 import { ipc, type CalendarEvent, type Meeting } from '@/lib/ipc';
+import { pickInProgressEvent } from '@/lib/calendar';
+import { heroHeadline, heroSubtitle } from '@/lib/hero';
 import { searchNotes } from '@/lib/noteSearch';
 import { navigate } from '@/lib/router';
 
@@ -57,6 +59,10 @@ export function Home({ mode }: HomeProps) {
   const [upcomingTickMs, setUpcomingTickMs] = React.useState<number>(() => Date.now());
   React.useEffect(() => {
     if (mode !== 'home') return;
+    // Refresh immediately on (re)entering Home, otherwise the hero copy
+    // is whatever `upcomingTickMs` was when the user last navigated away
+    // — potentially many minutes stale until the 60s interval fires.
+    setUpcomingTickMs(Date.now());
     const id = setInterval(() => setUpcomingTickMs(Date.now()), 60_000);
     return () => clearInterval(id);
   }, [mode]);
@@ -407,7 +413,52 @@ export function Home({ mode }: HomeProps) {
   const emptyStateCalendarNudge = renderCalendarNudge(false);
   const homeCalendarNudge = renderCalendarNudge(true);
 
-  const greeting = `Ready to capture beautiful notes`;
+  // Hero state inputs. All recompute on the existing 60s tick — no new
+  // intervals. `inProgressEvent` uses the same matching window as the
+  // backend's auto-detect (5 min early grace, 10 min late floor) so the
+  // hero copy and the "Meeting detected" notification agree.
+  const inProgressEvent = React.useMemo<CalendarEvent | null>(() => {
+    if (!calendar.data || calendar.data.needsAuth) return null;
+    return pickInProgressEvent(calendar.data.events, new Date(upcomingTickMs));
+  }, [calendar.data, upcomingTickMs]);
+
+  // `upcomingToday` is already all-day/declined/NaN-filtered and sorted by
+  // start ascending, so the soonest still-future event is just the first one
+  // that starts after now — no need to re-apply the guards here.
+  const nextSoonEvent = React.useMemo<CalendarEvent | null>(
+    () =>
+      upcomingToday.find((e) => new Date(e.start).getTime() > upcomingTickMs) ??
+      null,
+    [upcomingToday, upcomingTickMs],
+  );
+
+  // Whether we have live calendar data to reason about. Distinguishes a
+  // genuinely clear day (connected, no events) from "no calendar connected"
+  // so the hero only claims "Clear day ahead" when it actually knows.
+  const calendarConnected = !!calendar.data && !calendar.data.needsAuth;
+
+  const heroState = React.useMemo(
+    () => ({
+      status: recording.status,
+      sessionName: recording.sessionName,
+      inProgressEvent,
+      nextSoonEvent,
+      tomorrowPreview,
+      calendarConnected,
+      now: upcomingTickMs,
+    }),
+    [
+      recording.status,
+      recording.sessionName,
+      inProgressEvent,
+      nextSoonEvent,
+      tomorrowPreview,
+      calendarConnected,
+      upcomingTickMs,
+    ],
+  );
+  const greeting = heroHeadline(heroState);
+  const heroSub = heroSubtitle(heroState);
   const dateStr = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
     month: 'long',
@@ -492,7 +543,7 @@ export function Home({ mode }: HomeProps) {
                 className="max-w-[52ch] text-sm leading-[1.55]"
                 style={{ color: 'var(--fg-2)' }}
               >
-                {`Start recording from the top-right, or from anywhere with ${shortcut('⌘⇧R', 'Ctrl+Shift+R')}.`}
+                {heroSub}
               </p>
             </div>
           )}


### PR DESCRIPTION
Supersedes #147 by @sophiamariem, rebased onto current `main` and with the unit coverage that #147 was missing (the reason it couldn't merge as-is). #147 was 65 commits behind `main` and predated the renderer vitest harness; this lands the same feature on top of that harness so the tests actually run in CI. Closes #147.

## What this does
The Home hero was two static lines. It now reacts to **recording state** and **calendar state**:

| State | Headline |
|---|---|
| recording / paused / processing | `Recording` / `Recording paused` / `Processing your note` |
| meeting in progress | `In a meeting now` |
| meeting < 60 min out | `Next meeting in N min` |
| meeting later / tomorrow | `Next meeting in N hr` / `Clear day ahead` |
| idle / no calendar | `Ready to capture beautiful notes` |

Recording state wins over calendar state. Recomputes on the existing 60s tick (no new intervals) and refreshes immediately on Home entry.

## Notes for review
- **`lib/calendar.ts` → `pickInProgressEvent`** mirrors `main.js → pickCurrentCalendarEvent` (5-min early grace, 10-min late floor, all-day + declined filters, identical tie-breaks) so the hero and the auto-detect-meeting notification agree. I verified the two are line-for-line equivalent.
- **`lib/hero.ts`** — the pure copy logic was extracted out of `Home.tsx` so `heroHeadline`/`heroSubtitle` are unit-testable without mounting the route.
- **Tests (the gap that blocked #147):** `hero.test.ts` (full state matrix, the 60-min→hour flip, recording-wins, the early-join-grace gate) and `calendar.test.ts` (match window, filters, priority order). 20 new cases; full renderer unit suite green.
- One non-blocking lint warning (`react-hooks/set-state-in-effect`) on the intentional "refresh on Home entry" line — matches the file's existing idiom (same pattern on the `setUpcomingPage` effect).

## Follow-up (tracked, not in scope here)
`calendar.ts` and `main.js`'s matcher are two hand-maintained copies kept in sync by a comment. The real fix is a shared CommonJS module `require`-able from main and importable by the renderer, with a cross-impl equivalence test. Worth a tracked issue.

## Verification
- `npm run test:unit` — 23/23 green (incl. 20 new)
- `npm run typecheck:renderer` — clean
- `npm run lint:renderer` — 0 errors
- `npm run build:renderer` — builds
- Ran locally against a seeded calendar: confirmed `Next meeting in N min` + the idle/recording states render.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Home hero dynamic based on recording and calendar state. It now shows clear status and timing, and matches the main-process meeting detection.

- **New Features**
  - Headline/subtitle react to recording (recording/paused/processing) and calendar (in a meeting now, next meeting in N min/hr, clear day/idle). Recording state takes precedence.
  - Added `pickInProgressEvent` in `app/renderer/src/lib/calendar.ts` mirroring main’s `pickCurrentCalendarEvent` (5‑min early grace, 10‑min late floor, all‑day/declined filters, same tie‑breaks) so the hero and notification agree.
  - Recomputes on the existing 60s tick and refreshes immediately on Home entry.

- **Refactors**
  - Extracted hero copy to `app/renderer/src/lib/hero.ts` (`heroHeadline`/`heroSubtitle`) and added unit tests (`hero.test.ts`, `calendar.test.ts`) for the state matrix and matching rules.
  - Smoothed color change in `globals.css` for headline/subtitle transitions; no new intervals added.

<sup>Written for commit f8b8fbf2b81094ebed77a00c379e54f6b9128973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

