### PR TITLE
fix: navigate to note when clicking "Note ready" notification

### DIFF
--- a/app/docs/ipc-contract.md
+++ b/app/docs/ipc-contract.md
@@ -163,6 +163,7 @@ truth for elapsed time and paused state so remounts recover correctly.
 | `summary-complete` | M→R | yes | `stenoai.on.summaryComplete(cb)` |
 | `processing-complete` | M→R | yes | `stenoai.on.processingComplete(cb)` |
 | `processing-progress` | M→R | yes | `stenoai.on.processingProgress(cb)` |
+| `navigate-to-meeting` | M→R | yes | `stenoai.on.navigateToMeeting(cb)` — fired on "Note ready" notification click when a `summaryFile` exists; renderer navigates to that note's detail route |
 
 ```ts
 interface SessionInfo {
@@ -440,7 +441,7 @@ are string-cased (`"True"`/`"False"`) — that translation lives in main.js.
 | `set-silence-auto-stop-enabled` | R→M invoke | yes | `stenoai.settings.setSilenceAutoStopEnabled(b)` |
 | `set-silence-auto-stop-minutes` | R→M invoke | yes | `stenoai.settings.setSilenceAutoStopMinutes(n)` |
 | `show-silence-auto-stop-notification` | R→M invoke | yes | `stenoai.settings.showSilenceAutoStopNotification({ minutes, sessionName })` |
-| `show-note-ready-notification` | R→M invoke | yes | `stenoai.settings.showNoteReadyNotification({ title, failed?, hardFailure? })` — `failed`: graceful transcription failure (marked note written); `hardFailure`: processing crash / import that never enqueued (no note) |
+| `show-note-ready-notification` | R→M invoke | yes | `stenoai.settings.showNoteReadyNotification({ title, failed?, hardFailure?, summaryFile? })` — `failed`: graceful transcription failure (marked note written); `hardFailure`: processing crash / import that never enqueued (no note); `summaryFile`: when present, clicking the notification fires `navigate-to-meeting` to open that note |
 | `get-telemetry` / `set-telemetry` | R→M invoke | yes | `stenoai.settings.getTelemetry()` / `setTelemetry(b)` |
 | `get-dock-icon` / `set-dock-icon` | R→M invoke | yes | `stenoai.settings.getDockIcon()` / `setDockIcon(b)` |
 | `get-system-audio` / `set-system-audio` | R→M invoke | yes | `stenoai.settings.getSystemAudio()` / `setSystemAudio(b)` |
@@ -756,6 +757,6 @@ but the new renderer should not re-export them in `preload.js`:
 
 - `ipcMain.handle` channels: **78**
 - `ipcMain.on` channels: **6** (`focus-window`, `shortcut-renderer-ready`, `query-transcript-stream`, `query-cancel`, `install-update`, `system-audio-recording-state`)
-- `webContents.send` channels: **19** (`shortcut-start-recording`, `shortcut-stop-recording`, `tray-start-recording`, `tray-stop-recording`, `tray-open-settings`, `toggle-recording-hotkey`, `debug-log`, `trigger-setup-flow`, `summary-chunk`, `summary-title`, `summary-complete`, `processing-complete`, `query-chunk`, `query-done`, `model-pull-progress`, `model-pull-complete`, `update-available`, `update-download-progress`, `update-downloaded`, `google-auth-changed`, `outlook-auth-changed`)
+- `webContents.send` channels: **22** (`shortcut-start-recording`, `shortcut-stop-recording`, `tray-start-recording`, `tray-stop-recording`, `tray-open-settings`, `toggle-recording-hotkey`, `debug-log`, `trigger-setup-flow`, `summary-chunk`, `summary-title`, `summary-complete`, `processing-complete`, `query-chunk`, `query-done`, `model-pull-progress`, `model-pull-complete`, `update-available`, `update-download-progress`, `update-downloaded`, `google-auth-changed`, `outlook-auth-changed`, `navigate-to-meeting`)
 
 Total IPC surface to port: **~100 channels**.

--- a/app/main.js
+++ b/app/main.js
@@ -5867,16 +5867,17 @@ ipcMain.handle('show-silence-auto-stop-notification', async (_event, payload) =>
 
 // Fired by the renderer's processing-complete handler when we skipped
 // auto-navigate (user was on a route other than /meetings/processing).
-// Click just focuses Steno — same predictable behaviour as the auto-stop
-// notification. We don't navigate anywhere: the new note appears at the
-// top of the sidebar / Home list, so once Steno is focused the user
-// can see it instantly. Navigating away (especially when the user is
-// recording another note back-to-back) is worse than no navigation.
+// Clicking the banner is an explicit "take me there" from the user (unlike
+// the idle auto-navigate case this mirrors in spirit), so it navigates
+// straight to the finished note when one was written — via the
+// navigate-to-meeting event — and only falls back to focus-only when
+// `summaryFile` is absent (the hardFailure case: nothing was ever written,
+// so there's nothing to open).
 ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
   try {
     // `shown` = passed the notifications_enabled gate (see show-silence-auto-stop).
     if (!(await notificationsEnabled())) return { success: true, shown: false };
-    const { title, failed, hardFailure } = payload || {};
+    const { title, failed, hardFailure, summaryFile } = payload || {};
     // Three honest states:
     //  - hardFailure: processing crashed (or an import never enqueued) so no
     //    note was written — there's nothing to "open". Keep the message
@@ -5902,6 +5903,7 @@ ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
       if (mainWindow && !mainWindow.isDestroyed()) {
         if (!mainWindow.isVisible()) mainWindow.show();
         mainWindow.focus();
+        if (summaryFile) mainWindow.webContents.send('navigate-to-meeting', { summaryFile });
       }
     });
     notif.show();

--- a/app/preload.js
+++ b/app/preload.js
@@ -347,6 +347,7 @@ const stenoai = {
     autoPauseRequested: (cb) => subscribe('auto-pause-requested', cb),
     autoResumeRequested: (cb) => subscribe('auto-resume-requested', cb),
     autoSummariseRequested: (cb) => subscribe('auto-summarise-requested', cb),
+    navigateToMeeting: (cb) => subscribe('navigate-to-meeting', cb),
     trayOpenSettings: (cb) => subscribe('tray-open-settings', cb),
     showQuitDialog: (cb) => subscribe('show-quit-dialog', cb),
   },

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -436,10 +436,11 @@ export function useRecordingProcessingEffects() {
           // notification, because the route hasn't changed. They'll see
           // the static summary the moment they come back.
           //
-          // Click just focuses Steno (mirrors the auto-stop notification)
-          // — no navigation, so a back-to-back recording isn't yanked
-          // out and the user can find the new note in the sidebar / Home
-          // list at the top once Steno is focused.
+          // Clicking the banner navigates straight to this note (see the
+          // `navigate-to-meeting` listener below) — unlike the idle-route
+          // comparison above, a click is an explicit "take me there" from
+          // the user, so it doesn't have the back-to-back-recording
+          // interruption risk that auto-navigating here would.
           const title =
             data.meetingData?.session_info.name?.trim() ||
             data.sessionName?.trim() ||
@@ -454,6 +455,7 @@ export function useRecordingProcessingEffects() {
           void ipc()
             .settings.showNoteReadyNotification({
               title,
+              summaryFile: finishedSummaryFile,
               failed:
                 Boolean(data.transcriptionFailed) ||
                 Boolean(data.meetingData?.session_info.transcription_failed),
@@ -480,4 +482,12 @@ export function useRecordingProcessingEffects() {
     });
     return off;
   }, [qc]);
+
+  // Fired by main when the user clicks the "Note ready" notification —
+  // an explicit request to jump to that note, so navigate unconditionally.
+  React.useEffect(() => {
+    return ipc().on.navigateToMeeting(({ summaryFile }) => {
+      if (summaryFile) navigate(`/meetings/${encodeURIComponent(summaryFile)}`);
+    });
+  }, []);
 }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -832,7 +832,14 @@ export interface StenoaiBridge {
       Result<Record<string, never>>
     >;
     showNoteReadyNotification: RequestFn<
-      [payload: { title: string; failed?: boolean; hardFailure?: boolean }],
+      [
+        payload: {
+          title: string;
+          failed?: boolean;
+          hardFailure?: boolean;
+          summaryFile?: string | null;
+        },
+      ],
       Result<Record<string, never>>
     >;
     /** Design-for-test seam for the pre-meeting notification (production fire
@@ -924,6 +931,7 @@ export interface StenoaiBridge {
     autoPauseRequested: Subscribe<void>;
     autoResumeRequested: Subscribe<void>;
     autoSummariseRequested: Subscribe<void>;
+    navigateToMeeting: Subscribe<{ summaryFile: string }>;
     trayOpenSettings: Subscribe<void>;
     showQuitDialog: Subscribe<{ type: 'recording' | 'processing'; jobCount?: number }>;
   };

--- a/e2e/specs/notifications.t2.spec.ts
+++ b/e2e/specs/notifications.t2.spec.ts
@@ -33,7 +33,10 @@ const showSilence = (page: import('@playwright/test').Page) =>
   );
 const showNote = (page: import('@playwright/test').Page) =>
   page.evaluate(() =>
-    (window as StenoWindow).stenoai.settings.showNoteReadyNotification({ title: 'E2E note' }),
+    (window as StenoWindow).stenoai.settings.showNoteReadyNotification({
+      title: 'E2E note',
+      summaryFile: 'e2e-note.json',
+    }),
   );
 
 test('notifications toggle persists and gates the note-ready / silence notifications; real dir untouched', async ({


### PR DESCRIPTION
## Summary
- Clicking the "Note ready" desktop notification previously only refocused the Steno window; it now navigates straight to the note that just finished.
- Threads the finished note's `summaryFile` through `showNoteReadyNotification`, and on click, main.js sends a new `navigate-to-meeting` event that the renderer listens for and navigates to `/meetings/<summaryFile>`.
- Hard-failure notifications (nothing was ever written) keep the old focus-only behavior, since there's nothing to open.
- Auto-navigate-while-idle logic is untouched — only the explicit click case changes, since a click is unambiguous user intent, unlike the app auto-navigating someone away from what they're doing.

## Testing note
I was not able to manually verify the click behavior end-to-end. In this sandbox:
- The Python backend isn't built (no `dist/stenoai/stenoai`), so the onboarding wizard can't complete.
- More importantly, macOS itself refuses to deliver notifications from an **unsigned dev-mode Electron build** — confirmed by testing a bare `new Notification().show()` outside the app entirely, which emitted a `failed` event even with notification permissions correctly granted and no Focus/DND active. This is a known macOS/Electron constraint (code signing required for `UNNotification` delivery), not a bug in the app.
- No Developer ID signing identity is available in this workspace's keychain, so I couldn't produce a signed local build to work around it either.

What I did verify:
- `npm run typecheck:renderer` and `npm run lint:renderer` pass with no new issues.
- All 18 hermetic T1 e2e specs pass (no regressions).
- The change mirrors the exact `webContents.send` → `ipcRenderer.on` → `navigate()` pattern already used and tested elsewhere in the app (e.g. `auto-record-requested`, `shortcut-start-recording`).
- Updated `notifications.t2.spec.ts` to pass `summaryFile` through the existing notifications-gate test.

Recommend a real click-through test on a properly signed local build (or after this lands) before/soon after merge.

## Test plan
- [ ] On a signed local build (or after merge), background the app, let a note finish processing elsewhere, click the "Note ready" banner, confirm it opens the correct note.
- [ ] Confirm the hard-failure ("Processing failed") notification still only focuses the window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking the "Note ready" desktop notification now opens the exact note instead of just refocusing the app. This threads the note’s `summaryFile` through to main and emits a `navigate-to-meeting` IPC event that the renderer uses to navigate.

- **Bug Fixes**
  - Added `navigate-to-meeting` IPC and `stenoai.on.navigateToMeeting`; renderer navigates to `/meetings/<summaryFile>` on click.
  - Threaded `summaryFile` through `stenoai.settings.showNoteReadyNotification`; updated IPC docs and e2e to include it.
  - Hard-failure notifications still only focus the window; idle auto-navigate behavior is unchanged.

<sup>Written for commit 48e0c94d15f0c53d38b5eb6035730ba855b39671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

