### PR TITLE
fix(e2e): bump cancel-pull poll timeout for Windows cold start

### DIFF
--- a/e2e/specs/model-management.t2.spec.ts
+++ b/e2e/specs/model-management.t2.spec.ts
@@ -243,8 +243,11 @@ test('cancel-pull: stops an in-flight download and reports it as cancelled, not 
     // Wait for the pull-model subprocess to actually reach the mock server
     // (PyInstaller cold start can take longer than a short fixed sleep)
     // before cancelling, so this exercises a real in-flight download rather
-    // than racing the subprocess's own startup time.
-    await expect.poll(() => mockOllama.pullCalls()).toBeGreaterThan(0);
+    // than racing the subprocess's own startup time. Windows CI cold-starts
+    // the bundled exe slower than the 5s default (seen exceeding it when
+    // the backend bundle was just downloaded in the same job) -- 15s matches
+    // the same wait-on-spawned-backend pattern in org-lock-lifecycle.t2.
+    await expect.poll(() => mockOllama.pullCalls(), { timeout: 15_000 }).toBeGreaterThan(0);
 
     const cancelResult = await page.evaluate(() =>
       (window as StenoWindow).stenoai.models.cancelPull('gemma4:e2b-nvfp4'),


### PR DESCRIPTION
## What

The main `e2e` push run right after #272 merged failed on Windows T2 (`model-management.t2.spec.ts:229`, cancel-pull), then passed again 5 minutes later on the next push. Non-blocking per policy, but a genuine flake worth closing.

## Root cause

```
Error: expect(received).toBeGreaterThan(expected)
Expected: > 0
Received:   0
- Timeout 5000ms exceeded while waiting on the predicate
> 247 |     await expect.poll(() => mockOllama.pullCalls()).toBeGreaterThan(0);
```

All three attempts (initial + 2 retries) timed out with zero pull calls registered within Playwright's 5s default. This ran right after a fresh backend bundle download in the same job — the test's own comment already anticipates this ("PyInstaller cold start can take longer than a short fixed sleep"), the poll's timeout just wasn't bumped to match. `org-lock-lifecycle.t2.spec.ts:74` already uses a 15s timeout for the same wait-on-spawned-backend pattern.

## Fix

Bump this one poll to `{ timeout: 15_000 }`, matching the existing convention.

## Test plan

- [ ] CI green on `t2-windows`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
In the `cancel-pull` e2e test, increase the `expect.poll` timeout to 15s to handle Windows CI cold starts after fresh backend bundle downloads. This stabilizes `t2-windows` runs and matches the 15s pattern used in `org-lock-lifecycle.t2`.

<sup>Written for commit c094b513e2033554c45b616836c33aa96bd61bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

