### PR TITLE
feat: Ollama-native MLX/NVFP4 tag adoption on Apple Silicon

### DIFF
--- a/app/docs/ipc-contract.md
+++ b/app/docs/ipc-contract.md
@@ -325,7 +325,7 @@ type CreateFolderResponse = Result<{ folder: Folder }>;
 | `pull-model` | R→M invoke | yes | `stenoai.models.pull(name)` |
 | `cancel-pull` | R→M invoke | yes | `stenoai.models.cancelPull(name)` |
 | `verify-model` | R→M invoke | yes | `stenoai.models.verify(name)` |
-| `delete-model` | R→M invoke | yes | `stenoai.models.delete(name)` |
+| `delete-model` | R→M invoke | yes | `stenoai.models.delete(name)` — **`name` is checked against an allowlist** (`Config.list_supported_models()` keys + `Config._MLX_EQUIVALENTS.values()`) in `simple_recorder.py`; any other value returns `{success: false}` without calling `ollama.delete()` |
 | `get-active-pulls` | R→M invoke | yes | `stenoai.models.getActivePulls()` |
 | `ack-pull-complete` | R→M send (one-way) | yes | `stenoai.models.ackPullComplete(name)` |
 | `model-pull-progress` | M→R | yes | `stenoai.on.modelPullProgress(cb)` |

--- a/app/docs/ipc-contract.md
+++ b/app/docs/ipc-contract.md
@@ -323,8 +323,20 @@ type CreateFolderResponse = Result<{ folder: Folder }>;
 | `set-model` | R→M invoke | yes | `stenoai.models.set(name)` |
 | `check-model-installed` | R→M invoke | yes | `stenoai.models.checkInstalled(name)` |
 | `pull-model` | R→M invoke | yes | `stenoai.models.pull(name)` |
+| `cancel-pull` | R→M invoke | yes | `stenoai.models.cancelPull(name)` |
+| `verify-model` | R→M invoke | yes | `stenoai.models.verify(name)` |
+| `delete-model` | R→M invoke | yes | `stenoai.models.delete(name)` |
+| `get-active-pulls` | R→M invoke | yes | `stenoai.models.getActivePulls()` |
+| `ack-pull-complete` | R→M send (one-way) | yes | `stenoai.models.ackPullComplete(name)` |
 | `model-pull-progress` | M→R | yes | `stenoai.on.modelPullProgress(cb)` |
 | `model-pull-complete` | M→R | yes | `stenoai.on.modelPullComplete(cb)` |
+
+On Apple Silicon, a model's canonical (GGUF) id and its NVFP4/MLX runtime
+sibling are two different Ollama tags -- see
+`docs/superpowers/specs/2026-07-01-ollama-mlx-tag-adoption-design.md`.
+`config.json`'s `model` field always holds the GGUF id; the NVFP4 tag is
+resolved transiently at summarization time and is what `pull`/`cancelPull`
+actually target once "Select" or "switch to faster build" resolve to it.
 
 ```ts
 type CheckOllamaResponse = Result<{ installed: boolean; path?: string }>;
@@ -335,12 +347,31 @@ interface ListedModel {
   size_gb?: number;
   installed: boolean;
   current?: boolean;
+  mlxTag?: string;          // Apple Silicon only -- this model's NVFP4 sibling tag
+  mlxInstalled?: boolean;   // Apple Silicon only -- whether mlxTag is actually pulled
+  mlxSizeGb?: number;       // Apple Silicon only -- the NVFP4 blob's own (often larger) size
+  ggufInstalled?: boolean;  // whether the GGUF id itself was pulled (can differ from `installed`,
+                            // which is also true when only the NVFP4 sibling is installed)
 }
 type ListModelsResponse = Result<{ models: ListedModel[]; current?: string }>;
 type GetCurrentModelResponse = Result<{ model: string }>;
 
+// Flat, NOT Result<T>-wrapped: these responses already carry their own
+// `success` field, and Result<T>'s `{success:true} & T` intersection would
+// collapse it.
+type VerifyModelResponse = { success: boolean; error: string | null };
+type DeleteModelResponse = { success: boolean; error: string | null };
+type CancelPullResponse = { success: boolean; error: string | null };
+// model -> either its still-running progress string, or (done: true) its
+// terminal outcome, for a pull that finished with nothing mounted to
+// consume the live model-pull-complete event (e.g. Settings was unmounted).
+type GetActivePullsResponse = Record<
+  string,
+  { progress?: string; done: boolean; success?: boolean; error?: string; cancelled?: boolean }
+>;
+
 interface ModelPullProgressEvent { model: string; progress: string }
-interface ModelPullCompleteEvent  { model: string; success: boolean; error?: string }
+interface ModelPullCompleteEvent { model: string; success: boolean; error?: string; cancelled?: boolean }
 ```
 
 ---

--- a/app/main.js
+++ b/app/main.js
@@ -6923,10 +6923,19 @@ ipcMain.on('system-audio-recording-state', (event, isRecording) => {
   updateTrayMenu();
 });
 
+// Tracks in-flight pull-model downloads (model -> last progress string) so a
+// renderer that remounts (e.g. navigating away from Settings and back) can
+// ask "is anything still downloading?" instead of only finding out via
+// events it wasn't subscribed to receive while unmounted. The download
+// itself lives in this main process regardless of what the renderer is
+// doing, so this map is the source of truth for "is it still going".
+const activePulls = new Map();
+
 ipcMain.handle('pull-model', async (event, modelName) => {
   try {
     sendDebugLog(`Pulling model: ${modelName}`);
     sendDebugLog('This may take several minutes...');
+    activePulls.set(modelName, '');
 
     return new Promise((resolve) => {
       const proc = spawn(getBackendPath(), ['pull-model', modelName], {
@@ -6944,6 +6953,7 @@ ipcMain.handle('pull-model', async (event, modelName) => {
       let lastProgressSentAt = 0;
       const PROGRESS_THROTTLE_MS = 200;
       const sendProgress = (output) => {
+        activePulls.set(modelName, output);
         if (!mainWindow || mainWindow.isDestroyed()) return;
         const now = Date.now();
         if (now - lastProgressSentAt < PROGRESS_THROTTLE_MS) return;
@@ -6968,6 +6978,8 @@ ipcMain.handle('pull-model', async (event, modelName) => {
       });
 
       proc.on('close', (code) => {
+        activePulls.delete(modelName);
+
         // The backend prints a JSON result as the last stdout line.
         // Check it even on exit code 0, since the Python CLI may
         // catch errors and still exit cleanly.
@@ -7004,6 +7016,7 @@ ipcMain.handle('pull-model', async (event, modelName) => {
       });
 
       proc.on('error', (error) => {
+        activePulls.delete(modelName);
         sendDebugLog(`Error pulling model: ${error.message}`);
 
         if (mainWindow && !mainWindow.isDestroyed()) {
@@ -7018,10 +7031,13 @@ ipcMain.handle('pull-model', async (event, modelName) => {
       });
     });
   } catch (error) {
+    activePulls.delete(modelName);
     sendDebugLog(`Error in pull-model handler: ${error.message}`);
     return { success: false, error: error.message };
   }
 });
+
+ipcMain.handle('get-active-pulls', () => Object.fromEntries(activePulls));
 
 // Helper to build env vars for running the bundled Ollama binary directly.
 // Mirrors src/ollama_manager.get_ollama_env() so the dylib/DLL search path

--- a/app/main.js
+++ b/app/main.js
@@ -6939,6 +6939,15 @@ const activePulls = new Map();
 // 'ack-pull-complete' once it has acted on it (see useSwitchToFasterBuild).
 const completedPulls = new Map();
 
+// The live ChildProcess per in-flight pull, so 'cancel-pull' can kill the
+// right one. Deliberately NOT exposed via get-active-pulls -- a ChildProcess
+// handle isn't IPC-serializable, and nothing outside this handler needs it.
+const activeProcs = new Map();
+
+// Models whose pull was explicitly cancelled, so the close handler below
+// can report "Cancelled" instead of a confusing "exited with code null".
+const cancelledPulls = new Set();
+
 ipcMain.handle('pull-model', async (event, modelName) => {
   // Guards against a duplicate pull of the SAME model racing in (e.g. a
   // double-click before React re-renders the button as disabled) -- without
@@ -6956,6 +6965,7 @@ ipcMain.handle('pull-model', async (event, modelName) => {
       const proc = spawn(getBackendPath(), ['pull-model', modelName], {
         cwd: getBackendCwd()
       });
+      activeProcs.set(modelName, proc);
 
       let lastStdoutLine = '';
 
@@ -6994,6 +7004,24 @@ ipcMain.handle('pull-model', async (event, modelName) => {
 
       proc.on('close', (code) => {
         activePulls.delete(modelName);
+        activeProcs.delete(modelName);
+
+        if (cancelledPulls.delete(modelName)) {
+          sendDebugLog(`Cancelled pull: ${modelName}`);
+          completedPulls.set(modelName, { success: false, error: 'Cancelled', cancelled: true });
+
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('model-pull-complete', {
+              model: modelName,
+              success: false,
+              error: 'Cancelled',
+              cancelled: true
+            });
+          }
+
+          resolve({ success: false, error: 'Cancelled', cancelled: true });
+          return;
+        }
 
         // The backend prints a JSON result as the last stdout line.
         // Check it even on exit code 0, since the Python CLI may
@@ -7034,6 +7062,8 @@ ipcMain.handle('pull-model', async (event, modelName) => {
 
       proc.on('error', (error) => {
         activePulls.delete(modelName);
+        activeProcs.delete(modelName);
+        cancelledPulls.delete(modelName);
         sendDebugLog(`Error pulling model: ${error.message}`);
         completedPulls.set(modelName, { success: false, error: error.message });
 
@@ -7050,9 +7080,21 @@ ipcMain.handle('pull-model', async (event, modelName) => {
     });
   } catch (error) {
     activePulls.delete(modelName);
+    activeProcs.delete(modelName);
+    cancelledPulls.delete(modelName);
     sendDebugLog(`Error in pull-model handler: ${error.message}`);
     return { success: false, error: error.message };
   }
+});
+
+ipcMain.handle('cancel-pull', (event, modelName) => {
+  const proc = activeProcs.get(modelName);
+  if (!proc) {
+    return { success: false, error: 'No active pull for this model.' };
+  }
+  cancelledPulls.add(modelName);
+  proc.kill();
+  return { success: true, error: null };
 });
 
 ipcMain.handle('get-active-pulls', () => {

--- a/app/main.js
+++ b/app/main.js
@@ -6935,29 +6935,36 @@ ipcMain.handle('pull-model', async (event, modelName) => {
 
       let lastStdoutLine = '';
 
+      // Ollama's own pull-progress stream can emit dozens of updates per
+      // second on a large download (multi-GB models like the NVFP4/MLX
+      // builds) — forwarding every single one drove the renderer's model
+      // list to re-render faster than the compositor could keep up,
+      // visible as window flicker/tearing. Throttling to 5/sec keeps the
+      // UI smooth without making the progress text feel laggy.
+      let lastProgressSentAt = 0;
+      const PROGRESS_THROTTLE_MS = 200;
+      const sendProgress = (output) => {
+        if (!mainWindow || mainWindow.isDestroyed()) return;
+        const now = Date.now();
+        if (now - lastProgressSentAt < PROGRESS_THROTTLE_MS) return;
+        lastProgressSentAt = now;
+        mainWindow.webContents.send('model-pull-progress', {
+          model: modelName,
+          progress: output
+        });
+      };
+
       proc.stdout.on('data', (data) => {
         const output = data.toString().trim();
         sendDebugLog(output);
         if (output) lastStdoutLine = output;
-
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('model-pull-progress', {
-            model: modelName,
-            progress: output
-          });
-        }
+        sendProgress(output);
       });
 
       proc.stderr.on('data', (data) => {
         const output = data.toString().trim();
         sendDebugLog(output);
-
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('model-pull-progress', {
-            model: modelName,
-            progress: output
-          });
-        }
+        sendProgress(output);
       });
 
       proc.on('close', (code) => {

--- a/app/main.js
+++ b/app/main.js
@@ -7002,11 +7002,18 @@ ipcMain.handle('pull-model', async (event, modelName) => {
         sendProgress(output);
       });
 
-      proc.on('close', (code) => {
+      proc.on('close', (code, signal) => {
         activePulls.delete(modelName);
         activeProcs.delete(modelName);
 
-        if (cancelledPulls.delete(modelName)) {
+        // Only trust this as a real cancellation if the process was
+        // actually signal-killed. If cancel-pull's kill() arrived after the
+        // process had already finished on its own (a narrow but real race:
+        // proc.kill() is a no-op on an already-exited process, but the
+        // 'close' event for that natural exit hasn't been delivered yet),
+        // `signal` is null here -- treat it as its real outcome below
+        // instead of reporting a successful pull as cancelled.
+        if (cancelledPulls.delete(modelName) && signal) {
           sendDebugLog(`Cancelled pull: ${modelName}`);
           completedPulls.set(modelName, { success: false, error: 'Cancelled', cancelled: true });
 

--- a/app/main.js
+++ b/app/main.js
@@ -4838,9 +4838,13 @@ ipcMain.handle('setup-ollama-and-model', async () => {
     // and skip the pull entirely, so the default Local path needs no network for
     // anyone with a usable Ollama already set up. Best-effort: any failure here
     // falls through to the normal download below.
+    let pullTarget = DEFAULT_AI_MODEL;
     try {
       const resolvedRaw = await runPythonScript('simple_recorder.py', ['resolve-setup-model'], true);
       const resolved = JSON.parse(resolvedRaw.trim());
+      if (resolved && resolved.pull_target) {
+        pullTarget = resolved.pull_target;
+      }
       if (resolved && resolved.installed) {
         sendDebugLog(`Found already-installed model "${resolved.installed}" — skipping download`);
         // Persist it as the active model, and only report success once that
@@ -4868,11 +4872,11 @@ ipcMain.handle('setup-ollama-and-model', async () => {
     }
 
     sendDebugLog('Downloading AI model (this may take several minutes)...');
-    sendDebugLog(`POST http://127.0.0.1:11434/api/pull {name: "${DEFAULT_AI_MODEL}"}`);
+    sendDebugLog(`POST http://127.0.0.1:11434/api/pull {name: "${pullTarget}"}`);
 
     const http = require('http');
     return new Promise((resolve) => {
-      const postData = JSON.stringify({ name: DEFAULT_AI_MODEL });
+      const postData = JSON.stringify({ name: pullTarget });
       const req = http.request({
         hostname: '127.0.0.1',
         port: 11434,
@@ -5463,6 +5467,36 @@ ipcMain.handle('set-model', async (event, modelName) => {
     return { success: true, model: modelName };
   } catch (error) {
     sendDebugLog(`Error setting model: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('verify-model', async (event, modelName) => {
+  try {
+    sendDebugLog(`Verifying model: ${modelName}`);
+    const result = await runPythonScript('simple_recorder.py', ['verify-model', modelName]);
+    const jsonMatch = result.match(/\{.*\}/s);
+    if (jsonMatch) {
+      return JSON.parse(jsonMatch[0]);
+    }
+    return { success: true };
+  } catch (error) {
+    sendDebugLog(`Error verifying model: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('delete-model', async (event, modelName) => {
+  try {
+    sendDebugLog(`Deleting model: ${modelName}`);
+    const result = await runPythonScript('simple_recorder.py', ['delete-model', modelName]);
+    const jsonMatch = result.match(/\{.*\}/s);
+    if (jsonMatch) {
+      return JSON.parse(jsonMatch[0]);
+    }
+    return { success: true };
+  } catch (error) {
+    sendDebugLog(`Error deleting model: ${error.message}`);
     return { success: false, error: error.message };
   }
 });

--- a/app/main.js
+++ b/app/main.js
@@ -6931,7 +6931,22 @@ ipcMain.on('system-audio-recording-state', (event, isRecording) => {
 // doing, so this map is the source of truth for "is it still going".
 const activePulls = new Map();
 
+// Tracks a pull's terminal outcome (model -> {success, error}) after it
+// leaves activePulls, so a renderer that was unmounted for the whole
+// download (missed the live model-pull-progress/model-pull-complete events
+// entirely) can still discover on remount that it finished, rather than
+// silently going back to "not started". A client clears its own entry via
+// 'ack-pull-complete' once it has acted on it (see useSwitchToFasterBuild).
+const completedPulls = new Map();
+
 ipcMain.handle('pull-model', async (event, modelName) => {
+  // Guards against a duplicate pull of the SAME model racing in (e.g. a
+  // double-click before React re-renders the button as disabled) -- without
+  // this, two subprocesses would run concurrently and the first one's close
+  // handler would delete activePulls' entry out from under the second.
+  if (activePulls.has(modelName)) {
+    return { success: false, error: `A pull for ${modelName} is already in progress.` };
+  }
   try {
     sendDebugLog(`Pulling model: ${modelName}`);
     sendDebugLog('This may take several minutes...');
@@ -6990,6 +7005,7 @@ ipcMain.handle('pull-model', async (event, modelName) => {
 
         if (succeeded) {
           sendDebugLog(`Successfully pulled model: ${modelName}`);
+          completedPulls.set(modelName, { success: true });
 
           if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.webContents.send('model-pull-complete', {
@@ -7002,6 +7018,7 @@ ipcMain.handle('pull-model', async (event, modelName) => {
         } else {
           const errorMsg = (pullResult && pullResult.error) || `Process exited with code ${code}`;
           sendDebugLog(`Failed to pull model: ${modelName} - ${errorMsg}`);
+          completedPulls.set(modelName, { success: false, error: errorMsg });
 
           if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.webContents.send('model-pull-complete', {
@@ -7018,6 +7035,7 @@ ipcMain.handle('pull-model', async (event, modelName) => {
       proc.on('error', (error) => {
         activePulls.delete(modelName);
         sendDebugLog(`Error pulling model: ${error.message}`);
+        completedPulls.set(modelName, { success: false, error: error.message });
 
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send('model-pull-complete', {
@@ -7037,7 +7055,23 @@ ipcMain.handle('pull-model', async (event, modelName) => {
   }
 });
 
-ipcMain.handle('get-active-pulls', () => Object.fromEntries(activePulls));
+ipcMain.handle('get-active-pulls', () => {
+  const result = {};
+  for (const [model, progress] of activePulls) {
+    result[model] = { progress, done: false };
+  }
+  for (const [model, outcome] of completedPulls) {
+    result[model] = { done: true, ...outcome };
+  }
+  return result;
+});
+
+// Lets a renderer that consumed a completedPulls entry (via getActivePulls
+// on remount, or the live model-pull-complete listener) tell main it's been
+// handled, so a later remount doesn't replay an already-resolved outcome.
+ipcMain.on('ack-pull-complete', (event, modelName) => {
+  completedPulls.delete(modelName);
+});
 
 // Helper to build env vars for running the bundled Ollama binary directly.
 // Mirrors src/ollama_manager.get_ollama_env() so the dylib/DLL search path

--- a/app/preload.js
+++ b/app/preload.js
@@ -191,6 +191,7 @@ const stenoai = {
     verify: (name) => invoke('verify-model', name),
     delete: (name) => invoke('delete-model', name),
     getActivePulls: () => invoke('get-active-pulls'),
+    ackPullComplete: (name) => send('ack-pull-complete', name),
   },
 
   whisperModels: {

--- a/app/preload.js
+++ b/app/preload.js
@@ -188,6 +188,7 @@ const stenoai = {
     set: (name) => invoke('set-model', name),
     checkInstalled: (name) => invoke('check-model-installed', name),
     pull: (name) => invoke('pull-model', name),
+    cancelPull: (name) => invoke('cancel-pull', name),
     verify: (name) => invoke('verify-model', name),
     delete: (name) => invoke('delete-model', name),
     getActivePulls: () => invoke('get-active-pulls'),

--- a/app/preload.js
+++ b/app/preload.js
@@ -188,6 +188,8 @@ const stenoai = {
     set: (name) => invoke('set-model', name),
     checkInstalled: (name) => invoke('check-model-installed', name),
     pull: (name) => invoke('pull-model', name),
+    verify: (name) => invoke('verify-model', name),
+    delete: (name) => invoke('delete-model', name),
   },
 
   whisperModels: {

--- a/app/preload.js
+++ b/app/preload.js
@@ -190,6 +190,7 @@ const stenoai = {
     pull: (name) => invoke('pull-model', name),
     verify: (name) => invoke('verify-model', name),
     delete: (name) => invoke('delete-model', name),
+    getActivePulls: () => invoke('get-active-pulls'),
   },
 
   whisperModels: {

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -92,20 +92,55 @@ export function useSetCurrentModel() {
   });
 }
 
+// Shared by usePullModel and useSwitchToFasterBuild: both parse the same
+// "<status> <pct>% (<completed>/<total>)" progress string (see pull_model's
+// print format in simple_recorder.py) into a live bytes/sec figure, keyed by
+// model so multiple downloads can be tracked independently.
+function useByteRateTracker() {
+  const [bytesPerSecond, setBytesPerSecond] = React.useState<Record<string, number>>({});
+  const rateSamplesRef = React.useRef<Record<string, { bytes: number; at: number }>>({});
+
+  const sample = (model: string, progress: string) => {
+    const byteMatch = progress.match(/\((\d+)\/(\d+)\)/);
+    if (!byteMatch) return;
+    const completed = Number(byteMatch[1]);
+    const now = Date.now();
+    const prevSample = rateSamplesRef.current[model];
+    if (prevSample && now > prevSample.at && completed >= prevSample.bytes) {
+      const rate = (completed - prevSample.bytes) / ((now - prevSample.at) / 1000);
+      setBytesPerSecond((prev) => ({ ...prev, [model]: rate }));
+    }
+    rateSamplesRef.current[model] = { bytes: completed, at: now };
+  };
+
+  const drop = (model: string) => {
+    delete rateSamplesRef.current[model];
+    setBytesPerSecond((prev) => {
+      const { [model]: _drop, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  return { bytesPerSecond, sample, drop };
+}
+
 export function usePullModel() {
   const qc = useQueryClient();
   const [progress, setProgress] = React.useState<Record<string, string>>({});
   const [pendingSelect, setPendingSelect] = React.useState<string | null>(null);
+  const rate = useByteRateTracker();
 
   React.useEffect(() => {
     const offProgress = ipc().on.modelPullProgress(({ model, progress: p }) => {
       setProgress((prev) => ({ ...prev, [model]: p }));
+      rate.sample(model, p);
     });
     const offComplete = ipc().on.modelPullComplete(async ({ model, success }) => {
       setProgress((prev) => {
         const { [model]: _drop, ...rest } = prev;
         return rest;
       });
+      rate.drop(model);
       if (success && pendingSelect === model) {
         await ipc().models.set(model);
         setPendingSelect(null);
@@ -116,6 +151,7 @@ export function usePullModel() {
       offProgress();
       offComplete();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [qc, pendingSelect]);
 
   const pullAndSelect = async (name: string) => {
@@ -131,7 +167,7 @@ export function usePullModel() {
     void ipc().models.cancelPull(name);
   };
 
-  return { ...mutation, progress, cancel };
+  return { ...mutation, progress, bytesPerSecond: rate.bytesPerSecond, cancel };
 }
 
 // ---------------------------------------------------------------------------
@@ -163,12 +199,7 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
   const onVerifiedRef = React.useRef(onVerified);
   onVerifiedRef.current = onVerified;
 
-  // Transfer-rate tracking: the CLI prints "<status> <pct>% (<completed>/<total>)"
-  // (bytes). rateSamplesRef keeps the last {bytes, timestamp} sample per model so
-  // consecutive throttled progress ticks (~200ms apart, per the main-process
-  // throttle) can be diffed into a live bytes/sec figure.
-  const [bytesPerSecond, setBytesPerSecond] = React.useState<Record<string, number>>({});
-  const rateSamplesRef = React.useRef<Record<string, { bytes: number; at: number }>>({});
+  const rate = useByteRateTracker();
 
   // Shared by the live model-pull-complete listener and the on-mount
   // rehydration effect below -- both need to react identically to a pull's
@@ -187,11 +218,7 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
       const { [model]: _drop, ...rest } = prev;
       return rest;
     });
-    setBytesPerSecond((prev) => {
-      const { [model]: _drop, ...rest } = prev;
-      return rest;
-    });
-    delete rateSamplesRef.current[model];
+    rate.drop(model);
     ipc().models.ackPullComplete(model);
     if (cancelled) {
       // A user-initiated cancel isn't a failure -- go back to the plain
@@ -222,18 +249,7 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
   React.useEffect(() => {
     const offProgress = ipc().on.modelPullProgress(({ model, progress: p }) => {
       setProgress((prev) => ({ ...prev, [model]: p }));
-
-      const byteMatch = p.match(/\((\d+)\/(\d+)\)/);
-      if (byteMatch) {
-        const completed = Number(byteMatch[1]);
-        const now = Date.now();
-        const prevSample = rateSamplesRef.current[model];
-        if (prevSample && now > prevSample.at && completed >= prevSample.bytes) {
-          const rate = (completed - prevSample.bytes) / ((now - prevSample.at) / 1000);
-          setBytesPerSecond((prev) => ({ ...prev, [model]: rate }));
-        }
-        rateSamplesRef.current[model] = { bytes: completed, at: now };
-      }
+      rate.sample(model, p);
     });
     const offComplete = ipc().on.modelPullComplete(({ model, success, error: pullError, cancelled: wasCancelled }) => {
       if (model !== activeTagRef.current) return;
@@ -279,10 +295,7 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
         setState('pulling');
         const progressValue = entry.progress ?? '';
         setProgress((prev) => ({ ...prev, [model]: progressValue }));
-        const byteMatch = progressValue.match(/\((\d+)\/(\d+)\)/);
-        if (byteMatch) {
-          rateSamplesRef.current[model] = { bytes: Number(byteMatch[1]), at: Date.now() };
-        }
+        rate.sample(model, progressValue);
       });
     return () => {
       cancelled = true;
@@ -318,7 +331,7 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
     error,
     activeTag,
     progress: activeTag ? progress[activeTag] : undefined,
-    bytesPerSecond: activeTag ? bytesPerSecond[activeTag] : undefined,
+    bytesPerSecond: activeTag ? rate.bytesPerSecond[activeTag] : undefined,
     switchTo,
     reset,
     cancel,

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -127,7 +127,11 @@ export function usePullModel() {
     mutationFn: pullAndSelect,
   });
 
-  return { ...mutation, progress };
+  const cancel = (name: string) => {
+    void ipc().models.cancelPull(name);
+  };
+
+  return { ...mutation, progress, cancel };
 }
 
 // ---------------------------------------------------------------------------
@@ -173,7 +177,12 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
   // as a live event or was discovered after the fact via getActivePulls().
   // Only closes over stable setters/refs, so it's safe for the once-run
   // effects to capture the copy from their first render.
-  const handlePullOutcome = async (model: string, success: boolean, pullError?: string) => {
+  const handlePullOutcome = async (
+    model: string,
+    success: boolean,
+    pullError?: string,
+    cancelled?: boolean,
+  ) => {
     setProgress((prev) => {
       const { [model]: _drop, ...rest } = prev;
       return rest;
@@ -184,6 +193,15 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
     });
     delete rateSamplesRef.current[model];
     ipc().models.ackPullComplete(model);
+    if (cancelled) {
+      // A user-initiated cancel isn't a failure -- go back to the plain
+      // "Switch to faster build" prompt rather than an error state.
+      setState('idle');
+      setError(null);
+      setActiveTag(null);
+      activeTagRef.current = null;
+      return;
+    }
     if (!success) {
       setState('error');
       setError(pullError ?? 'Failed to download the faster build.');
@@ -217,9 +235,9 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
         rateSamplesRef.current[model] = { bytes: completed, at: now };
       }
     });
-    const offComplete = ipc().on.modelPullComplete(({ model, success, error: pullError }) => {
+    const offComplete = ipc().on.modelPullComplete(({ model, success, error: pullError, cancelled: wasCancelled }) => {
       if (model !== activeTagRef.current) return;
-      void handlePullOutcome(model, success, pullError);
+      void handlePullOutcome(model, success, pullError, wasCancelled);
     });
     return () => {
       offProgress();
@@ -255,7 +273,7 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
           // model-pull-complete listener never ran for it. Replay the same
           // outcome handling now instead of showing "Switch to faster
           // build" as if nothing had happened.
-          void handlePullOutcome(model, Boolean(entry.success), entry.error);
+          void handlePullOutcome(model, Boolean(entry.success), entry.error, entry.cancelled);
           return;
         }
         setState('pulling');
@@ -287,6 +305,14 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
     activeTagRef.current = null;
   };
 
+  // Only meaningful while state === 'pulling' -- the actual state reset
+  // happens when the resulting model-pull-complete(cancelled: true) event
+  // arrives via handlePullOutcome, not optimistically here.
+  const cancel = () => {
+    if (!activeTagRef.current) return;
+    void ipc().models.cancelPull(activeTagRef.current);
+  };
+
   return {
     state,
     error,
@@ -295,6 +321,7 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
     bytesPerSecond: activeTag ? bytesPerSecond[activeTag] : undefined,
     switchTo,
     reset,
+    cancel,
   };
 }
 

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -159,9 +159,28 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
   const onVerifiedRef = React.useRef(onVerified);
   onVerifiedRef.current = onVerified;
 
+  // Transfer-rate tracking: the CLI prints "<status> <pct>% (<completed>/<total>)"
+  // (bytes). rateSamplesRef keeps the last {bytes, timestamp} sample per model so
+  // consecutive throttled progress ticks (~200ms apart, per the main-process
+  // throttle) can be diffed into a live bytes/sec figure.
+  const [bytesPerSecond, setBytesPerSecond] = React.useState<Record<string, number>>({});
+  const rateSamplesRef = React.useRef<Record<string, { bytes: number; at: number }>>({});
+
   React.useEffect(() => {
     const offProgress = ipc().on.modelPullProgress(({ model, progress: p }) => {
       setProgress((prev) => ({ ...prev, [model]: p }));
+
+      const byteMatch = p.match(/\((\d+)\/(\d+)\)/);
+      if (byteMatch) {
+        const completed = Number(byteMatch[1]);
+        const now = Date.now();
+        const prevSample = rateSamplesRef.current[model];
+        if (prevSample && now > prevSample.at && completed >= prevSample.bytes) {
+          const rate = (completed - prevSample.bytes) / ((now - prevSample.at) / 1000);
+          setBytesPerSecond((prev) => ({ ...prev, [model]: rate }));
+        }
+        rateSamplesRef.current[model] = { bytes: completed, at: now };
+      }
     });
     const offComplete = ipc().on.modelPullComplete(async ({ model, success, error: pullError }) => {
       if (model !== activeTagRef.current) return;
@@ -169,6 +188,11 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
         const { [model]: _drop, ...rest } = prev;
         return rest;
       });
+      setBytesPerSecond((prev) => {
+        const { [model]: _drop, ...rest } = prev;
+        return rest;
+      });
+      delete rateSamplesRef.current[model];
       if (!success) {
         setState('error');
         setError(pullError ?? 'Failed to download the faster build.');
@@ -209,7 +233,15 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
     activeTagRef.current = null;
   };
 
-  return { state, error, activeTag, progress: activeTag ? progress[activeTag] : undefined, switchTo, reset };
+  return {
+    state,
+    error,
+    activeTag,
+    progress: activeTag ? progress[activeTag] : undefined,
+    bytesPerSecond: activeTag ? bytesPerSecond[activeTag] : undefined,
+    switchTo,
+    reset,
+  };
 }
 
 export function useDeleteModel() {

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -55,6 +55,7 @@ export function useModels() {
         quality: info.quality,
         mlxTag: info.mlx_tag,
         mlxInstalled: info.mlx_installed,
+        mlxSizeGb: parseSizeGb(info.mlx_size),
         ggufInstalled: info.gguf_installed,
       }));
       return { models, current: raw.current_model, provider: raw.provider };

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -218,6 +218,38 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // On mount, ask the main process whether a switch-to-faster-build download
+  // is already running from before this component (re)mounted -- e.g. the
+  // user navigated away from Settings and back. The download itself lives in
+  // the main process and keeps going regardless of what the renderer does;
+  // without this rehydration, the UI would show "Switch to faster build" as
+  // if nothing were happening until the user clicked it again. Filtered to
+  // "-nvfp4" tags so a regular (non-faster-build) model download in progress
+  // elsewhere in the app isn't mistaken for one of ours.
+  React.useEffect(() => {
+    let cancelled = false;
+    void ipc()
+      .models.getActivePulls()
+      .then((pulls) => {
+        if (cancelled) return;
+        const activeEntry = Object.entries(pulls).find(([model]) => model.endsWith('-nvfp4'));
+        if (!activeEntry) return;
+        const [model, progressValue] = activeEntry;
+        setActiveTag(model);
+        activeTagRef.current = model;
+        setState('pulling');
+        setProgress((prev) => ({ ...prev, [model]: progressValue }));
+        const byteMatch = progressValue.match(/\((\d+)\/(\d+)\)/);
+        if (byteMatch) {
+          rateSamplesRef.current[model] = { bytes: Number(byteMatch[1]), at: Date.now() };
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const switchTo = (mlxTag: string) => {
     setState('pulling');
     setError(null);

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -148,8 +148,16 @@ export function usePullModel() {
         return rest;
       });
       rate.drop(model);
-      if (success && pendingSelect?.pullTarget === model) {
-        await ipc().models.set(pendingSelect.name);
+      // Clear pendingSelect on ANY outcome for its own pullTarget, not just
+      // success -- modelPullComplete is a global event with no per-hook
+      // filtering, so a stale pendingSelect left behind by a cancelled/failed
+      // pull could otherwise be matched later by an unrelated pull of the
+      // same tag (e.g. a "switch to faster build" for the same model),
+      // silently calling models.set() for a selection change nothing asked for.
+      if (pendingSelect?.pullTarget === model) {
+        if (success) {
+          await ipc().models.set(pendingSelect.name);
+        }
         setPendingSelect(null);
       }
       qc.invalidateQueries({ queryKey: modelsKeys.all });
@@ -229,10 +237,10 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
       return rest;
     });
     rate.drop(model);
-    ipc().models.ackPullComplete(model);
     if (cancelled) {
       // A user-initiated cancel isn't a failure -- go back to the plain
       // "Switch to faster build" prompt rather than an error state.
+      ipc().models.ackPullComplete(model);
       setState('idle');
       setError(null);
       setActiveTag(null);
@@ -240,12 +248,19 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
       return;
     }
     if (!success) {
+      ipc().models.ackPullComplete(model);
       setState('error');
       setError(pullError ?? 'Failed to download the faster build.');
       return;
     }
     setState('verifying');
     const verifyResult = await ipc().models.verify(model);
+    // Deferred until after verify (not right after the download) so that
+    // navigating away mid-verify and back replays this whole outcome --
+    // including a redundant but harmless re-verify -- on the new mount,
+    // instead of the completedPulls entry already being consumed and the
+    // "offer to delete the old build" (onVerified) never firing for anyone.
+    ipc().models.ackPullComplete(model);
     if (verifyResult.success) {
       setState('done');
       qc.invalidateQueries({ queryKey: modelsKeys.all });

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -55,6 +55,7 @@ export function useModels() {
         quality: info.quality,
         mlxTag: info.mlx_tag,
         mlxInstalled: info.mlx_installed,
+        ggufInstalled: info.gguf_installed,
       }));
       return { models, current: raw.current_model, provider: raw.provider };
     },

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -127,7 +127,12 @@ function useByteRateTracker() {
 export function usePullModel() {
   const qc = useQueryClient();
   const [progress, setProgress] = React.useState<Record<string, string>>({});
-  const [pendingSelect, setPendingSelect] = React.useState<string | null>(null);
+  // `name` is the canonical GGUF id -- what models.set() must receive once
+  // the pull succeeds. `pullTarget` is what was actually requested from
+  // Ollama, which on Apple Silicon is the NVFP4 sibling (see pullAndSelect
+  // below) -- IPC progress/completion events report THAT string, so
+  // matching against it (not `name`) is what lets this resolve correctly.
+  const [pendingSelect, setPendingSelect] = React.useState<{ name: string; pullTarget: string } | null>(null);
   const rate = useByteRateTracker();
 
   React.useEffect(() => {
@@ -141,8 +146,8 @@ export function usePullModel() {
         return rest;
       });
       rate.drop(model);
-      if (success && pendingSelect === model) {
-        await ipc().models.set(model);
+      if (success && pendingSelect?.pullTarget === model) {
+        await ipc().models.set(pendingSelect.name);
         setPendingSelect(null);
       }
       qc.invalidateQueries({ queryKey: modelsKeys.all });
@@ -154,17 +159,20 @@ export function usePullModel() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [qc, pendingSelect]);
 
-  const pullAndSelect = async (name: string) => {
-    setPendingSelect(name);
-    unwrap(await ipc().models.pull(name));
+  // `pullTarget` defaults to `name` (the pre-existing behavior) for callers
+  // that don't need MLX resolution (e.g. off Apple Silicon, or no MLX
+  // equivalent exists for this model).
+  const pullAndSelect = async ({ name, pullTarget }: { name: string; pullTarget: string }) => {
+    setPendingSelect({ name, pullTarget });
+    unwrap(await ipc().models.pull(pullTarget));
   };
 
   const mutation = useMutation({
     mutationFn: pullAndSelect,
   });
 
-  const cancel = (name: string) => {
-    void ipc().models.cancelPull(name);
+  const cancel = (pullTarget: string) => {
+    void ipc().models.cancelPull(pullTarget);
   };
 
   return { ...mutation, progress, bytesPerSecond: rate.bytesPerSecond, cancel };

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -129,6 +129,88 @@ export function usePullModel() {
 }
 
 // ---------------------------------------------------------------------------
+// "Switch to faster build" -- pulls a model's NVFP4/MLX sibling, smoke-tests
+// it, and (on success) leaves it to the caller to offer deleting the old
+// GGUF tag. Deliberately does NOT call models.set() -- config.json already
+// points at the canonical GGUF id, and src/summarizer.py resolves it to the
+// MLX tag at runtime on Apple Silicon. See docs/superpowers/specs/
+// 2026-07-01-ollama-mlx-tag-adoption-design.md.
+// ---------------------------------------------------------------------------
+
+export type SwitchToFasterBuildState = 'idle' | 'pulling' | 'verifying' | 'done' | 'error';
+
+export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
+  const qc = useQueryClient();
+  const [state, setState] = React.useState<SwitchToFasterBuildState>('idle');
+  const [error, setError] = React.useState<string | null>(null);
+  const [activeTag, setActiveTag] = React.useState<string | null>(null);
+  const [progress, setProgress] = React.useState<Record<string, string>>({});
+
+  // activeTag is mirrored into a ref so the event listeners below (subscribed
+  // exactly once, on mount) always read the CURRENT tag rather than the value
+  // captured when the effect last ran. Without this, switchTo() below sets
+  // activeTag and immediately fires the pull in the same tick; a completion
+  // event racing the effect's re-subscription (before React has committed the
+  // new activeTag into this closure) would otherwise be silently dropped by
+  // the `model !== activeTag` check.
+  const activeTagRef = React.useRef<string | null>(null);
+  const onVerifiedRef = React.useRef(onVerified);
+  onVerifiedRef.current = onVerified;
+
+  React.useEffect(() => {
+    const offProgress = ipc().on.modelPullProgress(({ model, progress: p }) => {
+      setProgress((prev) => ({ ...prev, [model]: p }));
+    });
+    const offComplete = ipc().on.modelPullComplete(async ({ model, success, error: pullError }) => {
+      if (model !== activeTagRef.current) return;
+      setProgress((prev) => {
+        const { [model]: _drop, ...rest } = prev;
+        return rest;
+      });
+      if (!success) {
+        setState('error');
+        setError(pullError ?? 'Failed to download the faster build.');
+        return;
+      }
+      setState('verifying');
+      const verifyResult = await ipc().models.verify(model);
+      if (verifyResult.success) {
+        setState('done');
+        qc.invalidateQueries({ queryKey: modelsKeys.all });
+        onVerifiedRef.current?.(model);
+      } else {
+        setState('error');
+        setError(verifyResult.error ?? "Couldn't verify the faster build.");
+      }
+    });
+    return () => {
+      offProgress();
+      offComplete();
+    };
+    // Empty deps: subscribe once. activeTagRef (not activeTag state) is what
+    // the listeners consult, so they never need to be re-subscribed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const switchTo = (mlxTag: string) => {
+    setState('pulling');
+    setError(null);
+    setActiveTag(mlxTag);
+    activeTagRef.current = mlxTag;
+    void ipc().models.pull(mlxTag);
+  };
+
+  const reset = () => {
+    setState('idle');
+    setError(null);
+    setActiveTag(null);
+    activeTagRef.current = null;
+  };
+
+  return { state, error, activeTag, progress: activeTag ? progress[activeTag] : undefined, switchTo, reset };
+}
+
+// ---------------------------------------------------------------------------
 // Whisper models (mirrors the Ollama pattern above)
 // ---------------------------------------------------------------------------
 

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -53,6 +53,8 @@ export function useModels() {
         description: info.description,
         speed: info.speed,
         quality: info.quality,
+        mlxTag: info.mlx_tag,
+        mlxInstalled: info.mlx_installed,
       }));
       return { models, current: raw.current_model, provider: raw.provider };
     },
@@ -208,6 +210,18 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
   };
 
   return { state, error, activeTag, progress: activeTag ? progress[activeTag] : undefined, switchTo, reset };
+}
+
+export function useDeleteModel() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (tag: string) => {
+      const result = await ipc().models.delete(tag);
+      if (!result.success) throw new Error(result.error ?? 'Failed to delete the old build.');
+      return result;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: modelsKeys.all }),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -166,6 +166,41 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
   const [bytesPerSecond, setBytesPerSecond] = React.useState<Record<string, number>>({});
   const rateSamplesRef = React.useRef<Record<string, { bytes: number; at: number }>>({});
 
+  // Shared by the live model-pull-complete listener and the on-mount
+  // rehydration effect below -- both need to react identically to a pull's
+  // terminal outcome (drop progress tracking, verify on success, surface the
+  // error otherwise), the only difference being whether the outcome arrived
+  // as a live event or was discovered after the fact via getActivePulls().
+  // Only closes over stable setters/refs, so it's safe for the once-run
+  // effects to capture the copy from their first render.
+  const handlePullOutcome = async (model: string, success: boolean, pullError?: string) => {
+    setProgress((prev) => {
+      const { [model]: _drop, ...rest } = prev;
+      return rest;
+    });
+    setBytesPerSecond((prev) => {
+      const { [model]: _drop, ...rest } = prev;
+      return rest;
+    });
+    delete rateSamplesRef.current[model];
+    ipc().models.ackPullComplete(model);
+    if (!success) {
+      setState('error');
+      setError(pullError ?? 'Failed to download the faster build.');
+      return;
+    }
+    setState('verifying');
+    const verifyResult = await ipc().models.verify(model);
+    if (verifyResult.success) {
+      setState('done');
+      qc.invalidateQueries({ queryKey: modelsKeys.all });
+      onVerifiedRef.current?.(model);
+    } else {
+      setState('error');
+      setError(verifyResult.error ?? "Couldn't verify the faster build.");
+    }
+  };
+
   React.useEffect(() => {
     const offProgress = ipc().on.modelPullProgress(({ model, progress: p }) => {
       setProgress((prev) => ({ ...prev, [model]: p }));
@@ -182,32 +217,9 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
         rateSamplesRef.current[model] = { bytes: completed, at: now };
       }
     });
-    const offComplete = ipc().on.modelPullComplete(async ({ model, success, error: pullError }) => {
+    const offComplete = ipc().on.modelPullComplete(({ model, success, error: pullError }) => {
       if (model !== activeTagRef.current) return;
-      setProgress((prev) => {
-        const { [model]: _drop, ...rest } = prev;
-        return rest;
-      });
-      setBytesPerSecond((prev) => {
-        const { [model]: _drop, ...rest } = prev;
-        return rest;
-      });
-      delete rateSamplesRef.current[model];
-      if (!success) {
-        setState('error');
-        setError(pullError ?? 'Failed to download the faster build.');
-        return;
-      }
-      setState('verifying');
-      const verifyResult = await ipc().models.verify(model);
-      if (verifyResult.success) {
-        setState('done');
-        qc.invalidateQueries({ queryKey: modelsKeys.all });
-        onVerifiedRef.current?.(model);
-      } else {
-        setState('error');
-        setError(verifyResult.error ?? "Couldn't verify the faster build.");
-      }
+      void handlePullOutcome(model, success, pullError);
     });
     return () => {
       offProgress();
@@ -234,10 +246,20 @@ export function useSwitchToFasterBuild(onVerified?: (mlxTag: string) => void) {
         if (cancelled) return;
         const activeEntry = Object.entries(pulls).find(([model]) => model.endsWith('-nvfp4'));
         if (!activeEntry) return;
-        const [model, progressValue] = activeEntry;
+        const [model, entry] = activeEntry;
         setActiveTag(model);
         activeTagRef.current = model;
+        if (entry.done) {
+          // The pull finished while this component was unmounted (e.g. the
+          // user navigated away from Settings mid-download), so the live
+          // model-pull-complete listener never ran for it. Replay the same
+          // outcome handling now instead of showing "Switch to faster
+          // build" as if nothing had happened.
+          void handlePullOutcome(model, Boolean(entry.success), entry.error);
+          return;
+        }
         setState('pulling');
+        const progressValue = entry.progress ?? '';
         setProgress((prev) => ({ ...prev, [model]: progressValue }));
         const byteMatch = progressValue.match(/\((\d+)\/(\d+)\)/);
         if (byteMatch) {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -395,8 +395,9 @@ export type DeleteModelResponse = { success: boolean; error: string | null };
 // verbatim, no Result<T> wrapping.
 export type GetActivePullsResponse = Record<
   string,
-  { progress?: string; done: boolean; success?: boolean; error?: string }
+  { progress?: string; done: boolean; success?: boolean; error?: string; cancelled?: boolean }
 >;
+export type CancelPullResponse = { success: boolean; error: string | null };
 
 export type ListWhisperModelsResponse = Result<{
   supported_models: Record<string, RawSupportedModel>;
@@ -548,6 +549,7 @@ export interface ModelPullCompleteEvent {
   model: string;
   success: boolean;
   error?: string;
+  cancelled?: boolean;
 }
 export interface WhisperPullProgressEvent {
   model: string;
@@ -773,6 +775,7 @@ export interface StenoaiBridge {
     set: RequestFn<[name: string], Result<Record<string, never>>>;
     checkInstalled: RequestFn<[name: string], CheckModelInstalledResponse>;
     pull: RequestFn<[name: string], Result<Record<string, never>>>;
+    cancelPull: RequestFn<[name: string], CancelPullResponse>;
     verify: RequestFn<[name: string], VerifyModelResponse>;
     delete: RequestFn<[name: string], DeleteModelResponse>;
     getActivePulls: RequestFn<[], GetActivePullsResponse>;

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -367,6 +367,8 @@ export interface RawSupportedModel {
   quality?: string;
   deprecated?: boolean;
   installed?: boolean;
+  mlx_tag?: string;
+  mlx_installed?: boolean;
 }
 
 export type ListModelsResponse = Result<{
@@ -375,6 +377,15 @@ export type ListModelsResponse = Result<{
   provider: string;
 }>;
 export type GetCurrentModelResponse = Result<{ model: string }>;
+
+// Deliberately NOT wrapped in Result<T>: Result<T> is `({ success: true } & T)`,
+// and these responses already have their own `success` field, so wrapping would
+// collapse both `success` fields into one (`true & boolean` narrows to `true`)
+// and silently hide the real success/failure the caller needs to branch on.
+// main.js's verify-model/delete-model handlers (Task 8) return the Python CLI's
+// `{ success, error }` JSON verbatim, with no additional wrapping.
+export type VerifyModelResponse = { success: boolean; error: string | null };
+export type DeleteModelResponse = { success: boolean; error: string | null };
 
 export type ListWhisperModelsResponse = Result<{
   supported_models: Record<string, RawSupportedModel>;
@@ -751,6 +762,8 @@ export interface StenoaiBridge {
     set: RequestFn<[name: string], Result<Record<string, never>>>;
     checkInstalled: RequestFn<[name: string], CheckModelInstalledResponse>;
     pull: RequestFn<[name: string], Result<Record<string, never>>>;
+    verify: RequestFn<[name: string], VerifyModelResponse>;
+    delete: RequestFn<[name: string], DeleteModelResponse>;
   };
 
   whisperModels: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -71,6 +71,7 @@ export interface ListedModel {
   quality?: string;
   mlxTag?: string;
   mlxInstalled?: boolean;
+  mlxSizeGb?: number;
   ggufInstalled?: boolean;
 }
 
@@ -377,6 +378,9 @@ export interface RawSupportedModel {
   gguf_installed?: boolean;
   mlx_tag?: string;
   mlx_installed?: boolean;
+  // The NVFP4 blob's own size -- a different (often larger) download than
+  // this entry's `size`, which describes the GGUF variant only.
+  mlx_size?: string;
 }
 
 export type ListModelsResponse = Result<{

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -388,6 +388,10 @@ export type GetCurrentModelResponse = Result<{ model: string }>;
 // `{ success, error }` JSON verbatim, with no additional wrapping.
 export type VerifyModelResponse = { success: boolean; error: string | null };
 export type DeleteModelResponse = { success: boolean; error: string | null };
+// model -> last known progress string, for any pull-model download still
+// running in the main process. Flat for the same reason as the two types
+// above: main.js returns Object.fromEntries() of its in-memory map verbatim.
+export type GetActivePullsResponse = Record<string, string>;
 
 export type ListWhisperModelsResponse = Result<{
   supported_models: Record<string, RawSupportedModel>;
@@ -766,6 +770,7 @@ export interface StenoaiBridge {
     pull: RequestFn<[name: string], Result<Record<string, never>>>;
     verify: RequestFn<[name: string], VerifyModelResponse>;
     delete: RequestFn<[name: string], DeleteModelResponse>;
+    getActivePulls: RequestFn<[], GetActivePullsResponse>;
   };
 
   whisperModels: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -388,10 +388,15 @@ export type GetCurrentModelResponse = Result<{ model: string }>;
 // `{ success, error }` JSON verbatim, with no additional wrapping.
 export type VerifyModelResponse = { success: boolean; error: string | null };
 export type DeleteModelResponse = { success: boolean; error: string | null };
-// model -> last known progress string, for any pull-model download still
-// running in the main process. Flat for the same reason as the two types
-// above: main.js returns Object.fromEntries() of its in-memory map verbatim.
-export type GetActivePullsResponse = Record<string, string>;
+// model -> either its still-running progress string, or (done: true) its
+// terminal outcome if it finished while nothing was around to consume the
+// live model-pull-complete event (e.g. Settings was unmounted). Flat for the
+// same reason as the two types above: main.js returns its in-memory maps
+// verbatim, no Result<T> wrapping.
+export type GetActivePullsResponse = Record<
+  string,
+  { progress?: string; done: boolean; success?: boolean; error?: string }
+>;
 
 export type ListWhisperModelsResponse = Result<{
   supported_models: Record<string, RawSupportedModel>;
@@ -771,6 +776,7 @@ export interface StenoaiBridge {
     verify: RequestFn<[name: string], VerifyModelResponse>;
     delete: RequestFn<[name: string], DeleteModelResponse>;
     getActivePulls: RequestFn<[], GetActivePullsResponse>;
+    ackPullComplete: SendFn<[name: string]>;
   };
 
   whisperModels: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -69,6 +69,8 @@ export interface ListedModel {
   description?: string;
   speed?: string;
   quality?: string;
+  mlxTag?: string;
+  mlxInstalled?: boolean;
 }
 
 export interface CalendarEvent {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -71,6 +71,7 @@ export interface ListedModel {
   quality?: string;
   mlxTag?: string;
   mlxInstalled?: boolean;
+  ggufInstalled?: boolean;
 }
 
 export interface CalendarEvent {
@@ -369,6 +370,11 @@ export interface RawSupportedModel {
   quality?: string;
   deprecated?: boolean;
   installed?: boolean;
+  // Distinct from `installed`, which is also true when only the NVFP4
+  // sibling is present (see mlx_installed) -- this is specifically whether
+  // the GGUF id itself was pulled, needed by anything that must not act on
+  // a tag that was never actually downloaded (e.g. deleting it).
+  gguf_installed?: boolean;
   mlx_tag?: string;
   mlx_installed?: boolean;
 }

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -82,6 +82,7 @@ import {
 } from '@/hooks/useAi';
 import {
   useCurrentModel,
+  useDeleteModel,
   useModels,
   useParakeetModels,
   usePullModel,
@@ -89,6 +90,7 @@ import {
   usePullWhisperModel,
   useSetActiveTranscription,
   useSetCurrentModel,
+  useSwitchToFasterBuild,
   useTranscriptionEngine,
   useWhisperModels,
 } from '@/hooks/useModels';
@@ -361,6 +363,11 @@ interface ModelCardProps {
   isDownloading?: boolean;
   downloadProgress?: string;
   onSelect: () => void;
+  fasterBuildTag?: string;
+  fasterBuildInstalled?: boolean;
+  fasterBuildState?: 'idle' | 'pulling' | 'verifying' | 'done' | 'error';
+  fasterBuildProgress?: string;
+  onSwitchToFasterBuild?: () => void;
 }
 
 function ModelCard({
@@ -373,6 +380,11 @@ function ModelCard({
   isDownloading = false,
   downloadProgress,
   onSelect,
+  fasterBuildTag,
+  fasterBuildInstalled = false,
+  fasterBuildState = 'idle',
+  fasterBuildProgress,
+  onSwitchToFasterBuild,
 }: ModelCardProps) {
   return (
     <div
@@ -450,6 +462,31 @@ function ModelCard({
           </div>
         )}
       </div>
+      {fasterBuildTag && !fasterBuildInstalled && (
+        <div className="mt-1.5 flex items-center gap-2">
+          <span
+            className="rounded-[3px] px-1.5 py-px text-[11px]"
+            style={{
+              color: 'var(--fg-muted)',
+              border: '1px solid var(--border-subtle)',
+            }}
+          >
+            Faster build available
+          </span>
+          <button
+            type="button"
+            onClick={onSwitchToFasterBuild}
+            disabled={fasterBuildState === 'pulling' || fasterBuildState === 'verifying'}
+            className="cursor-pointer border-0 bg-transparent p-0 text-[12px] underline disabled:cursor-default disabled:no-underline disabled:opacity-60"
+            style={{ color: 'var(--fg-1)' }}
+          >
+            {fasterBuildState === 'pulling' && (fasterBuildProgress ?? 'Downloading…')}
+            {fasterBuildState === 'verifying' && 'Verifying…'}
+            {fasterBuildState === 'error' && 'Retry: switch to faster build'}
+            {(fasterBuildState === 'idle' || fasterBuildState === 'done') && 'Switch to faster build'}
+          </button>
+        </div>
+      )}
       {isCurrent ? (
         <span
           className="inline-flex shrink-0 items-center gap-1.5 text-[13px] font-medium"
@@ -1880,6 +1917,14 @@ function ModelList() {
   const setCurrent = useSetCurrentModel();
   const pull = usePullModel();
   const [showDeprecated, setShowDeprecated] = React.useState(false);
+  const [deleteCandidate, setDeleteCandidate] = React.useState<{ tag: string; sizeLabel?: string } | null>(null);
+  const deleteModel = useDeleteModel();
+  const fasterBuild = useSwitchToFasterBuild((mlxTag) => {
+    const match = models.data?.models.find((m) => m.mlxTag === mlxTag);
+    if (match) {
+      setDeleteCandidate({ tag: match.name, sizeLabel: formatModelSize(match.size_gb) });
+    }
+  });
 
   if (models.isLoading) {
     return (
@@ -1931,6 +1976,7 @@ function ModelList() {
     }
 
     const sizeLabel = formatModelSize(m.size_gb);
+    const isFasterBuildActive = fasterBuild.activeTag === m.mlxTag;
 
     const onSelect = () => {
       if (m.installed) {
@@ -1952,6 +1998,14 @@ function ModelList() {
         isDownloading={isDownloading}
         downloadProgress={downloadProgress}
         onSelect={onSelect}
+        fasterBuildTag={m.mlxTag}
+        fasterBuildInstalled={Boolean(m.mlxInstalled)}
+        fasterBuildState={isFasterBuildActive ? fasterBuild.state : 'idle'}
+        fasterBuildProgress={isFasterBuildActive ? fasterBuild.progress : undefined}
+        onSwitchToFasterBuild={() => {
+          if (!m.mlxTag) return;
+          fasterBuild.switchTo(m.mlxTag);
+        }}
       />
     );
   };
@@ -1980,6 +2034,27 @@ function ModelList() {
             <div className="mt-2">{deprecated.map(renderCard)}</div>
           )}
         </>
+      )}
+
+      {deleteCandidate && (
+        <ConfirmDialog
+          open={Boolean(deleteCandidate)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setDeleteCandidate(null);
+              fasterBuild.reset();
+            }
+          }}
+          title="Delete the old build?"
+          description={`${deleteCandidate.tag} (${deleteCandidate.sizeLabel ?? 'unknown size'}) is no longer needed now that the faster build is active. Delete it to free up disk space?`}
+          confirmLabel="Delete"
+          destructive
+          onConfirm={async () => {
+            await deleteModel.mutateAsync(deleteCandidate.tag);
+            setDeleteCandidate(null);
+            fasterBuild.reset();
+          }}
+        />
       )}
     </div>
   );

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -382,6 +382,14 @@ interface ModelCardProps {
   fasterBuildState?: 'idle' | 'pulling' | 'verifying' | 'done' | 'error';
   fasterBuildProgress?: string;
   fasterBuildBytesPerSecond?: number;
+  // True when a DIFFERENT model's switch-to-faster-build is in flight. The
+  // hook backing this only tracks one in-progress switch at a time, so
+  // starting a second one while the first is still pulling/verifying/awaiting
+  // its delete-confirmation silently drops the first one's completion event
+  // (see useSwitchToFasterBuild's activeTagRef check) -- blocking here rather
+  // than fixing that hook to track many at once, since real concurrent
+  // switches were never a requested use case.
+  fasterBuildBlocked?: boolean;
   onSwitchToFasterBuild?: () => void;
 }
 
@@ -400,6 +408,7 @@ function ModelCard({
   fasterBuildState = 'idle',
   fasterBuildProgress,
   fasterBuildBytesPerSecond,
+  fasterBuildBlocked = false,
   onSwitchToFasterBuild,
 }: ModelCardProps) {
   return (
@@ -530,7 +539,8 @@ function ModelCard({
             <button
               type="button"
               onClick={onSwitchToFasterBuild}
-              disabled={fasterBuildState === 'verifying'}
+              disabled={fasterBuildState === 'verifying' || fasterBuildBlocked}
+              title={fasterBuildBlocked ? 'Finish the current switch first' : undefined}
               className="cursor-pointer border-0 bg-transparent p-0 text-[12px] underline disabled:cursor-default disabled:no-underline disabled:opacity-60"
               style={{ color: 'var(--fg-1)' }}
             >
@@ -2031,6 +2041,10 @@ function ModelList() {
 
     const sizeLabel = formatModelSize(m.size_gb);
     const isFasterBuildActive = fasterBuild.activeTag === m.mlxTag;
+    const fasterBuildBlocked =
+      Boolean(fasterBuild.activeTag) &&
+      !isFasterBuildActive &&
+      (fasterBuild.state === 'pulling' || fasterBuild.state === 'verifying' || fasterBuild.state === 'done');
 
     const onSelect = () => {
       if (m.installed) {
@@ -2057,8 +2071,9 @@ function ModelList() {
         fasterBuildState={isFasterBuildActive ? fasterBuild.state : 'idle'}
         fasterBuildProgress={isFasterBuildActive ? fasterBuild.progress : undefined}
         fasterBuildBytesPerSecond={isFasterBuildActive ? fasterBuild.bytesPerSecond : undefined}
+        fasterBuildBlocked={fasterBuildBlocked}
         onSwitchToFasterBuild={() => {
-          if (!m.mlxTag) return;
+          if (!m.mlxTag || fasterBuildBlocked) return;
           fasterBuild.switchTo(m.mlxTag);
         }}
       />

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -377,6 +377,9 @@ interface ModelCardProps {
   isDownloading?: boolean;
   downloadProgress?: string;
   onSelect: () => void;
+  // Lets a user on a slow connection (or a misclick on a large model) back
+  // out of a download in progress instead of being stuck waiting for it.
+  onCancelDownload?: () => void;
   fasterBuildTag?: string;
   fasterBuildInstalled?: boolean;
   fasterBuildState?: 'idle' | 'pulling' | 'verifying' | 'done' | 'error';
@@ -391,6 +394,7 @@ interface ModelCardProps {
   // switches were never a requested use case.
   fasterBuildBlocked?: boolean;
   onSwitchToFasterBuild?: () => void;
+  onCancelFasterBuild?: () => void;
 }
 
 function ModelCard({
@@ -403,6 +407,7 @@ function ModelCard({
   isDownloading = false,
   downloadProgress,
   onSelect,
+  onCancelDownload,
   fasterBuildTag,
   fasterBuildInstalled = false,
   fasterBuildState = 'idle',
@@ -410,6 +415,7 @@ function ModelCard({
   fasterBuildBytesPerSecond,
   fasterBuildBlocked = false,
   onSwitchToFasterBuild,
+  onCancelFasterBuild,
 }: ModelCardProps) {
   return (
     <div
@@ -512,41 +518,51 @@ function ModelCard({
             Faster build available
           </span>
           {fasterBuildState === 'pulling' ? (
-            // Fixed-width bar instead of a variable-width percentage label:
-            // Ollama's pull progress can update dozens of times per second on
-            // a multi-GB download, and a text label whose width changes on
-            // every tick reflows this whole row each time, which read as
-            // window-level flicker. The bar's own footprint never changes —
-            // only the fill width and a fixed-width, tabular-nums percentage
-            // do — so rapid updates no longer shift any layout.
-            <div className="flex items-center gap-1.5" style={{ width: 96 }}>
-              <div
-                className="h-1.5 flex-1 overflow-hidden rounded-full"
-                style={{ background: 'var(--surface-sunken)' }}
-              >
+            <div className="flex items-center gap-2">
+              {/* Fixed-width bar instead of a variable-width percentage label:
+                  Ollama's pull progress can update dozens of times per second on
+                  a multi-GB download, and a text label whose width changes on
+                  every tick reflows this whole row each time, which read as
+                  window-level flicker. The bar's own footprint never changes —
+                  only the fill width and a fixed-width, tabular-nums percentage
+                  do — so rapid updates no longer shift any layout. */}
+              <div className="flex items-center gap-1.5" style={{ width: 96 }}>
                 <div
-                  className="h-full rounded-full"
-                  style={{
-                    width: `${parsePullPercent(fasterBuildProgress) ?? 0}%`,
-                    background: 'var(--fg-1)',
-                  }}
-                />
+                  className="h-1.5 flex-1 overflow-hidden rounded-full"
+                  style={{ background: 'var(--surface-sunken)' }}
+                >
+                  <div
+                    className="h-full rounded-full"
+                    style={{
+                      width: `${parsePullPercent(fasterBuildProgress) ?? 0}%`,
+                      background: 'var(--fg-1)',
+                    }}
+                  />
+                </div>
+                <span
+                  className="shrink-0 text-right text-[11px] tabular-nums"
+                  style={{ color: 'var(--fg-muted)', width: 28 }}
+                >
+                  {parsePullPercent(fasterBuildProgress) ?? 0}%
+                </span>
+                {/* Fixed width + overflow-hidden for the same reason as the bar
+                    above: "8.8 MB/s" and "120 KB/s" are different widths, so a
+                    naive inline text here would reflow the row on every tick. */}
+                <span
+                  className="shrink-0 overflow-hidden whitespace-nowrap text-[11px] tabular-nums"
+                  style={{ color: 'var(--fg-muted)', width: 60 }}
+                >
+                  {formatBytesPerSecond(fasterBuildBytesPerSecond)}
+                </span>
               </div>
-              <span
-                className="shrink-0 text-right text-[11px] tabular-nums"
-                style={{ color: 'var(--fg-muted)', width: 28 }}
+              <button
+                type="button"
+                onClick={onCancelFasterBuild}
+                className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-[11px] underline"
+                style={{ color: 'var(--fg-muted)' }}
               >
-                {parsePullPercent(fasterBuildProgress) ?? 0}%
-              </span>
-              {/* Fixed width + overflow-hidden for the same reason as the bar
-                  above: "8.8 MB/s" and "120 KB/s" are different widths, so a
-                  naive inline text here would reflow the row on every tick. */}
-              <span
-                className="shrink-0 overflow-hidden whitespace-nowrap text-[11px] tabular-nums"
-                style={{ color: 'var(--fg-muted)', width: 60 }}
-              >
-                {formatBytesPerSecond(fasterBuildBytesPerSecond)}
-              </span>
+                Cancel
+              </button>
             </div>
           ) : (
             <button
@@ -577,13 +593,12 @@ function ModelCard({
           variant="outline"
           size="sm"
           className="h-[28px] shrink-0 px-3.5 text-[13px]"
-          disabled={isDownloading}
-          onClick={onSelect}
+          onClick={isDownloading ? onCancelDownload : onSelect}
         >
           {isDownloading ? (
             <>
-              <Loader2 className="mr-1.5 size-3 animate-spin" />
-              Downloading
+              <X className="mr-1.5 size-3" />
+              Cancel
             </>
           ) : (
             'Select'
@@ -2079,6 +2094,7 @@ function ModelList() {
         isDownloading={isDownloading}
         downloadProgress={downloadProgress}
         onSelect={onSelect}
+        onCancelDownload={() => pull.cancel(m.name)}
         fasterBuildTag={m.installed ? m.mlxTag : undefined}
         fasterBuildInstalled={Boolean(m.mlxInstalled)}
         fasterBuildState={isFasterBuildActive ? fasterBuild.state : 'idle'}
@@ -2089,6 +2105,7 @@ function ModelList() {
           if (!m.mlxTag || fasterBuildBlocked) return;
           fasterBuild.switchTo(m.mlxTag);
         }}
+        onCancelFasterBuild={isFasterBuildActive ? fasterBuild.cancel : undefined}
       />
     );
   };

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -367,6 +367,63 @@ function formatBytesPerSecond(bytesPerSecond: number | undefined): string {
   return `${mbPerSecond.toFixed(1)} MB/s`;
 }
 
+// Shared by the general "Select an uninstalled model" download and the
+// "switch to faster build" pull -- both drive the same fixed-width
+// bar+percent+MB/s+Cancel row from the same "<status> <pct>% (<bytes>)"
+// progress string, so a naive per-flow copy would drift on cosmetic tweaks.
+// Fixed-width (not just the bar's fill) so rapid ticks never reflow the row.
+function PullProgressBar({
+  progress,
+  bytesPerSecond,
+  onCancel,
+}: {
+  progress: string | undefined;
+  bytesPerSecond: number | undefined;
+  onCancel: (() => void) | undefined;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5" style={{ width: 96 }}>
+        <div
+          className="h-1.5 flex-1 overflow-hidden rounded-full"
+          style={{ background: 'var(--surface-sunken)' }}
+        >
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${parsePullPercent(progress) ?? 0}%`,
+              background: 'var(--fg-1)',
+            }}
+          />
+        </div>
+        <span
+          className="shrink-0 text-right text-[11px] tabular-nums"
+          style={{ color: 'var(--fg-muted)', width: 28 }}
+        >
+          {parsePullPercent(progress) ?? 0}%
+        </span>
+        {/* Fixed width + overflow-hidden: "8.8 MB/s" and "120 KB/s" are
+            different widths, so a naive inline text here would reflow the
+            row on every tick. */}
+        <span
+          className="shrink-0 overflow-hidden whitespace-nowrap text-[11px] tabular-nums"
+          style={{ color: 'var(--fg-muted)', width: 60 }}
+        >
+          {formatBytesPerSecond(bytesPerSecond)}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-[11px] underline"
+        style={{ color: 'var(--fg-muted)' }}
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
 interface ModelCardProps {
   name: string;
   sizeLabel?: string;
@@ -376,10 +433,17 @@ interface ModelCardProps {
   deprecated?: boolean;
   isDownloading?: boolean;
   downloadProgress?: string;
+  downloadBytesPerSecond?: number;
   onSelect: () => void;
   // Lets a user on a slow connection (or a misclick on a large model) back
   // out of a download in progress instead of being stuck waiting for it.
   onCancelDownload?: () => void;
+  // Shown for an installed, non-current model so disk space can be reclaimed
+  // without needing the Ollama CLI. Omitted entirely while the model is
+  // downloading (that's what onCancelDownload is for) or is the active
+  // selection (deleting it would break the app until another is chosen).
+  isInstalled?: boolean;
+  onDeleteModel?: () => void;
   fasterBuildTag?: string;
   fasterBuildInstalled?: boolean;
   fasterBuildState?: 'idle' | 'pulling' | 'verifying' | 'done' | 'error';
@@ -406,8 +470,11 @@ function ModelCard({
   deprecated = false,
   isDownloading = false,
   downloadProgress,
+  downloadBytesPerSecond,
   onSelect,
   onCancelDownload,
+  isInstalled = false,
+  onDeleteModel,
   fasterBuildTag,
   fasterBuildInstalled = false,
   fasterBuildState = 'idle',
@@ -498,11 +565,12 @@ function ModelCard({
           </div>
         )}
         {isDownloading && downloadProgress && (
-          <div
-            className="mt-1 font-mono text-[12px]"
-            style={{ color: 'var(--fg-2)' }}
-          >
-            {downloadProgress}
+          <div className="mt-1">
+            <PullProgressBar
+              progress={downloadProgress}
+              bytesPerSecond={downloadBytesPerSecond}
+              onCancel={onCancelDownload}
+            />
           </div>
         )}
       </div>
@@ -518,52 +586,11 @@ function ModelCard({
             Faster build available
           </span>
           {fasterBuildState === 'pulling' ? (
-            <div className="flex items-center gap-2">
-              {/* Fixed-width bar instead of a variable-width percentage label:
-                  Ollama's pull progress can update dozens of times per second on
-                  a multi-GB download, and a text label whose width changes on
-                  every tick reflows this whole row each time, which read as
-                  window-level flicker. The bar's own footprint never changes —
-                  only the fill width and a fixed-width, tabular-nums percentage
-                  do — so rapid updates no longer shift any layout. */}
-              <div className="flex items-center gap-1.5" style={{ width: 96 }}>
-                <div
-                  className="h-1.5 flex-1 overflow-hidden rounded-full"
-                  style={{ background: 'var(--surface-sunken)' }}
-                >
-                  <div
-                    className="h-full rounded-full"
-                    style={{
-                      width: `${parsePullPercent(fasterBuildProgress) ?? 0}%`,
-                      background: 'var(--fg-1)',
-                    }}
-                  />
-                </div>
-                <span
-                  className="shrink-0 text-right text-[11px] tabular-nums"
-                  style={{ color: 'var(--fg-muted)', width: 28 }}
-                >
-                  {parsePullPercent(fasterBuildProgress) ?? 0}%
-                </span>
-                {/* Fixed width + overflow-hidden for the same reason as the bar
-                    above: "8.8 MB/s" and "120 KB/s" are different widths, so a
-                    naive inline text here would reflow the row on every tick. */}
-                <span
-                  className="shrink-0 overflow-hidden whitespace-nowrap text-[11px] tabular-nums"
-                  style={{ color: 'var(--fg-muted)', width: 60 }}
-                >
-                  {formatBytesPerSecond(fasterBuildBytesPerSecond)}
-                </span>
-              </div>
-              <button
-                type="button"
-                onClick={onCancelFasterBuild}
-                className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-[11px] underline"
-                style={{ color: 'var(--fg-muted)' }}
-              >
-                Cancel
-              </button>
-            </div>
+            <PullProgressBar
+              progress={fasterBuildProgress}
+              bytesPerSecond={fasterBuildBytesPerSecond}
+              onCancel={onCancelFasterBuild}
+            />
           ) : (
             <button
               type="button"
@@ -589,21 +616,34 @@ function ModelCard({
           Selected
         </span>
       ) : !deprecated ? (
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-[28px] shrink-0 px-3.5 text-[13px]"
-          onClick={isDownloading ? onCancelDownload : onSelect}
-        >
-          {isDownloading ? (
-            <>
-              <X className="mr-1.5 size-3" />
-              Cancel
-            </>
-          ) : (
-            'Select'
+        <div className="flex shrink-0 items-center gap-1.5">
+          {isInstalled && !isDownloading && onDeleteModel && (
+            <button
+              type="button"
+              onClick={onDeleteModel}
+              title="Delete this model to free up disk space"
+              className="flex size-[28px] cursor-pointer items-center justify-center rounded-[6px] border-0 bg-transparent"
+              style={{ color: 'var(--fg-muted)' }}
+            >
+              <Trash2 size={14} />
+            </button>
           )}
-        </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-[28px] px-3.5 text-[13px]"
+            onClick={isDownloading ? onCancelDownload : onSelect}
+          >
+            {isDownloading ? (
+              <>
+                <X className="mr-1.5 size-3" />
+                Cancel
+              </>
+            ) : (
+              'Select'
+            )}
+          </Button>
+        </div>
       ) : null}
     </div>
   );
@@ -2009,12 +2049,22 @@ function ModelList() {
   const setCurrent = useSetCurrentModel();
   const pull = usePullModel();
   const [showDeprecated, setShowDeprecated] = React.useState(false);
-  const [deleteCandidate, setDeleteCandidate] = React.useState<{ tag: string; sizeLabel?: string } | null>(null);
+  // Backs two distinct triggers that both end in "confirm, then delete one or
+  // more tags": the automatic post-switch offer to remove the now-redundant
+  // GGUF build, and the manual "delete this model to free up disk space"
+  // action. Only one delete can be in flight/confirmed at a time in this UI,
+  // so a single piece of state covers both.
+  const [deleteCandidate, setDeleteCandidate] = React.useState<{ tags: string[]; description: string } | null>(
+    null,
+  );
   const deleteModel = useDeleteModel();
   const fasterBuild = useSwitchToFasterBuild((mlxTag) => {
     const match = models.data?.models.find((m) => m.mlxTag === mlxTag);
     if (match) {
-      setDeleteCandidate({ tag: match.name, sizeLabel: formatModelSize(match.size_gb) });
+      setDeleteCandidate({
+        tags: [match.name],
+        description: `${match.name} (${formatModelSize(match.size_gb) ?? 'unknown size'}) is no longer needed now that the faster build is active. Delete it to free up disk space?`,
+      });
     }
   });
 
@@ -2082,6 +2132,16 @@ function ModelList() {
       }
     };
 
+    const onDeleteModel = () => {
+      const tags = m.mlxInstalled && m.mlxTag ? [m.name, m.mlxTag] : [m.name];
+      const label = tags.length > 1 ? `${m.name} and its faster build` : m.name;
+      const pronoun = tags.length > 1 ? 'them' : 'it';
+      setDeleteCandidate({
+        tags,
+        description: `Delete ${label} (${sizeLabel ?? 'unknown size'}) to free up disk space? You can re-download ${pronoun} anytime.`,
+      });
+    };
+
     return (
       <ModelCard
         key={m.name}
@@ -2093,8 +2153,11 @@ function ModelList() {
         deprecated={Boolean(m.deprecated)}
         isDownloading={isDownloading}
         downloadProgress={downloadProgress}
+        downloadBytesPerSecond={pull.bytesPerSecond[m.name]}
         onSelect={onSelect}
         onCancelDownload={() => pull.cancel(m.name)}
+        isInstalled={Boolean(m.installed)}
+        onDeleteModel={onDeleteModel}
         fasterBuildTag={m.installed ? m.mlxTag : undefined}
         fasterBuildInstalled={Boolean(m.mlxInstalled)}
         fasterBuildState={isFasterBuildActive ? fasterBuild.state : 'idle'}
@@ -2145,12 +2208,12 @@ function ModelList() {
               fasterBuild.reset();
             }
           }}
-          title="Delete the old build?"
-          description={`${deleteCandidate.tag} (${deleteCandidate.sizeLabel ?? 'unknown size'}) is no longer needed now that the faster build is active. Delete it to free up disk space?`}
+          title="Delete model?"
+          description={deleteCandidate.description}
           confirmLabel="Delete"
           destructive
           onConfirm={async () => {
-            await deleteModel.mutateAsync(deleteCandidate.tag);
+            await Promise.all(deleteCandidate.tags.map((tag) => deleteModel.mutateAsync(tag)));
             setDeleteCandidate(null);
             fasterBuild.reset();
           }}

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -2171,8 +2171,16 @@ function ModelList() {
     };
 
     const onDeleteModel = () => {
-      const tags = m.mlxInstalled && m.mlxTag ? [m.name, m.mlxTag] : [m.name];
-      const label = tags.length > 1 ? `${m.name} and its faster build` : m.name;
+      // Only tags actually present in Ollama -- a model pulled straight to
+      // its NVFP4 tag (general "Select" on Apple Silicon) never has the
+      // GGUF blob itself installed, and ollama.delete() on a tag that was
+      // never pulled throws. Blindly including m.name here caused exactly
+      // that: a stuck confirm dialog on a model with no GGUF blob.
+      const tags: string[] = [];
+      if (m.ggufInstalled) tags.push(m.name);
+      if (m.mlxInstalled && m.mlxTag) tags.push(m.mlxTag);
+      if (tags.length === 0) return;
+      const label = tags.length > 1 ? `${m.name} and its faster build` : tags[0];
       const pronoun = tags.length > 1 ? 'them' : 'it';
       setDeleteCandidate({
         tags,
@@ -2251,9 +2259,17 @@ function ModelList() {
           confirmLabel="Delete"
           destructive
           onConfirm={async () => {
-            await Promise.all(deleteCandidate.tags.map((tag) => deleteModel.mutateAsync(tag)));
-            setDeleteCandidate(null);
-            fasterBuild.reset();
+            // finally, not just a trailing statement: a delete call
+            // rejecting (unexpected -- e.g. Ollama briefly unreachable)
+            // must not leave this dialog stuck open with no way to close
+            // it except Cancel (which, since some deletes may have already
+            // succeeded, looked like "cancel deletes it anyway").
+            try {
+              await Promise.all(deleteCandidate.tags.map((tag) => deleteModel.mutateAsync(tag)));
+            } finally {
+              setDeleteCandidate(null);
+              fasterBuild.reset();
+            }
           }}
         />
       )}

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -671,13 +671,24 @@ function ModelCard({
             variant="outline"
             size="sm"
             className="h-[28px] px-3.5 text-[13px]"
+            // Whisper/Parakeet share this component but don't wire cancel
+            // support -- without the `onCancelDownload` check, this showed
+            // an active-looking "Cancel" for them that did nothing on click.
+            disabled={isDownloading && !onCancelDownload}
             onClick={isDownloading ? onCancelDownload : onSelect}
           >
             {isDownloading ? (
-              <>
-                <X className="mr-1.5 size-3" />
-                Cancel
-              </>
+              onCancelDownload ? (
+                <>
+                  <X className="mr-1.5 size-3" />
+                  Cancel
+                </>
+              ) : (
+                <>
+                  <Loader2 className="mr-1.5 size-3 animate-spin" />
+                  Downloading
+                </>
+              )
             ) : (
               'Select'
             )}
@@ -2280,8 +2291,18 @@ function ModelList() {
             // must not leave this dialog stuck open with no way to close
             // it except Cancel (which, since some deletes may have already
             // succeeded, looked like "cancel deletes it anyway").
+            // allSettled (not all): waits for every tag's attempt to finish
+            // rather than returning as soon as the first one rejects, so the
+            // dialog doesn't close while a sibling delete is still pending.
             try {
-              await Promise.all(deleteCandidate.tags.map((tag) => deleteModel.mutateAsync(tag)));
+              const results = await Promise.allSettled(
+                deleteCandidate.tags.map((tag) => deleteModel.mutateAsync(tag)),
+              );
+              const failed = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+              if (failed.length > 0) {
+                // eslint-disable-next-line no-console -- no toast/error-surface system exists yet; at least don't fail silently.
+                console.error('Failed to delete some model tags:', failed.map((f) => f.reason));
+              }
             } finally {
               setDeleteCandidate(null);
               fasterBuild.reset();

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -475,6 +475,10 @@ interface ModelCardProps {
   // selection (deleting it would break the app until another is chosen).
   isInstalled?: boolean;
   onDeleteModel?: () => void;
+  // Whether the GGUF id itself was ever actually pulled -- false when
+  // "Select" resolved straight to the NVFP4 tag on Apple Silicon, in which
+  // case there's nothing to have "switched" from (see the MLX badge tooltip).
+  ggufInstalled?: boolean;
   fasterBuildTag?: string;
   fasterBuildInstalled?: boolean;
   fasterBuildState?: 'idle' | 'pulling' | 'verifying' | 'done' | 'error';
@@ -506,6 +510,7 @@ function ModelCard({
   onCancelDownload,
   isInstalled = false,
   onDeleteModel,
+  ggufInstalled = false,
   fasterBuildTag,
   fasterBuildInstalled = false,
   fasterBuildState = 'idle',
@@ -576,7 +581,11 @@ function ModelCard({
           {fasterBuildTag && fasterBuildInstalled && (
             <span
               className="rounded-[3px] px-1.5 py-px text-[11px]"
-              title={`Running the MLX build (${fasterBuildTag}) instead of ${name}`}
+              title={
+                ggufInstalled
+                  ? `Running the MLX build (${fasterBuildTag}) instead of ${name}`
+                  : `Downloaded directly as the MLX build (${fasterBuildTag}) -- ${name} was never pulled`
+              }
               style={{
                 background: 'var(--surface-sunken)',
                 color: 'var(--fg-muted)',
@@ -2155,7 +2164,13 @@ function ModelList() {
       note = parts.length ? parts.join(' · ') : undefined;
     }
 
-    const sizeLabel = formatModelSize(m.size_gb);
+    // The NVFP4 blob is a different (often larger) download than the GGUF
+    // entry's own size -- show it instead whenever NVFP4 is what's actually
+    // installed, or (nothing installed yet) what "Select" will actually
+    // pull on Apple Silicon. Otherwise (GGUF installed, no NVFP4) the GGUF
+    // size is what's really on disk.
+    const showMlxSize = m.mlxTag && m.mlxSizeGb !== undefined && (m.mlxInstalled || !m.ggufInstalled);
+    const sizeLabel = formatModelSize(showMlxSize ? m.mlxSizeGb : m.size_gb);
     const isFasterBuildActive = fasterBuild.activeTag === m.mlxTag;
     const fasterBuildBlocked =
       Boolean(fasterBuild.activeTag) &&
@@ -2204,6 +2219,7 @@ function ModelList() {
         onCancelDownload={() => pull.cancel(pullTarget)}
         isInstalled={Boolean(m.installed)}
         onDeleteModel={onDeleteModel}
+        ggufInstalled={Boolean(m.ggufInstalled)}
         fasterBuildTag={m.installed ? m.mlxTag : undefined}
         fasterBuildInstalled={Boolean(m.mlxInstalled)}
         fasterBuildState={isFasterBuildActive ? fasterBuild.state : 'idle'}

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1998,7 +1998,7 @@ function ModelList() {
         isDownloading={isDownloading}
         downloadProgress={downloadProgress}
         onSelect={onSelect}
-        fasterBuildTag={m.mlxTag}
+        fasterBuildTag={m.installed ? m.mlxTag : undefined}
         fasterBuildInstalled={Boolean(m.mlxInstalled)}
         fasterBuildState={isFasterBuildActive ? fasterBuild.state : 'idle'}
         fasterBuildProgress={isFasterBuildActive ? fasterBuild.progress : undefined}

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -431,14 +431,19 @@ function PullProgressBar({
           {parsePullPart(progress) ? `Part ${parsePullPart(progress)}` : ''}
         </span>
       </div>
-      <button
-        type="button"
-        onClick={onCancel}
-        className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-[11px] underline"
-        style={{ color: 'var(--fg-muted)' }}
-      >
-        Cancel
-      </button>
+      {/* Only rendered when the caller doesn't already have its own cancel
+          control (e.g. the general download flow's top-right Select/Cancel
+          button) -- otherwise this duplicates it right below the name. */}
+      {onCancel && (
+        <button
+          type="button"
+          onClick={onCancel}
+          className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-[11px] underline"
+          style={{ color: 'var(--fg-muted)' }}
+        >
+          Cancel
+        </button>
+      )}
     </div>
   );
 }
@@ -583,16 +588,15 @@ function ModelCard({
             {note}
           </div>
         )}
-        {isDownloading && downloadProgress && (
-          <div className="mt-1">
-            <PullProgressBar
-              progress={downloadProgress}
-              bytesPerSecond={downloadBytesPerSecond}
-              onCancel={onCancelDownload}
-            />
-          </div>
-        )}
       </div>
+      {isDownloading && downloadProgress && (
+        // Inline, to the right of the name -- matching where the
+        // switch-to-faster-build progress bar sits, instead of a separate
+        // line below the name (that read as a second, unrelated download).
+        // No onCancel here -- the top-right Button already doubles as
+        // Cancel while isDownloading (see the button block below).
+        <PullProgressBar progress={downloadProgress} bytesPerSecond={downloadBytesPerSecond} onCancel={undefined} />
+      )}
       {fasterBuildTag && !fasterBuildInstalled && (
         <div className="mt-1.5 flex items-center gap-2">
           <span

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -393,7 +393,7 @@ function PullProgressBar({
   onCancel: (() => void) | undefined;
 }) {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex shrink-0 items-center gap-2">
       {/* No outer fixed width here -- it previously hardcoded 96px, which
           fit only the bar+percent pair it was designed for. Adding the
           MB/s and Part columns later pushed the total past 96px, so they
@@ -522,7 +522,12 @@ function ModelCard({
 }: ModelCardProps) {
   return (
     <div
-      className="mb-1.5 flex items-center gap-4 rounded-[8px] px-4 py-[13px] transition-colors"
+      // flex-wrap + gap-y lets the wide faster-build row (badge + progress bar
+      // + Cancel) drop onto its own line under the name at a realistic Settings
+      // width, instead of being forced onto one line that squeezes the name to
+      // near-zero (char-wrapping it) and overflows the fixed-width progress
+      // columns into an overlapping mess. The name/button row stays on line 1.
+      className="mb-1.5 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-[8px] px-4 py-[13px] transition-colors"
       style={{
         border: `1px solid ${
           isCurrent ? 'var(--border-strong)' : 'var(--border-subtle)'
@@ -606,45 +611,13 @@ function ModelCard({
         )}
       </div>
       {isDownloading && downloadProgress && (
-        // Inline, to the right of the name -- matching where the
-        // switch-to-faster-build progress bar sits, instead of a separate
-        // line below the name (that read as a second, unrelated download).
-        // No onCancel here -- the top-right Button already doubles as
-        // Cancel while isDownloading (see the button block below).
+        // Inline, to the right of the name, on the same row as the Select /
+        // Cancel button (it's shrink-0, so it stays intact; the name gives way
+        // via its own min-w-0 block). No onCancel here -- the top-right Button
+        // already doubles as Cancel while isDownloading (see the button block
+        // below). A faster-build switch is excluded from isDownloading upstream,
+        // so this never double-renders with the faster-build progress bar.
         <PullProgressBar progress={downloadProgress} bytesPerSecond={downloadBytesPerSecond} onCancel={undefined} />
-      )}
-      {fasterBuildTag && !fasterBuildInstalled && (
-        <div className="mt-1.5 flex items-center gap-2">
-          <span
-            className="rounded-[3px] px-1.5 py-px text-[11px]"
-            style={{
-              color: 'var(--fg-muted)',
-              border: '1px solid var(--border-subtle)',
-            }}
-          >
-            Faster build available
-          </span>
-          {fasterBuildState === 'pulling' ? (
-            <PullProgressBar
-              progress={fasterBuildProgress}
-              bytesPerSecond={fasterBuildBytesPerSecond}
-              onCancel={onCancelFasterBuild}
-            />
-          ) : (
-            <button
-              type="button"
-              onClick={onSwitchToFasterBuild}
-              disabled={fasterBuildState === 'verifying' || fasterBuildBlocked}
-              title={fasterBuildBlocked ? 'Finish the current switch first' : undefined}
-              className="cursor-pointer border-0 bg-transparent p-0 text-[12px] underline disabled:cursor-default disabled:no-underline disabled:opacity-60"
-              style={{ color: 'var(--fg-1)' }}
-            >
-              {fasterBuildState === 'verifying' && 'Verifying…'}
-              {fasterBuildState === 'error' && 'Retry: switch to faster build'}
-              {(fasterBuildState === 'idle' || fasterBuildState === 'done') && 'Switch to faster build'}
-            </button>
-          )}
-        </div>
       )}
       {isCurrent ? (
         <span
@@ -695,6 +668,43 @@ function ModelCard({
           </Button>
         </div>
       ) : null}
+      {/* Rendered LAST and w-full so flex-wrap pushes it onto its own line
+          below the name + Select/Selected row, rather than fighting them for
+          horizontal space. The badge + progress bar (or switch button) can
+          then sit comfortably at full width. */}
+      {fasterBuildTag && !fasterBuildInstalled && (
+        <div className="flex w-full items-center gap-2">
+          <span
+            className="shrink-0 rounded-[3px] px-1.5 py-px text-[11px]"
+            style={{
+              color: 'var(--fg-muted)',
+              border: '1px solid var(--border-subtle)',
+            }}
+          >
+            Faster build available
+          </span>
+          {fasterBuildState === 'pulling' ? (
+            <PullProgressBar
+              progress={fasterBuildProgress}
+              bytesPerSecond={fasterBuildBytesPerSecond}
+              onCancel={onCancelFasterBuild}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={onSwitchToFasterBuild}
+              disabled={fasterBuildState === 'verifying' || fasterBuildBlocked}
+              title={fasterBuildBlocked ? 'Finish the current switch first' : undefined}
+              className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-[12px] underline disabled:cursor-default disabled:no-underline disabled:opacity-60"
+              style={{ color: 'var(--fg-1)' }}
+            >
+              {fasterBuildState === 'verifying' && 'Verifying…'}
+              {fasterBuildState === 'error' && 'Retry: switch to faster build'}
+              {(fasterBuildState === 'idle' || fasterBuildState === 'done') && 'Switch to faster build'}
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -2161,8 +2171,16 @@ function ModelList() {
     // NVFP4 tag. Off Apple Silicon (no mlxTag) this is just m.name, same as
     // before.
     const pullTarget = m.mlxTag ?? m.name;
-    const isDownloading = Boolean(pull.progress[pullTarget]);
-    const downloadProgress = pull.progress[pullTarget];
+    const isFasterBuildActive = fasterBuild.activeTag === m.mlxTag;
+    // A "switch to faster build" pulls the SAME -nvfp4 tag a general "Select"
+    // would, and usePullModel's progress listener is a global (unfiltered) IPC
+    // subscription -- so it records that tag's progress too. Without this guard
+    // pull.progress[pullTarget] lights up during a switch, and the card renders
+    // a SECOND, duplicate progress bar (plus a duplicate Cancel) on top of the
+    // faster-build one. While a switch is in flight the faster-build block owns
+    // that UI, so suppress the general-download surface for this row.
+    const isDownloading = Boolean(pull.progress[pullTarget]) && !isFasterBuildActive;
+    const downloadProgress = isDownloading ? pull.progress[pullTarget] : undefined;
     const isDefault = !isRemote && isDefaultModel(m.description);
 
     let note: string | undefined;
@@ -2182,7 +2200,6 @@ function ModelList() {
     // size is what's really on disk.
     const showMlxSize = m.mlxTag && m.mlxSizeGb !== undefined && (m.mlxInstalled || !m.ggufInstalled);
     const sizeLabel = formatModelSize(showMlxSize ? m.mlxSizeGb : m.size_gb);
-    const isFasterBuildActive = fasterBuild.activeTag === m.mlxTag;
     const fasterBuildBlocked =
       Boolean(fasterBuild.activeTag) &&
       !isFasterBuildActive &&

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -360,6 +360,13 @@ function parsePullPercent(progress: string | undefined): number | null {
   return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : null;
 }
 
+function formatBytesPerSecond(bytesPerSecond: number | undefined): string {
+  if (!bytesPerSecond || bytesPerSecond <= 0) return '';
+  const mbPerSecond = bytesPerSecond / (1024 * 1024);
+  if (mbPerSecond < 1) return `${Math.round(bytesPerSecond / 1024)} KB/s`;
+  return `${mbPerSecond.toFixed(1)} MB/s`;
+}
+
 interface ModelCardProps {
   name: string;
   sizeLabel?: string;
@@ -374,6 +381,7 @@ interface ModelCardProps {
   fasterBuildInstalled?: boolean;
   fasterBuildState?: 'idle' | 'pulling' | 'verifying' | 'done' | 'error';
   fasterBuildProgress?: string;
+  fasterBuildBytesPerSecond?: number;
   onSwitchToFasterBuild?: () => void;
 }
 
@@ -391,6 +399,7 @@ function ModelCard({
   fasterBuildInstalled = false,
   fasterBuildState = 'idle',
   fasterBuildProgress,
+  fasterBuildBytesPerSecond,
   onSwitchToFasterBuild,
 }: ModelCardProps) {
   return (
@@ -506,6 +515,15 @@ function ModelCard({
                 style={{ color: 'var(--fg-muted)', width: 28 }}
               >
                 {parsePullPercent(fasterBuildProgress) ?? 0}%
+              </span>
+              {/* Fixed width + overflow-hidden for the same reason as the bar
+                  above: "8.8 MB/s" and "120 KB/s" are different widths, so a
+                  naive inline text here would reflow the row on every tick. */}
+              <span
+                className="shrink-0 overflow-hidden whitespace-nowrap text-[11px] tabular-nums"
+                style={{ color: 'var(--fg-muted)', width: 60 }}
+              >
+                {formatBytesPerSecond(fasterBuildBytesPerSecond)}
               </span>
             </div>
           ) : (
@@ -2038,6 +2056,7 @@ function ModelList() {
         fasterBuildInstalled={Boolean(m.mlxInstalled)}
         fasterBuildState={isFasterBuildActive ? fasterBuild.state : 'idle'}
         fasterBuildProgress={isFasterBuildActive ? fasterBuild.progress : undefined}
+        fasterBuildBytesPerSecond={isFasterBuildActive ? fasterBuild.bytesPerSecond : undefined}
         onSwitchToFasterBuild={() => {
           if (!m.mlxTag) return;
           fasterBuild.switchTo(m.mlxTag);

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -469,6 +469,19 @@ function ModelCard({
               Deprecated
             </span>
           )}
+          {fasterBuildTag && fasterBuildInstalled && (
+            <span
+              className="rounded-[3px] px-1.5 py-px text-[11px]"
+              title={`Running the MLX build (${fasterBuildTag}) instead of ${name}`}
+              style={{
+                background: 'var(--surface-sunken)',
+                color: 'var(--fg-muted)',
+                border: '1px solid var(--border)',
+              }}
+            >
+              MLX model
+            </span>
+          )}
         </div>
         {note && (
           <div

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -353,6 +353,13 @@ function isDefaultModel(description: string | undefined): boolean {
   return /\((default|recommended)\)/i.test(description ?? '');
 }
 
+function parsePullPercent(progress: string | undefined): number | null {
+  const match = progress?.match(/(\d{1,3})%/);
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : null;
+}
+
 interface ModelCardProps {
   name: string;
   sizeLabel?: string;
@@ -473,18 +480,47 @@ function ModelCard({
           >
             Faster build available
           </span>
-          <button
-            type="button"
-            onClick={onSwitchToFasterBuild}
-            disabled={fasterBuildState === 'pulling' || fasterBuildState === 'verifying'}
-            className="cursor-pointer border-0 bg-transparent p-0 text-[12px] underline disabled:cursor-default disabled:no-underline disabled:opacity-60"
-            style={{ color: 'var(--fg-1)' }}
-          >
-            {fasterBuildState === 'pulling' && (fasterBuildProgress ?? 'Downloading…')}
-            {fasterBuildState === 'verifying' && 'Verifying…'}
-            {fasterBuildState === 'error' && 'Retry: switch to faster build'}
-            {(fasterBuildState === 'idle' || fasterBuildState === 'done') && 'Switch to faster build'}
-          </button>
+          {fasterBuildState === 'pulling' ? (
+            // Fixed-width bar instead of a variable-width percentage label:
+            // Ollama's pull progress can update dozens of times per second on
+            // a multi-GB download, and a text label whose width changes on
+            // every tick reflows this whole row each time, which read as
+            // window-level flicker. The bar's own footprint never changes —
+            // only the fill width and a fixed-width, tabular-nums percentage
+            // do — so rapid updates no longer shift any layout.
+            <div className="flex items-center gap-1.5" style={{ width: 96 }}>
+              <div
+                className="h-1.5 flex-1 overflow-hidden rounded-full"
+                style={{ background: 'var(--surface-sunken)' }}
+              >
+                <div
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${parsePullPercent(fasterBuildProgress) ?? 0}%`,
+                    background: 'var(--fg-1)',
+                  }}
+                />
+              </div>
+              <span
+                className="shrink-0 text-right text-[11px] tabular-nums"
+                style={{ color: 'var(--fg-muted)', width: 28 }}
+              >
+                {parsePullPercent(fasterBuildProgress) ?? 0}%
+              </span>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={onSwitchToFasterBuild}
+              disabled={fasterBuildState === 'verifying'}
+              className="cursor-pointer border-0 bg-transparent p-0 text-[12px] underline disabled:cursor-default disabled:no-underline disabled:opacity-60"
+              style={{ color: 'var(--fg-1)' }}
+            >
+              {fasterBuildState === 'verifying' && 'Verifying…'}
+              {fasterBuildState === 'error' && 'Retry: switch to faster build'}
+              {(fasterBuildState === 'idle' || fasterBuildState === 'done') && 'Switch to faster build'}
+            </button>
+          )}
         </div>
       )}
       {isCurrent ? (

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -360,6 +360,17 @@ function parsePullPercent(progress: string | undefined): number | null {
   return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : null;
 }
 
+// Ollama models are made of several blobs, each streamed as its own 0-100%
+// phase (see pull_model's "[Part N]" suffix in simple_recorder.py) -- without
+// this, the percentage restarting from a new blob reads as a second,
+// unrelated download starting.
+function parsePullPart(progress: string | undefined): number | null {
+  const match = progress?.match(/\[Part (\d+)\]/);
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
 function formatBytesPerSecond(bytesPerSecond: number | undefined): string {
   if (!bytesPerSecond || bytesPerSecond <= 0) return '';
   const mbPerSecond = bytesPerSecond / (1024 * 1024);
@@ -410,6 +421,14 @@ function PullProgressBar({
           style={{ color: 'var(--fg-muted)', width: 60 }}
         >
           {formatBytesPerSecond(bytesPerSecond)}
+        </span>
+        {/* Reserved even when blank so the one-time appearance of a second
+            blob's part number doesn't shift anything else in the row. */}
+        <span
+          className="shrink-0 overflow-hidden whitespace-nowrap text-[11px] tabular-nums"
+          style={{ color: 'var(--fg-muted)', width: 44 }}
+        >
+          {parsePullPart(progress) ? `Part ${parsePullPart(progress)}` : ''}
         </span>
       </div>
       <button
@@ -2103,8 +2122,16 @@ function ModelList() {
 
   const renderCard = (m: (typeof sorted)[number]) => {
     const isCurrent = m.name === current.data;
-    const isDownloading = Boolean(pull.progress[m.name]);
-    const downloadProgress = pull.progress[m.name];
+    // On Apple Silicon, an uninstalled model is pulled straight to its NVFP4
+    // sibling (matching what first-run setup's pull_target already does) --
+    // config.json still ends up with the canonical GGUF id via models.set()
+    // (see usePullModel's pendingSelect), but the actual download, and so
+    // the IPC events this row's progress/cancel keys off of, are for the
+    // NVFP4 tag. Off Apple Silicon (no mlxTag) this is just m.name, same as
+    // before.
+    const pullTarget = m.mlxTag ?? m.name;
+    const isDownloading = Boolean(pull.progress[pullTarget]);
+    const downloadProgress = pull.progress[pullTarget];
     const isDefault = !isRemote && isDefaultModel(m.description);
 
     let note: string | undefined;
@@ -2128,7 +2155,7 @@ function ModelList() {
       if (m.installed) {
         setCurrent.mutate(m.name);
       } else {
-        pull.mutate(m.name);
+        pull.mutate({ name: m.name, pullTarget });
       }
     };
 
@@ -2153,9 +2180,9 @@ function ModelList() {
         deprecated={Boolean(m.deprecated)}
         isDownloading={isDownloading}
         downloadProgress={downloadProgress}
-        downloadBytesPerSecond={pull.bytesPerSecond[m.name]}
+        downloadBytesPerSecond={pull.bytesPerSecond[pullTarget]}
         onSelect={onSelect}
-        onCancelDownload={() => pull.cancel(m.name)}
+        onCancelDownload={() => pull.cancel(pullTarget)}
         isInstalled={Boolean(m.installed)}
         onDeleteModel={onDeleteModel}
         fasterBuildTag={m.installed ? m.mlxTag : undefined}

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -394,10 +394,17 @@ function PullProgressBar({
 }) {
   return (
     <div className="flex items-center gap-2">
-      <div className="flex items-center gap-1.5" style={{ width: 96 }}>
+      {/* No outer fixed width here -- it previously hardcoded 96px, which
+          fit only the bar+percent pair it was designed for. Adding the
+          MB/s and Part columns later pushed the total past 96px, so they
+          silently overflowed the box and collided with whatever sat to its
+          right (the Cancel button). Each child below still has its own
+          fixed width, so per-tick reflow is still fully prevented -- this
+          container just needs to actually be wide enough for all of them. */}
+      <div className="flex items-center gap-1.5">
         <div
-          className="h-1.5 flex-1 overflow-hidden rounded-full"
-          style={{ background: 'var(--surface-sunken)' }}
+          className="h-1.5 overflow-hidden rounded-full"
+          style={{ width: 56, background: 'var(--surface-sunken)' }}
         >
           <div
             className="h-full rounded-full"
@@ -428,7 +435,7 @@ function PullProgressBar({
           className="shrink-0 overflow-hidden whitespace-nowrap text-[11px] tabular-nums"
           style={{ color: 'var(--fg-muted)', width: 44 }}
         >
-          {parsePullPart(progress) ? `Part ${parsePullPart(progress)}` : ''}
+          {parsePullPart(progress) !== null ? `Part ${parsePullPart(progress)}` : ''}
         </span>
       </div>
       {/* Only rendered when the caller doesn't already have its own cancel

--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -2,7 +2,7 @@
 // src/ollama_manager.py checks http://127.0.0.1:11434/api/tags first and skips
 // starting its own `ollama serve` on a 200 (ollama_manager.py ~148), so
 // prebinding here keeps the real/ bundled Ollama out of the test. Answers
-// /api/tags, /api/pull, and a streaming NDJSON /api/chat.
+// /api/tags, /api/pull, /api/delete, and a streaming NDJSON /api/chat.
 //
 // Bind is hard by design (listen throws on EADDRINUSE): if a real Ollama is
 // already answering on 11434 the test would silently hit the live LLM instead
@@ -23,14 +23,21 @@ const OLLAMA_PORT = 11434;
  * @param {object} [opts]
  * @param {string} [opts.chatReply='ok'] assistant content returned by /api/chat.
  * @param {string[]} [opts.chatReplyQueue=[]] queue of replies to dequeue per call; falls back to chatReply when exhausted.
- * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number, pullCalls: () => number, remainingQueueLength: () => number }>}
+ * @param {string[]} [opts.installedModels=['gemma4:e2b-it-qat','llama3.2:3b']] models /api/tags reports as installed.
+ * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number, pullCalls: () => number, remainingQueueLength: () => number, lastPulledModel: () => string|null, deleteCalls: () => number, lastDeletedModel: () => string|null }>}
  */
 function startMockOllama(opts = {}) {
   const chatReply = opts.chatReply ?? 'ok';
   const chatReplyQueue = Array.isArray(opts.chatReplyQueue) ? [...opts.chatReplyQueue] : [];
+  const installedModels = Array.isArray(opts.installedModels)
+    ? opts.installedModels
+    : ['gemma4:e2b-it-qat', 'llama3.2:3b'];
   let lastChatPrompt = null;
   let chatCalls = 0;
   let pullCalls = 0;
+  let lastPulledModel = null;
+  let deleteCalls = 0;
+  let lastDeletedModel = null;
 
   return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
@@ -39,29 +46,21 @@ function startMockOllama(opts = {}) {
       // configured model isn't found it tries to PULL it, so we must list it
       // under `model` or the pull path 404s and crashes summarisation.
       if (req.method === 'GET' && req.url === '/api/tags') {
+        // gemma4:e2b-it-qat is the config default (Config.DEFAULT_MODEL); listed
+        // by default so the summarizer finds the configured model installed
+        // instead of taking the pull path. llama3.2:3b kept for tests that pin
+        // the older model explicitly. Callers can override via opts.installedModels
+        // (e.g. [] to force the pull path).
         res.writeHead(200, { 'content-type': 'application/json' });
         res.end(
           JSON.stringify({
-            models: [
-              // gemma4:e2b-it-qat is the config default (Config.DEFAULT_MODEL);
-              // list it so the summarizer finds the configured model installed
-              // instead of taking the pull path. llama3.2:3b kept for tests that
-              // pin the older model explicitly.
-              {
-                name: 'gemma4:e2b-it-qat',
-                model: 'gemma4:e2b-it-qat',
-                modified_at: '2024-01-01T00:00:00Z',
-                size: 4301000000,
-                digest: 'mock',
-              },
-              {
-                name: 'llama3.2:3b',
-                model: 'llama3.2:3b',
-                modified_at: '2024-01-01T00:00:00Z',
-                size: 2019393189,
-                digest: 'mock',
-              },
-            ],
+            models: installedModels.map((name) => ({
+              name,
+              model: name,
+              modified_at: '2024-01-01T00:00:00Z',
+              size: 4301000000,
+              digest: 'mock',
+            })),
           }),
         );
         return;
@@ -69,9 +68,18 @@ function startMockOllama(opts = {}) {
       // /api/pull — defensive: if the model is ever considered missing, answer
       // a success stream rather than 404 so summarisation doesn't crash.
       if (req.method === 'POST' && req.url === '/api/pull') {
-        pullCalls++;
-        res.writeHead(200, { 'content-type': 'application/x-ndjson' });
-        res.end(JSON.stringify({ status: 'success' }) + '\n');
+        const chunks = [];
+        req.on('data', (c) => chunks.push(c));
+        req.on('end', () => {
+          pullCalls++;
+          let body = {};
+          try {
+            body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+          } catch { /* ignore */ }
+          lastPulledModel = body.name || body.model || null;
+          res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+          res.end(JSON.stringify({ status: 'success' }) + '\n');
+        });
         return;
       }
       if (req.method === 'POST' && req.url === '/api/chat') {
@@ -109,6 +117,21 @@ function startMockOllama(opts = {}) {
         });
         return;
       }
+      if (req.method === 'DELETE' && req.url === '/api/delete') {
+        const chunks = [];
+        req.on('data', (c) => chunks.push(c));
+        req.on('end', () => {
+          deleteCalls++;
+          let body = {};
+          try {
+            body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+          } catch { /* ignore */ }
+          lastDeletedModel = body.model || body.name || null;
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ status: 'success' }));
+        });
+        return;
+      }
       res.writeHead(404, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'mock: not found' }));
     });
@@ -121,6 +144,9 @@ function startMockOllama(opts = {}) {
         chatCalls: () => chatCalls,
         pullCalls: () => pullCalls,
         remainingQueueLength: () => chatReplyQueue.length,
+        lastPulledModel: () => lastPulledModel,
+        deleteCalls: () => deleteCalls,
+        lastDeletedModel: () => lastDeletedModel,
       });
     });
   });

--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -24,6 +24,8 @@ const OLLAMA_PORT = 11434;
  * @param {string} [opts.chatReply='ok'] assistant content returned by /api/chat.
  * @param {string[]} [opts.chatReplyQueue=[]] queue of replies to dequeue per call; falls back to chatReply when exhausted.
  * @param {string[]} [opts.installedModels=['gemma4:e2b-it-qat','llama3.2:3b']] models /api/tags reports as installed.
+ * @param {number} [opts.pullDelayMs=0] hold the /api/pull response open this long before completing it -- gives a
+ *   cancel-mid-download test a real window to call cancel-pull before the mock would otherwise finish first.
  * @returns {Promise<{ close: () => Promise<void>, lastChatPrompt: () => string|null, chatCalls: () => number, pullCalls: () => number, remainingQueueLength: () => number, lastPulledModel: () => string|null, deleteCalls: () => number, lastDeletedModel: () => string|null }>}
  */
 function startMockOllama(opts = {}) {
@@ -32,6 +34,7 @@ function startMockOllama(opts = {}) {
   const installedModels = Array.isArray(opts.installedModels)
     ? opts.installedModels
     : ['gemma4:e2b-it-qat', 'llama3.2:3b'];
+  const pullDelayMs = opts.pullDelayMs ?? 0;
   let lastChatPrompt = null;
   let chatCalls = 0;
   let pullCalls = 0;
@@ -78,7 +81,19 @@ function startMockOllama(opts = {}) {
           } catch { /* ignore */ }
           lastPulledModel = body.name || body.model || null;
           res.writeHead(200, { 'content-type': 'application/x-ndjson' });
-          res.end(JSON.stringify({ status: 'success' }) + '\n');
+          const finish = () => {
+            if (res.writableEnded || res.destroyed) return;
+            res.end(JSON.stringify({ status: 'success' }) + '\n');
+          };
+          if (pullDelayMs > 0) {
+            const timer = setTimeout(finish, pullDelayMs);
+            // If the client (our pull-model subprocess) disconnects early --
+            // e.g. it was killed by a cancel-pull -- don't fire the delayed
+            // write against an already-closed socket.
+            res.on('close', () => clearTimeout(timer));
+          } else {
+            finish();
+          }
         });
         return;
       }

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { readUserConfig } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { killOllama } from '../fixtures/kill-ollama';
 
 /**
  * T2 — model management (the deterministic, model-free subset). Covers the
@@ -22,12 +24,18 @@ type ListResult = {
 type CurrentModel = { success: boolean; model?: string };
 type StatusResult = { success: boolean; model?: string; installed?: boolean };
 type Result = { success?: boolean };
+type PullResult = { success: boolean; error?: string };
+type VerifyResult = { success: boolean; error: string | null };
+type DeleteResult = { success: boolean; error: string | null };
 
 type StenoWindow = Window & {
   stenoai: {
     models: {
       getCurrent: () => Promise<CurrentModel>;
       set: (name: string) => Promise<Result>;
+      pull: (name: string) => Promise<PullResult>;
+      verify: (name: string) => Promise<VerifyResult>;
+      delete: (name: string) => Promise<DeleteResult>;
     };
     whisperModels: {
       list: () => Promise<ListResult>;
@@ -130,4 +138,36 @@ test('parakeet models: list + status return a coherent installed shape', async (
   expect(typeof status.installed).toBe('boolean');
   // status + list agree on the default model id.
   expect(status.model).toBe(listed.current_model);
+});
+
+test('switch-to-faster-build: pull, verify, and delete the old tag all round-trip through IPC', async ({
+  launchApp,
+}) => {
+  killOllama();
+  const mockOllama = await startMockOllama();
+  try {
+    const { page } = await launchApp();
+
+    const pullResult = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.pull('gemma4:e2b-nvfp4'),
+    );
+    expect(pullResult.success).toBe(true);
+    expect(mockOllama.lastPulledModel()).toBe('gemma4:e2b-nvfp4');
+
+    const verifyResult = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.verify('gemma4:e2b-nvfp4'),
+    );
+    expect(verifyResult.success).toBe(true);
+    expect(verifyResult.error).toBeNull();
+
+    const deleteResult = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.delete('gemma4:e2b-it-qat'),
+    );
+    expect(deleteResult.success).toBe(true);
+    expect(deleteResult.error).toBeNull();
+    expect(mockOllama.deleteCalls()).toBe(1);
+    expect(mockOllama.lastDeletedModel()).toBe('gemma4:e2b-it-qat');
+  } finally {
+    await mockOllama.close();
+  }
 });

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -24,9 +24,10 @@ type ListResult = {
 type CurrentModel = { success: boolean; model?: string };
 type StatusResult = { success: boolean; model?: string; installed?: boolean };
 type Result = { success?: boolean };
-type PullResult = { success: boolean; error?: string };
+type PullResult = { success: boolean; error?: string; cancelled?: boolean };
 type VerifyResult = { success: boolean; error: string | null };
 type DeleteResult = { success: boolean; error: string | null };
+type CancelPullResult = { success: boolean; error: string | null };
 
 type StenoWindow = Window & {
   stenoai: {
@@ -34,6 +35,7 @@ type StenoWindow = Window & {
       getCurrent: () => Promise<CurrentModel>;
       set: (name: string) => Promise<Result>;
       pull: (name: string) => Promise<PullResult>;
+      cancelPull: (name: string) => Promise<CancelPullResult>;
       verify: (name: string) => Promise<VerifyResult>;
       delete: (name: string) => Promise<DeleteResult>;
     };
@@ -167,6 +169,48 @@ test('switch-to-faster-build: pull, verify, and delete the old tag all round-tri
     expect(deleteResult.error).toBeNull();
     expect(mockOllama.deleteCalls()).toBe(1);
     expect(mockOllama.lastDeletedModel()).toBe('gemma4:e2b-it-qat');
+  } finally {
+    await mockOllama.close();
+  }
+});
+
+test('cancel-pull: stops an in-flight download and reports it as cancelled, not a failure', async ({
+  launchApp,
+}) => {
+  killOllama();
+  // Holds the mock's /api/pull response open so there's a real window to
+  // cancel before it would otherwise complete on its own.
+  const mockOllama = await startMockOllama({ pullDelayMs: 3000 });
+  try {
+    const { page } = await launchApp();
+
+    const pullPromise = page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.pull('gemma4:e2b-nvfp4'),
+    );
+
+    // Wait for the pull-model subprocess to actually reach the mock server
+    // (PyInstaller cold start can take longer than a short fixed sleep)
+    // before cancelling, so this exercises a real in-flight download rather
+    // than racing the subprocess's own startup time.
+    await expect.poll(() => mockOllama.pullCalls()).toBeGreaterThan(0);
+
+    const cancelResult = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.cancelPull('gemma4:e2b-nvfp4'),
+    );
+    expect(cancelResult.success).toBe(true);
+    expect(cancelResult.error).toBeNull();
+
+    const pullResult = await pullPromise;
+    expect(pullResult.success).toBe(false);
+    expect(pullResult.cancelled).toBe(true);
+    expect(mockOllama.pullCalls()).toBe(1);
+
+    // Nothing left to cancel now -- a second call must fail cleanly rather
+    // than silently succeeding or throwing.
+    const secondCancel = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.cancelPull('gemma4:e2b-nvfp4'),
+    );
+    expect(secondCancel.success).toBe(false);
   } finally {
     await mockOllama.close();
   }

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -14,7 +14,7 @@ import { killOllama } from '../fixtures/kill-ollama';
  * never a specific install state.
  */
 
-type ModelInfo = { installed?: boolean };
+type ModelInfo = { installed?: boolean; mlx_tag?: string; mlx_installed?: boolean };
 type ListResult = {
   success: boolean;
   current_model?: string;
@@ -32,6 +32,7 @@ type CancelPullResult = { success: boolean; error: string | null };
 type StenoWindow = Window & {
   stenoai: {
     models: {
+      list: () => Promise<ListResult>;
       getCurrent: () => Promise<CurrentModel>;
       set: (name: string) => Promise<Result>;
       pull: (name: string) => Promise<PullResult>;
@@ -140,6 +141,30 @@ test('parakeet models: list + status return a coherent installed shape', async (
   expect(typeof status.installed).toBe('boolean');
   // status + list agree on the default model id.
   expect(status.model).toBe(listed.current_model);
+});
+
+test('a model pulled straight to its NVFP4 tag (no GGUF ever downloaded) still reports installed', async ({
+  launchApp,
+}) => {
+  test.skip(process.platform !== 'darwin' || process.arch !== 'arm64', 'MLX enrichment only applies on Apple Silicon');
+  killOllama();
+  // Only the NVFP4 tag is "installed" -- the GGUF blob was never pulled,
+  // e.g. because "Select" resolved straight to the faster build.
+  const mockOllama = await startMockOllama({ installedModels: ['gemma4:e2b-nvfp4'] });
+  try {
+    const { page } = await launchApp();
+
+    const listed = await page.evaluate(() => (window as StenoWindow).stenoai.models.list());
+    expect(listed.success).toBe(true);
+    const e2bEntry = listed.supported_models?.['gemma4:e2b-it-qat'];
+    expect(e2bEntry?.mlx_tag).toBe('gemma4:e2b-nvfp4');
+    expect(e2bEntry?.mlx_installed).toBe(true);
+    // The GGUF id itself was never pulled, but the model is fully usable via
+    // its NVFP4 sibling -- must not leave "Select" offered forever.
+    expect(e2bEntry?.installed).toBe(true);
+  } finally {
+    await mockOllama.close();
+  }
 });
 
 test('switch-to-faster-build: pull, verify, and delete the old tag all round-trip through IPC', async ({

--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -174,6 +174,33 @@ test('switch-to-faster-build: pull, verify, and delete the old tag all round-tri
   }
 });
 
+test('delete-model: the general "free up disk space" action can remove a GGUF model and its NVFP4 sibling directly', async ({
+  launchApp,
+}) => {
+  killOllama();
+  const mockOllama = await startMockOllama();
+  try {
+    const { page } = await launchApp();
+
+    // Unlike the switch-to-faster-build flow (which only ever deletes the
+    // GGUF id), the general delete action can target either tag on its own.
+    const ggufDelete = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.delete('gemma4:e4b-it-qat'),
+    );
+    expect(ggufDelete.success).toBe(true);
+    expect(mockOllama.lastDeletedModel()).toBe('gemma4:e4b-it-qat');
+
+    const nvfp4Delete = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.models.delete('gemma4:e4b-nvfp4'),
+    );
+    expect(nvfp4Delete.success).toBe(true);
+    expect(mockOllama.lastDeletedModel()).toBe('gemma4:e4b-nvfp4');
+    expect(mockOllama.deleteCalls()).toBe(2);
+  } finally {
+    await mockOllama.close();
+  }
+});
+
 test('cancel-pull: stops an in-flight download and reports it as cancelled, not a failure', async ({
   launchApp,
 }) => {

--- a/e2e/specs/setup-model-reuse.t2.spec.ts
+++ b/e2e/specs/setup-model-reuse.t2.spec.ts
@@ -80,3 +80,46 @@ test('setup reuses an installed supported model and skips the pull (#123)', asyn
   // Keystone: the real user-data dir is byte-for-byte untouched.
   expect(fileSig(realUserDataDir())).toBe(realDirBefore);
 });
+
+test('setup pulls the NVFP4 tag on Apple Silicon, but still persists the canonical GGUF id', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  if (!ollamaBinaryExists()) {
+    // eslint-disable-next-line no-console
+    console.warn('[t2] SKIPPED setup-model-reuse (mlx pull_target): bundled bin/ollama absent on this host.');
+    test.info().annotations.push({
+      type: 'skip-reason',
+      description: 'bin/ollama not present; setup-ollama-and-model refuses to proceed',
+    });
+  }
+  test.skip(!ollamaBinaryExists(), 'bundled bin/ollama unavailable on this runner');
+  test.skip(process.platform !== 'darwin' || process.arch !== 'arm64', 'pull_target only diverges on Apple Silicon');
+
+  const realDirBefore = fileSig(realUserDataDir());
+  killOllama();
+  // installedModels: [] -- unlike every other test in this file, this one
+  // needs setup to actually issue a pull rather than reuse an "already
+  // installed" default, so the mock must report nothing installed.
+  const mock = await startMockOllama({ installedModels: [] });
+  try {
+    // No config seeded and the mock lists nothing installed, so setup must pull.
+    const { page } = await launchApp();
+
+    const res = await page.evaluate(() =>
+      (window as StenoWindow).stenoai.setup.ollamaAndModel(),
+    );
+    expect(res.success).toBe(true);
+
+    // The Electron main process pulled the NVFP4 tag (pull_target from
+    // resolve-setup-model on Apple Silicon)...
+    expect(mock.lastPulledModel()).toBe('gemma4:e2b-nvfp4');
+    // ...but config.json still holds the canonical GGUF id -- config never
+    // stores an MLX tag (see docs/superpowers/specs/2026-07-01-ollama-mlx-tag-adoption-design.md).
+    await expect.poll(() => readUserConfig(userDataDir).model).toBe('gemma4:e2b-it-qat');
+  } finally {
+    await mock.close();
+  }
+
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-OLLAMA_VERSION="v0.30.8"
+OLLAMA_VERSION="v0.31.1"
 BIN_DIR="$(cd "$(dirname "$0")/.." && pwd)/bin"
 
 # --- Download ffmpeg ---

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3190,10 +3190,19 @@ def list_models():
         for model_id, info in models.items():
             # Match exactly, or where Ollama appended extra detail after the tag
             # e.g. "deepseek-r1:14b" matches "deepseek-r1:14b-qwen-distill-q4_K_M"
-            info['installed'] = any(
+            gguf_installed = any(
                 name == model_id or name.startswith(model_id + '-')
                 for name in installed_names
             )
+            # Kept distinct from 'installed' below: a model pulled straight to
+            # its NVFP4 tag (general "Select" resolves to that on Apple
+            # Silicon) never has the GGUF blob itself in Ollama, so callers
+            # that need to know "is the GGUF id actually there" (e.g. the
+            # Settings delete-to-free-space action, which must not try to
+            # delete a tag that was never pulled) can't rely on 'installed'
+            # alone once it's true-via-NVFP4-fallback.
+            info['gguf_installed'] = gguf_installed
+            info['installed'] = gguf_installed
             if apple_silicon:
                 mlx_tag = Config._MLX_EQUIVALENTS.get(model_id)
                 if mlx_tag:
@@ -3202,11 +3211,9 @@ def list_models():
                         name == mlx_tag or name.startswith(mlx_tag + '-')
                         for name in installed_names
                     )
-                    # A model pulled straight to its NVFP4 tag (general
-                    # "Select" now resolves to that on Apple Silicon, same as
-                    # setup's pull_target) is fully usable even though the
-                    # GGUF id itself was never downloaded -- report it
-                    # installed rather than leaving "Select" re-offered.
+                    # Fully usable even though the GGUF id itself was never
+                    # downloaded -- report it installed rather than leaving
+                    # "Select" re-offered.
                     if info['mlx_installed']:
                         info['installed'] = True
         result = {

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4065,15 +4065,18 @@ def verify_model(model_name):
 def delete_model(model_name):
     """Delete a locally-pulled Ollama model (uses HTTP API).
 
-    Only ever called by the Settings "switch to faster build" flow, and only
-    with the OLD GGUF tag, after its NVFP4 sibling has been pulled and
-    verified -- never the tag currently in active use. Restricted to
-    supported GGUF ids: this is a destructive IPC-reachable operation, so it
-    must not delete an arbitrary caller-supplied model name.
+    Called by the Settings "switch to faster build" flow (the old GGUF tag,
+    after its NVFP4 sibling has been pulled and verified) and by the general
+    "delete this model to free up disk space" action (either the GGUF id or
+    its NVFP4 sibling) -- never a tag currently in active use. Restricted to
+    supported GGUF ids and their NVFP4 siblings: this is a destructive
+    IPC-reachable operation, so it must not delete an arbitrary
+    caller-supplied model name.
     """
-    from src.config import get_config
+    from src.config import get_config, Config
 
-    if model_name not in get_config().list_supported_models():
+    allowed = set(get_config().list_supported_models()) | set(Config._MLX_EQUIVALENTS.values())
+    if model_name not in allowed:
         print(json.dumps({"success": False, "error": f"Refusing to delete unsupported model: {model_name}"}))
         return
     try:

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4179,9 +4179,20 @@ def resolve_setup_model():
         # Canonicalize any already-installed MLX tag back to its GGUF id so an
         # Apple-Silicon machine that only has e.g. gemma4:e2b-nvfp4 (from a
         # prior manual switch) is still recognised as "has a supported model".
-        canonical_installed = {
-            Config._MLX_TO_GGUF.get(name, name) for name in installed
-        }
+        # Also matches an NVFP4 tag with extra detail Ollama appended after
+        # it (the same fuzzy pattern list_models() uses for GGUF ids below,
+        # e.g. "deepseek-r1:14b" matching "deepseek-r1:14b-qwen-distill-q4_K_M")
+        # -- an exact dict lookup alone would miss that and cause a redundant
+        # re-download here even though list_models() already recognises it.
+        def _canonicalize_mlx_tag(name):
+            if name in Config._MLX_TO_GGUF:
+                return Config._MLX_TO_GGUF[name]
+            for mlx_tag, gguf_id in Config._MLX_TO_GGUF.items():
+                if name.startswith(mlx_tag + '-'):
+                    return gguf_id
+            return name
+
+        canonical_installed = {_canonicalize_mlx_tag(name) for name in installed}
         result["installed"] = pick_installed_supported_model(
             installed_names=canonical_installed,
             preferred=[config.get_model(), Config.DEFAULT_MODEL],

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4067,8 +4067,15 @@ def delete_model(model_name):
 
     Only ever called by the Settings "switch to faster build" flow, and only
     with the OLD GGUF tag, after its NVFP4 sibling has been pulled and
-    verified -- never the tag currently in active use.
+    verified -- never the tag currently in active use. Restricted to
+    supported GGUF ids: this is a destructive IPC-reachable operation, so it
+    must not delete an arbitrary caller-supplied model name.
     """
+    from src.config import get_config
+
+    if model_name not in get_config().list_supported_models():
+        print(json.dumps({"success": False, "error": f"Refusing to delete unsupported model: {model_name}"}))
+        return
     try:
         import ollama
         ollama.delete(model=model_name)

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3207,6 +3207,9 @@ def list_models():
                 mlx_tag = Config._MLX_EQUIVALENTS.get(model_id)
                 if mlx_tag:
                     info['mlx_tag'] = mlx_tag
+                    mlx_size = Config._MLX_SIZES.get(mlx_tag)
+                    if mlx_size:
+                        info['mlx_size'] = mlx_size
                     info['mlx_installed'] = any(
                         name == mlx_tag or name.startswith(mlx_tag + '-')
                         for name in installed_names

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4056,6 +4056,23 @@ def verify_model(model_name):
         print(json.dumps({"success": False, "error": str(e)}))
 
 
+@cli.command(name='delete-model')
+@click.argument('model_name')
+def delete_model(model_name):
+    """Delete a locally-pulled Ollama model (uses HTTP API).
+
+    Only ever called by the Settings "switch to faster build" flow, and only
+    with the OLD GGUF tag, after its NVFP4 sibling has been pulled and
+    verified -- never the tag currently in active use.
+    """
+    try:
+        import ollama
+        ollama.delete(model=model_name)
+        print(json.dumps({"success": True, "error": None}))
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+
+
 def pick_installed_supported_model(installed_names, preferred, supported_order, deprecated=()):
     """Pick the best already-installed supported Ollama model id, or None (#123).
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4022,7 +4022,11 @@ def pull_model(model_name):
             completed = getattr(progress, 'completed', 0) or 0
             if total > 0:
                 pct = int(completed / total * 100)
-                print(f"{status} {pct}%", flush=True)
+                # Byte counts appended in a machine-parseable suffix, on the
+                # SAME line as the percentage (not a separate print), so the
+                # renderer can compute a live transfer rate without it ever
+                # desyncing from the percentage it corresponds to.
+                print(f"{status} {pct}% ({completed}/{total})", flush=True)
             elif status:
                 print(status, flush=True)
         print(json.dumps({"success": True, "model": model_name}))

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3202,6 +3202,13 @@ def list_models():
                         name == mlx_tag or name.startswith(mlx_tag + '-')
                         for name in installed_names
                     )
+                    # A model pulled straight to its NVFP4 tag (general
+                    # "Select" now resolves to that on Apple Silicon, same as
+                    # setup's pull_target) is fully usable even though the
+                    # GGUF id itself was never downloaded -- report it
+                    # installed rather than leaving "Select" re-offered.
+                    if info['mlx_installed']:
+                        info['installed'] = True
         result = {
             "current_model": current_model,
             "supported_models": models,
@@ -4016,17 +4023,30 @@ def pull_model(model_name):
     start_ollama_server()
     try:
         import ollama
+        # Ollama models are made of several blobs (weights, params, tokenizer,
+        # ...), each streamed as its own 0-100% phase with a distinct status
+        # string -- without a marker, the percentage appearing to "restart"
+        # reads as a second, unrelated download. seen_statuses tracks which
+        # weighted (total>0) phases have already started so blob_index only
+        # advances on a genuinely new one, not on every repeated tick of the
+        # same blob.
+        seen_statuses = set()
+        blob_index = 0
         for progress in ollama.pull(model_name, stream=True):
             status = getattr(progress, 'status', '') or ''
             total = getattr(progress, 'total', 0) or 0
             completed = getattr(progress, 'completed', 0) or 0
             if total > 0:
+                if status not in seen_statuses:
+                    seen_statuses.add(status)
+                    blob_index += 1
                 pct = int(completed / total * 100)
-                # Byte counts appended in a machine-parseable suffix, on the
-                # SAME line as the percentage (not a separate print), so the
-                # renderer can compute a live transfer rate without it ever
-                # desyncing from the percentage it corresponds to.
-                print(f"{status} {pct}% ({completed}/{total})", flush=True)
+                # Byte counts and the blob/part index are appended in a
+                # machine-parseable suffix, on the SAME line as the
+                # percentage (not a separate print), so the renderer can
+                # compute a live transfer rate and part label without either
+                # ever desyncing from the percentage it corresponds to.
+                print(f"{status} {pct}% ({completed}/{total}) [Part {blob_index}]", flush=True)
             elif status:
                 print(status, flush=True)
         print(json.dumps({"success": True, "model": model_name}))

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4072,8 +4072,9 @@ def resolve_setup_model():
     """
     from src.config import get_config, Config
     from src.ollama_manager import start_ollama_server
+    from src.config import is_apple_silicon
 
-    result = {"installed": None}
+    result = {"installed": None, "pull_target": Config.DEFAULT_MODEL}
     try:
         start_ollama_server()
         import ollama
@@ -4088,11 +4089,22 @@ def resolve_setup_model():
             mid for mid, meta in Config.SUPPORTED_MODELS.items()
             if meta.get('deprecated')
         ]
+        # Canonicalize any already-installed MLX tag back to its GGUF id so an
+        # Apple-Silicon machine that only has e.g. gemma4:e2b-nvfp4 (from a
+        # prior manual switch) is still recognised as "has a supported model".
+        canonical_installed = {
+            Config._MLX_TO_GGUF.get(name, name) for name in installed
+        }
         result["installed"] = pick_installed_supported_model(
-            installed_names=installed,
+            installed_names=canonical_installed,
             preferred=[config.get_model(), Config.DEFAULT_MODEL],
             supported_order=list(Config.SUPPORTED_MODELS.keys()),
             deprecated=deprecated,
+        )
+        result["pull_target"] = (
+            Config._MLX_EQUIVALENTS.get(Config.DEFAULT_MODEL, Config.DEFAULT_MODEL)
+            if is_apple_silicon()
+            else Config.DEFAULT_MODEL
         )
     except Exception as e:
         result["error"] = str(e)

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4030,6 +4030,32 @@ def pull_model(model_name):
         print(json.dumps({"success": False, "error": str(e)}))
 
 
+@cli.command(name='verify-model')
+@click.argument('model_name')
+def verify_model(model_name):
+    """Smoke-test a just-pulled model with a 1-token chat call (uses HTTP API).
+
+    Used only by the Settings "switch to faster build" flow, to prove an
+    MLX/NVFP4 tag actually loads and responds before offering to delete the
+    old GGUF build. A generous timeout accounts for MLX cold-load (several
+    seconds after a fresh pull, per local benchmarking) -- a slow-but-working
+    model must not be reported as a failure.
+    """
+    from src.ollama_manager import start_ollama_server
+    start_ollama_server()
+    try:
+        import ollama
+        client = ollama.Client(timeout=90)
+        client.chat(
+            model=model_name,
+            messages=[{"role": "user", "content": "hi"}],
+            options={"num_predict": 1},
+        )
+        print(json.dumps({"success": True, "error": None}))
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+
+
 def pick_installed_supported_model(installed_names, preferred, supported_order, deprecated=()):
     """Pick the best already-installed supported Ollama model id, or None (#123).
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3174,12 +3174,19 @@ def list_models():
                 "error": error_msg
             }
     else:
-        models = config.list_supported_models()
+        # Per-entry dicts must be copied, not mutated in place: list_supported_models()
+        # returns a shallow copy whose nested dicts are the SAME objects as
+        # Config.SUPPORTED_MODELS. Mutating them directly would leak 'installed' /
+        # 'mlx_tag' / 'mlx_installed' into the class-level dict, contaminating any
+        # later call within the same process (e.g. repeated invocations in tests).
+        models = {model_id: dict(info) for model_id, info in config.list_supported_models().items()}
         try:
             import ollama as ollama_pkg
             installed_names = {getattr(m, 'model', '') for m in (getattr(ollama_pkg.list(), 'models', []) or [])}
         except Exception:
             installed_names = set()
+        from src.config import is_apple_silicon, Config
+        apple_silicon = provider == "local" and is_apple_silicon()
         for model_id, info in models.items():
             # Match exactly, or where Ollama appended extra detail after the tag
             # e.g. "deepseek-r1:14b" matches "deepseek-r1:14b-qwen-distill-q4_K_M"
@@ -3187,6 +3194,14 @@ def list_models():
                 name == model_id or name.startswith(model_id + '-')
                 for name in installed_names
             )
+            if apple_silicon:
+                mlx_tag = Config._MLX_EQUIVALENTS.get(model_id)
+                if mlx_tag:
+                    info['mlx_tag'] = mlx_tag
+                    info['mlx_installed'] = any(
+                        name == mlx_tag or name.startswith(mlx_tag + '-')
+                        for name in installed_names
+                    )
         result = {
             "current_model": current_model,
             "supported_models": models,

--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,7 @@ Handles storing and loading user preferences like model selection.
 import json
 import logging
 import os
+import platform
 import shutil
 import sys
 import tempfile
@@ -105,6 +106,15 @@ def is_bundled() -> bool:
         return True
     path = str(Path(__file__))
     return "StenoAI.app" in path or "Applications" in path
+
+
+def is_apple_silicon() -> bool:
+    """True on macOS running on Apple Silicon (arm64/aarch64).
+
+    The single gate for every Ollama-MLX-tag decision in this module — no
+    other function should re-derive this check.
+    """
+    return sys.platform == "darwin" and platform.machine() in ("arm64", "aarch64")
 
 
 class Config:
@@ -309,6 +319,17 @@ class Config:
         "gemma4:4b": "gemma4:e4b-it-qat",
         "gemma4:12b": "gemma4:12b-it-qat",
     }
+
+    # The three curated Gemma 4 QAT models' NVFP4/MLX-engine equivalents,
+    # adopted on Apple Silicon for a large generation-speed win (Ollama's MLX
+    # engine is GA there). Deliberately NOT applied to llama3.2:3b/qwen3.5:9b/
+    # gpt-oss:20b — Ollama does not ship MLX builds of those.
+    _MLX_EQUIVALENTS = {
+        "gemma4:e2b-it-qat": "gemma4:e2b-nvfp4",
+        "gemma4:e4b-it-qat": "gemma4:e4b-nvfp4",
+        "gemma4:12b-it-qat": "gemma4:12b-nvfp4",
+    }
+    _MLX_TO_GGUF = {mlx_tag: gguf_id for gguf_id, mlx_tag in _MLX_EQUIVALENTS.items()}
 
     # Curated models we retired — a user pinned to one is migrated to the
     # default on load. Deliberately a specific allow-list, NOT "anything not in
@@ -1116,3 +1137,18 @@ def get_data_dirs() -> Dict[str, Path]:
         d.mkdir(parents=True, exist_ok=True)
 
     return dirs
+
+
+def resolve_runtime_tag(model_id: str) -> str:
+    """Map a canonical GGUF model id to its NVFP4/MLX-engine tag on Apple
+    Silicon; a no-op everywhere else (including for models with no MLX
+    equivalent, e.g. llama3.2:3b).
+
+    This is the ONLY place a GGUF id is ever translated to an NVFP4 tag.
+    config.json, SUPPORTED_MODELS, and every migration/validation path keep
+    using the canonical GGUF id — callers must call this at the point a
+    literal Ollama model string is about to be sent, not before.
+    """
+    if not is_apple_silicon():
+        return model_id
+    return Config._MLX_EQUIVALENTS.get(model_id, model_id)

--- a/src/config.py
+++ b/src/config.py
@@ -331,6 +331,17 @@ class Config:
     }
     _MLX_TO_GGUF = {mlx_tag: gguf_id for gguf_id, mlx_tag in _MLX_EQUIVALENTS.items()}
 
+    # NVFP4 blobs are a different quantization than their GGUF counterpart in
+    # SUPPORTED_MODELS and can be meaningfully larger -- shown instead of the
+    # GGUF size whenever the NVFP4 tag is what's actually installed or (on a
+    # fresh pull) what "Select" will actually download. Keyed by the NVFP4
+    # tag, not the GGUF id, matching how it's looked up in list_models().
+    _MLX_SIZES = {
+        "gemma4:e2b-nvfp4": "6.5GB",
+        "gemma4:e4b-nvfp4": "8.8GB",
+        "gemma4:12b-nvfp4": "7.7GB",
+    }
+
     # Curated models we retired — a user pinned to one is migrated to the
     # default on load. Deliberately a specific allow-list, NOT "anything not in
     # SUPPORTED_MODELS": set_model intentionally allows arbitrary user-pulled

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -11,7 +11,7 @@ import time
 import os
 from typing import Optional, Dict, Any
 from .models import MeetingTranscript, ActionItem, Decision
-from .config import resolve_runtime_tag
+from .config import Config, resolve_runtime_tag
 from . import ollama_manager
 
 logger = logging.getLogger(__name__)
@@ -87,7 +87,13 @@ def resolve_num_ctx(model_name: str) -> int:
     Sized per known model, clamped to ``[FLOOR, CEILING]``; unknown models fall
     back to the conservative default. Pure function — unit-testable without a
     running model or Ollama.
+
+    ``model_name`` may be an NVFP4 tag (the resolved runtime model on Apple
+    Silicon) rather than the canonical GGUF id the lookup table is keyed by —
+    canonicalize back to the GGUF id first so both runtime variants share the
+    same window.
     """
+    model_name = Config._MLX_TO_GGUF.get(model_name, model_name)
     base = _OLLAMA_MODEL_NUM_CTX.get(model_name, OLLAMA_NUM_CTX_DEFAULT)
     return max(OLLAMA_NUM_CTX_FLOOR, min(base, OLLAMA_NUM_CTX_CEILING))
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -11,6 +11,7 @@ import time
 import os
 from typing import Optional, Dict, Any
 from .models import MeetingTranscript, ActionItem, Decision
+from .config import resolve_runtime_tag
 from . import ollama_manager
 
 logger = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ class OllamaSummarizer:
                     logger.warning(f"Failed to load model from config: {e}, using default")
                     model_name = config.DEFAULT_MODEL
 
-            self.model_name = model_name
+            self.model_name = resolve_runtime_tag(model_name)
             self._ensure_ollama_ready()
             self.client = ollama.Client()
     

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -351,5 +351,50 @@ class ConfigTemplateSeedingResilienceTests(unittest.TestCase):
         self.assertNotIn("nope", ids)
 
 
+class MlxTagResolutionTests(unittest.TestCase):
+    def test_is_apple_silicon_true_on_darwin_arm64(self):
+        with patch("src.config.sys.platform", "darwin"), \
+             patch("src.config.platform.machine", return_value="arm64"):
+            from src.config import is_apple_silicon
+            self.assertTrue(is_apple_silicon())
+
+    def test_is_apple_silicon_false_on_darwin_x86_64(self):
+        with patch("src.config.sys.platform", "darwin"), \
+             patch("src.config.platform.machine", return_value="x86_64"):
+            from src.config import is_apple_silicon
+            self.assertFalse(is_apple_silicon())
+
+    def test_is_apple_silicon_false_on_windows(self):
+        with patch("src.config.sys.platform", "win32"), \
+             patch("src.config.platform.machine", return_value="ARM64"):
+            from src.config import is_apple_silicon
+            self.assertFalse(is_apple_silicon())
+
+    def test_resolve_runtime_tag_maps_gguf_to_nvfp4_on_apple_silicon(self):
+        from src.config import resolve_runtime_tag
+        with patch("src.config.is_apple_silicon", return_value=True):
+            self.assertEqual(resolve_runtime_tag("gemma4:e2b-it-qat"), "gemma4:e2b-nvfp4")
+            self.assertEqual(resolve_runtime_tag("gemma4:e4b-it-qat"), "gemma4:e4b-nvfp4")
+            self.assertEqual(resolve_runtime_tag("gemma4:12b-it-qat"), "gemma4:12b-nvfp4")
+
+    def test_resolve_runtime_tag_is_noop_off_apple_silicon(self):
+        from src.config import resolve_runtime_tag
+        with patch("src.config.is_apple_silicon", return_value=False):
+            self.assertEqual(resolve_runtime_tag("gemma4:e2b-it-qat"), "gemma4:e2b-it-qat")
+
+    def test_resolve_runtime_tag_is_noop_for_non_gemma_models(self):
+        from src.config import resolve_runtime_tag
+        with patch("src.config.is_apple_silicon", return_value=True):
+            self.assertEqual(resolve_runtime_tag("llama3.2:3b"), "llama3.2:3b")
+            self.assertEqual(resolve_runtime_tag("qwen3.5:9b"), "qwen3.5:9b")
+            self.assertEqual(resolve_runtime_tag("gpt-oss:20b"), "gpt-oss:20b")
+
+    def test_mlx_to_gguf_is_exact_reverse_of_mlx_equivalents(self):
+        from src.config import Config
+        for gguf_id, mlx_tag in Config._MLX_EQUIVALENTS.items():
+            self.assertEqual(Config._MLX_TO_GGUF[mlx_tag], gguf_id)
+        self.assertEqual(len(Config._MLX_TO_GGUF), len(Config._MLX_EQUIVALENTS))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -32,6 +32,35 @@ class ListModelsMlxEnrichmentTests(unittest.TestCase):
         # "Select" now resolves to that on Apple Silicon) is fully usable,
         # and "installed: false" would leave "Select" offered forever.
         self.assertTrue(e2b_entry["installed"])
+        # But 'gguf_installed' must stay false so a caller (e.g. the Settings
+        # delete-to-free-space action) can tell the GGUF blob itself was
+        # never pulled, and not attempt to delete a tag that was never
+        # there (regression: this used to throw and leave the confirm
+        # dialog stuck, since ollama.delete() on a nonexistent tag errors).
+        self.assertFalse(e2b_entry["gguf_installed"])
+
+    def test_gguf_installed_true_when_gguf_blob_actually_present(self):
+        """The ordinary case: both the GGUF id and its NVFP4 sibling are
+        actually installed (e.g. after "switch to faster build")."""
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        fake_models = [
+            mock.Mock(model="gemma4:e2b-it-qat"),
+            mock.Mock(model="gemma4:e2b-nvfp4"),
+        ]
+        fake_response = mock.Mock(models=fake_models)
+
+        with mock.patch("src.config.is_apple_silicon", return_value=True), \
+             mock.patch("ollama.list", return_value=fake_response):
+            result = runner.invoke(cli, ["list-models"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        e2b_entry = data["supported_models"]["gemma4:e2b-it-qat"]
+        self.assertTrue(e2b_entry["gguf_installed"])
+        self.assertTrue(e2b_entry["mlx_installed"])
+        self.assertTrue(e2b_entry["installed"])
 
         # A model with no MLX equivalent gets neither field.
         llama_entry = data["supported_models"]["llama3.2:3b"]

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -176,6 +176,36 @@ class DeleteModelCommandTests(unittest.TestCase):
         self.assertFalse(data["success"])
         self.assertIn("not found", data["error"])
 
+    def test_delete_model_refuses_unsupported_model(self):
+        """delete-model is IPC-reachable and destructive, so it must not
+        forward an arbitrary caller-supplied name straight to ollama.delete()
+        -- only the canonical supported GGUF ids."""
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        with mock.patch("ollama.delete") as delete_mock:
+            result = runner.invoke(cli, ["delete-model", "not-a-real-model"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertFalse(data["success"])
+        self.assertIn("not-a-real-model", data["error"])
+        delete_mock.assert_not_called()
+
+    def test_delete_model_refuses_nvfp4_tag(self):
+        """The NVFP4/MLX tag itself is never a valid delete target -- only
+        its canonical GGUF sibling (the one actually in config.json)."""
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        with mock.patch("ollama.delete") as delete_mock:
+            result = runner.invoke(cli, ["delete-model", "gemma4:e2b-nvfp4"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertFalse(data["success"])
+        delete_mock.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -50,5 +50,53 @@ class ListModelsMlxEnrichmentTests(unittest.TestCase):
             self.assertNotIn("mlx_installed", entry)
 
 
+class ResolveSetupModelPullTargetTests(unittest.TestCase):
+    def test_pull_target_is_nvfp4_on_apple_silicon(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        fake_response = mock.Mock(models=[])
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("src.config.is_apple_silicon", return_value=True), \
+             mock.patch("ollama.list", return_value=fake_response):
+            result = runner.invoke(cli, ["resolve-setup-model"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertEqual(data["pull_target"], "gemma4:e2b-nvfp4")
+        self.assertIsNone(data["installed"])
+
+    def test_pull_target_is_gguf_default_off_apple_silicon(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        fake_response = mock.Mock(models=[])
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("src.config.is_apple_silicon", return_value=False), \
+             mock.patch("ollama.list", return_value=fake_response):
+            result = runner.invoke(cli, ["resolve-setup-model"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertEqual(data["pull_target"], "gemma4:e2b-it-qat")
+
+    def test_existing_nvfp4_install_is_recognised_as_supported(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        # Only the NVFP4 tag is installed (e.g. from a prior manual switch) --
+        # pick_installed_supported_model must canonicalize it back to the
+        # GGUF id to recognise "a supported model is already present".
+        fake_response = mock.Mock(models=[mock.Mock(model="gemma4:e2b-nvfp4")])
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("src.config.is_apple_silicon", return_value=True), \
+             mock.patch("ollama.list", return_value=fake_response):
+            result = runner.invoke(cli, ["resolve-setup-model"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertEqual(data["installed"], "gemma4:e2b-it-qat")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -192,9 +192,10 @@ class DeleteModelCommandTests(unittest.TestCase):
         self.assertIn("not-a-real-model", data["error"])
         delete_mock.assert_not_called()
 
-    def test_delete_model_refuses_nvfp4_tag(self):
-        """The NVFP4/MLX tag itself is never a valid delete target -- only
-        its canonical GGUF sibling (the one actually in config.json)."""
+    def test_delete_model_allows_nvfp4_sibling(self):
+        """The general "delete this model to free up disk space" action can
+        target either the GGUF id or its NVFP4 sibling directly -- e.g. to
+        remove just the faster build while keeping the GGUF installed."""
         from simple_recorder import cli
 
         runner = CliRunner()
@@ -203,8 +204,8 @@ class DeleteModelCommandTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         data = json.loads(result.output)
-        self.assertFalse(data["success"])
-        delete_mock.assert_not_called()
+        self.assertTrue(data["success"])
+        delete_mock.assert_called_once_with(model="gemma4:e2b-nvfp4")
 
 
 if __name__ == "__main__":

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -26,6 +26,11 @@ class ListModelsMlxEnrichmentTests(unittest.TestCase):
         e2b_entry = data["supported_models"]["gemma4:e2b-it-qat"]
         self.assertEqual(e2b_entry["mlx_tag"], "gemma4:e2b-nvfp4")
         self.assertTrue(e2b_entry["mlx_installed"])
+        # The NVFP4 blob is a different (larger) download than the GGUF
+        # entry's own 'size' -- shown separately so the UI doesn't claim the
+        # GGUF size while the NVFP4 tag is what's actually installed/pulled.
+        self.assertEqual(e2b_entry["mlx_size"], "6.5GB")
+        self.assertNotEqual(e2b_entry["mlx_size"], e2b_entry["size"])
         # Only the NVFP4 tag is in the fake `ollama.list()` response above --
         # the GGUF blob itself was never pulled. It must still report as
         # installed: a model fetched straight to its NVFP4 tag (general
@@ -82,6 +87,7 @@ class ListModelsMlxEnrichmentTests(unittest.TestCase):
         for entry in data["supported_models"].values():
             self.assertNotIn("mlx_tag", entry)
             self.assertNotIn("mlx_installed", entry)
+            self.assertNotIn("mlx_size", entry)
 
 
 class ResolveSetupModelPullTargetTests(unittest.TestCase):

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -132,5 +132,31 @@ class VerifyModelCommandTests(unittest.TestCase):
         self.assertIn("model not found", data["error"])
 
 
+class DeleteModelCommandTests(unittest.TestCase):
+    def test_delete_model_success(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        with mock.patch("ollama.delete") as delete_mock:
+            result = runner.invoke(cli, ["delete-model", "gemma4:e2b-it-qat"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertTrue(data["success"])
+        delete_mock.assert_called_once_with(model="gemma4:e2b-it-qat")
+
+    def test_delete_model_reports_failure(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        with mock.patch("ollama.delete", side_effect=RuntimeError("not found")):
+            result = runner.invoke(cli, ["delete-model", "gemma4:e2b-it-qat"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertFalse(data["success"])
+        self.assertIn("not found", data["error"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -98,5 +98,40 @@ class ResolveSetupModelPullTargetTests(unittest.TestCase):
         self.assertEqual(data["installed"], "gemma4:e2b-it-qat")
 
 
+class VerifyModelCommandTests(unittest.TestCase):
+    def test_verify_model_success(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("ollama.Client") as client_cls:
+            client_cls.return_value.chat.return_value = {
+                "message": {"role": "assistant", "content": "hi"}
+            }
+            result = runner.invoke(cli, ["verify-model", "gemma4:e2b-nvfp4"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertTrue(data["success"])
+        self.assertIsNone(data.get("error"))
+        client_cls.return_value.chat.assert_called_once()
+        _, kwargs = client_cls.return_value.chat.call_args
+        self.assertEqual(kwargs["model"], "gemma4:e2b-nvfp4")
+
+    def test_verify_model_reports_failure(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("ollama.Client") as client_cls:
+            client_cls.return_value.chat.side_effect = RuntimeError("model not found")
+            result = runner.invoke(cli, ["verify-model", "gemma4:e2b-nvfp4"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertFalse(data["success"])
+        self.assertIn("model not found", data["error"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -26,6 +26,12 @@ class ListModelsMlxEnrichmentTests(unittest.TestCase):
         e2b_entry = data["supported_models"]["gemma4:e2b-it-qat"]
         self.assertEqual(e2b_entry["mlx_tag"], "gemma4:e2b-nvfp4")
         self.assertTrue(e2b_entry["mlx_installed"])
+        # Only the NVFP4 tag is in the fake `ollama.list()` response above --
+        # the GGUF blob itself was never pulled. It must still report as
+        # installed: a model fetched straight to its NVFP4 tag (general
+        # "Select" now resolves to that on Apple Silicon) is fully usable,
+        # and "installed: false" would leave "Select" offered forever.
+        self.assertTrue(e2b_entry["installed"])
 
         # A model with no MLX equivalent gets neither field.
         llama_entry = data["supported_models"]["llama3.2:3b"]
@@ -146,9 +152,33 @@ class PullModelCommandTests(unittest.TestCase):
             result = runner.invoke(cli, ["pull-model", "gemma4:e2b-nvfp4"])
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("pulling model 21% (210/1000)", result.output)
+        self.assertIn("pulling model 21% (210/1000) [Part 1]", result.output)
         data = json.loads(result.output.strip().splitlines()[-1])
         self.assertTrue(data["success"])
+
+    def test_progress_line_increments_part_on_each_new_blob(self):
+        """A real model pull streams several weighted (total>0) blobs in
+        sequence -- the part index must advance once per distinct blob, not
+        once per repeated progress tick of the same blob."""
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        progress_events = [
+            mock.Mock(status="pulling abc123", total=1000, completed=500),
+            mock.Mock(status="pulling abc123", total=1000, completed=1000),
+            mock.Mock(status="pulling def456", total=2000, completed=1000),
+            mock.Mock(status="verifying sha256 digest", total=0, completed=0),
+        ]
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("ollama.pull", return_value=iter(progress_events)):
+            result = runner.invoke(cli, ["pull-model", "gemma4:e2b-nvfp4"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        lines = result.output.strip().splitlines()
+        self.assertIn("pulling abc123 50% (500/1000) [Part 1]", lines)
+        self.assertIn("pulling abc123 100% (1000/1000) [Part 1]", lines)
+        self.assertIn("pulling def456 50% (1000/2000) [Part 2]", lines)
+        self.assertIn("verifying sha256 digest", lines)
 
 
 class DeleteModelCommandTests(unittest.TestCase):

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -132,6 +132,25 @@ class VerifyModelCommandTests(unittest.TestCase):
         self.assertIn("model not found", data["error"])
 
 
+class PullModelCommandTests(unittest.TestCase):
+    def test_progress_line_includes_raw_byte_counts(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        progress_events = [
+            mock.Mock(status="pulling manifest", total=0, completed=0),
+            mock.Mock(status="pulling model", total=1000, completed=210),
+        ]
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("ollama.pull", return_value=iter(progress_events)):
+            result = runner.invoke(cli, ["pull-model", "gemma4:e2b-nvfp4"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("pulling model 21% (210/1000)", result.output)
+        data = json.loads(result.output.strip().splitlines()[-1])
+        self.assertTrue(data["success"])
+
+
 class DeleteModelCommandTests(unittest.TestCase):
     def test_delete_model_success(self):
         from simple_recorder import cli

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -137,6 +137,25 @@ class ResolveSetupModelPullTargetTests(unittest.TestCase):
         data = json.loads(result.output)
         self.assertEqual(data["installed"], "gemma4:e2b-it-qat")
 
+    def test_nvfp4_install_with_extra_tag_detail_is_recognised(self):
+        """Ollama can append extra detail after a tag (the same pattern
+        list_models() already handles for GGUF ids, e.g. "deepseek-r1:14b"
+        matching "deepseek-r1:14b-qwen-distill-q4_K_M"). An exact dict
+        lookup alone would miss this for NVFP4 tags and cause a redundant
+        re-download even though a supported model is already present."""
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        fake_response = mock.Mock(models=[mock.Mock(model="gemma4:e2b-nvfp4-extra-detail")])
+        with mock.patch("src.ollama_manager.start_ollama_server", return_value=True), \
+             mock.patch("src.config.is_apple_silicon", return_value=True), \
+             mock.patch("ollama.list", return_value=fake_response):
+            result = runner.invoke(cli, ["resolve-setup-model"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        self.assertEqual(data["installed"], "gemma4:e2b-it-qat")
+
 
 class VerifyModelCommandTests(unittest.TestCase):
     def test_verify_model_success(self):

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -1,0 +1,54 @@
+"""Tests for the list_models() CLI command's platform-conditional MLX enrichment."""
+
+import json
+import unittest
+from unittest import mock
+
+from click.testing import CliRunner
+
+
+class ListModelsMlxEnrichmentTests(unittest.TestCase):
+    def test_apple_silicon_gemma_entries_gain_mlx_fields(self):
+        # Exercises the real Config.SUPPORTED_MODELS + list_supported_models(),
+        # only mocking the Ollama HTTP call and the platform gate.
+        from simple_recorder import cli
+        from src.config import Config
+
+        runner = CliRunner()
+        fake_models = [mock.Mock(model="gemma4:e2b-nvfp4")]
+        fake_response = mock.Mock(models=fake_models)
+
+        with mock.patch("src.config.is_apple_silicon", return_value=True), \
+             mock.patch("ollama.list", return_value=fake_response):
+            result = runner.invoke(cli, ["list-models"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        e2b_entry = data["supported_models"]["gemma4:e2b-it-qat"]
+        self.assertEqual(e2b_entry["mlx_tag"], "gemma4:e2b-nvfp4")
+        self.assertTrue(e2b_entry["mlx_installed"])
+
+        # A model with no MLX equivalent gets neither field.
+        llama_entry = data["supported_models"]["llama3.2:3b"]
+        self.assertNotIn("mlx_tag", llama_entry)
+        self.assertNotIn("mlx_installed", llama_entry)
+
+    def test_off_apple_silicon_payload_has_no_mlx_fields(self):
+        from simple_recorder import cli
+
+        runner = CliRunner()
+        fake_response = mock.Mock(models=[])
+
+        with mock.patch("src.config.is_apple_silicon", return_value=False), \
+             mock.patch("ollama.list", return_value=fake_response):
+            result = runner.invoke(cli, ["list-models"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output)
+        for entry in data["supported_models"].values():
+            self.assertNotIn("mlx_tag", entry)
+            self.assertNotIn("mlx_installed", entry)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_simple_recorder_models.py
+++ b/tests/test_simple_recorder_models.py
@@ -12,7 +12,6 @@ class ListModelsMlxEnrichmentTests(unittest.TestCase):
         # Exercises the real Config.SUPPORTED_MODELS + list_supported_models(),
         # only mocking the Ollama HTTP call and the platform gate.
         from simple_recorder import cli
-        from src.config import Config
 
         runner = CliRunner()
         fake_models = [mock.Mock(model="gemma4:e2b-nvfp4")]

--- a/tests/test_summarizer_num_ctx.py
+++ b/tests/test_summarizer_num_ctx.py
@@ -67,14 +67,26 @@ class ResolveNumCtxTests(unittest.TestCase):
         )
 
     def test_nvfp4_tag_resolves_to_same_num_ctx_as_its_gguf_sibling(self):
-        self.assertEqual(
-            resolve_num_ctx("gemma4:12b-nvfp4"),
-            resolve_num_ctx("gemma4:12b-it-qat"),
-        )
-        self.assertEqual(
-            resolve_num_ctx("gemma4:e2b-nvfp4"),
-            resolve_num_ctx("gemma4:e2b-it-qat"),
-        )
+        # A value deliberately different from OLLAMA_NUM_CTX_DEFAULT proves the
+        # NVFP4 tag is actually canonicalized to its GGUF sibling before lookup,
+        # rather than merely falling through to the default (which happens to
+        # equal today's real Gemma entries, making a same-value test pass
+        # either way regardless of whether canonicalization runs).
+        with mock.patch.dict(
+            _OLLAMA_MODEL_NUM_CTX,
+            {"gemma4:12b-it-qat": 65536, "gemma4:e2b-it-qat": 16384},
+        ):
+            self.assertEqual(
+                resolve_num_ctx("gemma4:12b-nvfp4"),
+                resolve_num_ctx("gemma4:12b-it-qat"),
+            )
+            self.assertEqual(resolve_num_ctx("gemma4:12b-nvfp4"), 65536)
+
+            self.assertEqual(
+                resolve_num_ctx("gemma4:e2b-nvfp4"),
+                resolve_num_ctx("gemma4:e2b-it-qat"),
+            )
+            self.assertEqual(resolve_num_ctx("gemma4:e2b-nvfp4"), 16384)
 
 
 class LocalProviderModelResolutionTests(unittest.TestCase):

--- a/tests/test_summarizer_num_ctx.py
+++ b/tests/test_summarizer_num_ctx.py
@@ -66,6 +66,16 @@ class ResolveNumCtxTests(unittest.TestCase):
             msg=f"active registry models missing a num_ctx entry: {missing}",
         )
 
+    def test_nvfp4_tag_resolves_to_same_num_ctx_as_its_gguf_sibling(self):
+        self.assertEqual(
+            resolve_num_ctx("gemma4:12b-nvfp4"),
+            resolve_num_ctx("gemma4:12b-it-qat"),
+        )
+        self.assertEqual(
+            resolve_num_ctx("gemma4:e2b-nvfp4"),
+            resolve_num_ctx("gemma4:e2b-it-qat"),
+        )
+
 
 class LocalProviderModelResolutionTests(unittest.TestCase):
     def _make_config(self, model_id):

--- a/tests/test_summarizer_num_ctx.py
+++ b/tests/test_summarizer_num_ctx.py
@@ -67,5 +67,43 @@ class ResolveNumCtxTests(unittest.TestCase):
         )
 
 
+class LocalProviderModelResolutionTests(unittest.TestCase):
+    def _make_config(self, model_id):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = model_id
+        return cfg
+
+    def test_local_provider_resolves_to_nvfp4_on_apple_silicon(self):
+        from src.summarizer import OllamaSummarizer
+        cfg = self._make_config("gemma4:e2b-it-qat")
+        with mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready"), \
+             mock.patch("src.summarizer.ollama.Client"), \
+             mock.patch("src.config.is_apple_silicon", return_value=True):
+            summarizer = OllamaSummarizer(config=cfg)
+        self.assertEqual(summarizer.model_name, "gemma4:e2b-nvfp4")
+
+    def test_local_provider_keeps_gguf_off_apple_silicon(self):
+        from src.summarizer import OllamaSummarizer
+        cfg = self._make_config("gemma4:e2b-it-qat")
+        with mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready"), \
+             mock.patch("src.summarizer.ollama.Client"), \
+             mock.patch("src.config.is_apple_silicon", return_value=False):
+            summarizer = OllamaSummarizer(config=cfg)
+        self.assertEqual(summarizer.model_name, "gemma4:e2b-it-qat")
+
+    def test_remote_provider_is_never_resolved(self):
+        from src.summarizer import OllamaSummarizer
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "remote"
+        cfg.get_remote_ollama_url.return_value = "http://192.168.1.50:11434"
+        cfg.get_model.return_value = "gemma4:e2b-it-qat"
+        with mock.patch("src.summarizer.ollama.Client"), \
+             mock.patch("src.config.is_apple_silicon", return_value=True):
+            summarizer = OllamaSummarizer(config=cfg)
+        self.assertEqual(summarizer.model_name, "gemma4:e2b-it-qat")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Ollama shipped a native MLX inference engine for Apple Silicon behind alternate
model tags (e.g. `gemma4:e2b-nvfp4` vs. the GGUF `gemma4:e2b-it-qat`), and
0.31.1 added Multi-Token Prediction for Gemma 4 on top of that — a real,
locally-benchmarked speedup with no code on our side beyond adopting the tags.
This bundles the newer Ollama build and adds a "switch to faster build" flow
so existing users on Apple Silicon can opt into it without a fresh setup.

This is one of the two active tracks agreed during the current feature freeze
(alongside #258); it doesn't touch #232 (the larger in-process MLX-LM
question), which stays open as a structural discussion now that this closes
the pure performance gap.

## What changed

- **Core resolution**: `config.json`'s `model` field always stays the
  canonical GGUF id. `resolve_runtime_tag()` in `src/config.py` maps it to
  the NVFP4 sibling only at the point `OllamaSummarizer` (local provider
  only) hands a model string to Ollama's HTTP API — gated by
  `is_apple_silicon()`. Verified end-to-end that no write path ever persists
  an NVFP4 tag to disk.
- **Settings UI**: a "Switch to faster build" affordance per installed model
  (Apple Silicon + not already on the faster tag) that pulls the NVFP4 tag,
  smoke-tests it with a 1-token chat call before declaring success, and
  offers to delete the now-redundant GGUF build.
- **New backend commands**: `verify-model` (post-pull smoke test) and
  `delete-model` (remove the old GGUF build), both via Ollama's HTTP API —
  no shelling out to the bundled binary.
- **Bundled Ollama bumped to v0.31.1.**

### Fixed along the way (live manual testing + independent Codex review)

- `resolve_num_ctx()` now canonicalizes NVFP4 tags back to GGUF before its
  context-length lookup (was silently falling back to the default).
- Window flicker during large downloads: throttled `model-pull-progress` IPC
  to 5/sec, and replaced variable-width progress text with a fixed-width bar
  (two independent causes of the same visual symptom).
- Live transfer-rate (MB/s) indicator on the download progress bar.
- Download progress now rehydrates on remount (e.g. navigating away from
  Settings and back) — the download lives in the main process regardless of
  renderer lifecycle, and so does its terminal outcome now (a pull that
  finishes while unmounted is still discovered and verified on return,
  instead of resetting to "not started").
- Guard against starting a second "switch to faster build" while one is
  already in flight — both for a different model (UI-level) and for the
  same model racing in twice, e.g. a double-click (main-process-level).
- `delete-model` restricted to the canonical supported GGUF ids — it's a
  destructive IPC-reachable operation and shouldn't forward an arbitrary
  caller-supplied name straight to `ollama.delete()`.

## Testing

- `python -m unittest discover tests`: 314 passed
- `npm run typecheck:renderer` / `npm run lint:renderer`: clean (41
  pre-existing, unrelated warnings)
- New/updated e2e coverage: Apple-Silicon-gated `pull_target` on setup, and
  the switch/verify/delete round-trip through IPC
  (`model-management.t2.spec.ts`)
- Manually tested the packaged flow end-to-end on Apple Silicon: fresh pull,
  window-flicker fixes, transfer-rate display, navigate-away-and-back
  rehydration, and the concurrent-switch guard
- Independent Codex review of the full branch diff before opening this PR;
  all Important findings fixed (see above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Ollama’s MLX/NVFP4 Apple Silicon builds and improves model management and download UX for faster local inference. On Apple Silicon, selecting an uninstalled model now pulls the NVFP4 tag with clearer multi‑part progress, cancel, and correct NVFP4 sizes; config always keeps the GGUF id.

- **New Features**
  - Apple Silicon: resolve GGUF ids to NVFP4/MLX at send‑time; first‑run setup and “Select” pull the NVFP4 tag; config stores the GGUF id.
  - Models list: adds `mlx_tag`/`mlx_installed` and `gguf_installed`; shows the NVFP4 blob’s size when NVFP4 is installed or targeted; treats an NVFP4‑only install as “installed”; shows an “MLX model” badge when active.
  - Settings: “Switch to faster build” pulls NVFP4, verifies with a 1‑token chat, then offers to delete the old GGUF build; new “Delete model to free up disk space” removes a GGUF id and, when present, its NVFP4 sibling (accepts either tag).
  - Unified downloads: fixed‑width bar with live MB/s and “Part N” for multi‑blob pulls; Cancel control; progress rehydrates on remount via tracked in‑flight/completed pulls.
  - IPC/CLI: `verify-model`, `delete-model`, `cancel-pull`, `get-active-pulls`; main blocks duplicate pulls. Bundled `ollama` updated to `v0.31.1`.

- **Bug Fixes**
  - `resolve_num_ctx` canonicalizes NVFP4 tags back to GGUF for correct window lookups.
  - Smoothed large‑download UI: throttled progress events to 5/sec; removed per‑tick text reflow; fixed overflow that clipped MB/s/Part and overlapped Cancel.
  - Prevented concurrent “switch to faster build” attempts and duplicate pulls; canceling a pull reports “Cancelled” only when the process was actually signal‑killed; `delete-model` restricted to supported GGUF ids and NVFP4 siblings.
  - “Delete to free up disk space” no longer tries to delete a GGUF tag that was never pulled; waits for all tag deletions and logs failures; always closes the confirm dialog even on errors.
  - Size and labels: show the NVFP4 blob’s own size instead of the GGUF entry’s when applicable; MLX badge tooltip reflects whether the GGUF build was ever pulled.
  - Setup on Apple Silicon: fuzzy NVFP4 matching avoids redundant re‑downloads when Ollama appends extra tag detail; outcome persists so a remount replays verify and delete‑old‑build offers.
  - Select/download UX: Whisper/Parakeet show a disabled “Downloading” when no cancel handler is wired; cleared pending selections on any pull outcome to prevent stray `set()` calls after a cancel/failure.
  - Switch to faster build: removed a duplicate progress bar and layout collapse by suppressing the general download UI during a switch, enabling flex‑wrap, and rendering the switch block full‑width.

<sup>Written for commit cb7c4bc88e450f6b0f9ad5b40316b338a007b74f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

