### PR TITLE
feat(transcript): per-segment [MM:SS] timestamps (live + saved)

### DIFF
--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -23,6 +23,21 @@ import { PARAKEET_LANGUAGES } from '@/lib/transcription-languages';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { formatElapsed } from '@/lib/utils';
 
+// Format a segment's start offset (seconds since recording start): MM:SS under
+// an hour, H:MM:SS beyond it. The live pipeline already emits per-segment
+// `start` on every LIVE_SEG, so this is a pure render of data we already have.
+// Kept in the same MM:SS / H:MM:SS shape as the saved-transcript formatter
+// (_format_timestamp in src/transcriber.py, which TranscriptPanel then parses
+// back out) so the live view and the saved transcript read the same.
+function fmtTimestamp(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const hh = Math.floor(s / 3600);
+  const mm = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return hh ? `${hh}:${pad(mm)}:${pad(ss)}` : `${pad(mm)}:${pad(ss)}`;
+}
+
 /**
  * Live transcript dock — Granola-style.
  *
@@ -270,11 +285,17 @@ function LiveTranscriptBodyState({ status, error, segments, filtering, slow }: B
           <li
             key={i}
             className={cn(
-              'flex px-1 py-0.5',
-              isYou ? 'justify-end' : 'justify-start',
+              'flex flex-col gap-0.5 px-1 py-0.5',
+              isYou ? 'items-end' : 'items-start',
             )}
             style={{ opacity: seg.isFinal ? 1 : 0.55 }}
           >
+            <span
+              className="px-1.5 text-[10.5px] tabular-nums"
+              style={{ color: 'var(--fg-2)' }}
+            >
+              {fmtTimestamp(seg.start)}
+            </span>
             <div
               className={cn(
                 'max-w-[78%] rounded-2xl px-3 py-1.5 text-sm leading-[1.5]',

--- a/app/renderer/src/components/TranscriptPanel.tsx
+++ b/app/renderer/src/components/TranscriptPanel.tsx
@@ -4,11 +4,7 @@ import { Search as SearchIcon } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { useMeeting } from '@/hooks/useMeetings';
-
-interface Segment {
-  speaker: 'You' | 'Others' | null;
-  text: string;
-}
+import { parseTranscript, type Segment } from '@/lib/transcriptSegments';
 
 /** Local-meeting wrapper — fetches the meeting JSON, then renders. Kept as
  *  the original API so existing callers don't change. */
@@ -140,7 +136,12 @@ function TranscriptRow({ segment, highlight }: { segment: Segment; highlight: st
   // `Others` markers still render as grey/left.
   const isYou = segment.speaker !== 'Others';
   return (
-    <div className={cn('flex px-1 py-0.5', isYou ? 'justify-end' : 'justify-start')}>
+    <div className={cn('flex flex-col gap-0.5 px-1 py-0.5', isYou ? 'items-end' : 'items-start')}>
+      {segment.timestamp && (
+        <span className="px-1.5 text-[10.5px] tabular-nums" style={{ color: 'var(--fg-2)' }}>
+          {segment.timestamp}
+        </span>
+      )}
       <div
         className={cn(
           'max-w-[78%] rounded-2xl px-3 py-1.5 text-sm leading-[1.5]',
@@ -183,25 +184,4 @@ function renderHighlighted(text: string, highlight: string): React.ReactNode {
   return parts;
 }
 
-function parseTranscript(text: string, isDiarised: boolean): Segment[] {
-  if (isDiarised) {
-    const blocks = text.split(/(?=\[You\]|\[Others\])/);
-    return blocks
-      .map((b) => b.trim())
-      .filter(Boolean)
-      .map((b): Segment => {
-        if (b.startsWith('[You]')) return { speaker: 'You', text: b.replace('[You]', '').trim() };
-        if (b.startsWith('[Others]'))
-          return { speaker: 'Others', text: b.replace('[Others]', '').trim() };
-        return { speaker: null, text: b };
-      });
-  }
-  const trimmed = text.trim();
-  if (!trimmed) return [];
-  const sentences = trimmed
-    .split(/(?<=[.!?])\s+(?=[A-Z"'([])/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-  return (sentences.length > 1 ? sentences : [trimmed]).map((s) => ({ speaker: null, text: s }));
-}
 

--- a/app/renderer/src/lib/transcriptSegments.test.ts
+++ b/app/renderer/src/lib/transcriptSegments.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest';
+import { parseTranscript } from '@/lib/transcriptSegments';
+
+/**
+ * parseTranscript splits a diarised transcript into speaker segments, pulling
+ * the optional leading `[MM:SS]` / `[H:MM:SS]` timestamp (written by
+ * transcriber.py's _format_timestamp) into its own field. The load-bearing
+ * edges: a timestamp must attach to its OWN segment (not trail the previous
+ * one), and transcripts saved BEFORE timestamps (no `[MM:SS]`) must still parse.
+ */
+describe('parseTranscript — diarised', () => {
+  test('extracts timestamp, speaker, and text per turn', () => {
+    const segs = parseTranscript(
+      '[00:01] [You] Hello there\n\n[00:15] [Others] Hi back',
+      true,
+    );
+    expect(segs).toEqual([
+      { speaker: 'You', text: 'Hello there', timestamp: '00:01' },
+      { speaker: 'Others', text: 'Hi back', timestamp: '00:15' },
+    ]);
+  });
+
+  test('handles the H:MM:SS form for long meetings', () => {
+    const segs = parseTranscript('[1:02:03] [You] Still going', true);
+    expect(segs[0].timestamp).toBe('1:02:03');
+    expect(segs[0].text).toBe('Still going');
+  });
+
+  test('parses timestamp-less transcripts (saved before this feature)', () => {
+    const segs = parseTranscript('[You] Hello\n\n[Others] Hi', true);
+    expect(segs).toEqual([
+      { speaker: 'You', text: 'Hello', timestamp: undefined },
+      { speaker: 'Others', text: 'Hi', timestamp: undefined },
+    ]);
+  });
+
+  test('multi-line segment text stays with its turn', () => {
+    const segs = parseTranscript('[00:00] [You] line one\nline two\n\n[00:05] [Others] reply', true);
+    expect(segs[0].text).toContain('line one');
+    expect(segs[0].text).toContain('line two');
+    expect(segs[1].timestamp).toBe('00:05');
+  });
+});
+
+describe('parseTranscript — non-diarised', () => {
+  test('splits into sentence segments with no speaker or timestamp', () => {
+    const segs = parseTranscript('First sentence. Second sentence.', false);
+    expect(segs.length).toBeGreaterThan(0);
+    expect(segs.every((s) => s.speaker === null && s.timestamp === undefined)).toBe(true);
+  });
+
+  test('empty input yields no segments', () => {
+    expect(parseTranscript('   ', false)).toEqual([]);
+  });
+});

--- a/app/renderer/src/lib/transcriptSegments.ts
+++ b/app/renderer/src/lib/transcriptSegments.ts
@@ -1,0 +1,38 @@
+// Pure parsing of a saved transcript string into speaker segments. Kept out of
+// TranscriptPanel.tsx (which pulls in hooks/Sidebar/localStorage) so it can be
+// unit-tested in isolation, and so the live dock could share it later.
+
+export interface Segment {
+  speaker: 'You' | 'Others' | null;
+  text: string;
+  /** `MM:SS` / `H:MM:SS` offset parsed from a diarised line's leading
+   *  `[MM:SS]` marker (transcriber.py writes it). Absent on older transcripts
+   *  saved before timestamps, and on the non-diarised path. */
+  timestamp?: string;
+}
+
+// A diarised line: an optional `[MM:SS]` / `[H:MM:SS]` timestamp, then the
+// `[You]`/`[Others]` speaker marker, then the text up to the next marker (or
+// end). Matched globally rather than split so the optional timestamp stays
+// attached to its own segment instead of trailing the previous one.
+const DIARISED_SEGMENT_RE =
+  /(?:\[(\d{1,3}:\d{2}(?::\d{2})?)\]\s*)?\[(You|Others)\]\s*([\s\S]*?)(?=(?:\[\d{1,3}:\d{2}(?::\d{2})?\]\s*)?\[(?:You|Others)\]|$)/g;
+
+export function parseTranscript(text: string, isDiarised: boolean): Segment[] {
+  if (isDiarised) {
+    const segments: Segment[] = [];
+    for (const m of text.matchAll(DIARISED_SEGMENT_RE)) {
+      const body = m[3].trim();
+      if (!body) continue;
+      segments.push({ speaker: m[2] as 'You' | 'Others', text: body, timestamp: m[1] });
+    }
+    return segments;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  const sentences = trimmed
+    .split(/(?<=[.!?])\s+(?=[A-Z"'([])/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return (sentences.length > 1 ? sentences : [trimmed]).map((s) => ({ speaker: null, text: s }));
+}

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -6,15 +6,30 @@ except ImportError:
     OLLAMA_AVAILABLE = False
 import json
 import logging
+import re
 import subprocess
 import time
-import os
 from typing import Optional, Dict, Any
 from .models import MeetingTranscript, ActionItem, Decision
 from .config import Config, resolve_runtime_tag
 from . import ollama_manager
 
 logger = logging.getLogger(__name__)
+
+# The diarised transcript carries a leading per-turn `[MM:SS]`/`[H:MM:SS]`
+# timestamp for display (see transcriber._format_timestamp). Those markers are
+# a UI/export concern only — strip them before the transcript reaches the LLM
+# so summarisation input (token cost + output) is unchanged by the timestamp
+# feature. The `[You]`/`[Others]` speaker labels are deliberately kept (the
+# prompt relies on them). Anchored to line start so a bracketed time inside
+# body text isn't touched.
+_LEADING_TIMESTAMP_RE = re.compile(r'(?m)^\[\d{1,3}:\d{2}(?::\d{2})?\]\s*')
+
+
+def _strip_leading_timestamps(transcript: str) -> str:
+    if not transcript:
+        return transcript
+    return _LEADING_TIMESTAMP_RE.sub('', transcript)
 
 
 def bedrock_converse_url(region: str, target_id: str) -> str:
@@ -1133,6 +1148,7 @@ Return ONLY the response in this exact JSON format:
         Returns:
             MeetingTranscript object or None if summarization failed
         """
+        transcript = _strip_leading_timestamps(transcript)
         try:
             # Handle empty or None transcripts
             if not transcript or transcript.strip() == "" or transcript.lower().strip() == "none":
@@ -1513,6 +1529,7 @@ TRANSCRIPT:
         Yields:
             str: Text chunks as they arrive from the LLM
         """
+        transcript = _strip_leading_timestamps(transcript)
         if template_prompt:
             # Free-form template report: no chunking/map-reduce (those prompts are
             # summary-schema specific and don't apply here). Stream through the
@@ -1627,7 +1644,7 @@ TRANSCRIPT:
         """
         try:
             # Use summary if available, otherwise fall back to first part of transcript
-            context = summary if summary else transcript[:2000]
+            context = summary if summary else _strip_leading_timestamps(transcript)[:2000]
             if not context or context.strip() == "":
                 return None
 

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -257,10 +257,11 @@ def _format_timestamp(seconds: float) -> str:
     """Format a segment offset (seconds since recording start) as a transcript
     timestamp: ``MM:SS`` under an hour, ``H:MM:SS`` beyond it.
 
-    Kept identical to the live-dock formatter (fmtTimestamp in
-    LiveTranscriptBar.tsx) so the saved transcript and the live view read the
-    same. Only used for the diarised (labelled) transcript — the plain ``text``
-    field stays timestamp-free.
+    Same MM:SS / H:MM:SS shape as the live-dock formatter (fmtTimestamp in
+    LiveTranscriptBar.tsx) so the live view and the saved transcript read
+    alike. (They aren't 1:1: the live dock stamps every segment, the saved
+    transcript stamps each collapsed turn's first segment.) Only used for the
+    diarised (labelled) transcript — the plain ``text`` field stays clean.
     """
     total = max(0, int(seconds))
     hh, rem = divmod(total, 3600)
@@ -1233,8 +1234,13 @@ class WhisperTranscriber:
             tagged.sort(key=lambda t: t[0])
 
             # Each turn carries the start offset of its FIRST segment so the
-            # diarised transcript can be timestamped. The plain text field stays
-            # timestamp-free (it's the summary/fallback body without labels).
+            # diarised transcript can be timestamped. Only diarised_text is
+            # timestamped (it's what the UI displays + what #215 exports); the
+            # plain text field stays clean. NOTE: diarised_text is also the
+            # summariser input (simple_recorder: text_for_summary = diarised_text
+            # or transcript_text), so the summariser strips these [MM:SS] markers
+            # back out on the way in (summarizer._strip_leading_timestamps) —
+            # summarisation is unaffected by this display feature.
             turns: list[tuple[float, str, list[str]]] = []
             for start, speaker, text in tagged:
                 if turns and turns[-1][1] == speaker:

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -29,6 +29,7 @@ anything; the model is the source of truth.
 
 import inspect
 import logging
+import math
 import os
 import re
 import subprocess
@@ -263,6 +264,11 @@ def _format_timestamp(seconds: float) -> str:
     transcript stamps each collapsed turn's first segment.) Only used for the
     diarised (labelled) transcript — the plain ``text`` field stays clean.
     """
+    # A non-finite start (a backend emitting NaN/inf) must not crash the whole
+    # diarised assembly — int(NaN) raises ValueError, int(inf) OverflowError.
+    # Fall back to 00:00 rather than blowing up the transcription.
+    if not math.isfinite(seconds):
+        seconds = 0
     total = max(0, int(seconds))
     hh, rem = divmod(total, 3600)
     mm, ss = divmod(rem, 60)

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -253,6 +253,23 @@ def _scan_max_rms(wf, window: int, step: int, early_exit_threshold: float) -> fl
     return max_rms
 
 
+def _format_timestamp(seconds: float) -> str:
+    """Format a segment offset (seconds since recording start) as a transcript
+    timestamp: ``MM:SS`` under an hour, ``H:MM:SS`` beyond it.
+
+    Kept identical to the live-dock formatter (fmtTimestamp in
+    LiveTranscriptBar.tsx) so the saved transcript and the live view read the
+    same. Only used for the diarised (labelled) transcript — the plain ``text``
+    field stays timestamp-free.
+    """
+    total = max(0, int(seconds))
+    hh, rem = divmod(total, 3600)
+    mm, ss = divmod(rem, 60)
+    if hh:
+        return f"{hh:d}:{mm:02d}:{ss:02d}"
+    return f"{mm:02d}:{ss:02d}"
+
+
 def _token_jaccard(a: str, b: str) -> float:
     """Jaccard similarity over normalised word tokens.
 
@@ -1215,20 +1232,24 @@ class WhisperTranscriber:
                     tagged.append((float(s.get("start") or 0.0), "Others", text))
             tagged.sort(key=lambda t: t[0])
 
-            turns: list[tuple[str, list[str]]] = []
-            for _start, speaker, text in tagged:
-                if turns and turns[-1][0] == speaker:
-                    turns[-1][1].append(text)
+            # Each turn carries the start offset of its FIRST segment so the
+            # diarised transcript can be timestamped. The plain text field stays
+            # timestamp-free (it's the summary/fallback body without labels).
+            turns: list[tuple[float, str, list[str]]] = []
+            for start, speaker, text in tagged:
+                if turns and turns[-1][1] == speaker:
+                    turns[-1][2].append(text)
                 else:
-                    turns.append((speaker, [text]))
+                    turns.append((start, speaker, [text]))
 
-            plain_parts = [' '.join(parts) for _speaker, parts in turns]
+            plain_parts = [' '.join(parts) for _start, _speaker, parts in turns]
             plain_text = "\n\n".join(plain_parts) if plain_parts else SILENCE_SENTINEL
 
             is_diarised = bool(mic_segments) and bool(system_segments)
             if is_diarised:
                 labelled_parts = [
-                    f"[{speaker}] {' '.join(parts)}" for speaker, parts in turns
+                    f"[{_format_timestamp(start)}] [{speaker}] {' '.join(parts)}"
+                    for start, speaker, parts in turns
                 ]
                 diarised_text = "\n\n".join(labelled_parts)
             else:

--- a/tests/test_summarizer_timestamps.py
+++ b/tests/test_summarizer_timestamps.py
@@ -1,0 +1,40 @@
+"""The [MM:SS] display timestamps on diarised transcripts must NOT reach the
+LLM: the summariser strips them on the way in so summarisation input (and
+therefore output / token cost) is unchanged by the timestamp feature. The
+[You]/[Others] speaker labels are kept."""
+import unittest
+
+from src.summarizer import _strip_leading_timestamps
+
+
+class StripLeadingTimestampsTests(unittest.TestCase):
+    def test_strips_mm_ss_prefix_keeps_speaker_label(self):
+        src = "[00:01] [You] Hello there\n\n[00:15] [Others] Hi back"
+        self.assertEqual(
+            _strip_leading_timestamps(src),
+            "[You] Hello there\n\n[Others] Hi back",
+        )
+
+    def test_strips_h_mm_ss_prefix(self):
+        self.assertEqual(
+            _strip_leading_timestamps("[1:02:03] [You] Still going"),
+            "[You] Still going",
+        )
+
+    def test_leaves_untimestamped_transcript_untouched(self):
+        src = "[You] Hello\n\n[Others] Hi"
+        self.assertEqual(_strip_leading_timestamps(src), src)
+
+    def test_does_not_touch_bracketed_time_inside_body(self):
+        # Only a LINE-LEADING [MM:SS] is a display marker; a time mentioned
+        # mid-sentence must survive.
+        src = "[You] we met at [12:30] downtown"
+        self.assertEqual(_strip_leading_timestamps(src), src)
+
+    def test_empty_input(self):
+        self.assertEqual(_strip_leading_timestamps(""), "")
+        self.assertIsNone(_strip_leading_timestamps(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -52,6 +52,13 @@ class FormatTimestampTests(unittest.TestCase):
     def test_negative_clamps_to_zero(self):
         self.assertEqual(_format_timestamp(-5), "00:00")
 
+    def test_non_finite_falls_back_to_zero(self):
+        # A backend emitting NaN/inf in a segment's start must not crash the
+        # diarised assembly (int(NaN) raises ValueError, int(inf) OverflowError).
+        self.assertEqual(_format_timestamp(float("nan")), "00:00")
+        self.assertEqual(_format_timestamp(float("inf")), "00:00")
+        self.assertEqual(_format_timestamp(float("-inf")), "00:00")
+
 
 class TranscribeDiarisedTimestampTests(unittest.TestCase):
     """The diarised transcript prefixes each turn with an [MM:SS] timestamp

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -15,6 +15,7 @@ import tempfile
 import unittest
 import wave
 from pathlib import Path
+from unittest.mock import Mock
 
 from src.transcriber import (
     BLEED_JACCARD_THRESHOLD,
@@ -22,10 +23,86 @@ from src.transcriber import (
     MIN_RMS_THRESHOLD,
     WhisperTranscriber,
     _diarised_split_timeout,
+    _format_timestamp,
     _parse_channels_from_ffmpeg_stderr,
     _parse_duration_from_ffmpeg_stderr,
     _token_jaccard,
 )
+
+
+class FormatTimestampTests(unittest.TestCase):
+    def test_zero(self):
+        self.assertEqual(_format_timestamp(0), "00:00")
+
+    def test_under_a_minute_pads_seconds(self):
+        self.assertEqual(_format_timestamp(5), "00:05")
+
+    def test_minutes_and_seconds(self):
+        self.assertEqual(_format_timestamp(65), "01:05")
+
+    def test_floors_fractional_seconds(self):
+        self.assertEqual(_format_timestamp(1.8), "00:01")
+
+    def test_hour_switches_to_h_mm_ss(self):
+        self.assertEqual(_format_timestamp(3661), "1:01:01")
+
+    def test_exactly_one_hour(self):
+        self.assertEqual(_format_timestamp(3600), "1:00:00")
+
+    def test_negative_clamps_to_zero(self):
+        self.assertEqual(_format_timestamp(-5), "00:00")
+
+
+class TranscribeDiarisedTimestampTests(unittest.TestCase):
+    """The diarised transcript prefixes each turn with an [MM:SS] timestamp
+    from the turn's first segment. Mocks the per-channel transcription so no
+    model/audio is needed. Disjoint mock text avoids the bleed-correction RMS
+    read (which would need real WAVs)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        d = Path(self._tmp.name)
+        self.audio_path = d / "source.wav"
+        self.mic_path = d / "mic.wav"
+        self.system_path = d / "system.wav"
+        for p in (self.audio_path, self.mic_path, self.system_path):
+            p.write_bytes(b"stub")
+        self.transcriber = WhisperTranscriber.__new__(WhisperTranscriber)
+        self.transcriber.backend = "parakeet"
+        self.transcriber._split_stereo_to_channels = Mock(
+            return_value=(self.mic_path, self.system_path, 3.0)
+        )
+        self.transcriber._check_rms_energy = Mock(return_value=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_interleaves_diarised_segments_with_timestamps(self):
+        self.transcriber.transcribe_audio = Mock(side_effect=[
+            {"text": "Hello. Later.", "segments": [
+                {"text": "Hello.", "start": 1.2, "end": 1.8},
+                {"text": "Later.", "start": 4.0, "end": 4.5},
+            ]},
+            {"text": "Reply.", "segments": [{"text": "Reply.", "start": 2.1, "end": 2.8}]},
+        ])
+        result = self.transcriber.transcribe_diarised(self.audio_path)
+        self.assertTrue(result["is_diarised"])
+        self.assertEqual(
+            result["diarised_text"],
+            "[00:01] [You] Hello.\n\n[00:02] [Others] Reply.\n\n[00:04] [You] Later.",
+        )
+        # The plain text field stays timestamp- and label-free.
+        self.assertNotIn("[00:0", result["text"])
+        self.assertNotIn("[You]", result["text"])
+
+    def test_single_source_is_not_timestamped_or_diarised(self):
+        self.transcriber.transcribe_audio = Mock(side_effect=[
+            {"text": "Only mic.", "segments": [{"text": "Only mic.", "start": 0.4, "end": 1.0}]},
+            {"text": "", "segments": []},
+        ])
+        result = self.transcriber.transcribe_diarised(self.audio_path)
+        self.assertFalse(result["is_diarised"])
+        self.assertIsNone(result["diarised_text"])
 
 
 class TokenJaccardTests(unittest.TestCase):


### PR DESCRIPTION
## What

Adds per-segment `[MM:SS]` (/ `H:MM:SS` beyond an hour) timestamps to transcripts:

- **Live dock** (`LiveTranscriptBar`): a muted timestamp above each segment bubble, from the `start` offset already present on every `LIVE_SEG` — renderer-only, no backend change.
- **Saved diarised transcript** (`transcribe_diarised`): each turn is prefixed with `[MM:SS]` from its first segment's start. `TranscriptPanel` parses the marker back out (parse extracted to `lib/transcriptSegments.ts` for isolated testing; backward-compatible with pre-timestamp transcripts).

The `[MM:SS]` format is shared in shape across live + saved (`_format_timestamp` in Python, `fmtTimestamp` in TS).

## Design notes

- `diarised_text` feeds **both** the displayed transcript and the summariser input (`text_for_summary = diarised_text or transcript_text`). To keep this a pure display feature, the summariser **strips the leading timestamps back out** at its entry points (`summarize_transcript` / `_streaming` / `generate_title`) — so summarisation input, output and token cost are unchanged. The `[You]`/`[Others]` labels are kept. Timestamps remain on the displayed transcript and the transcript export (#215).
- Engine-agnostic: the timestamp logic consumes segment `{start,end}` uniformly (both Parakeet and whisper.cpp already return them) and never branches on engine, per MECHANICS.

## Credit

The saved/diarised-transcript timestamp logic is adapted from #102 by **@BrianNguyen291**, decoupled from that PR's unrelated Chinese-language-support changes (which stay in #102 for separate review).

## Tests

- Python: `_format_timestamp` (padding/hour-rollover/negative), diarised interleaving asserting `[MM:SS] [Speaker]` output + plain `text` stays clean, and `_strip_leading_timestamps` (keeps labels + mid-line times).
- Renderer: `parseTranscript` incl. timestamp-less backward-compat, `H:MM:SS`, multi-line turns.
- `python -m unittest discover tests` (351) + `npm run typecheck:renderer` green.
- Verified at runtime: seeded a diarised meeting, opened the transcript panel, confirmed timestamps render correctly (screenshot).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-segment timestamps to transcripts for easier context while keeping summaries unchanged. Live shows a `[MM:SS]` above each bubble; saved diarised transcripts prefix each turn with `[MM:SS]` or `[H:MM:SS]`.

- **New Features**
  - Live: `LiveTranscriptBar` displays a muted timestamp above each segment using its `start` offset.
  - Saved: diarised turns are prefixed with `[MM:SS]` from the first segment via `_format_timestamp`; `TranscriptPanel` parses `[MM:SS] [Speaker]` through `lib/transcriptSegments` (backward-compatible with old transcripts).

- **Bug Fixes**
  - Strip leading `[MM:SS]` from summarizer inputs in `summarize_transcript`, streaming, and title generation; keep `[You]/[Others]`.
  - Harden `_format_timestamp` against non-finite `start` values (NaN/inf) by falling back to `00:00`.
  - Added unit tests for timestamp formatting (incl. hour rollover and non-finite), diarised interleaving, parsing, and stripping.

<sup>Written for commit e3da21ae984d3fc55f4c56c8973f15ddf320bd4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

