### PR TITLE
fix(auto-detect): ignore app_id-less mic events on macOS 14+ (#262)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -36,6 +36,7 @@ if (process.platform !== 'darwin') {
 const path = require('path');
 const { spawn: _spawnRaw, exec } = require('child_process');
 const processingLog = require('./processing-log');
+const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
 
 // Wrap spawn so every backend / ollama launch defaults to windowsHide:true.
 // The PyInstaller backend (stenoai.exe) and bundled ollama.exe are console
@@ -4326,37 +4327,15 @@ const APP_NAME_OVERRIDES = [
 // web, Whereby, Around, etc.) route mic capture through the browser bundle
 // id or a helper sub-process (see APP_NAME_OVERRIDES). Tradeoff: in-browser
 // dictation extensions also match, but browser meetings are far more common.
-const MEETING_APP_ALLOWLIST = [
-  // Native videoconf / meeting apps (prefix match catches helper sub-processes)
-  /^us\.zoom\.xos/,                    // Zoom
-  /^com\.microsoft\.teams/,            // Microsoft Teams (classic + new "teams2")
-  /^com\.cisco\.webexmeetingsapp/,     // Cisco Webex
-  /^com\.webex\.meetingmanager/,       // Cisco Webex (alt id)
-  /^com\.apple\.FaceTime/,             // FaceTime
-  /^com\.hnc\.Discord/,                // Discord
-  /^com\.tinyspeck\.slackmacgap/,      // Slack (huddles)
-  /^com\.logmein\.GoToMeeting/,        // GoToMeeting
-  /^com\.bluejeansnet\.BlueJeans/,     // BlueJeans
-  /^co\.pop\.desktop/,                 // Pop
-  /^com\.google\.meetings/,            // Google Meet (standalone PWA)
-  /^com\.apple\.VoiceMemos/,           // Apple Voice Memos
-  // Browsers — most web meetings route mic capture through here
-  /^com\.apple\.WebKit/,               // Safari (helper)
-  /^com\.apple\.Safari/,               // Safari (main)
-  /^com\.google\.Chrome/,              // Chrome (+ helpers)
-  /^org\.chromium\./,                  // Chromium
-  /^com\.microsoft\.edgemac/,          // Edge
-  /^company\.thebrowser\.Browser/,     // Arc
-  /^com\.brave\.Browser/,              // Brave
-  /^org\.mozilla\./,                   // Firefox
-];
-
-function isMeetingApp(evt) {
-  // macOS 12/13 fallback emits no app_id (device-level signal). We can't
-  // filter there, so preserve legacy behaviour and notify regardless.
-  if (!evt.app_id) return true;
-  return MEETING_APP_ALLOWLIST.some((re) => re.test(evt.app_id));
-}
+// The allowlist + isMeetingApp live in ./meeting-detect (unit-tested). Whether
+// an app_id-less device-level event is treated as a meeting is decided once at
+// startup from the OS version: macOS 12/13 emit such events legitimately;
+// macOS 14+ always carries an app_id, so an app_id-less event there is an
+// AEC / system-audio artifact, not a meeting (see #262).
+const ALLOW_DEVICE_LEVEL_FALLBACK = allowsDeviceLevelFallback(
+  process.platform,
+  (() => { try { return process.getSystemVersion(); } catch (_) { return ''; } })(),
+);
 
 // Wait this long after the meeting app releases the mic before triggering
 // auto-pause + "Meeting ended" prompt. Verified empirically that Zoom/Meet/
@@ -4488,8 +4467,8 @@ async function handleMicEvent(line) {
     return;
   }
 
-  if (!isMeetingApp(evt)) {
-    sendDebugLog(`[auto-detect] ignoring non-meeting app: ${evt.app_name || evt.app_id}`);
+  if (!isMeetingApp(evt, { allowDeviceLevelFallback: ALLOW_DEVICE_LEVEL_FALLBACK })) {
+    sendDebugLog(`[auto-detect] ignoring non-meeting app: ${evt.app_name || evt.app_id || 'device-level (no app_id)'}`);
     return;
   }
 

--- a/app/meeting-detect.js
+++ b/app/meeting-detect.js
@@ -40,7 +40,8 @@ function allowsDeviceLevelFallback(platform, systemVersion) {
 }
 
 function isMeetingApp(evt, { allowDeviceLevelFallback = false } = {}) {
-  if (!evt || !evt.app_id) return allowDeviceLevelFallback;
+  if (!evt) return false;
+  if (!evt.app_id) return allowDeviceLevelFallback;
   return MEETING_APP_ALLOWLIST.some((re) => re.test(evt.app_id));
 }
 

--- a/app/meeting-detect.js
+++ b/app/meeting-detect.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Bundle-id allowlist for auto-detect "Meeting detected" notifications.
+// Prefix match catches helper sub-processes.
+const MEETING_APP_ALLOWLIST = [
+  // Native videoconf / meeting apps
+  /^us\.zoom\.xos/,                    // Zoom
+  /^com\.microsoft\.teams/,            // Microsoft Teams (classic + new "teams2")
+  /^com\.cisco\.webexmeetingsapp/,     // Cisco Webex
+  /^com\.webex\.meetingmanager/,       // Cisco Webex (alt id)
+  /^com\.apple\.FaceTime/,             // FaceTime
+  /^com\.hnc\.Discord/,                // Discord
+  /^com\.tinyspeck\.slackmacgap/,      // Slack (huddles)
+  /^com\.logmein\.GoToMeeting/,        // GoToMeeting
+  /^com\.bluejeansnet\.BlueJeans/,     // BlueJeans
+  /^co\.pop\.desktop/,                 // Pop
+  /^com\.google\.meetings/,            // Google Meet (standalone PWA)
+  /^com\.apple\.VoiceMemos/,           // Apple Voice Memos
+  // Browsers — most web meetings route mic capture through here
+  /^com\.apple\.WebKit/,               // Safari (helper)
+  /^com\.apple\.Safari/,               // Safari (main)
+  /^com\.google\.Chrome/,              // Chrome (+ helpers)
+  /^org\.chromium\./,                  // Chromium
+  /^com\.microsoft\.edgemac/,          // Edge
+  /^company\.thebrowser\.Browser/,     // Arc
+  /^com\.brave\.Browser/,              // Brave
+  /^org\.mozilla\./,                   // Firefox
+];
+
+// Decide whether an app_id-less ("device-level") mic event should still be
+// treated as a meeting. macOS 12/13 emit device-level signals with no app_id,
+// so the legacy fallback notifies regardless. macOS 14+ always provides an
+// app_id, so an app_id-less event there is an AEC / system-audio artifact
+// (e.g. a notification ping briefly opening the mic), NOT a meeting — see #262.
+function allowsDeviceLevelFallback(platform, systemVersion) {
+  if (platform !== 'darwin') return false;
+  const major = parseInt(String(systemVersion).split('.')[0], 10);
+  if (!Number.isFinite(major)) return false;
+  return major < 14;
+}
+
+function isMeetingApp(evt, { allowDeviceLevelFallback = false } = {}) {
+  if (!evt || !evt.app_id) return allowDeviceLevelFallback;
+  return MEETING_APP_ALLOWLIST.some((re) => re.test(evt.app_id));
+}
+
+module.exports = { MEETING_APP_ALLOWLIST, isMeetingApp, allowsDeviceLevelFallback };

--- a/app/meeting-detect.test.js
+++ b/app/meeting-detect.test.js
@@ -19,6 +19,14 @@ test('isMeetingApp ignores an app_id-less (device-level) event by default', () =
   assert.strictEqual(isMeetingApp({ app_id: '' }), false);
 });
 
+test('isMeetingApp rejects a null/undefined event even with the fallback allowed', () => {
+  // A missing event is not a meeting, regardless of the device-level fallback —
+  // the fallback only applies to an event that exists but carries no app_id.
+  assert.strictEqual(isMeetingApp(null, { allowDeviceLevelFallback: true }), false);
+  assert.strictEqual(isMeetingApp(undefined, { allowDeviceLevelFallback: true }), false);
+  assert.strictEqual(isMeetingApp(null), false);
+});
+
 test('isMeetingApp honors the device-level fallback when explicitly allowed', () => {
   // Legacy macOS 12/13 path: device-level events have no app_id and we still
   // want to notify there.

--- a/app/meeting-detect.test.js
+++ b/app/meeting-detect.test.js
@@ -1,0 +1,49 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
+
+test('isMeetingApp accepts a known meeting app bundle id', () => {
+  assert.strictEqual(isMeetingApp({ app_id: 'us.zoom.xos' }), true);
+  assert.strictEqual(isMeetingApp({ app_id: 'com.microsoft.teams2' }), true);
+});
+
+test('isMeetingApp rejects a non-allowlisted app bundle id', () => {
+  assert.strictEqual(isMeetingApp({ app_id: 'com.example.Conductor' }), false);
+});
+
+test('isMeetingApp ignores an app_id-less (device-level) event by default', () => {
+  // The macOS 14+ regression: AEC/notification-ping events arrive with no
+  // app_id and must NOT be treated as a meeting.
+  assert.strictEqual(isMeetingApp({ event: 'start' }), false);
+  assert.strictEqual(isMeetingApp({ app_id: '' }), false);
+});
+
+test('isMeetingApp honors the device-level fallback when explicitly allowed', () => {
+  // Legacy macOS 12/13 path: device-level events have no app_id and we still
+  // want to notify there.
+  assert.strictEqual(
+    isMeetingApp({ event: 'start' }, { allowDeviceLevelFallback: true }),
+    true,
+  );
+});
+
+test('allowsDeviceLevelFallback is false on macOS 14+ (app_id always present)', () => {
+  assert.strictEqual(allowsDeviceLevelFallback('darwin', '14.5'), false);
+  assert.strictEqual(allowsDeviceLevelFallback('darwin', '15.0'), false);
+});
+
+test('allowsDeviceLevelFallback is true on legacy macOS 12/13', () => {
+  assert.strictEqual(allowsDeviceLevelFallback('darwin', '13.6.1'), true);
+  assert.strictEqual(allowsDeviceLevelFallback('darwin', '12.0'), true);
+});
+
+test('allowsDeviceLevelFallback is false off macOS', () => {
+  assert.strictEqual(allowsDeviceLevelFallback('win32', '10.0.22631'), false);
+  assert.strictEqual(allowsDeviceLevelFallback('linux', '6.1'), false);
+});
+
+test('allowsDeviceLevelFallback is false for an unparseable version (fail safe)', () => {
+  assert.strictEqual(allowsDeviceLevelFallback('darwin', ''), false);
+  assert.strictEqual(allowsDeviceLevelFallback('darwin', undefined), false);
+});

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",


### PR DESCRIPTION
Fixes hole 1 of #262 (the device-level false positive).

**Problem:** `isMeetingApp` returned `true` for any mic event with no `app_id`. That fallback exists for macOS 12/13, which emit device-level signals without an `app_id`. But on macOS 14+ the mic-monitor always attributes an `app_id`, so an `app_id`-less event there is an AEC / system-audio artifact — e.g. a notification ping (Conductor) briefly opening the mic for echo cancellation. It wrongly fired "Meeting detected".

**Fix:** Gate the `app_id`-less fallback on OS version — keep it for macOS 12/13, drop it for 14+. Extracted `isMeetingApp` + the bundle-id allowlist into `app/meeting-detect.js` (following the `processing-log.js` pattern) and added `node --test` unit tests covering both the allowlist and the version gate (wired into `test:unit`).

**Scope note:** This addresses hole 1 only. Hole 2 (broad browser allowlist firing on any browser mic use) is a behavioural/product tradeoff — I've left a separate comment on #262 rather than bundle a gating decision in here.

**Assumption:** the "macOS 14+ always carries an `app_id`" contract comes from the bundled `mic-monitor` helper (not in this repo) + the existing code comment + the reporter's observation; the fix is deliberately conservative and only narrows the 14+ path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false “Meeting detected” on macOS 14+ by ignoring mic events without an `app_id`, and treats null/undefined mic events as not meetings. Keeps the legacy device-level fallback on macOS 12/13. Addresses the device-level false positive in #262 and fixes a null-event edge case from #263.

- **Bug Fixes**
  - Gate the app_id-less fallback by OS version: off on macOS 14+, on for 12/13.
  - Return false for null/undefined mic events, regardless of the fallback.

- **Refactors**
  - Extracted the allowlist and `isMeetingApp` into `app/meeting-detect.js` with `allowsDeviceLevelFallback`.
  - Added `node --test` unit tests for detection logic and wired them into `test:unit` alongside `vitest`.

<sup>Written for commit b94287e81c9924bc5350a5503507c98ce75202e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

