### PR TITLE
fix(transcribe): let Parakeet users pin a European language

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -217,6 +217,11 @@ function install({ ipcMain }) {
     'list-folders': { success: true, folders: [] },
     'get-calendar-events': { success: true, events: [] },
     'parakeet-status': { success: true, model: '', installed: false },
+    // Transcribe tab reads these on first paint. Default to Parakeet (the new
+    // default engine) + auto so the language picker renders enabled and shows
+    // the Parakeet language set (parakeet-language-picker.t1).
+    'get-transcription-engine': { success: true, engine: 'parakeet' },
+    'get-language': { success: true, language: 'auto' },
     'list-whisper-models': {
       success: true,
       supported_models: {},

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/lib/utils';
 import { useLiveTranscript } from '@/hooks/useLiveTranscript';
 import { useRecording } from '@/hooks/useRecording';
 import { useLanguageSetting, useSetLanguage } from '@/hooks/useSettings';
-import { PARAKEET_LANGUAGE_CODES } from '@/lib/transcription-languages';
+import { PARAKEET_LANGUAGES } from '@/lib/transcription-languages';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { formatElapsed } from '@/lib/utils';
 
@@ -316,22 +316,11 @@ interface LanguageOption {
   hint: string;
 }
 
-// Two quick presets (Multi / English) plus the concrete European languages a
-// user can pin so summaries/notes come out in them. This writes the same
-// global language setting as Settings → Transcribe, so it must surface a
-// concrete pin (not relabel it "Multi" and clobber it to 'auto' on the next
-// pick). Filtered against PARAKEET_LANGUAGE_CODES so it stays in sync with the
-// Settings picker.
-const ALL_LANGUAGE_OPTIONS: LanguageOption[] = [
-  { code: 'auto', label: 'Multi-language', hint: 'Auto-detect per recording (European languages)' },
-  { code: 'en', label: 'English', hint: 'Best accuracy when meetings are always in English' },
-  { code: 'fr', label: 'French', hint: 'Transcribe and summarise in French' },
-  { code: 'de', label: 'German', hint: 'Transcribe and summarise in German' },
-  { code: 'es', label: 'Spanish', hint: 'Transcribe and summarise in Spanish' },
-  { code: 'nl', label: 'Dutch', hint: 'Transcribe and summarise in Dutch' },
-  { code: 'pt', label: 'Portuguese', hint: 'Transcribe and summarise in Portuguese' },
-];
-const LANGUAGE_OPTIONS = ALL_LANGUAGE_OPTIONS.filter((o) => PARAKEET_LANGUAGE_CODES.has(o.code));
+// The pinnable languages (a "Multi" preset + concrete European pins) come
+// straight from the shared PARAKEET_LANGUAGES source of truth, so this picker
+// can't drift from Settings or the engine-switch coercion. Writes the same
+// global language setting as Settings → Transcribe.
+const LANGUAGE_OPTIONS: LanguageOption[] = PARAKEET_LANGUAGES.map((l) => ({ ...l }));
 
 function LanguageSelector() {
   const language = useLanguageSetting();

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 import { useLiveTranscript } from '@/hooks/useLiveTranscript';
 import { useRecording } from '@/hooks/useRecording';
 import { useLanguageSetting, useSetLanguage } from '@/hooks/useSettings';
+import { PARAKEET_LANGUAGE_CODES } from '@/lib/transcription-languages';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { formatElapsed } from '@/lib/utils';
 
@@ -315,10 +316,22 @@ interface LanguageOption {
   hint: string;
 }
 
-const LANGUAGE_OPTIONS: LanguageOption[] = [
-  { code: 'en', label: 'English only', hint: 'Best accuracy when meetings are always in English' },
-  { code: 'auto', label: 'Multi-language', hint: '25 European languages, auto-detect per recording' },
+// Two quick presets (Multi / English) plus the concrete European languages a
+// user can pin so summaries/notes come out in them. This writes the same
+// global language setting as Settings → Transcribe, so it must surface a
+// concrete pin (not relabel it "Multi" and clobber it to 'auto' on the next
+// pick). Filtered against PARAKEET_LANGUAGE_CODES so it stays in sync with the
+// Settings picker.
+const ALL_LANGUAGE_OPTIONS: LanguageOption[] = [
+  { code: 'auto', label: 'Multi-language', hint: 'Auto-detect per recording (European languages)' },
+  { code: 'en', label: 'English', hint: 'Best accuracy when meetings are always in English' },
+  { code: 'fr', label: 'French', hint: 'Transcribe and summarise in French' },
+  { code: 'de', label: 'German', hint: 'Transcribe and summarise in German' },
+  { code: 'es', label: 'Spanish', hint: 'Transcribe and summarise in Spanish' },
+  { code: 'nl', label: 'Dutch', hint: 'Transcribe and summarise in Dutch' },
+  { code: 'pt', label: 'Portuguese', hint: 'Transcribe and summarise in Portuguese' },
 ];
+const LANGUAGE_OPTIONS = ALL_LANGUAGE_OPTIONS.filter((o) => PARAKEET_LANGUAGE_CODES.has(o.code));
 
 function LanguageSelector() {
   const language = useLanguageSetting();
@@ -326,8 +339,11 @@ function LanguageSelector() {
   const [popoverOpen, setPopoverOpen] = React.useState(false);
 
   const current = language.data ?? 'auto';
-  const isEnglish = current === 'en';
-  const display = isEnglish ? 'English' : 'Multi';
+  const selected = LANGUAGE_OPTIONS.find((o) => o.code === current);
+  // Concrete pins show their name; 'auto' shows the compact "Multi". An
+  // out-of-list pin (e.g. a Whisper-only language set in Settings) shows its
+  // code rather than being mislabelled "Multi" and silently reset.
+  const display = current === 'auto' ? 'Multi' : (selected?.label ?? current.toUpperCase());
 
   const pick = (code: string) => {
     setLanguage.mutate(code);
@@ -353,7 +369,7 @@ function LanguageSelector() {
       </PopoverTrigger>
       <PopoverContent align="end" sideOffset={8} className="w-56 p-1">
         {LANGUAGE_OPTIONS.map((opt) => {
-          const active = isEnglish ? opt.code === 'en' : opt.code === 'auto';
+          const active = opt.code === current;
           return (
             <button
               key={opt.code}

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -255,6 +255,10 @@ export function usePullParakeetModel() {
         await coerceLanguageForParakeet();
         await ipc().transcriptionEngine.set('parakeet');
         setPendingSelect(null);
+        // Coercion may have reset the pin to 'auto'; refresh the language query
+        // so the Settings dropdown + live dock toggle don't show the stale
+        // pre-coercion code. Mirrors useSetActiveTranscription's onSuccess.
+        qc.invalidateQueries({ queryKey: ['settings', 'language'] });
       }
       qc.invalidateQueries({ queryKey: parakeetKeys.all });
       qc.invalidateQueries({ queryKey: transcriptionEngineKeys.all });

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ipc, type ListedModel, type TranscriptionEngine } from '@/lib/ipc';
 import { unwrap } from '@/lib/result';
+import { PARAKEET_LANGUAGE_CODES } from '@/lib/transcription-languages';
 
 export const modelsKeys = {
   all: ['models'] as const,
@@ -249,6 +250,9 @@ export function usePullParakeetModel() {
         return rest;
       });
       if (success && pendingSelect === key) {
+        // Same coercion as an explicit switch: auto-selecting Parakeet after a
+        // download must not leave a Whisper-only pin (e.g. 'ja') in config.
+        await coerceLanguageForParakeet();
         await ipc().transcriptionEngine.set('parakeet');
         setPendingSelect(null);
       }
@@ -288,12 +292,23 @@ export function useTranscriptionEngine() {
   });
 }
 
-// Language sets the engine-aware dropdown lists honour. Mirrors the
-// LANGUAGES_PARAKEET / LANGUAGES_WHISPER arrays in Settings.tsx — kept in
-// useModels because the coercion below needs to run regardless of where
-// the engine switch was triggered from (Settings card click, Setup
-// wizard, future shortcut, etc.).
-const PARAKEET_LANGUAGES = new Set(['auto', 'en']);
+// Activating Parakeet must drop a pin Parakeet can't honour as an output
+// language (a Whisper-only 'hi'/'ja'/…) back to 'auto' — otherwise the config
+// and live-recording metadata keep a language outside PARAKEET_LANGUAGE_CODES.
+// Default to 'auto' (not 'en') so the user's "detect / multi-language" intent
+// survives. Shared by every Parakeet-activation path: the explicit engine
+// switch (useSetActiveTranscription) and the post-download auto-select
+// (usePullParakeetModel's complete handler).
+async function coerceLanguageForParakeet(): Promise<void> {
+  try {
+    const current = unwrap(await ipc().settings.getLanguage()).language;
+    if (!PARAKEET_LANGUAGE_CODES.has(current)) {
+      unwrap(await ipc().settings.setLanguage('auto'));
+    }
+  } catch {
+    // Best-effort: activation shouldn't fail because the language read errored.
+  }
+}
 
 export function useSetActiveTranscription() {
   const qc = useQueryClient();
@@ -305,22 +320,8 @@ export function useSetActiveTranscription() {
       engine: TranscriptionEngine;
       whisperModel?: string;
     }) => {
-      // Coerce config.language when switching to an engine that doesn't
-      // support the current pick (e.g. Whisper → Parakeet with language=hi).
-      // Default to 'auto' rather than 'en' so the user's "I want
-      // detection / multi-language" intent is preserved across the switch.
-      // Per-engine memory ("restore the Parakeet language I had last
-      // time") is a richer UX but needs a new config field; deferred.
       if (engine === 'parakeet') {
-        try {
-          const current = unwrap(await ipc().settings.getLanguage()).language;
-          if (!PARAKEET_LANGUAGES.has(current)) {
-            unwrap(await ipc().settings.setLanguage('auto'));
-          }
-        } catch {
-          // Best-effort coercion; the engine switch itself shouldn't fail
-          // just because the language read errored.
-        }
+        await coerceLanguageForParakeet();
       }
       unwrap(await ipc().transcriptionEngine.set(engine));
       if (engine === 'whisper' && whisperModel) {

--- a/app/renderer/src/lib/transcription-languages.ts
+++ b/app/renderer/src/lib/transcription-languages.ts
@@ -1,0 +1,23 @@
+// Single source of truth for which languages the Parakeet engine offers.
+//
+// Parakeet TDT v3 is language-agnostic at inference (the decoder ignores the
+// pin), but the language setting still drives the OUTPUT language of the
+// summary, title, chat and reports — so a French/German/… user must be able
+// to pin their language or those default to English. We expose the European
+// languages Parakeet transcribes well; the non-European codes (ja/zh/ko/hi/ar)
+// stay Whisper-only because Parakeet can't transcribe them.
+//
+// Every Parakeet-aware language control imports this set so they can't drift:
+//   - Settings → Transcribe picker (LANGUAGES_PARAKEET, routes/Settings.tsx)
+//   - the engine-switch coercion (useSetActiveTranscription, hooks/useModels.ts)
+//   - the live transcript bar's language selector (components/LiveTranscriptBar.tsx)
+// If they drift, switching to Parakeet would reset a still-valid pin to 'auto'.
+export const PARAKEET_LANGUAGE_CODES: ReadonlySet<string> = new Set([
+  'auto',
+  'en',
+  'es',
+  'fr',
+  'de',
+  'nl',
+  'pt',
+]);

--- a/app/renderer/src/lib/transcription-languages.ts
+++ b/app/renderer/src/lib/transcription-languages.ts
@@ -7,17 +7,32 @@
 // languages Parakeet transcribes well; the non-European codes (ja/zh/ko/hi/ar)
 // stay Whisper-only because Parakeet can't transcribe them.
 //
-// Every Parakeet-aware language control imports this set so they can't drift:
+// Every Parakeet-aware language control derives from this ONE list so they
+// can't drift — codes AND the live-bar copy live here:
 //   - Settings → Transcribe picker (LANGUAGES_PARAKEET, routes/Settings.tsx)
+//     filters the Whisper list by PARAKEET_LANGUAGE_CODES.
 //   - the engine-switch coercion (useSetActiveTranscription, hooks/useModels.ts)
-//   - the live transcript bar's language selector (components/LiveTranscriptBar.tsx)
-// If they drift, switching to Parakeet would reset a still-valid pin to 'auto'.
-export const PARAKEET_LANGUAGE_CODES: ReadonlySet<string> = new Set([
-  'auto',
-  'en',
-  'es',
-  'fr',
-  'de',
-  'nl',
-  'pt',
-]);
+//     resets an out-of-set pin to 'auto'.
+//   - the live transcript bar's language selector
+//     (components/LiveTranscriptBar.tsx) maps PARAKEET_LANGUAGES directly.
+// Adding a language is now a one-line edit here; the codes set is derived, so
+// no second hardcoded list can fall out of sync.
+export interface ParakeetLanguageOption {
+  code: string;
+  label: string;
+  hint: string;
+}
+
+export const PARAKEET_LANGUAGES: readonly ParakeetLanguageOption[] = [
+  { code: 'auto', label: 'Multi-language', hint: 'Auto-detect per recording (European languages)' },
+  { code: 'en', label: 'English', hint: 'Best accuracy when meetings are always in English' },
+  { code: 'fr', label: 'French', hint: 'Transcribe and summarise in French' },
+  { code: 'de', label: 'German', hint: 'Transcribe and summarise in German' },
+  { code: 'es', label: 'Spanish', hint: 'Transcribe and summarise in Spanish' },
+  { code: 'nl', label: 'Dutch', hint: 'Transcribe and summarise in Dutch' },
+  { code: 'pt', label: 'Portuguese', hint: 'Transcribe and summarise in Portuguese' },
+];
+
+export const PARAKEET_LANGUAGE_CODES: ReadonlySet<string> = new Set(
+  PARAKEET_LANGUAGES.map((l) => l.code),
+);

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/components/ui/dialog';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import { useNavigate, getLastNonSettingsRoute, useRoute, getRouteParam } from '@/lib/router';
+import { PARAKEET_LANGUAGE_CODES } from '@/lib/transcription-languages';
 import {
   clearDebugLogs,
   getDebugLogs,
@@ -127,11 +128,7 @@ type LangOption = { value: string; label: string };
 
 // Curated language list shown in Settings → Transcribe. Whisper supports
 // all 12 (it covers 99 languages at the model level; the dropdown is just
-// the tested curation). Parakeet TDT v3 supports 25 European languages
-// and is language-agnostic at inference — per-language hints don't bias
-// the decoder, so we expose only Auto vs English-only. Picking a
-// non-European concrete code (e.g. Hindi) on Parakeet would produce
-// garbage; hiding the option avoids that footgun.
+// the tested curation).
 const LANGUAGES_WHISPER: LangOption[] = [
   { value: 'auto', label: 'Auto (detect)' },
   { value: 'en', label: 'English' },
@@ -146,10 +143,13 @@ const LANGUAGES_WHISPER: LangOption[] = [
   { value: 'hi', label: 'Hindi' },
   { value: 'ar', label: 'Arabic' },
 ];
-const LANGUAGES_PARAKEET: LangOption[] = [
-  { value: 'auto', label: 'Auto (detect)' },
-  { value: 'en', label: 'English' },
-];
+// Parakeet exposes the European subset (see transcription-languages.ts for
+// why pinning matters even though the decoder is language-agnostic). Derived
+// from the Whisper list so labels stay identical and the picker can't drift
+// from the shared code set.
+const LANGUAGES_PARAKEET: LangOption[] = LANGUAGES_WHISPER.filter((l) =>
+  PARAKEET_LANGUAGE_CODES.has(l.value),
+);
 
 const TABS = [
   { id: 'general', label: 'General' },
@@ -864,7 +864,7 @@ function TranscriptionTab() {
   const displayValue = options.some((o) => o.value === persisted) ? persisted : 'auto';
   const helperText =
     engine === 'parakeet'
-      ? 'Auto-detect covers 25 European languages. For other languages, switch to Whisper.'
+      ? 'Pick your meeting language so summaries and notes come out in it. Parakeet covers European languages; for Japanese, Chinese, Korean, Hindi or Arabic, switch to Whisper.'
       : 'Language for transcription and summaries';
 
   return (

--- a/e2e/specs/parakeet-language-picker.t1.spec.ts
+++ b/e2e/specs/parakeet-language-picker.t1.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../fixtures/electron';
+import type { Page } from '@playwright/test';
+
+/**
+ * T1 — renderer-only, mock IPC, no backend. Proves the Settings → Transcribe
+ * language picker exposes the European languages on the Parakeet engine, so a
+ * French/German/… user can pin their language (which drives the summary/title/
+ * chat output language even though Parakeet's decoder is language-agnostic).
+ * Before #264's fix the Parakeet picker offered only Auto/English, leaving
+ * non-English European users stuck with English notes.
+ *
+ * The picker list is engine-gated in the renderer (LANGUAGES_PARAKEET in
+ * Settings.tsx, mirrored by PARAKEET_LANGUAGES in hooks/useModels.ts for the
+ * engine-switch coercion). Mock IPC seeds engine=parakeet + language=auto (see
+ * app/e2e-mock-ipc.js) so the picker renders enabled on first paint.
+ */
+
+const EUROPEAN = ['English', 'Spanish', 'French', 'German', 'Dutch', 'Portuguese'];
+// Non-European: Whisper-only, must NOT appear on Parakeet (it can't transcribe them).
+const NON_EUROPEAN = ['Japanese', 'Chinese', 'Korean', 'Hindi', 'Arabic'];
+
+async function openTranscribeLanguagePicker(page: Page) {
+  await page.evaluate(() => {
+    window.location.hash = '#/settings?tab=transcription';
+  });
+  // The Language Select is the only combobox in the Transcribe section (keep-
+  // recordings is a Switch, the model list uses buttons), so scope to the
+  // section rather than relying on document order.
+  const trigger = page.locator('[data-settings-tab="transcription"]').getByRole('combobox');
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+}
+
+test('Parakeet language picker offers European languages and hides non-European ones', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  await openTranscribeLanguagePicker(page);
+
+  // Auto + the six European languages are pinnable on Parakeet.
+  await expect(page.getByRole('option', { name: 'Auto (detect)' })).toBeVisible();
+  for (const lang of EUROPEAN) {
+    await expect(page.getByRole('option', { name: lang, exact: true })).toBeVisible();
+  }
+  // Languages Parakeet cannot transcribe stay Whisper-only.
+  for (const lang of NON_EUROPEAN) {
+    await expect(page.getByRole('option', { name: lang, exact: true })).toHaveCount(0);
+  }
+});


### PR DESCRIPTION
## Why

On the **Parakeet** engine (the new default) the Settings → Transcribe language picker only offered **Auto / English**, so a French/German/… speaker couldn't pin their language. Parakeet's decoder is language-agnostic, but the language setting still drives the **output language of the summary, title, chat and reports** — so those users got **English notes for a non-English meeting** with no in-product lever. Reported in #264 (and verified: Parakeet transcribes clean French/German well; the gap is the missing language pin, not transcription quality).

## What changed

- **Expose the European subset on Parakeet** (`en/es/fr/de/nl/pt`). The non-European codes (`ja/zh/ko/hi/ar`) stay Whisper-only since Parakeet can't transcribe them. Pinning a language then drives the correct output language for summary/title/chat/reports.
- **Single source of truth** — `app/renderer/src/lib/transcription-languages.ts` (`PARAKEET_LANGUAGE_CODES`), imported by the Settings picker, the engine-switch coercion, and the live-transcript bar, so the three lists can't drift.
- **Coercion factored into one helper** (`coerceLanguageForParakeet`) used by **both** Parakeet-activation paths — the explicit engine switch *and* the post-download auto-select (the latter previously bypassed it, so a Whisper-only pin like `ja` could be left on Parakeet).
- **Live transcript bar** now surfaces a concrete pin by name and selects by exact code, so it no longer relabels a French/German pin as "Multi" and clobbers it back to `auto`.
- Updated the Transcribe hint copy to match.

## Testing

- New `parakeet-language-picker.t1.spec.ts`: asserts the Parakeet picker exposes the European languages and hides the non-European ones.
- `typecheck:renderer` clean, `lint:renderer` 0 errors, full T1 suite green (18/18), renderer build OK.

## Follow-up

- A behavioral e2e for the engine-switch coercion (pin preserved for European, reset to `auto` for non-European) is a sensible add — deferred here because it needs stateful mock IPC + model-row driving; the logic is now single-sourced and the picker contents are covered.
- Companion to #266 (re-transcribe), which would let users recover already-recorded meetings after pinning the right language.

Closes #264

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let Parakeet users pin a European language in Settings and the Live Transcript Bar so summaries, titles, chat, and reports use that language instead of defaulting to English. Unsupported pins are reset to auto when activating or auto-selecting Parakeet, and the UI updates immediately.

- **Bug Fixes**
  - Parakeet now offers en/es/fr/de/nl/pt in Settings and the Live Transcript Bar; the bar shows the exact pin (not “Multi”) and selects by exact code from a shared list.
  - Switching or auto-selecting Parakeet drops Whisper-only pins (ja/zh/ko/hi/ar) to 'auto' and invalidates the language query so Settings and the dock reflect the change.
  - Single source of truth for labels and codes via `PARAKEET_LANGUAGES` (with `PARAKEET_LANGUAGE_CODES` derived). Updated Transcribe hint, added a T1 spec, and seeded mock IPC defaults.

Closes #264.

<sup>Written for commit a90914a1110584bbdb9eb9230d8ce90f56ae0421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

