### PR TITLE
chore(release): v0.5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
-- **2026-06-22** 🛡️ Works behind corporate proxies — org backup, AI, and note sync now route through your system proxy (incl. PAC) and trust the OS certificate store, so Steno works on managed enterprise networks that force egress through a proxy or inspect TLS.
-- **2026-06-22** 💾 Backup status you can see — when an org note fails to back up it now shows a quiet "Not backed up" indicator you can click to retry, and the failure is written to the diagnostic log, instead of failing silently.
-- **2026-06-21** 🔎 Instant search (⌘K) — a global command palette to jump to any note from anywhere.
-- **2026-06-21** 🎙️ Import audio files — drag & drop or pick an existing recording to transcribe and summarize it.
+- **2026-06-28** 📝 Report templates & per-meeting reports — define your own report styles and generate them from any note; a meeting can now hold multiple reports (the structured summary plus template-driven ones), switchable in the detail view.
+- **2026-06-28** 📤 Transcript export — copy the full transcript or save it as Markdown (title, metadata, notes, and diarised `[You]`/`[Others]` text) to paste into any external tool.
+- **2026-06-28** 🛟 Never lose a transcript — if batch transcription comes back empty, Steno now falls back to the live transcript you watched during the recording instead of saving a blank note.
+- **2026-06-28** 🧩 Better long-meeting summaries — map-reduce summarization chunks long transcripts so multi-hour meetings summarize reliably without overflowing the model's context.
 
 
 ## Features
@@ -58,6 +58,8 @@ If you're looking for a hosted desktop recording API, consider checking out [Rec
 - **Ask your meetings** — Natural-language Q&A across a single note *or* your entire library via the Chat tab. Pulls from summary, key topics, and the full transcript.
 - **Multi-language (25 live, 99 total)** — Parakeet covers 25 European languages with live transcription; Whisper handles 99 languages including Chinese, Japanese, Arabic, and Hindi post-stop.
 - **Markdown ownership** — Summaries and transcripts save as clean Markdown you can edit, search, or sync to whatever knowledge base you live in.
+- **Report templates** — Define custom report styles and generate them per meeting; a note can hold multiple reports (the structured summary plus template-driven ones), switchable in the detail view.
+- **Transcript export** — Copy the full transcript or save it as Markdown (with metadata, notes, and speaker labels) to drop into any external tool.
 - **Bring your own cloud model** — Optional OpenAI, Anthropic, AWS Bedrock (Claude — including application inference profile ARNs for governed AWS environments), or custom API endpoint for users who prefer a hosted LLM.
 - **Organisation AI** — On managed deployments, sign in to your org's Steno adapter and AI routes through it automatically — no local API key, no per-user setup.
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",


### PR DESCRIPTION
Version bump to 0.5.6 + What's New / Features for the 0.5.6 cycle (report templates #252, transcript export #215, live-transcript rescue #247, map-reduce #250, QAT models #251, home hero #257). Release-prep only — no functional code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release prep for v0.5.6: bump `stenoai` to 0.5.6 and update README “What’s New” and Features with this cycle’s highlights. Docs-only; no functional code changes.

- **New Features**
  - Report templates and per-meeting reports.
  - Transcript export to Markdown with metadata and speakers.
  - Fallback to live transcript when batch transcription is empty.
  - Map-reduce summarization for reliable long-meeting summaries.

- **Dependencies**
  - Update `app/package.json` version to `0.5.6`.

<sup>Written for commit 33b17d1852981946b08c19e8da892332c8026815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

