### PR TITLE
fix: path-containment gaps, dead retry button, temp-file race

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1590,10 +1590,41 @@ ipcMain.handle('process-recording', async (event, audioFile, sessionName) => {
     // 'process-streaming' label), serialises behind any in-flight job, and
     // emits 'processing-complete' when done.
     //
+    // Security: this handler imports a USER-PICKED file (native dialog OR
+    // drag-drop → webUtils.getPathForFile), so — unlike the meeting-file
+    // handlers — we deliberately can't require containment in
+    // getAllowedBaseDirs: importing an external ~/Desktop/interview.m4a is the
+    // whole point. The path is still renderer-supplied, though, so harden the
+    // trust boundary: resolve symlinks, then require a REGULAR FILE with a
+    // supported audio extension. This rejects directories, device/FIFO/socket
+    // special files (copyFile on which could hang or exhaust disk) and non-audio
+    // arbitrary-read targets like /etc/passwd — the same constraints the picker
+    // dialog filter and drag-drop isAudioFile() already apply upstream, now also
+    // enforced where the renderer's trust actually crosses into main.
+    if (!audioFile || typeof audioFile !== 'string') {
+      return { success: false, error: 'Invalid file path' };
+    }
+    let realAudioFile;
+    try {
+      // realpath (not just resolve) follows symlinks to the true target, so the
+      // isFile()/extension checks and the copy all act on the same real file.
+      realAudioFile = await fs.promises.realpath(path.resolve(audioFile));
+      const stat = await fs.promises.stat(realAudioFile);
+      if (!stat.isFile()) {
+        return { success: false, error: 'Invalid file path' };
+      }
+    } catch {
+      return { success: false, error: 'Audio file not found' };
+    }
+    const ext = path.extname(realAudioFile).slice(1).toLowerCase();
+    if (!IMPORT_AUDIO_EXTENSIONS.includes(ext)) {
+      return { success: false, error: 'Unsupported file type' };
+    }
+
     // Copy the import into our recordings/ dir first: process-streaming
     // unlinks the source after a successful transcribe (keep_recordings
     // defaults off), so queueing the user's original path would delete it.
-    const queuedFile = await copyImportIntoRecordings(audioFile);
+    const queuedFile = await copyImportIntoRecordings(realAudioFile);
     addToProcessingQueue(queuedFile, sessionName, null);
     return { success: true };
   } catch (error) {
@@ -1804,38 +1835,57 @@ function parseMeetingMarkdown(content, mdPath) {
   };
 }
 
+/**
+ * Validate a renderer-supplied meeting summary path (symlink-safe containment).
+ *
+ * Returns { realPath, allowedOutputDirs } when `summaryFile` is a .md/.json that
+ * resolves — with symlinks followed — into one of the app's known output/
+ * directories, or { error } describing why it was rejected. Extracted from
+ * get-meeting so every handler taking a summaryFile applies the SAME check:
+ * realpath BOTH the target and each <baseDir>/output before the prefix test, so
+ * a symlink planted inside an allowed dir can't escape the allowlist into an
+ * arbitrary-file read/write (path.resolve only collapses '..', it does not
+ * follow symlinks), while a legitimately symlinked base dir (macOS
+ * /tmp -> /private/tmp, which the e2e temp data dir uses) still matches. The
+ * output/ scoping + extension gate also stop a renderer-controlled path to some
+ * other JSON inside an allowed root from being treated as a meeting file.
+ * Callers MUST use the returned realPath downstream (backend CLI args, file
+ * reads) rather than the original string, so the thing validated is the thing
+ * used. realpath needs the path to exist; a missing target -> denied.
+ */
+async function validateMeetingFilePath(summaryFile) {
+  if (!summaryFile || (!summaryFile.endsWith('.json') && !summaryFile.endsWith('.md'))) {
+    return { error: 'Invalid file path' };
+  }
+  let realPath;
+  try {
+    realPath = await fs.promises.realpath(path.resolve(summaryFile));
+  } catch {
+    return { error: 'Access denied' };
+  }
+  const allowedOutputDirs = await Promise.all(
+    getAllowedBaseDirs().map(async d => {
+      try {
+        return (await fs.promises.realpath(path.resolve(d, 'output'))) + path.sep;
+      } catch {
+        return null; // output dir may not exist yet
+      }
+    }),
+  );
+  const allowed = allowedOutputDirs.some(base => base && realPath.startsWith(base));
+  if (!allowed) {
+    return { error: 'Access denied' };
+  }
+  return { realPath, allowedOutputDirs };
+}
+
 ipcMain.handle('get-meeting', async (_event, summaryFile) => {
   try {
-    if (!summaryFile || (!summaryFile.endsWith('.json') && !summaryFile.endsWith('.md'))) {
-      return { success: false, error: 'Invalid file path' };
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
     }
-    // Path containment: the file's REAL path (symlinks resolved) must live under
-    // one of the known output directories (default data dir, custom storage, or
-    // dev project root). We canonicalize BOTH the target and the allowed dirs
-    // with realpath so (a) a symlink planted in the output dir can't escape the
-    // allowlist into an arbitrary-file read — path.resolve only collapses '..',
-    // it does not follow symlinks — and (b) a legitimately symlinked base dir
-    // (e.g. macOS /tmp -> /private/tmp, which the e2e temp data dir uses) still
-    // matches. realpath needs the path to exist; a missing target -> denied.
-    let realResolved;
-    try {
-      realResolved = await fs.promises.realpath(path.resolve(summaryFile));
-    } catch {
-      return { success: false, error: 'Access denied' };
-    }
-    const allowedOutputDirs = await Promise.all(
-      getAllowedBaseDirs().map(async d => {
-        try {
-          return (await fs.promises.realpath(path.resolve(d, 'output'))) + path.sep;
-        } catch {
-          return null; // output dir may not exist yet
-        }
-      }),
-    );
-    const allowed = allowedOutputDirs.some(base => base && realResolved.startsWith(base));
-    if (!allowed) {
-      return { success: false, error: 'Access denied' };
-    }
+    const { realPath: realResolved, allowedOutputDirs } = validated;
     const content = await fs.promises.readFile(realResolved, 'utf-8');
     if (summaryFile.endsWith('.md')) {
       // Legacy .md meetings are still listed by list-meetings, so their detail
@@ -1865,7 +1915,17 @@ ipcMain.handle('clear-state', async () => {
 
 ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, sessionName) => {
   try {
-    const args = ['reprocess', summaryFile];
+    // Security: symlink-safe containment-check the renderer-supplied summary path
+    // before it reaches the backend CLI, and pass the canonical realPath (not the
+    // original string) downstream. Event/map keys stay keyed on the original
+    // summaryFile — that's UI correlation the renderer matches on, not file access.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+    const { realPath } = validated;
+
+    const args = ['reprocess', realPath];
     if (regenerateTitle) args.push('--regenerate-title');
 
     sendDebugLog(`🔄 Reprocessing meeting: ${summaryFile}`);
@@ -1988,17 +2048,27 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
 });
 
 ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId) => {
+  // Security: symlink-safe containment-check the renderer-supplied summary path
+  // before ANY use of it — including the sessionName read below, which opens the
+  // file directly — and use the canonical realPath downstream. Event/map keys
+  // stay keyed on the original summaryFile (UI correlation the renderer matches).
+  const validated = await validateMeetingFilePath(summaryFile);
+  if (validated.error) {
+    return { success: false, error: validated.error };
+  }
+  const { realPath } = validated;
+
   // Resolve the sessionName from the meeting JSON so streaming events carry the
   // same key as the reprocess flow (keyed by sessionName, disambiguated by summaryFile).
   let sessionName = null;
   try {
     const fs = require('fs');
-    const data = JSON.parse(fs.readFileSync(summaryFile, 'utf-8'));
+    const data = JSON.parse(fs.readFileSync(realPath, 'utf-8'));
     sessionName = data?.session_info?.name || null;
   } catch (_) { /* non-fatal — sessionName stays null */ }
 
   try {
-    const args = ['generate-report', summaryFile, templateId];
+    const args = ['generate-report', realPath, templateId];
 
     sendDebugLog(`📄 Generating report for: ${summaryFile} (template: ${templateId})`);
     sendDebugLog(`$ stenoai ${args.join(' ')}`);
@@ -2114,25 +2184,47 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
 
 ipcMain.handle('set-active-report', async (_e, summaryFile, reportId) => {
   try {
-    const out = await runPythonScript('simple_recorder.py', ['set-active-report', summaryFile, reportId]);
+    // Security: symlink-safe containment-check + canonical realPath. The backend's
+    // report_store derives a <stem>_reports.json sidecar NEXT TO this path, so the
+    // realpath'd, output-scoped path is what must be passed — not the raw string.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+    const out = await runPythonScript('simple_recorder.py', ['set-active-report', validated.realPath, reportId]);
     return JSON.parse(out);
   } catch (error) { return { success: false, error: error.message }; }
 });
 
 ipcMain.handle('delete-report', async (_e, summaryFile, reportId) => {
   try {
-    const out = await runPythonScript('simple_recorder.py', ['delete-report', summaryFile, reportId]);
+    // Security: symlink-safe containment-check + canonical realPath. The backend's
+    // report_store derives a <stem>_reports.json sidecar NEXT TO this path, so the
+    // realpath'd, output-scoped path is what must be passed — not the raw string.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+    const out = await runPythonScript('simple_recorder.py', ['delete-report', validated.realPath, reportId]);
     return JSON.parse(out);
   } catch (error) { return { success: false, error: error.message }; }
 });
 
 ipcMain.handle('regen-meeting-title', async (event, summaryFile, sessionName) => {
   try {
+    // Security: symlink-safe containment-check the renderer-supplied summary path
+    // and pass the canonical realPath to the backend CLI, not the raw string.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+    const { realPath } = validated;
+
     const aiEnv = getAiEnv();
     const regenEnv = Object.keys(aiEnv).length > 0 ? { ...require('process').env, ...aiEnv } : undefined;
 
     await new Promise((resolve, reject) => {
-      const proc = spawn(getBackendPath(), ['regen-title', summaryFile], {
+      const proc = spawn(getBackendPath(), ['regen-title', realPath], {
         cwd: getBackendCwd(),
         env: regenEnv,
       });
@@ -3535,7 +3627,11 @@ async function processNextInQueue() {
       mainWindow.webContents.send('processing-complete', {
         success: false,
         sessionName: currentProcessingJob.sessionName,
-        error: error.message
+        error: error.message,
+        // The source audio is preserved above; hand its path to the renderer
+        // so the Processing screen's "Try again" can re-queue it via
+        // process-recording instead of dead-ending on an infinite spinner.
+        audioFile: currentProcessingJob.audioFile || undefined
       });
     }
   } finally {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -530,6 +530,12 @@ export interface ProcessingCompleteEvent {
    *  app-level cleanup find the matching streamCache entry to clear
    *  even when MeetingDetail unmounted mid-reprocess. */
   summaryFile?: string;
+  /** Preserved source-audio path on a HARD processing crash (success: false).
+   *  No note/summaryFile is written on that path, so this is the only handle
+   *  the Processing screen's "Try again" has to re-queue the recording via
+   *  `recording.processFile`. Absent on success and on the graceful
+   *  transcription-failure path (which writes a reprocessable note instead). */
+  audioFile?: string;
   /** Set when the backend gracefully marked a transcription crash: the
    *  audio was preserved and a reprocessable meeting was saved, so the
    *  flow still succeeds (success: true) but the renderer should surface

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -56,6 +56,13 @@ export function Processing() {
   const [chunkProgress, setChunkProgress] = React.useState<string | null>(null);
   const [streamText, setStreamText] = React.useState('');
   const [streamedTitle, setStreamedTitle] = React.useState<string | null>(null);
+  // Preserved source-audio path from a hard processing crash — the only handle
+  // we have to actually re-run the failed job (no note/summaryFile is written
+  // on that path). Null when unavailable, which disables "Try again" so it can
+  // never re-arm the spinner without a real backing job.
+  const [retryAudioFile, setRetryAudioFile] = React.useState<string | null>(null);
+  const [retrying, setRetrying] = React.useState(false);
+  const [retryError, setRetryError] = React.useState<string | null>(null);
 
   // Buffer streamed chunks and flush at most every 50ms (~20fps). At a
   // typical token rate of 30-60 tokens/sec, this batches ~3 tokens per
@@ -97,6 +104,7 @@ export function Processing() {
       ipc().on.processingComplete((e) => {
         if (activeSession && e.sessionName !== activeSession) return;
         if (!e.success) {
+          setRetryAudioFile(e.audioFile ?? null);
           setStage('error');
           return;
         }
@@ -131,6 +139,36 @@ export function Processing() {
     ];
     return () => offs.forEach((fn) => fn());
   }, [activeSession, updateMeeting]);
+
+  // Actually re-run the failed job: re-queue the preserved source audio via the
+  // same import pipeline a stopped recording uses. Its copy-then-queue semantics
+  // keep the original safe across repeated retries. Only re-arm the loading UI
+  // once the queue call is confirmed issued — a failed/rejected call stays in
+  // the error state instead of spinning forever.
+  const handleRetry = React.useCallback(async () => {
+    if (!retryAudioFile || !activeSession || retrying) return;
+    setRetrying(true);
+    setRetryError(null);
+    try {
+      const res = await ipc().recording.processFile(retryAudioFile, activeSession);
+      if (!res.success) {
+        setRetryError(res.error || 'Couldn’t restart processing. Please try again.');
+        return;
+      }
+      pendingChunkRef.current = '';
+      setStreamText('');
+      setStreamedTitle(null);
+      setChunkProgress(null);
+      setRetryAudioFile(null);
+      setStage('transcribing');
+    } catch (err) {
+      setRetryError(
+        err instanceof Error ? err.message : 'Couldn’t restart processing. Please try again.',
+      );
+    } finally {
+      setRetrying(false);
+    }
+  }, [retryAudioFile, activeSession, retrying]);
 
   const displayTitle =
     streamedTitle ?? draft?.title ?? activeSession ?? 'Note';
@@ -177,7 +215,12 @@ export function Processing() {
         </header>
 
         {stage === 'error' ? (
-          <ErrorPanel onRetry={() => setStage('transcribing')} />
+          <ErrorPanel
+            onRetry={handleRetry}
+            canRetry={Boolean(retryAudioFile && activeSession)}
+            retrying={retrying}
+            error={retryError}
+          />
         ) : (
           <StageCard stage={stage} streamText={streamText} chunkProgress={chunkProgress} />
         )}
@@ -313,7 +356,17 @@ function StageCard({
   );
 }
 
-function ErrorPanel({ onRetry }: { onRetry: () => void }) {
+function ErrorPanel({
+  onRetry,
+  canRetry,
+  retrying,
+  error,
+}: {
+  onRetry: () => void;
+  canRetry: boolean;
+  retrying: boolean;
+  error: string | null;
+}) {
   return (
     <div className="py-3">
       <p
@@ -326,19 +379,31 @@ function ErrorPanel({ onRetry }: { onRetry: () => void }) {
         className="mt-1 text-[14px]"
         style={{ color: 'var(--fg-2)' }}
       >
-        Try again, or reprocess the recording from the meeting list once it
-        appears.
+        {canRetry
+          ? 'Try again to re-run processing on this recording.'
+          : 'This recording couldn’t be recovered automatically. Try importing the audio file again from Home.'}
       </p>
+      {error && (
+        <p
+          className="mt-2 text-[14px]"
+          role="alert"
+          style={{ color: 'var(--danger, #b4231f)' }}
+        >
+          {error}
+        </p>
+      )}
       <button
         type="button"
         onClick={onRetry}
-        className="mt-4 inline-flex h-9 cursor-pointer items-center rounded-[8px] border-0 px-4 text-[14px] font-medium"
+        disabled={!canRetry || retrying}
+        className="mt-4 inline-flex h-9 cursor-pointer items-center gap-2 rounded-[8px] border-0 px-4 text-[14px] font-medium disabled:cursor-not-allowed disabled:opacity-60"
         style={{
           background: 'var(--fg-1)',
           color: 'var(--fg-inverse)',
         }}
       >
-        Try again
+        {retrying && <Loader2 className="animate-spin" size={14} />}
+        {retrying ? 'Retrying…' : 'Try again'}
       </button>
     </div>
   );

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -721,8 +721,21 @@ class WhisperTranscriber:
             pass  # not a readable WAV — fall through to ffmpeg
 
         ffmpeg = _resolve_ffmpeg() or 'ffmpeg'
-        temp_dir = tempfile.gettempdir()
-        converted_path = Path(temp_dir) / f"stenoai_16khz_{audio_filepath.stem}.wav"
+        # mkstemp (not a name derived from the input stem) so concurrent CLI
+        # invocations over same-named files can't overwrite or unlink each
+        # other's converted audio mid-transcription — same guard as
+        # _preprocess_audio. The caller (_run_whisper_cpp) owns deleting this
+        # temp when it returns as the converted path; on any failure we return
+        # the original audio, so we must clean up the mkstemp file ourselves.
+        try:
+            fd, temp_name = tempfile.mkstemp(
+                prefix=f"stenoai_16khz_{audio_filepath.stem}_", suffix=".wav"
+            )
+            os.close(fd)
+        except OSError as e:
+            logger.error("Could not create 16 kHz temp file: %s", e)
+            return audio_filepath, None
+        converted_path = Path(temp_name)
         try:
             result = subprocess.run(
                 [ffmpeg, '-y', '-i', str(audio_filepath),
@@ -731,7 +744,7 @@ class WhisperTranscriber:
                 capture_output=True,
                 timeout=60,
             )
-            if result.returncode == 0 and converted_path.exists():
+            if result.returncode == 0 and converted_path.exists() and converted_path.stat().st_size > 0:
                 duration_seconds = None
                 try:
                     with wave.open(str(converted_path), 'rb') as wf:
@@ -740,10 +753,15 @@ class WhisperTranscriber:
                     logger.warning("Could not read duration from converted WAV: %s", e)
                 return converted_path, duration_seconds
             logger.error("ffmpeg conversion failed: %s", result.stderr.decode())
-            return audio_filepath, None
         except Exception as e:
             logger.error("Audio conversion error: %s", e)
-            return audio_filepath, None
+        # Clean up the (empty or partial) temp output before falling back.
+        try:
+            if converted_path.exists():
+                converted_path.unlink()
+        except OSError:
+            pass
+        return audio_filepath, None
 
     def _run_whisper_cpp(self, audio_filepath: Path, language: str) -> dict:
         """Call into pywhispercpp on the converted 16 kHz mono WAV.


### PR DESCRIPTION
## Summary
Three issues found in a full codebase review (Electron main process, React renderer, Python backend), each fixed and independently re-verified with Codex:

- **`app/main.js`** — `reprocess-meeting`, `generate-report-meeting`, `set-active-report`, `delete-report`, and `regen-meeting-title` took a renderer-supplied `summaryFile` path with no containment check, unlike sibling meeting-file handlers. Extracted `get-meeting`'s existing symlink-safe realpath+output-dir+extension check into a shared `validateMeetingFilePath()` helper and applied it to all five, passing the canonical `realPath` downstream instead of the raw string. Also hardened `process-recording`'s `audioFile` arg (realpath + `isFile()` + extension allowlist) since it's a renderer-reachable copy-into-recordings primitive.
- **`app/renderer/src/routes/Processing.tsx`** — the error panel's "Try again" button only reset UI state (`setStage('transcribing')`) without re-invoking any IPC call, so a backend processing crash left the user on a permanent spinner (same symptom class as #212, different trigger). It now re-queues the preserved source audio via `recording.processFile` and only re-arms the loading UI on confirmed success; shows a retry-in-flight state and a real error if the retry itself fails.
- **`src/transcriber.py`** — `_convert_to_16khz()` wrote to a predictable temp filename, letting two concurrent transcriptions over same-stem audio corrupt each other's file via `ffmpeg -y`. Switched to `tempfile.mkstemp()`, matching the sibling `_preprocess_audio()` guard that already handles this.

An independent Codex review of the first version of the `main.js` fix caught a symlink-bypass gap (the initial guard used `validateSafeFilePath`, which doesn't call `realpath`) — that was addressed by reusing `get-meeting`'s stricter logic instead, and re-verified clean.

## Test plan
- [x] `node --check app/main.js`
- [x] `npm run typecheck:renderer` — clean
- [x] `npm run lint:renderer` — 0 errors, no new warnings (Processing.tsx's 3 pre-existing warnings unchanged)
- [x] `ruff check src/transcriber.py` — clean
- [x] `python -m unittest discover tests` — 352 tests, all pass
- [x] Codex independent security review, two passes (gap found + fix re-verified)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three issues: secure meeting file path handling, a working retry after processing crashes, and a temp-file race in audio conversion. Increases security and makes failed transcriptions recoverable.

- **Bug Fixes**
  - Electron main: extracted a symlink-safe `validateMeetingFilePath()` and applied it to `reprocess-meeting`, `generate-report-meeting`, `set-active-report`, `delete-report`, and `regen-meeting-title`; now passes the canonical real path. Also hardened `process-recording` to realpath the import, require a regular file, and enforce an extension allowlist.
  - Renderer: the Processing screen’s “Try again” now re-queues the preserved source audio via `recording.processFile`, shows retry progress/errors, and only returns to loading on success; `processing-complete` can now include `audioFile` for this path and typings were updated.
  - Backend: `_convert_to_16khz()` now uses `tempfile.mkstemp()` and cleans up on failure to avoid concurrent conversion races over same-stem audio.

<sup>Written for commit 6abf78d7ae426e7cdaf4d0f5624bd606957abbca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

