### PR TITLE
chore(release): v0.5.7

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
-# Require @ruzin review on all changes. With require_code_owner_reviews
-# enabled on main, every PR needs the owner's approval before merge.
-* @ruzin
+# Require a code-owner review on all changes. With require_code_owner_reviews
+# enabled on main, every PR needs approval from one of these owners before
+# merge. @Optic00 (top contributor) is a co-owner alongside @ruzin — a review
+# from either satisfies the requirement.
+* @ruzin @Optic00

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
-- **2026-06-28** 📝 Report templates & per-meeting reports — define your own report styles and generate them from any note; a meeting can now hold multiple reports (the structured summary plus template-driven ones), switchable in the detail view.
-- **2026-06-28** 📤 Transcript export — copy the full transcript or save it as Markdown (title, metadata, notes, and diarised `[You]`/`[Others]` text) to paste into any external tool.
-- **2026-06-28** 🛟 Never lose a transcript — if batch transcription comes back empty, Steno now falls back to the live transcript you watched during the recording instead of saving a blank note.
-- **2026-06-28** 🧩 Better long-meeting summaries — map-reduce summarization chunks long transcripts so multi-hour meetings summarize reliably without overflowing the model's context.
+- **2026-07-02** ⏱️ Transcript timestamps — every turn of your live and saved transcripts now shows a `[MM:SS]` timestamp, so you can see (and cite) when things were said.
+- **2026-07-02** ⚡ Faster on Apple Silicon — opt into Ollama's native MLX model builds for quicker summaries (Settings → "Switch to faster build"); your model choice and settings are preserved.
+- **2026-07-02** 🌍 Pin your meeting language — Parakeet users can now pin a European language (French, German, Spanish, Dutch, Portuguese) so summaries and notes come out in it, not English.
+- **2026-07-02** 🧹 Cleaner summaries — reasoning-model "thinking" blocks are stripped before your notes render, so scratchpad text never leaks into a summary.
 
 
 ## Features

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",


### PR DESCRIPTION
Release prep for 0.5.7: version bump, README What's New (transcript timestamps #272, faster MLX #269, language pinning #267, cleaner summaries #256), and adds @Optic00 as a CODEOWNER alongside @ruzin (either can satisfy the required code-owner review). No functional code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prep v0.5.7 release. Bumps `app/package.json` to 0.5.7, updates README What's New (transcript timestamps, faster MLX on Apple Silicon, Parakeet language pinning, cleaner summaries), and adds `@Optic00` as a CODEOWNER alongside `@ruzin` so either can approve.

<sup>Written for commit 38b448e4a881d9a5cd361f03437a59b94d0e518f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

