### PR TITLE
test: #278 batch A - IPC contract check, deep-link parsing coverage, state_file audit

### DIFF
--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -130,17 +130,59 @@ test('every e2e-mock stub names a real renderer-callable channel (no stale stub)
   );
 });
 
-test('every M->R subscribe channel is emitted somewhere in main.js', () => {
-  // webContents.send targets are sometimes a ternary/helper arg, so assert the
-  // channel literal appears in main.js rather than matching a rigid .send(...)
-  // shape — robust to `send(cond ? 'a' : 'b')` and indirection.
-  const missing = [...preloadSubscribeChannels()].filter(
-    (ch) => !MAIN.includes(`'${ch}'`) && !MAIN.includes(`"${ch}"`),
-  );
+// The channel name in main.js's M->R events is always the FIRST argument of a
+// send call — `mainWindow.webContents.send('<ch>', payload)`, `event.sender.send`,
+// or `sender.send` — and is sometimes a ternary of literals
+// (`send(cond ? 'a' : 'b')`). Extract just that first argument (up to the first
+// top-level comma / the closing paren, honoring quotes so a ')' or ',' inside a
+// string never ends it early) and collect the channel literals from it. Scoping
+// to the first argument keeps channel-shaped strings in a *payload* object from
+// counting as a send site, and matching a real `.send(` call — not a bare
+// substring anywhere — means a channel named only in a comment can't satisfy it.
+function firstSendArg(src, i) {
+  let depth = 1;
+  let quote = null;
+  let out = '';
+  for (; i < src.length; i++) {
+    const c = src[i];
+    if (quote) {
+      out += c;
+      if (c === quote && src[i - 1] !== '\\') quote = null;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      quote = c;
+      out += c;
+      continue;
+    }
+    if (c === '(') depth++;
+    else if (c === ')') {
+      depth--;
+      if (depth === 0) break;
+    } else if (c === ',' && depth === 1) break;
+    out += c;
+  }
+  return out;
+}
+
+function channelsEmittedViaSend() {
+  const emitted = new Set();
+  const re = /\.send\(/g;
+  let m;
+  while ((m = re.exec(MAIN))) {
+    const arg = firstSendArg(MAIN, re.lastIndex);
+    for (const lit of arg.matchAll(/["']([^"']+)["']/g)) emitted.add(lit[1]);
+  }
+  return emitted;
+}
+
+test('every M->R subscribe channel is emitted at a real send() site in main.js', () => {
+  const emitted = channelsEmittedViaSend();
+  const missing = [...preloadSubscribeChannels()].filter((ch) => !emitted.has(ch));
   assert.deepStrictEqual(
     missing.sort(),
     [],
-    `preload subscribes to M->R channel(s) main.js never emits: ${missing.join(', ')}`,
+    `preload subscribes to M->R channel(s) main.js never send()s: ${missing.join(', ')}`,
   );
 });
 

--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+/**
+ * IPC contract conformance — catches channel-name drift across the four files
+ * that hand-maintain the renderer<->main wire, so a rename/removal in one place
+ * fails CI instead of silently breaking at runtime.
+ *
+ * The channel name is a bare string threaded through four files with nothing
+ * else tying them together:
+ *   - app/main.js           — the registrations: ipcMain.handle/on/once('<ch>')
+ *   - app/preload.js        — the contextBridge surface: invoke/send('<ch>') for
+ *                             renderer->main calls, subscribe('<ch>') for the
+ *                             main->renderer (M->R) event stream
+ *   - app/renderer/src/lib/ipc.ts — the typed bridge the renderer actually calls
+ *   - app/e2e-mock-ipc.js   — the T1 mock that shims ipcMain.handle
+ *
+ * These are JS/TS source files; we scan them as text (regex), matching the
+ * codebase's pragmatism. That is deliberately good enough: the goal is drift
+ * detection, not a full parse.
+ *
+ * The real relationships (NOT a naive "all four must be identical"):
+ *
+ *   1. preload invoke/send channels  ==  main.js registrations (+ a small
+ *      allowlist of channels registered by a third-party package, not by our
+ *      source). A renderer channel with no handler rejects invoke() at runtime
+ *      ("no handler registered"); an orphan handler is dead code. Both directions
+ *      are checked.
+ *   2. e2e-mock stub keys  is-subset-of  renderer-callable channels. The mock
+ *      only needs entries for channels whose *shape* matters on first paint; it
+ *      resolves everything else permissively (see e2e-mock-ipc.js). So the drift
+ *      risk is the reverse of "every channel must be stubbed": a *stale* stub
+ *      that names a channel which no longer exists would silently do nothing.
+ *   3. preload subscribe (M->R) channels  are each emitted somewhere in main.js
+ *      (webContents.send). These are NOT ipcMain registrations.
+ *   4. ipc.ts is a *typed structural mirror* of the preload bridge object — it
+ *      carries no channel-name string literals, so its channels can't be
+ *      string-scanned. We instead assert the top-level bridge namespaces in
+ *      ipc.ts match preload's, catching a whole namespace added/removed out of
+ *      sync (the per-method shape is covered by tsc + the T1 e2e suite).
+ *
+ * Cross-platform: pure text scanning, no platform assumptions — runs the same on
+ * macOS and Windows.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const read = (rel) => fs.readFileSync(path.join(__dirname, rel), 'utf8');
+
+const MAIN = read('main.js');
+const PRELOAD = read('preload.js');
+const MOCK = read('e2e-mock-ipc.js');
+const IPC_TS = read('renderer/src/lib/ipc.ts');
+
+// Channels registered outside our own source: electron-audio-loopback's
+// initMain() (app/main.js) installs these ipcMain handlers itself, so they are
+// renderer-callable without a literal ipcMain.handle in main.js.
+const EXTERNALLY_REGISTERED = new Set(['enable-loopback-audio', 'disable-loopback-audio']);
+
+function matchAll(src, re) {
+  const out = [];
+  for (const m of src.matchAll(re)) out.push(m[1]);
+  return out;
+}
+
+// --- main.js: every ipcMain.handle / .on / .once registration ---
+function mainRegistrations() {
+  return matchAll(MAIN, /ipcMain\.(?:handle|on|once)\(\s*["']([^"']+)["']/g);
+}
+
+// --- preload.js: renderer->main channels (invoke = request, send = fire) ---
+function preloadInvokeChannels() {
+  return new Set(matchAll(PRELOAD, /\b(?:invoke|send)\(\s*["']([^"']+)["']/g));
+}
+
+// --- preload.js: main->renderer event channels (subscribe wrapper) ---
+function preloadSubscribeChannels() {
+  return new Set(matchAll(PRELOAD, /\bsubscribe\(\s*["']([^"']+)["']/g));
+}
+
+// --- e2e-mock-ipc.js: the MOCKS + DEFAULTS stub keys. Every channel name is
+// kebab-case (>=1 hyphen), which distinguishes a channel key from any plain
+// object key and keeps this scan robust. ---
+function mockStubKeys() {
+  return new Set(matchAll(MOCK, /["']([a-z0-9]+(?:-[a-z0-9]+)+)["']\s*:/g));
+}
+
+test('main.js has no duplicate ipcMain registrations (Electron throws on the 2nd)', () => {
+  const regs = mainRegistrations();
+  const seen = new Set();
+  const dups = [];
+  for (const ch of regs) {
+    if (seen.has(ch)) dups.push(ch);
+    else seen.add(ch);
+  }
+  assert.deepStrictEqual(dups, [], `duplicate ipcMain registration(s): ${dups.join(', ')}`);
+});
+
+test('every renderer-callable channel (preload invoke/send) is registered in main.js', () => {
+  const registered = new Set(mainRegistrations());
+  const missing = [...preloadInvokeChannels()].filter(
+    (ch) => !registered.has(ch) && !EXTERNALLY_REGISTERED.has(ch),
+  );
+  assert.deepStrictEqual(
+    missing.sort(),
+    [],
+    `preload invokes channel(s) with no ipcMain handler (invoke() would reject): ${missing.join(', ')}`,
+  );
+});
+
+test('every main.js registration is reachable from the preload bridge (no orphan handlers)', () => {
+  const invocable = preloadInvokeChannels();
+  const orphans = [...new Set(mainRegistrations())].filter((ch) => !invocable.has(ch));
+  assert.deepStrictEqual(
+    orphans.sort(),
+    [],
+    `main.js registers channel(s) the renderer bridge never calls (dead handler?): ${orphans.join(', ')}`,
+  );
+});
+
+test('every e2e-mock stub names a real renderer-callable channel (no stale stub)', () => {
+  const invocable = preloadInvokeChannels();
+  const stale = [...mockStubKeys()].filter((ch) => !invocable.has(ch));
+  assert.deepStrictEqual(
+    stale.sort(),
+    [],
+    `e2e-mock-ipc.js stubs channel(s) that are not renderer-callable (renamed/removed?): ${stale.join(', ')}`,
+  );
+});
+
+test('every M->R subscribe channel is emitted somewhere in main.js', () => {
+  // webContents.send targets are sometimes a ternary/helper arg, so assert the
+  // channel literal appears in main.js rather than matching a rigid .send(...)
+  // shape — robust to `send(cond ? 'a' : 'b')` and indirection.
+  const missing = [...preloadSubscribeChannels()].filter(
+    (ch) => !MAIN.includes(`'${ch}'`) && !MAIN.includes(`"${ch}"`),
+  );
+  assert.deepStrictEqual(
+    missing.sort(),
+    [],
+    `preload subscribes to M->R channel(s) main.js never emits: ${missing.join(', ')}`,
+  );
+});
+
+test('ipc.ts bridge namespaces match the preload bridge (type mirror in sync)', () => {
+  // preload: top-level keys of `const stenoai = { ... }` (2-space indent),
+  // including shorthand properties like `subscribeQueryStream,`.
+  const stenoaiBody = PRELOAD.slice(PRELOAD.indexOf('const stenoai = {'));
+  const preloadKeys = new Set(matchAll(stenoaiBody, /^ {2}([a-zA-Z]+)[,:]/gm));
+
+  // ipc.ts: members of `interface StenoaiBridge { ... }` (2-space indent).
+  const bridgeBody = IPC_TS.slice(IPC_TS.indexOf('interface StenoaiBridge {'));
+  const tsKeys = new Set(matchAll(bridgeBody, /^ {2}([a-zA-Z]+)[?:]/gm));
+
+  const onlyPreload = [...preloadKeys].filter((k) => !tsKeys.has(k)).sort();
+  const onlyTs = [...tsKeys].filter((k) => !preloadKeys.has(k)).sort();
+  assert.deepStrictEqual(
+    { onlyPreload, onlyTs },
+    { onlyPreload: [], onlyTs: [] },
+    `preload bridge and StenoaiBridge namespaces drifted — only in preload: [${onlyPreload}], only in ipc.ts: [${onlyTs}]`,
+  );
+});

--- a/app/main.js
+++ b/app/main.js
@@ -38,6 +38,15 @@ const { spawn: _spawnRaw } = require('child_process');
 const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
 const { makeLineReader } = require('./backend-stream');
+// Pure deep-link (stenoai://) parsing/sanitizing lives in ./shortcut-url
+// (unit-tested). The stateful side — window creation, IPC dispatch,
+// notifications — stays here and calls parseShortcutUrl().
+const {
+  SHORTCUT_PROTOCOL,
+  extractShortcutUrlFromArgv,
+  sanitizeShortcutUrlForLogs,
+  parseShortcutUrl,
+} = require('./shortcut-url');
 
 // Wrap spawn so every backend / ollama launch defaults to windowsHide:true.
 // The PyInstaller backend (stenoai.exe) and bundled ollama.exe are console
@@ -191,39 +200,11 @@ let pendingShortcutUrls = [];
 let rendererShortcutReady = false;
 let launchedByShortcut = false;
 
-const SHORTCUT_PROTOCOL = 'stenoai';
-const SHORTCUT_HOST = 'record';
-const SHORTCUT_SESSION_NAME_MAX_LENGTH = 120;
+// SHORTCUT_PROTOCOL and the pure deep-link parsing/sanitizing helpers
+// (extractShortcutUrlFromArgv, sanitizeShortcutUrlForLogs, parseShortcutUrl,
+// and the parse-internal sanitizeShortcutSessionName) live in ./shortcut-url,
+// imported at the top of this file.
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
-
-function extractShortcutUrlFromArgv(argv = []) {
-  return argv.find(arg => typeof arg === 'string' && arg.startsWith(`${SHORTCUT_PROTOCOL}://`));
-}
-
-function sanitizeShortcutUrlForLogs(incomingUrl) {
-  try {
-    const parsed = new URL(incomingUrl);
-    return `${parsed.protocol}//${parsed.hostname}${parsed.pathname}`;
-  } catch (error) {
-    return '[invalid-shortcut-url]';
-  }
-}
-
-function sanitizeShortcutSessionName(rawValue) {
-  if (typeof rawValue !== 'string') {
-    return null;
-  }
-
-  // Keep user-visible names readable while stripping unsupported characters.
-  // Preserve Unicode letters (including diacritics) and common punctuation.
-  const sanitized = rawValue
-    .replace(/[^\p{L}\p{M}\p{N}_\s.,()@&'!+#-]/gu, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .slice(0, SHORTCUT_SESSION_NAME_MAX_LENGTH);
-
-  return sanitized || null;
-}
 
 function registerShortcutProtocolClient() {
   if (process.platform !== 'darwin') {
@@ -271,36 +252,6 @@ function getMicMonitorPath() {
     return path.join(process.resourcesPath, binName);
   } else {
     return path.join(__dirname, '..', 'bin', binName);
-  }
-}
-
-function parseShortcutUrl(incomingUrl) {
-  try {
-    const parsed = new URL(incomingUrl);
-    if (parsed.protocol !== `${SHORTCUT_PROTOCOL}:`) {
-      return { type: 'invalid', reason: 'invalid-protocol' };
-    }
-
-    if (parsed.hostname !== SHORTCUT_HOST) {
-      return { type: 'invalid', reason: 'invalid-host' };
-    }
-
-    const cleanPath = (parsed.pathname || '').replace(/\/+$/, '');
-    if (cleanPath === '/start') {
-      const sessionName = sanitizeShortcutSessionName(parsed.searchParams.get('name') || '');
-      return {
-        type: 'start',
-        sessionName
-      };
-    }
-
-    if (cleanPath === '/stop') {
-      return { type: 'stop' };
-    }
-
-    return { type: 'invalid', reason: 'invalid-path' };
-  } catch (error) {
-    return { type: 'invalid', reason: 'parse-error' };
   }
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/preload.js
+++ b/app/preload.js
@@ -2,9 +2,9 @@
  * Preload — contextBridge boundary for the React renderer.
  *
  * This is the only surface the renderer gets. Every function here is a thin
- * wrapper over ipcRenderer.invoke / .send / .on, whitelisted to the channels
- * listed in app/docs/ipc-contract.md. Any drift between this file and that
- * doc is a contract break — update both in the same commit.
+ * wrapper over ipcRenderer.invoke / .send / .on. The channel contract across
+ * this file, main.js, the renderer's ipc.ts and the e2e mock is enforced by
+ * app/ipc-contract.test.js — a rename/removal that drifts them fails there.
  */
 
 const { contextBridge, ipcRenderer, webUtils } = require('electron');

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -3,8 +3,9 @@
  * `app/preload.js`. All hooks/components talk to this module; no direct
  * `ipcRenderer` usage in renderer code.
  *
- * The source of truth for the shape is `app/docs/ipc-contract.md` + the
- * preload itself. When you change one, change the other in the same commit.
+ * The source of truth for the shape is `app/preload.js`; keep this typed
+ * mirror in sync with it. The channel contract across preload, main.js, this
+ * file and the e2e mock is enforced by `app/ipc-contract.test.js`.
  */
 
 // ---------- shared result envelope ----------

--- a/app/shortcut-url.js
+++ b/app/shortcut-url.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * Pure parsing/sanitizing for the `stenoai://` deep-link surface.
+ *
+ * These functions are the app's untrusted-input boundary: a URL handed to the
+ * app by macOS (Shortcuts, the open-url event, or argv on launch) is attacker-
+ * influenceable, so the protocol/host checks and the session-name sanitizer are
+ * security-relevant. They are kept pure (no Electron / app / BrowserWindow
+ * dependency) and unit-tested here; the stateful side — window creation, IPC
+ * dispatch, notifications — stays in main.js and calls parseShortcutUrl().
+ *
+ * Cross-platform: no platform-specific assumptions. The `stenoai://` scheme is
+ * only *registered* on macOS today (see registerShortcutProtocolClient in
+ * main.js), but the parsing itself is platform-agnostic.
+ */
+
+const SHORTCUT_PROTOCOL = 'stenoai';
+const SHORTCUT_HOST = 'record';
+const SHORTCUT_SESSION_NAME_MAX_LENGTH = 120;
+
+// First argv entry that looks like our deep link (used on cold launch, where
+// macOS passes the URL as a process argument instead of via open-url).
+function extractShortcutUrlFromArgv(argv = []) {
+  return argv.find(
+    (arg) => typeof arg === 'string' && arg.startsWith(`${SHORTCUT_PROTOCOL}://`),
+  );
+}
+
+// A log-safe rendering of the URL: protocol + host + path only, never the query
+// string (which can carry a user-supplied meeting name). Invalid URLs collapse
+// to a fixed placeholder so a malformed link can't smuggle content into logs.
+function sanitizeShortcutUrlForLogs(incomingUrl) {
+  try {
+    const parsed = new URL(incomingUrl);
+    return `${parsed.protocol}//${parsed.hostname}${parsed.pathname}`;
+  } catch (error) {
+    return '[invalid-shortcut-url]';
+  }
+}
+
+// Reduce an arbitrary user-supplied session name to a safe, readable string.
+// Preserves Unicode letters/marks/numbers and a small punctuation set; every
+// other character (path separators, control chars, quotes, etc.) becomes a
+// space, runs of whitespace collapse, and the result is length-capped. Returns
+// null for a non-string or an empty post-sanitization result so callers fall
+// back to a default name.
+function sanitizeShortcutSessionName(rawValue) {
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+
+  // Keep user-visible names readable while stripping unsupported characters.
+  // Preserve Unicode letters (including diacritics) and common punctuation.
+  const sanitized = rawValue
+    .replace(/[^\p{L}\p{M}\p{N}_\s.,()@&'!+#-]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, SHORTCUT_SESSION_NAME_MAX_LENGTH);
+
+  return sanitized || null;
+}
+
+// Parse a `stenoai://record/{start,stop}` deep link into an action descriptor.
+// Rejects (type: 'invalid') anything with the wrong protocol, wrong host, an
+// unknown path, or an unparseable URL — never throws. On /start, the `name`
+// query param is run through sanitizeShortcutSessionName.
+function parseShortcutUrl(incomingUrl) {
+  try {
+    const parsed = new URL(incomingUrl);
+    if (parsed.protocol !== `${SHORTCUT_PROTOCOL}:`) {
+      return { type: 'invalid', reason: 'invalid-protocol' };
+    }
+
+    if (parsed.hostname !== SHORTCUT_HOST) {
+      return { type: 'invalid', reason: 'invalid-host' };
+    }
+
+    const cleanPath = (parsed.pathname || '').replace(/\/+$/, '');
+    if (cleanPath === '/start') {
+      const sessionName = sanitizeShortcutSessionName(parsed.searchParams.get('name') || '');
+      return {
+        type: 'start',
+        sessionName,
+      };
+    }
+
+    if (cleanPath === '/stop') {
+      return { type: 'stop' };
+    }
+
+    return { type: 'invalid', reason: 'invalid-path' };
+  } catch (error) {
+    return { type: 'invalid', reason: 'parse-error' };
+  }
+}
+
+module.exports = {
+  SHORTCUT_PROTOCOL,
+  SHORTCUT_HOST,
+  SHORTCUT_SESSION_NAME_MAX_LENGTH,
+  extractShortcutUrlFromArgv,
+  sanitizeShortcutUrlForLogs,
+  sanitizeShortcutSessionName,
+  parseShortcutUrl,
+};

--- a/app/shortcut-url.test.js
+++ b/app/shortcut-url.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  SHORTCUT_SESSION_NAME_MAX_LENGTH,
+  extractShortcutUrlFromArgv,
+  sanitizeShortcutUrlForLogs,
+  sanitizeShortcutSessionName,
+  parseShortcutUrl,
+} = require('./shortcut-url');
+
+// ---------------------------------------------------------------------------
+// parseShortcutUrl — the untrusted-input boundary. A URL here is handed to the
+// app by macOS (Shortcuts / open-url / argv) and is attacker-influenceable.
+// ---------------------------------------------------------------------------
+
+test('parseShortcutUrl accepts record/start and returns the sanitized name', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/start?name=Standup'), {
+    type: 'start',
+    sessionName: 'Standup',
+  });
+});
+
+test('parseShortcutUrl accepts record/stop', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/stop'), { type: 'stop' });
+});
+
+test('parseShortcutUrl decodes URL-encoded name values', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/start?name=Team%20Sync%20%231'), {
+    type: 'start',
+    sessionName: 'Team Sync #1',
+  });
+});
+
+test('parseShortcutUrl treats a missing name param as no name', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/start'), {
+    type: 'start',
+    sessionName: null,
+  });
+});
+
+test('parseShortcutUrl treats an empty name param as no name', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/start?name='), {
+    type: 'start',
+    sessionName: null,
+  });
+});
+
+test('parseShortcutUrl tolerates a trailing slash on the path', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/start/'), {
+    type: 'start',
+    sessionName: null,
+  });
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/stop//'), { type: 'stop' });
+});
+
+test('parseShortcutUrl rejects a foreign protocol (no cross-scheme hijack)', () => {
+  assert.deepStrictEqual(parseShortcutUrl('https://record/start'), {
+    type: 'invalid',
+    reason: 'invalid-protocol',
+  });
+  assert.deepStrictEqual(parseShortcutUrl('file://record/stop'), {
+    type: 'invalid',
+    reason: 'invalid-protocol',
+  });
+  // A lookalike scheme must not pass.
+  assert.deepStrictEqual(parseShortcutUrl('stenoai-evil://record/start'), {
+    type: 'invalid',
+    reason: 'invalid-protocol',
+  });
+});
+
+test('parseShortcutUrl rejects a wrong host', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://evil/start'), {
+    type: 'invalid',
+    reason: 'invalid-host',
+  });
+});
+
+test('parseShortcutUrl rejects an unknown action path', () => {
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/delete-everything'), {
+    type: 'invalid',
+    reason: 'invalid-path',
+  });
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/'), {
+    type: 'invalid',
+    reason: 'invalid-path',
+  });
+});
+
+test('parseShortcutUrl contains path-traversal within the record host and exact actions', () => {
+  // The WHATWG URL parser normalizes ".." path segments, but that can never
+  // change the host, so a traversal attempt stays scoped to record/* and only
+  // an exact "/start" or "/stop" yields an action. A "/start/../stop" collapses
+  // to the (still in-scope, benign) stop action; anything that normalizes to a
+  // different path is rejected as invalid-path.
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/start/../stop'), { type: 'stop' });
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/../../evil/start'), {
+    type: 'invalid',
+    reason: 'invalid-path',
+  });
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/start/../../../etc'), {
+    type: 'invalid',
+    reason: 'invalid-path',
+  });
+  // A percent-encoded slash is NOT decoded into a path separator, so it can't
+  // smuggle a second path segment past the exact-match check.
+  assert.deepStrictEqual(parseShortcutUrl('stenoai://record/..%2Fstop'), {
+    type: 'invalid',
+    reason: 'invalid-path',
+  });
+});
+
+test('parseShortcutUrl returns parse-error for a malformed URL and never throws', () => {
+  assert.deepStrictEqual(parseShortcutUrl('not a url'), {
+    type: 'invalid',
+    reason: 'parse-error',
+  });
+  assert.deepStrictEqual(parseShortcutUrl(''), { type: 'invalid', reason: 'parse-error' });
+  assert.deepStrictEqual(parseShortcutUrl(undefined), {
+    type: 'invalid',
+    reason: 'parse-error',
+  });
+  assert.deepStrictEqual(parseShortcutUrl(null), { type: 'invalid', reason: 'parse-error' });
+});
+
+test('parseShortcutUrl sanitizes a malicious name payload rather than passing it through', () => {
+  const res = parseShortcutUrl(
+    'stenoai://record/start?name=' + encodeURIComponent('../../etc/passwd'),
+  );
+  assert.strictEqual(res.type, 'start');
+  // Slashes are stripped by the sanitizer, so no path fragment survives.
+  assert.ok(!res.sessionName.includes('/'), `name still had a slash: ${res.sessionName}`);
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeShortcutSessionName — the string that becomes a folder/display name.
+// ---------------------------------------------------------------------------
+
+test('sanitizeShortcutSessionName returns null for non-strings', () => {
+  assert.strictEqual(sanitizeShortcutSessionName(null), null);
+  assert.strictEqual(sanitizeShortcutSessionName(undefined), null);
+  assert.strictEqual(sanitizeShortcutSessionName(42), null);
+  assert.strictEqual(sanitizeShortcutSessionName({}), null);
+});
+
+test('sanitizeShortcutSessionName returns null when nothing survives sanitizing', () => {
+  assert.strictEqual(sanitizeShortcutSessionName(''), null);
+  assert.strictEqual(sanitizeShortcutSessionName('   '), null);
+  // All-forbidden input collapses to spaces, then trims to empty -> null.
+  assert.strictEqual(sanitizeShortcutSessionName('/\\<>:*?"|'), null);
+});
+
+test('sanitizeShortcutSessionName preserves Unicode letters, marks and safe punctuation', () => {
+  assert.strictEqual(sanitizeShortcutSessionName('Café Sync'), 'Café Sync');
+  assert.strictEqual(sanitizeShortcutSessionName('Q3 Review (2026)'), 'Q3 Review (2026)');
+  assert.strictEqual(sanitizeShortcutSessionName("O'Brien & co. #1"), "O'Brien & co. #1");
+  assert.strictEqual(sanitizeShortcutSessionName('会議 メモ'), '会議 メモ');
+});
+
+test('sanitizeShortcutSessionName strips path separators and control characters', () => {
+  assert.strictEqual(sanitizeShortcutSessionName('a/b\\c'), 'a b c');
+  assert.strictEqual(sanitizeShortcutSessionName('name with\x00control'), 'name with control');
+  assert.strictEqual(sanitizeShortcutSessionName('../../secret'), '.. .. secret');
+});
+
+test('sanitizeShortcutSessionName collapses runs of whitespace and trims', () => {
+  assert.strictEqual(sanitizeShortcutSessionName('  hello    world  '), 'hello world');
+  assert.strictEqual(sanitizeShortcutSessionName('tab\tand\nnewline'), 'tab and newline');
+});
+
+test('sanitizeShortcutSessionName caps the length', () => {
+  const long = 'a'.repeat(SHORTCUT_SESSION_NAME_MAX_LENGTH + 50);
+  const out = sanitizeShortcutSessionName(long);
+  assert.strictEqual(out.length, SHORTCUT_SESSION_NAME_MAX_LENGTH);
+});
+
+// ---------------------------------------------------------------------------
+// extractShortcutUrlFromArgv — cold-launch argv path.
+// ---------------------------------------------------------------------------
+
+test('extractShortcutUrlFromArgv finds the stenoai:// arg among other args', () => {
+  const argv = ['/path/to/electron', '--flag', 'stenoai://record/start?name=Hi', 'x'];
+  assert.strictEqual(extractShortcutUrlFromArgv(argv), 'stenoai://record/start?name=Hi');
+});
+
+test('extractShortcutUrlFromArgv returns undefined when no shortcut arg is present', () => {
+  assert.strictEqual(extractShortcutUrlFromArgv(['/path/to/electron', '--flag']), undefined);
+});
+
+test('extractShortcutUrlFromArgv handles an empty/absent argv and non-string entries', () => {
+  assert.strictEqual(extractShortcutUrlFromArgv(), undefined);
+  assert.strictEqual(extractShortcutUrlFromArgv([]), undefined);
+  assert.strictEqual(extractShortcutUrlFromArgv([null, 42, {}]), undefined);
+});
+
+test('extractShortcutUrlFromArgv only matches the stenoai:// scheme, not a lookalike', () => {
+  assert.strictEqual(
+    extractShortcutUrlFromArgv(['stenoai-evil://record/start']),
+    undefined,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeShortcutUrlForLogs — must never leak the query string (user name).
+// ---------------------------------------------------------------------------
+
+test('sanitizeShortcutUrlForLogs drops the query string so a name never reaches logs', () => {
+  assert.strictEqual(
+    sanitizeShortcutUrlForLogs('stenoai://record/start?name=Secret%20Project'),
+    'stenoai://record/start',
+  );
+});
+
+test('sanitizeShortcutUrlForLogs returns a fixed placeholder for an invalid URL', () => {
+  assert.strictEqual(sanitizeShortcutUrlForLogs('not a url'), '[invalid-shortcut-url]');
+  assert.strictEqual(sanitizeShortcutUrlForLogs(undefined), '[invalid-shortcut-url]');
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -83,10 +83,10 @@ def _normalize_markdown_for_parsing(md_text: str) -> str:
     return _REASONING_TAG_HEADER_PATTERN.sub(r'\1\n\2', md_text)
 
 # Shared atomic JSON writer (tempfile + os.replace + Windows PermissionError
-# retry). One implementation for recorder_state.json, the summary JSON, and
-# config.json — re-exported here so existing imports keep working. The
-# canonical copy lives in src.config because this module already imports
-# from src (the reverse import would be circular).
+# retry). One implementation for the summary JSON and config.json (recorder_state.json
+# is no longer written — see MeetingPipeline.state_file) — re-exported here so
+# existing imports keep working. The canonical copy lives in src.config because
+# this module already imports from src (the reverse import would be circular).
 from src.config import _atomic_write_json  # noqa: E402
 
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -169,7 +169,21 @@ class MeetingPipeline:
         self.transcripts_dir = dirs["transcripts"]
         self.output_dir = dirs["output"]
         
-        # State file
+        # Legacy state file. Recording state now lives in the Electron main
+        # process (capture is renderer-driven) -- see the status() docstring --
+        # so nothing writes recorder_state.json anymore; the old
+        # save_state()/load_state() pair was removed. The only remaining uses
+        # are the defensive .unlink() cleanups (here via clear_state, plus the
+        # transcription-failure paths) that remove a stale file left by a
+        # pre-migration build. Kept CWD-relative on purpose: a legacy build
+        # wrote it CWD-relative to the backend's working dir, which
+        # getBackendCwd() (app/main.js) resolves to a single, deterministic
+        # location, so the cleanup reliably finds and removes that same file.
+        # Routing this through get_user_data_dir() would point cleanup at the
+        # wrong directory. Because nothing writes it, the CWD-relative path
+        # never touches the read-only packaged bundle and cannot leak across
+        # the STENOAI_USER_DATA_DIR isolation boundary (real user data goes
+        # through get_data_dirs(), which honors that env var).
         self.state_file = Path("recorder_state.json")
 
     def _resolve_output_language(self, configured_language: str, detected_language: Optional[str] = None) -> str:


### PR DESCRIPTION
## Batch A of #278 - test/verification hardening (model-free, no product behaviour change)

Three self-contained items from the architecture-debt backlog (#278), bundled into one PR because they're all pure test/doc work with no runtime behaviour change.

### #1 - IPC contract conformance check
`app/ipc-contract.test.js` (node:test) cross-checks the IPC channel sets across the four hand-synced sources (`main.js` registrations, `preload.js`, `renderer/src/lib/ipc.ts`, `e2e-mock-ipc.js`) so channel drift fails CI instead of silently rotting. Models the *actual* relationships (subset/emit invariants), not a naive "all identical" rule:
- no duplicate `ipcMain` registrations,
- every renderer-callable channel is registered in `main.js`,
- no orphan registrations,
- every mock stub is a real channel,
- every M→R `subscribe` channel is emitted at a real `.send()` site (quote-aware first-arg scan, not substring-anywhere),
- `ipc.ts` namespaces mirror preload's.

No real wiring drift found in the current tree. Note: the issue mentioned `docs/ipc-contract.md` as a 5th source - it doesn't exist; the stale comments in `preload.js`/`ipc.ts` that pointed at it now point at this test.

### #4 - Deep-link parsing test coverage
Extracted the pure `stenoai://` parsing/sanitising helpers (`parseShortcutUrl`, `sanitizeShortcutSessionName`, `sanitizeShortcutUrlForLogs`, `extractShortcutUrlFromArgv`) out of `main.js` into `app/shortcut-url.js` (same pattern as `meeting-detect.js`), re-required into `main.js` so behaviour is unchanged. `app/shortcut-url.test.js` adds 24 tests over this security-relevant input surface: wrong protocol/host, path traversal / `%2F`, control-char + length sanitising of session names, URL-encoded params, malformed/empty/null input, and the start/stop actions.

### #8 - `MeetingPipeline.state_file` CWD-relative: verified, documented (no code change)
Investigated whether the CWD-relative `recorder_state.json` is a bug. **It isn't:** nothing writes `recorder_state.json` anymore (the `save_state`/`load_state` pair was removed in #225-228); the only remaining uses are defensive `.unlink()` cleanups of a stale pre-migration file. `getBackendCwd()` resolves to a single deterministic dir, so the cleanup reliably finds that legacy file - routing it through `get_user_data_dir()` would point at the wrong directory. Documented the reasoning at the definition site; fixed a stale nearby comment that still implied the atomic writer wrote it.

### Verification
- `cd app && npm run test:unit` → node:test 53/53, vitest 33/33.
- `python -m unittest discover tests` → 355 passed.
- Independent Codex review: no critical/medium; the three low findings it raised are folded into this branch.

Part of #278. Batches B/C/D tracked separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens tests around IPC wiring and deep-link parsing with zero runtime changes. Catches channel drift in CI and adds coverage for `stenoai://` URL handling. Part of #278.

- New Features
  - Added IPC contract check that validates channels across `main.js`, `preload.js`, `renderer/src/lib/ipc.ts`, and the e2e mock (no dup registrations, renderer channels registered, no orphans, mock stubs subset, subscribe channels emitted, namespaces in sync).
  - Added unit tests for `stenoai://` parsing/sanitizing (protocol/host validation, path handling, URL-encoded params, control-char and path-separator stripping, malformed inputs).

- Refactors
  - Extracted pure deep-link helpers into `app/shortcut-url.js` and reused them in `main.js` (behavior unchanged); wired tests into `npm run test:unit`.
  - Documented why `MeetingPipeline.state_file` stays CWD-relative and updated stale inline comments in `preload.js`, `ipc.ts`, and `simple_recorder.py`.

<sup>Written for commit b56b8e54aee8a7d59d85ee22bb71648ec85b8960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

