### PR TITLE
feat: add granola-to-steno migration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ If you're looking for a hosted desktop recording API, consider checking out [Rec
 - **Bring your own cloud model** — Optional OpenAI, Anthropic, AWS Bedrock (Claude — including application inference profile ARNs for governed AWS environments), or custom API endpoint for users who prefer a hosted LLM.
 - **Organisation AI** — On managed deployments, sign in to your org's Steno adapter and AI routes through it automatically — no local API key, no per-user setup.
 
+## Coming from Granola?
+
+If you already use Claude Code / Cowork with a connected Granola MCP, the
+[`granola-to-steno`](skills/granola-to-steno/README.md) skill syncs your Granola
+meeting notes (titles, dates, participants, summaries, and transcripts) into
+Steno's file-based store. It is idempotent and re-runnable, so you can backfill
+your history once and keep it in sync on a schedule. This is an agent skill you
+drop into your skills folder and invoke conversationally ("sync Granola to
+Steno"), not an in-app feature. See
+[`skills/granola-to-steno/README.md`](skills/granola-to-steno/README.md) for
+setup and limitations.
+
 ## macOS Shortcuts (Optional)
 
 <details>

--- a/skills/granola-to-steno/README.md
+++ b/skills/granola-to-steno/README.md
@@ -1,0 +1,84 @@
+# granola-to-steno
+
+Originally contributed by @SylvainRamousse in ruzin/stenoai#265, polished for
+inclusion in the repo.
+
+A Cowork / Claude **skill** that syncs Granola meeting notes into StenoAI's
+file-based store. Drop it into a Cowork session (or any Claude environment that
+loads skills) and ask it to "sync Granola to Steno".
+
+## What it does
+
+1. Reads recent meetings from a connected **Granola MCP**
+   (`list_meetings` -> `get_meetings` -> `get_meeting_transcript`).
+2. Stages each meeting as plain-text files (`meta.txt`, `summary.txt`,
+   `transcript.txt`).
+3. Runs `scripts/steno_gen.py` to render StenoAI's expected files:
+   - `output/<stem>_summary.md`
+   - `transcripts/<stem>_transcript.txt`
+4. Copies them into the target StenoAI directory (iCloud-aware, with retries).
+
+The sync is **idempotent and append-only**: filenames derive from
+`date + slug(title)`, so re-running rewrites existing meetings in place and only
+adds new ones. Safe to run on a schedule. Each generated file also carries the
+source Granola meeting id in its frontmatter (`granola_id`), so if two different
+meetings ever hash to the same filename, the generator can tell them apart
+across separate runs instead of one silently overwriting the other - see
+"Notes for the StenoAI team" below for the residual edge case this doesn't
+cover.
+
+## Who it's for
+
+People who already migrated (or are migrating) from Granola to StenoAI and use
+Claude Code / Cowork with a connected Granola MCP. It is an agent skill, not an
+in-app feature: nothing in the StenoAI app runs it, and it never talks to Granola
+directly - it drives the Granola MCP tools the host agent already has.
+
+## Contents
+
+- `SKILL.md` - the skill definition and step-by-step instructions for the agent.
+- `scripts/steno_gen.py` - the standalone generator (the StenoAI-specific
+  formatting). Usage:
+  `python3 steno_gen.py <input_dir> <target_dir> [--language LANG]`.
+
+## Notes for the StenoAI team
+
+- The generator **never writes `*_summary.json`** (StenoAI's lister prefers JSON
+  and its JSON branch drops `session_info.summary_file`, breaking the detail
+  view). The `.md` carries everything the parser needs.
+- Summary text is normalized for StenoAI's plain-text renderer (UPPERCASE
+  headings, `•` bullets, blank line between blocks).
+- Output language is a `--language` flag (default `en`), written to both the
+  frontmatter `language` field and the transcript header. Granola exposes no
+  per-meeting language, so it is one value per sync run.
+- `duration_seconds` is written as `null` (unknown), matching what StenoAI's own
+  writer emits when it has no duration - the app hides an absent/`0` duration
+  identically, so this is a correctness fix (represent unknown as unknown), not
+  a behavior change.
+- Dates that fail to parse fall back to a **deterministic** placeholder (hash of
+  the raw date + title), never `datetime.now()`, so the stem is stable across
+  runs and the meeting is not duplicated. A `WARNING` is printed to stderr so the
+  operator can fix the locale mismatch.
+- **Cross-run stem collisions.** Two different meetings can compute the same
+  stem (same title + date to the minute). Within a single run this was already
+  suffixed; across separate runs (e.g. meeting X drops out of the sync window
+  in a later run, meeting Y takes over its stem) the generator now checks the
+  on-disk file's `granola_id` before writing: if it belongs to a different
+  meeting (or has no `granola_id` at all, e.g. a file from before this fix, or
+  something unrelated), the incoming write is suffixed with the source id
+  instead of overwriting it. This is safe-by-default but not perfect: a file
+  that already existed under the exact target stem *before* this fix shipped
+  will look "foreign" the first time and get a one-off suffixed sibling rather
+  than being adopted in place.
+
+## Known limitations
+
+- **Key Topics / Key Points / Action Items are empty.** Granola's data shape does
+  not expose these as separate structured fields (they are folded into the free
+  text summary), so the generator leaves those StenoAI sections blank rather than
+  inventing content. The full summary still lands in the Summary section.
+- **Language is per-run, not per-meeting.** Granola does not report a detected
+  language, so `--language` applies to the whole batch. Run separate syncs if you
+  have meetings in different languages and care about the tag.
+- **Duration is unknown.** Granola does not expose a meeting duration, so
+  `duration_seconds` is always `null` (the app simply omits the duration badge).

--- a/skills/granola-to-steno/SKILL.md
+++ b/skills/granola-to-steno/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: granola-to-steno
+description: >
+  Sync Granola meeting notes into StenoAI's file-based store. Reads recent
+  meetings from the Granola MCP (titles, dates, participants, AI summaries,
+  verbatim transcripts) and regenerates StenoAI's `output/*_summary.md` and
+  `transcripts/*_transcript.txt` files in a target folder (e.g. an iCloud Drive
+  directory). The operation is idempotent: filenames derive from date + title,
+  so re-running rewrites existing meetings in place and only adds new ones. Use
+  when the user says "sync Granola to Steno", "import my Granola meetings into
+  StenoAI", "resync Steno", "refresh Steno from Granola", or runs this on a
+  schedule. Requires a connected Granola MCP and Python 3.
+---
+
+# Granola -> StenoAI sync
+
+This skill rebuilds StenoAI's local meeting files from Granola. StenoAI stores
+each meeting as two files in a folder it watches:
+
+```
+<STENO_DIR>/output/<stem>_summary.md        # frontmatter + Summary + Transcript + sections
+<STENO_DIR>/transcripts/<stem>_transcript.txt
+```
+
+`<stem>` is `YYYYMMDD-HHMM_<slugified-title>`. Because the stem is derived from
+the meeting's date and title, **rewriting an existing meeting is a no-op and new
+meetings are simply added** - the whole flow is safe to run repeatedly and on a
+schedule.
+
+The bundled generator (`scripts/steno_gen.py`) does the StenoAI-specific
+formatting (cleans Granola markdown into the plain-text shape Steno renders,
+diarises the transcript, writes both files). This skill's job is to gather the
+raw Granola data into a simple staging folder and hand it to the generator.
+
+---
+
+## Prerequisites
+
+- A connected **Granola MCP** exposing `list_meetings`, `get_meetings`, and
+  `get_meeting_transcript`. The MCP server id is environment-specific, so load
+  the tools by name with ToolSearch rather than assuming a fixed prefix.
+- **Python 3** available in the shell.
+- A **target StenoAI directory** containing (or able to contain) `output/` and
+  `transcripts/` subfolders. This is often inside iCloud Drive - see Step 3.
+
+---
+
+## Step 0 - Gather settings
+
+Decide these up front (ask the user only if not obvious; otherwise use the
+defaults):
+
+- **Time range** - default: union of `this_week` and `last_week`. For a one-off
+  backfill use `last_30_days` or a `custom` range.
+- **Target StenoAI directory** (`STENO_DIR`) - see Step 3.
+- **Language** - the language your meetings are in, as a short code (`en`, `fr`,
+  `de`, ...). Defaults to `en`. Passed to the generator via `--language` in
+  Step 6.
+
+## Step 1 - Load the Granola tools
+
+Load the three Granola tools in one ToolSearch call, e.g.:
+
+```
+ToolSearch { query: "list_meetings get_meetings get_meeting_transcript", max_results: 5 }
+```
+
+Confirm the matched tools belong to the Granola server before calling them.
+
+## Step 2 - List recent meetings
+
+Call `list_meetings(time_range="this_week")` and
+`list_meetings(time_range="last_week")` (or the chosen range). Take the **union
+of meeting ids** and de-duplicate. If there are none, report "Nothing to sync"
+and stop.
+
+## Step 3 - Locate the target StenoAI directory
+
+Resolve `STENO_DIR` in this order:
+
+1. An explicit path the user gave you.
+2. A `STENO_DIR` environment variable, if set.
+3. Auto-detect a StenoAI folder under the user's connected folders. In a shell
+   with iCloud mounted this is typically:
+   ```bash
+   BASE=$(ls -d /sessions/*/mnt/*CloudDocs* 2>/dev/null | head -1)
+   STENO_DIR="$BASE/StenoAI"
+   ```
+   (Adjust the mount glob to the actual workspace layout.)
+
+If you cannot find it, ask the user for the path. Ensure
+`"$STENO_DIR/output"` and `"$STENO_DIR/transcripts"` exist (create them).
+
+> **iCloud note:** files in an iCloud folder can be cloud-only or briefly locked
+> by sync. If a shell command on such a path fails with *"Resource deadlock
+> avoided"* or the file is cloud-only, fall back to the host file tools
+> (Read/Write) for that file - they download/write through iCloud natively.
+> See Step 6.
+
+## Step 4 - Fetch meeting data and transcripts
+
+For the collected ids:
+
+- Call `get_meetings(meeting_ids=[...])` in **batches of <=10**. Capture for each
+  meeting: `title`, the **exact displayed date** string (e.g.
+  `"Jun 26, 2026 2:30 PM GMT+2"`), `known_participants`, and `summary`.
+- Call `get_meeting_transcript(meeting_id)` for each meeting. It may return
+  `null`/empty (no transcript) - that's fine, treat it as an empty transcript.
+
+## Step 5 - Write the raw staging files
+
+In your working directory, create `granola_sync/<id>/` per meeting and write
+**plain-text `.txt` files only** (do not write `.md` for staging, and never
+write a `_summary.json`):
+
+- `meta.txt` - exactly three lines, a real **TAB** between key and value:
+  ```
+  title<TAB><title>
+  date<TAB><exact date string>
+  participants<TAB><Name A>; <Name B>; ...
+  ```
+  Strip emails (`<...>`), `from <Company>`, and `(note creator)` from
+  participant names; separate names with `; `.
+- `summary.txt` - the raw Granola summary verbatim (empty file if none).
+- `transcript.txt` - the raw verbatim transcript (empty file if null).
+
+## Step 6 - Generate and copy into StenoAI
+
+Snapshot the existing summaries first so you can report what's new, then run the
+bundled generator and copy the results into `STENO_DIR` with retries (iCloud may
+lock files transiently):
+
+```bash
+WORK=/path/to/your/working/dir          # holds granola_sync/
+SKILL_DIR=/path/to/this/skill           # holds scripts/steno_gen.py
+LANG_CODE=en                            # meeting language from Step 0
+
+ls "$STENO_DIR/output" > /tmp/steno_before.txt 2>/dev/null || true
+
+rm -rf /tmp/steno_out
+python3 "$SKILL_DIR/scripts/steno_gen.py" "$WORK/granola_sync" /tmp/steno_out --language "$LANG_CODE"
+
+cp_retry(){ for i in 1 2 3 4 5 6; do cp -f "$1" "$2" 2>/dev/null && return 0; sleep 2; done; echo "FAIL $2"; }
+mkdir -p "$STENO_DIR/output" "$STENO_DIR/transcripts"
+for f in /tmp/steno_out/output/*;      do cp_retry "$f" "$STENO_DIR/output/$(basename "$f")"; done
+for f in /tmp/steno_out/transcripts/*; do cp_retry "$f" "$STENO_DIR/transcripts/$(basename "$f")"; done
+```
+
+Verify by comparing file **sizes** between `/tmp/steno_out/...` and
+`STENO_DIR/...` (use `stat -c %s`, which does not trigger the iCloud read lock
+that `cmp`/`diff` can). If any file failed to copy because of an iCloud
+*"Resource deadlock avoided"* lock, write that one file through the **host file
+tools** instead: read the generated file's content and Write it directly to the
+`STENO_DIR` path (the host filesystem handles iCloud natively).
+
+If the generator prints a `WARNING: could not parse date ...` line to stderr,
+surface it to the user: that meeting's date could not be read (usually a locale
+mismatch in the displayed Granola date), so it got a stable placeholder date.
+The file is still written idempotently, but its date will be wrong until the raw
+date string parses.
+
+## Step 7 - Report
+
+Give a short summary: number of meetings processed, and the list of **new**
+titles - those whose `*_summary.md` was not present in
+`/tmp/steno_before.txt`. Do not paste summaries or transcripts into the report.
+
+---
+
+## Notes for implementers (StenoAI team)
+
+- The generator intentionally **never writes `*_summary.json`**. StenoAI's
+  `list_meetings` scans JSON before Markdown and de-dupes by stem; the JSON
+  branch omits `session_info.summary_file`, which breaks the detail view
+  ("Note not found"). The `.md` carries everything the parser needs.
+- StenoAI renders the **Summary** field as plain text and collapses single
+  newlines, so the generator converts Granola markdown into clean text:
+  de-escapes `\~ \* \_` etc., turns `### Heading` into an UPPERCASE line and
+  `- bullet` into `• bullet`, and inserts a blank line between blocks so nothing
+  collapses. Change this only if StenoAI's renderer changes.
+- The output **language** is a CLI flag: `--language <code>` (default `en`). It
+  is written to the frontmatter `language` field and to the transcript header's
+  `Language setting:` / `Detected language:` / `Summary output language:` lines.
+  Granola does not expose a per-meeting language, so this is a single value for
+  the whole sync run.
+- `duration_seconds` is written as `null` (unknown), matching what StenoAI's own
+  writer emits when it has no duration. Granola does not expose a meeting
+  duration.
+- An **unparseable date** falls back to a *deterministic* placeholder derived
+  from the raw date + title (never `now()`), so re-running the sync produces the
+  same stem and the meeting is not duplicated. The generator prints a `WARNING`
+  to stderr in that case.
+- Transcript diarisation keys off `Me:` / `Them:` / `Speaker N:` markers and puts
+  each turn on its own line. Meetings with no transcript yield an empty
+  transcript body (and `is_diarised: false` in the frontmatter).
+- Everything is keyed on `stem = <date>_<slug(title)>`, so the sync is
+  idempotent and append-only by construction. Each file's frontmatter also
+  carries the source `granola_id`, so if two different meetings ever compute
+  the same stem, a later run can tell "this is the same meeting again" apart
+  from "a different meeting took this stem" and suffix the newcomer instead of
+  overwriting unrelated content.

--- a/skills/granola-to-steno/SKILL.md
+++ b/skills/granola-to-steno/SKILL.md
@@ -142,13 +142,15 @@ python3 "$SKILL_DIR/scripts/steno_gen.py" "$WORK/granola_sync" /tmp/steno_out --
 
 cp_retry(){ for i in 1 2 3 4 5 6; do cp -f "$1" "$2" 2>/dev/null && return 0; sleep 2; done; echo "FAIL $2"; }
 mkdir -p "$STENO_DIR/output" "$STENO_DIR/transcripts"
-for f in /tmp/steno_out/output/*;      do cp_retry "$f" "$STENO_DIR/output/$(basename "$f")"; done
-for f in /tmp/steno_out/transcripts/*; do cp_retry "$f" "$STENO_DIR/transcripts/$(basename "$f")"; done
+for f in /tmp/steno_out/output/*;      do [ -e "$f" ] || continue; cp_retry "$f" "$STENO_DIR/output/$(basename "$f")"; done
+for f in /tmp/steno_out/transcripts/*; do [ -e "$f" ] || continue; cp_retry "$f" "$STENO_DIR/transcripts/$(basename "$f")"; done
 ```
 
 Verify by comparing file **sizes** between `/tmp/steno_out/...` and
-`STENO_DIR/...` (use `stat -c %s`, which does not trigger the iCloud read lock
-that `cmp`/`diff` can). If any file failed to copy because of an iCloud
+`STENO_DIR/...` — use `stat -f %z "$f"` on macOS (or `stat -c %s "$f"` on
+Linux), which reports the byte size without triggering the iCloud read lock
+that `cmp`/`diff` can. StenoAI + iCloud Drive run on macOS, so `stat -f %z` is
+the one you'll normally need. If any file failed to copy because of an iCloud
 *"Resource deadlock avoided"* lock, write that one file through the **host file
 tools** instead: read the generated file's content and Write it directly to the
 `STENO_DIR` path (the host filesystem handles iCloud natively).

--- a/skills/granola-to-steno/scripts/steno_gen.py
+++ b/skills/granola-to-steno/scripts/steno_gen.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Granola -> StenoAI migration generator.
+
+Reads one folder per meeting from an input dir:
+  <in>/<id>/meta.txt        # lines "key<TAB>value": title, date, participants
+  <in>/<id>/summary.txt     # raw Granola AI summary (may be empty/missing)
+  <in>/<id>/transcript.txt  # raw verbatim transcript (may be empty/missing)
+
+meta.txt:
+  title<TAB>Candidature peopulse S Ramousse
+  date<TAB>Jun 26, 2026 2:30 PM GMT+2
+  participants<TAB>Name A <a@x>; Name B from Co <b@y>
+
+Writes StenoAI's file-based store into:
+  <target>/output/<stem>_summary.md      (ONLY this is globbed for listing)
+  <target>/transcripts/<stem>_transcript.txt
+
+Usage:
+  python3 steno_gen.py <input_dir> <target_dir> [--language LANG]
+
+NOTE: never write *_summary.json -- StenoAI's list_meetings scans json before md,
+dedupes by stem, and the json branch omits session_info.summary_file, which breaks
+the detail view ("Note not found"). The .md carries everything the parser needs.
+"""
+import argparse
+import datetime
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+MONTHS = {m: i for i, m in enumerate(
+    ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], 1)}
+
+
+def _stable_fallback_date(raw: str, title: str) -> str:
+    # The file stem is derived from this timestamp, so an unparseable date MUST
+    # yield the same value on every run or the meeting would get a new stem each
+    # sync and duplicate forever. datetime.now() would break that invariant, so
+    # we hash the raw date + title into a deterministic pseudo-timestamp instead.
+    seed = hashlib.sha256(f"{raw}\x00{title}".encode("utf-8")).hexdigest()
+    offset = int(seed[:8], 16)
+    dt = datetime.datetime(2000, 1, 1) + datetime.timedelta(seconds=offset)
+    return dt.replace(microsecond=0).isoformat()
+
+
+def parse_date(raw: str, title: str = "") -> str:
+    m = re.match(r"([A-Za-z]{3})\s+(\d{1,2}),\s+(\d{4})\s+(\d{1,2}):(\d{2})\s*(AM|PM)?", raw or "")
+    if m:
+        mon, day, year, hh, mm, ap = m.groups()
+        hh = int(hh)
+        mm = int(mm)
+        if ap == "PM" and hh != 12:
+            hh += 12
+        if ap == "AM" and hh == 12:
+            hh = 0
+        try:
+            return datetime.datetime(int(year), MONTHS[mon], int(day), hh, mm, 0).isoformat()
+        except Exception:
+            pass
+    print(
+        f"WARNING: could not parse date {raw!r} for {title!r}, using a stable "
+        "fallback timestamp - this meeting's date will be wrong, check your "
+        "Granola locale",
+        file=sys.stderr,
+    )
+    return _stable_fallback_date(raw or "", title or "")
+
+
+def slugify(s, maxlen=48):
+    s = (s or "").strip().lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return (s[:maxlen].rstrip("-")) or "meeting"
+
+
+def make_stem(date_iso, title):
+    d = date_iso.replace(":", "").replace("-", "")
+    d = re.sub(r"T(\d{2})(\d{2})\d{2}", r"-\1\2", d)
+    return f"{d}_{slugify(title)}"
+
+
+def name_only(p):
+    p = re.sub(r"<[^>]*>", "", p)
+    p = re.split(r"\s+from\s+", p)[0]
+    p = p.replace("(note creator)", "")
+    return p.strip().strip(",").strip()
+
+
+def clean_summary(summary):
+    """StenoAI renders the Summary field as PLAIN TEXT (no markdown) and
+    collapses single newlines. So convert Granola markdown into clean text:
+    de-escape, '### Heading' -> UPPERCASE line, '- bullet' -> '* bullet',
+    and put a blank line between every block so nothing collapses."""
+    if not summary or not summary.strip():
+        return ""
+    s = re.sub(r'\\([~*_`#\-])', r'\1', summary)
+    out = []
+    for raw in s.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        h = re.match(r'^#{1,6}\s+(.+)$', line)
+        if h:
+            out.append(h.group(1).strip().upper())
+        elif re.match(r'^[-*]\s+', line):
+            out.append(re.sub(r'^[-*]\s+', '• ', line))
+        else:
+            out.append(line)
+    return "\n\n".join(out)
+
+
+def diarise(transcript):
+    if not transcript:
+        return "", False
+    t = transcript.strip()
+    has = bool(re.search(r"\b(Me|Them|Speaker\s*\d+):", t))
+    t = re.sub(r"\s*\b(Me|Them|Speaker\s*\d+):\s*", lambda m: "\n" + m.group(1) + ": ", t)
+    t = re.sub(r"\n{2,}", "\n", t).strip()
+    return t, has
+
+
+def yaml_scalar(v):
+    if v is None:
+        return ": null"
+    if isinstance(v, bool):
+        return ": true" if v else ": false"
+    if isinstance(v, int):
+        return f": {v}"
+    # A literal newline in a scalar would inject a bogus extra "key" line into
+    # the frontmatter block once StenoAI's line-by-line parser reads it back,
+    # so collapse embedded newlines before quoting rather than trying to
+    # round-trip them (the app's frontmatter has no multi-line scalar syntax).
+    s = str(v).replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    s = s.replace("\\", "\\\\").replace('"', '\\"')
+    return f': "{s}"'
+
+
+def render_frontmatter(d):
+    return "\n".join(["---"] + [f"{k}{yaml_scalar(v)}" for k, v in d.items()] + ["---"])
+
+
+def build(meeting, language="en"):
+    title = (meeting.get("title") or "Untitled").strip()
+    date_iso = parse_date(meeting.get("date_raw", ""), title)
+    stem = make_stem(date_iso, title)
+    parts = [name_only(p) for p in meeting.get("participants", []) if name_only(p)
+             and name_only(p).lower() != "unknown"]
+    summary = clean_summary(meeting.get("summary") or "")
+    transcript, is_diar = diarise(meeting.get("transcript") or "")
+
+    fm = render_frontmatter({
+        "title": title,
+        "date": date_iso,
+        "duration_seconds": None,
+        "language": language,
+        "is_diarised": is_diar,
+        "transcription_failed": False,
+        # Unknown frontmatter keys are ignored by StenoAI's parser. This one
+        # lets a later run tell "re-syncing the same Granola meeting" apart
+        # from "a different meeting collided on the same computed stem".
+        "granola_id": meeting.get("id"),
+    })
+    md = [fm, ""]
+    md += ["## Summary", "", summary or "_(migrated from Granola)_", ""]
+    md += ["## Participants", "", ", ".join(parts), ""]
+    md += ["## Key Topics", "", ""]
+    md += ["## Key Points", "", ""]
+    md += ["## Action Items", "", ""]
+    md += ["## Transcript", "", transcript, ""]
+    md += ["## User Notes", "", ""]
+    summary_md = "\n".join(md)
+
+    header = (
+        f"Session: {title}\nFile: {stem}\n"
+        f"Date: {date_iso.replace('T', ' ')}\n"
+        f"Language setting: {language}\nDetected language: {language}\n"
+        f"Summary output language: {language}\n"
+        + "=" * 60 + "\n"
+    )
+    transcript_txt = header + transcript + "\n"
+    return stem, summary_md, transcript_txt
+
+
+def load_meeting(folder: Path):
+    meta = {}
+    mp = folder / "meta.txt"
+    if mp.exists():
+        for line in mp.read_text(encoding="utf-8").splitlines():
+            if "\t" in line:
+                k, v = line.split("\t", 1)
+                meta[k.strip().lower()] = v.strip()
+    parts = []
+    if meta.get("participants"):
+        parts = [p.strip() for p in re.split(r"[;|]", meta["participants"]) if p.strip()]
+    summary = ""
+    for cand in ("summary.txt", "summary.md"):
+        sp = folder / cand
+        if sp.exists():
+            summary = sp.read_text(encoding="utf-8")
+            break
+    transcript = ""
+    tp = folder / "transcript.txt"
+    if tp.exists():
+        transcript = tp.read_text(encoding="utf-8")
+    return {
+        "id": folder.name,
+        "title": meta.get("title", ""),
+        "date_raw": meta.get("date", ""),
+        "participants": parts,
+        "summary": summary,
+        "transcript": transcript,
+    }
+
+
+def _stem_owner(md_path: Path):
+    """Return the granola_id recorded in an existing StenoAI file's frontmatter,
+    or None if the file has no such marker (pre-upgrade file, or unrelated
+    content). Used to distinguish a re-sync of the same meeting from a
+    same-stem collision with something else."""
+    try:
+        content = md_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not content.startswith("---"):
+        return None
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None
+    for line in parts[1].strip().splitlines():
+        if line.startswith("granola_id:"):
+            value = line.split(":", 1)[1].strip()
+            return value.strip('"') or None
+    return None
+
+
+def _stem_taken(out_dir: Path, candidate: str, source_id: str, seen: set) -> bool:
+    if candidate in seen:
+        return True
+    existing = out_dir / f"{candidate}_summary.md"
+    return existing.exists() and _stem_owner(existing) != source_id
+
+
+def resolve_stem(out_dir: Path, stem: str, source_id: str, seen: set) -> str:
+    """Pick the stem to actually write under. A stem collides if it was
+    already claimed earlier in this run, or if a file for it already exists on
+    disk and belongs (per its granola_id) to a different meeting -- including
+    files with no marker at all, which are treated conservatively as foreign
+    rather than silently overwritten. On collision, suffix with (a prefix of)
+    the source meeting's own id so repeated runs land on the same name.
+
+    The suffixed candidate is checked for uniqueness too: two different ids
+    can share their first few characters, so a short prefix alone isn't
+    guaranteed free. We widen the prefix and, in the pathological case where
+    even the full id is taken, fall back to a deterministic counter -- never
+    randomness, so the same input always resolves to the same final stem."""
+    if not _stem_taken(out_dir, stem, source_id, seen):
+        return stem
+
+    sid = source_id or "dup"
+    tried_ids = []
+    for length in (6, 8, len(sid)):
+        candidate_id = sid[:length]
+        if candidate_id in tried_ids:
+            continue
+        tried_ids.append(candidate_id)
+        candidate = f"{stem}-{candidate_id}"
+        if not _stem_taken(out_dir, candidate, source_id, seen):
+            return candidate
+
+    counter = 2
+    while True:
+        candidate = f"{stem}-{sid}-{counter}"
+        if not _stem_taken(out_dir, candidate, source_id, seen):
+            return candidate
+        counter += 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render StenoAI files from staged Granola meetings.")
+    ap.add_argument("input_dir")
+    ap.add_argument("target_dir")
+    ap.add_argument("--language", default="en",
+                    help="Language code written to the frontmatter and transcript header (default: en).")
+    args = ap.parse_args()
+
+    in_dir = Path(args.input_dir)
+    target = Path(args.target_dir)
+    out_dir = target / "output"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tr_dir = target / "transcripts"
+    tr_dir.mkdir(parents=True, exist_ok=True)
+    n = 0
+    seen = set()
+    for folder in sorted(p for p in in_dir.iterdir() if p.is_dir()):
+        if not (folder / "meta.txt").exists():
+            continue
+        meeting = load_meeting(folder)
+        if not meeting["title"]:
+            print(f"  ! skip {folder.name} (no title)")
+            continue
+        stem, smd, ttxt = build(meeting, language=args.language)
+        final_stem = resolve_stem(out_dir, stem, meeting["id"], seen)
+        if final_stem != stem:
+            ttxt = ttxt.replace(f"File: {stem}\n", f"File: {final_stem}\n", 1)
+        seen.add(final_stem)
+        (out_dir / f"{final_stem}_summary.md").write_text(smd, encoding="utf-8")
+        (tr_dir / f"{final_stem}_transcript.txt").write_text(ttxt, encoding="utf-8")
+        n += 1
+    print(f"Done: {n} meeting(s) -> {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_granola_steno_gen.py
+++ b/tests/test_granola_steno_gen.py
@@ -1,0 +1,269 @@
+import importlib.util
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "skills" / "granola-to-steno" / "scripts" / "steno_gen.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("granola_steno_gen", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+steno_gen = _load_module()
+
+
+class LanguageFlagTests(unittest.TestCase):
+    def test_language_flows_into_frontmatter_and_header(self):
+        meeting = {
+            "title": "Weekly sync",
+            "date_raw": "Jun 26, 2026 2:30 PM GMT+2",
+            "participants": ["Alice", "Bob"],
+            "summary": "Some notes",
+            "transcript": "Me: hello\nThem: hi",
+        }
+        _stem, summary_md, transcript_txt = steno_gen.build(meeting, language="de")
+
+        self.assertIn('language: "de"', summary_md)
+        self.assertIn("Language setting: de", transcript_txt)
+        self.assertIn("Detected language: de", transcript_txt)
+        self.assertIn("Summary output language: de", transcript_txt)
+
+    def test_language_defaults_to_en(self):
+        meeting = {"title": "Standup", "date_raw": "Jun 26, 2026 2:30 PM GMT+2"}
+        _stem, summary_md, transcript_txt = steno_gen.build(meeting)
+
+        self.assertIn('language: "en"', summary_md)
+        self.assertIn("Language setting: en", transcript_txt)
+
+
+class CliInvocationTests(unittest.TestCase):
+    def test_language_flag_via_actual_cli(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            meeting_dir = tmp_path / "in" / "meeting-1"
+            meeting_dir.mkdir(parents=True)
+            (meeting_dir / "meta.txt").write_text(
+                "title\tWeekly Sync\ndate\tJun 26, 2026 2:30 PM GMT+2\nparticipants\tAlice; Bob\n",
+                encoding="utf-8",
+            )
+            (meeting_dir / "summary.txt").write_text("Some notes", encoding="utf-8")
+            (meeting_dir / "transcript.txt").write_text("Me: hi\n", encoding="utf-8")
+
+            out_dir = tmp_path / "out"
+            result = subprocess.run(
+                [
+                    sys.executable, str(_SCRIPT),
+                    str(tmp_path / "in"), str(out_dir),
+                    "--language", "de",
+                ],
+                capture_output=True, text=True, check=True,
+            )
+            self.assertEqual(result.returncode, 0)
+
+            generated = list((out_dir / "output").glob("*_summary.md"))
+            self.assertEqual(len(generated), 1)
+            content = generated[0].read_text(encoding="utf-8")
+            self.assertIn('language: "de"', content)
+
+
+class DurationTests(unittest.TestCase):
+    def test_unknown_duration_renders_as_null_not_zero(self):
+        meeting = {"title": "Standup", "date_raw": "Jun 26, 2026 2:30 PM GMT+2"}
+        _stem, summary_md, _transcript_txt = steno_gen.build(meeting)
+
+        self.assertIn("duration_seconds: null", summary_md)
+        self.assertNotIn("duration_seconds: 0", summary_md)
+
+
+class DeterministicDateFallbackTests(unittest.TestCase):
+    def test_unparseable_date_is_deterministic_across_runs(self):
+        meeting = {"title": "Réunion", "date_raw": "26 juin 2026 14:30"}
+
+        with redirect_stderr(io.StringIO()):
+            stem_a, _md_a, _tx_a = steno_gen.build(meeting)
+            stem_b, _md_b, _tx_b = steno_gen.build(meeting)
+
+        self.assertEqual(stem_a, stem_b)
+
+    def test_different_unparseable_inputs_produce_different_stems(self):
+        # Guards against a hardcoded/constant fallback: the deterministic
+        # timestamp must actually vary with the input, not just be stable.
+        meeting_a = {"title": "Réunion A", "date_raw": "26 juin 2026 14:30"}
+        meeting_b = {"title": "Réunion B", "date_raw": "27 juillet 2026 09:00"}
+
+        with redirect_stderr(io.StringIO()):
+            stem_a, _md_a, _tx_a = steno_gen.build(meeting_a)
+            stem_b, _md_b, _tx_b = steno_gen.build(meeting_b)
+
+        self.assertNotEqual(stem_a, stem_b)
+
+    def test_unparseable_date_warns_on_stderr(self):
+        meeting = {"title": "Réunion", "date_raw": "26 juin 2026 14:30"}
+
+        err = io.StringIO()
+        with redirect_stderr(err):
+            steno_gen.build(meeting)
+
+        message = err.getvalue()
+        self.assertIn("could not parse date", message)
+        self.assertIn("26 juin 2026 14:30", message)
+
+    def test_parseable_date_does_not_warn(self):
+        meeting = {"title": "Standup", "date_raw": "Jun 26, 2026 2:30 PM GMT+2"}
+
+        err = io.StringIO()
+        with redirect_stderr(err):
+            steno_gen.build(meeting)
+
+        self.assertEqual(err.getvalue(), "")
+
+
+class FrontmatterEscapingTests(unittest.TestCase):
+    def test_title_with_embedded_newline_does_not_break_frontmatter(self):
+        meeting = {
+            "title": "Line one\nLine two",
+            "date_raw": "Jun 26, 2026 2:30 PM GMT+2",
+        }
+        _stem, summary_md, _transcript_txt = steno_gen.build(meeting)
+
+        fm_block = summary_md.split("---")[1]
+        fm_lines = [line for line in fm_block.strip().splitlines() if line.strip()]
+        # One line per frontmatter key -- an unescaped newline in a scalar
+        # would inject a bogus extra "key" line here and corrupt the block.
+        self.assertEqual(len(fm_lines), 7)
+        self.assertIn('title: "Line one Line two"', summary_md)
+
+
+class StemCollisionTests(unittest.TestCase):
+    def test_no_existing_file_returns_base_stem(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = steno_gen.resolve_stem(out_dir, "20260626-1430_weekly-sync", "id-a", set())
+            self.assertEqual(stem, "20260626-1430_weekly-sync")
+
+    def test_same_owner_on_disk_is_not_a_collision(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = "20260626-1430_weekly-sync"
+            (out_dir / f"{stem}_summary.md").write_text(
+                '---\ntitle: "Weekly Sync"\ngranola_id: "id-a"\n---\n', encoding="utf-8"
+            )
+            resolved = steno_gen.resolve_stem(out_dir, stem, "id-a", set())
+            self.assertEqual(resolved, stem)
+
+    def test_different_owner_on_disk_gets_suffixed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = "20260626-1430_weekly-sync"
+            (out_dir / f"{stem}_summary.md").write_text(
+                '---\ntitle: "Weekly Sync"\ngranola_id: "id-a"\n---\n', encoding="utf-8"
+            )
+            resolved = steno_gen.resolve_stem(out_dir, stem, "id-b", set())
+            self.assertNotEqual(resolved, stem)
+            self.assertTrue(resolved.startswith(stem + "-"))
+
+    def test_unmarked_existing_file_is_treated_as_foreign(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = "20260626-1430_weekly-sync"
+            (out_dir / f"{stem}_summary.md").write_text(
+                '---\ntitle: "Weekly Sync"\n---\n', encoding="utf-8"
+            )
+            resolved = steno_gen.resolve_stem(out_dir, stem, "id-b", set())
+            self.assertNotEqual(resolved, stem)
+
+    def test_cross_run_collision_does_not_clobber_a_dropped_out_meeting(self):
+        # Reproduces the reported scenario: run A writes meetings X and Y
+        # under a colliding stem (Y suffixed); a later run B only carries Y
+        # (X has left the sync window) and must not silently take over X's
+        # file just because run B's in-memory `seen` set starts empty.
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = "20260626-1430_weekly-sync"
+
+            seen_run_a = set()
+            x_stem = steno_gen.resolve_stem(out_dir, stem, "id-x", seen_run_a)
+            (out_dir / f"{x_stem}_summary.md").write_text(
+                '---\ntitle: "Weekly Sync"\ngranola_id: "id-x"\n---\n', encoding="utf-8"
+            )
+            seen_run_a.add(x_stem)
+
+            y_stem = steno_gen.resolve_stem(out_dir, stem, "id-y", seen_run_a)
+            self.assertNotEqual(y_stem, x_stem)
+            (out_dir / f"{y_stem}_summary.md").write_text(
+                '---\ntitle: "Weekly Sync"\ngranola_id: "id-y"\n---\n', encoding="utf-8"
+            )
+
+            # Run B: fresh process, fresh `seen` set, only Y in the window.
+            y_stem_run_b = steno_gen.resolve_stem(out_dir, stem, "id-y", set())
+            self.assertEqual(y_stem_run_b, y_stem)
+
+            x_content = (out_dir / f"{x_stem}_summary.md").read_text(encoding="utf-8")
+            self.assertIn("id-x", x_content)
+
+    def test_suffixed_candidates_sharing_an_id_prefix_still_get_distinct_stems(self):
+        # Reproduces the exact report: two different ids share their first 6
+        # characters, so the naive single-candidate suffix ("stem-abcdef" for
+        # both) would collide with itself and the second write would clobber
+        # the first. resolve_stem must widen the suffix until it finds a
+        # stem that is actually free.
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = "20260626-1430_weekly-sync"
+            seen = {stem, f"{stem}-abcdef"}
+
+            first = steno_gen.resolve_stem(out_dir, stem, "abcdef1", set(seen))
+            second = steno_gen.resolve_stem(out_dir, stem, "abcdef2", set(seen))
+
+            self.assertNotEqual(first, second)
+            self.assertNotEqual(first, f"{stem}-abcdef")
+            self.assertNotEqual(second, f"{stem}-abcdef")
+
+    def test_suffixed_candidates_stay_distinct_when_written_in_sequence(self):
+        # Same scenario as above but driven like main() actually drives it:
+        # each resolved stem is written to disk and added to `seen` before
+        # the next meeting is resolved, within a single run.
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = "20260626-1430_weekly-sync"
+            (out_dir / f"{stem}_summary.md").write_text(
+                '---\ntitle: "Weekly Sync"\ngranola_id: "id-other"\n---\n', encoding="utf-8"
+            )
+            (out_dir / f"{stem}-abcdef_summary.md").write_text(
+                '---\ntitle: "Weekly Sync"\ngranola_id: "abcdef0"\n---\n', encoding="utf-8"
+            )
+            seen = {stem, f"{stem}-abcdef"}
+
+            first = steno_gen.resolve_stem(out_dir, stem, "abcdef1", seen)
+            seen.add(first)
+            second = steno_gen.resolve_stem(out_dir, stem, "abcdef2", seen)
+
+            self.assertNotEqual(first, second)
+
+    def test_pathological_full_id_collision_falls_back_to_a_counter(self):
+        # Even if a full id is somehow already taken (adversarial input, or
+        # two identical ids from different sources), resolve_stem must still
+        # terminate deterministically rather than looping or colliding.
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stem = "20260626-1430_weekly-sync"
+            seen = {stem, f"{stem}-dupid", f"{stem}-dupid-2"}
+
+            resolved = steno_gen.resolve_stem(out_dir, stem, "dupid", seen)
+
+            self.assertEqual(resolved, f"{stem}-dupid-3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adopts and polishes the Claude-agent skill @SylvainRamousse contributed in #265 to sync Granola meeting notes into StenoAI's file-based store. Per discussion, this is not an app feature - it's a standalone skill for users who already run Claude Code/Cowork with a connected Granola MCP, referenced from the README.

- Adds `skills/granola-to-steno/` (`SKILL.md`, `README.md`, `scripts/steno_gen.py`), based on Sylvain's contribution.
- Adds a "Coming from Granola?" section to the root README pointing at it.
- Fixes found while polishing:
  - `language` was hardcoded to `"fr"` in two places -> now a `--language` CLI flag (default `en`).
  - `duration_seconds` was hardcoded to `0` -> now `null` (matches StenoAI's own writer's "unknown" representation; the UI hides both identically, so no visible behavior change, just more honest data).
  - Unparseable dates fell back to `datetime.now()`, which broke the skill's own "idempotent, rewrite in place" claim - a date that failed to parse got a new stem (and therefore a duplicate file) on every sync run. Now falls back to a deterministic placeholder derived from the raw date + title, with a stderr warning.
  - Added a `granola_id` frontmatter marker so cross-run stem collisions (two different meetings landing on the same computed filename across separate sync runs) get detected and suffixed instead of one silently overwriting the other.
- Left alone on purpose: Key Topics / Key Points / Action Items stay empty, since Granola's summary doesn't come pre-split into those categories. Documented as a known limitation.

## Test plan

- [x] `python -m unittest tests.test_granola_steno_gen -v` - 17 tests, all passing
- [x] `ruff check skills/ tests/test_granola_steno_gen.py` - clean
- [x] Two rounds of Codex review against the diff, all findings (cross-run collision, suffix-uniqueness, CLI-flag test coverage, YAML newline escaping) addressed
- [x] No changes to `app/`, `simple_recorder.py`, or `src/` - purely additive

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone `granola-to-steno` skill to sync Granola meeting notes into StenoAI’s file-based store. Includes a Python generator and docs, plus a README entry to help users migrate from Granola.

- **New Features**
  - Added `skills/granola-to-steno/` with `SKILL.md`, `README.md`, and `scripts/steno_gen.py`.
  - Idempotent sync generates `output/*_summary.md` and `transcripts/*_transcript.txt`.
  - Root README adds “Coming from Granola?” with setup and limitations.

- **Bug Fixes**
  - Language is now a `--language` CLI flag (default `en`) written to frontmatter and transcript header.
  - `duration_seconds` set to `null` when unknown.
  - Unparseable dates fall back to a deterministic timestamp with a stderr warning (prevents duplicate stems).
  - Added `granola_id` frontmatter and collision-safe stem resolution to stop cross-run overwrites; suffixes with the meeting id when needed.
  - SKILL guide uses macOS-correct `stat -f %z` with a Linux fallback, and guards empty `cp` globs to avoid retry loops.

<sup>Written for commit 1056d25d5a3347d5e331e16238b42d7fe0f308eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

