### PR TITLE
ci: skip Windows build + e2e on website-only pushes

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,6 +20,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'website/**'
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'website/**'
   pull_request:
+    paths-ignore:
+      - 'website/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- `build-windows.yml` and `e2e.yml` had no path filter on their `push`/`pull_request` triggers, so a change touching only `website/**` still kicked off the full Windows installer build and e2e suite on every push to main.
- `deploy-website.yml` already scopes correctly (`paths: ['website/**']`); this brings the other two workflows in line by adding `paths-ignore: ['website/**']`.

## Test plan
- [ ] Push a website-only change and confirm `Build Windows installer` and `e2e` no longer trigger
- [ ] Confirm app/backend changes still trigger both workflows as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip running the Windows installer build and E2E workflows on website-only changes by adding `paths-ignore: ['website/**']` to their triggers (push for Windows, push and pull_request for E2E). This aligns them with `deploy-website.yml` and prevents unnecessary CI runs on main and PRs.

<sup>Written for commit 74b967f58a09f4391009ca68ca95d46bf516445d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

