### PR TITLE
refactor: #278 - setup-check emits JSON instead of scraped emoji text

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -47,6 +47,7 @@ const {
   sanitizeShortcutUrlForLogs,
   parseShortcutUrl,
 } = require('./shortcut-url');
+const { parseSetupCheckOutput } = require('./setup-check-parse');
 
 // Wrap spawn so every backend / ollama launch defaults to windowsHide:true.
 // The PyInstaller backend (stenoai.exe) and bundled ollama.exe are console
@@ -3965,9 +3966,12 @@ ipcMain.handle('startup-setup-check', async () => {
     const result = await runPythonScript('simple_recorder.py', ['setup-check', '--json']);
     console.log('Setup check result:', result);
 
-    const parsed = JSON.parse(result);
-    const allGood = parsed.allGood === true;
-    const checks = Array.isArray(parsed.checks) ? parsed.checks : [];
+    // Extract + validate the JSON payload from stdout. We don't JSON.parse the
+    // whole buffer because the checks import third-party libs that can print to
+    // stdout; parseSetupCheckOutput scans for the JSON line and validates the
+    // schema, throwing (→ caught below as an error) if the backend is broken so a
+    // malformed payload isn't masked as a clean "setup incomplete".
+    const { allGood, checks } = parseSetupCheckOutput(result);
 
     console.log('Parsed checks:', checks);
     console.log('All good:', allGood);

--- a/app/main.js
+++ b/app/main.js
@@ -3958,32 +3958,22 @@ ipcMain.handle('stop-recording-ui', async () => {
 ipcMain.handle('startup-setup-check', async () => {
   try {
     console.log('Running startup setup check...');
-    
-    // Use Python backend to check setup
-    const result = await runPythonScript('simple_recorder.py', ['setup-check']);
+
+    // Ask the backend for machine-readable JSON rather than scraping emoji out
+    // of the human-readable report. The `--json` path emits a single object:
+    //   { allGood: boolean, checks: [{ name, ok, status, detail }, ...] }
+    const result = await runPythonScript('simple_recorder.py', ['setup-check', '--json']);
     console.log('Setup check result:', result);
-    
-    // Parse the output to determine if setup is complete
-    const allGood = result.includes('🎉 System check passed!');
-    
-    // Extract check results for UI display
-    const lines = result.split('\n');
-    const checks = [];
-    
-    lines.forEach(line => {
-      if (line.includes('✅') || line.includes('❌') || line.includes('⚠️')) {
-        const parts = line.split(/\s{2,}/); // Split on multiple spaces
-        if (parts.length >= 2) {
-          checks.push([parts[0].trim(), parts[1].trim()]);
-        }
-      }
-    });
-    
+
+    const parsed = JSON.parse(result);
+    const allGood = parsed.allGood === true;
+    const checks = Array.isArray(parsed.checks) ? parsed.checks : [];
+
     console.log('Parsed checks:', checks);
     console.log('All good:', allGood);
-    
-    return { 
-      success: true, 
+
+    return {
+      success: true,
       allGood,
       checks
     };

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -292,9 +292,19 @@ export type CloudProvider = 'openai' | 'anthropic' | 'bedrock' | 'custom';
 // ---------- response envelopes ----------
 export type AppVersionResponse = Result<{ version: string; name: string }>;
 export type StatusResponse = Result<{ status: string; details?: unknown }>;
+export type SetupCheckStatus = 'pass' | 'fail' | 'warn';
+export interface SetupCheckItem {
+  /** Bare check name, e.g. "Python", "ffmpeg", "recordings/". */
+  name: string;
+  /** true unless the check failed; warnings are still ok. */
+  ok: boolean;
+  status: SetupCheckStatus;
+  /** Human-readable detail, e.g. "3.11.5" or "not found - run: brew install ffmpeg". */
+  detail: string;
+}
 export type SetupCheckResponse = Result<{
   allGood: boolean;
-  checks: Array<[icon: string, label: string]>;
+  checks: SetupCheckItem[];
 }>;
 
 export type MicPermissionResponse = Result<{ status: MicPermissionStatus }>;

--- a/app/setup-check-parse.js
+++ b/app/setup-check-parse.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Parsing for `stenoai setup-check --json`.
+//
+// The backend emits one clean JSON object as the FINAL stdout line, but the
+// checks it runs import third-party libraries (sounddevice, pywhispercpp,
+// ollama, …) that can print unrelated chatter to stdout. So we can't assume the
+// whole stdout buffer is JSON — we scan for the JSON payload and validate its
+// schema before trusting it. This module is the single source of truth for that
+// rule so the unit tests exercise exactly what production runs.
+
+const VALID_STATUS = new Set(['pass', 'fail', 'warn']);
+
+/**
+ * Extract the setup-check JSON payload from a raw stdout buffer.
+ *
+ * Rule: the last non-empty line that JSON-parses to an object carrying a
+ * boolean `allGood`. Scanning from the end tolerates leading import chatter;
+ * requiring the `allGood` key avoids latching onto some other JSON line.
+ *
+ * @param {string} stdout
+ * @returns {object|null} the parsed payload, or null if none matches.
+ */
+function extractSetupCheckPayload(stdout) {
+  if (typeof stdout !== 'string') return null;
+  const lines = stdout.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line || line[0] !== '{') continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch (_) {
+      continue;
+    }
+    if (parsed && typeof parsed === 'object' && typeof parsed.allGood === 'boolean') {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate that a payload matches the setup-check contract:
+ *   { allGood: boolean, checks: [{ name, ok, status, detail }, ...] }
+ * with a non-empty checks array. A valid-but-wrong payload (e.g. `{}`) must be
+ * treated as a broken backend, not a passing/empty "setup incomplete".
+ *
+ * @returns {boolean}
+ */
+function isValidSetupCheckPayload(payload) {
+  if (!payload || typeof payload !== 'object') return false;
+  if (typeof payload.allGood !== 'boolean') return false;
+  if (!Array.isArray(payload.checks) || payload.checks.length === 0) return false;
+  return payload.checks.every(
+    (c) =>
+      c &&
+      typeof c === 'object' &&
+      typeof c.name === 'string' &&
+      c.name.length > 0 &&
+      typeof c.ok === 'boolean' &&
+      typeof c.status === 'string' &&
+      VALID_STATUS.has(c.status) &&
+      typeof c.detail === 'string'
+  );
+}
+
+/**
+ * Extract + validate the setup-check payload from raw stdout, throwing on any
+ * problem so callers can treat a malformed backend response as a failure.
+ *
+ * @param {string} stdout
+ * @returns {{ allGood: boolean, checks: Array<{name:string, ok:boolean, status:string, detail:string}> }}
+ */
+function parseSetupCheckOutput(stdout) {
+  const payload = extractSetupCheckPayload(stdout);
+  if (payload === null) {
+    throw new Error('setup-check produced no parseable JSON payload');
+  }
+  if (!isValidSetupCheckPayload(payload)) {
+    throw new Error('setup-check JSON did not match the expected schema');
+  }
+  return { allGood: payload.allGood, checks: payload.checks };
+}
+
+module.exports = {
+  extractSetupCheckPayload,
+  isValidSetupCheckPayload,
+  parseSetupCheckOutput,
+};

--- a/app/setup-check-parse.js
+++ b/app/setup-check-parse.js
@@ -52,7 +52,7 @@ function isValidSetupCheckPayload(payload) {
   if (!payload || typeof payload !== 'object') return false;
   if (typeof payload.allGood !== 'boolean') return false;
   if (!Array.isArray(payload.checks) || payload.checks.length === 0) return false;
-  return payload.checks.every(
+  const typesOk = payload.checks.every(
     (c) =>
       c &&
       typeof c === 'object' &&
@@ -63,6 +63,14 @@ function isValidSetupCheckPayload(payload) {
       VALID_STATUS.has(c.status) &&
       typeof c.detail === 'string'
   );
+  if (!typesOk) return false;
+  // Re-check the backend's derived invariants so an inconsistent payload (a
+  // future backend bug or a tampered response) can't masquerade as a clean pass
+  // on this startup-gating path: each check's `ok` is exactly "not a failure",
+  // and `allGood` is exactly "every check ok".
+  if (!payload.checks.every((c) => c.ok === (c.status !== 'fail'))) return false;
+  if (payload.allGood !== payload.checks.every((c) => c.ok)) return false;
+  return true;
 }
 
 /**

--- a/app/setup-check-parse.test.js
+++ b/app/setup-check-parse.test.js
@@ -53,6 +53,48 @@ test('isValidSetupCheckPayload rejects valid-but-wrong payloads', () => {
   );
 });
 
+test('isValidSetupCheckPayload rejects payloads that violate the derived invariants', () => {
+  // (a) allGood:true while a check is failing — an inconsistent payload must not
+  // masquerade as a clean pass on the startup-gating path.
+  assert.strictEqual(
+    isValidSetupCheckPayload({
+      allGood: true,
+      checks: [
+        { name: 'Python', ok: true, status: 'pass', detail: 'd' },
+        { name: 'Ollama', ok: false, status: 'fail', detail: 'not found' },
+      ],
+    }),
+    false
+  );
+  // (b) ok and status disagree within a single check (ok:true but status:'fail').
+  assert.strictEqual(
+    isValidSetupCheckPayload({
+      allGood: false,
+      checks: [{ name: 'Ollama', ok: true, status: 'fail', detail: 'not found' }],
+    }),
+    false
+  );
+  // A consistent failing payload (allGood:false, ok matches status) is still valid.
+  assert.strictEqual(
+    isValidSetupCheckPayload({
+      allGood: false,
+      checks: [
+        { name: 'Python', ok: true, status: 'pass', detail: 'd' },
+        { name: 'Ollama', ok: false, status: 'fail', detail: 'not found' },
+      ],
+    }),
+    true
+  );
+  // A warn check counts as ok, so an all-warn/pass payload stays allGood:true.
+  assert.strictEqual(
+    isValidSetupCheckPayload({
+      allGood: true,
+      checks: [{ name: 'whisper-model', ok: true, status: 'warn', detail: 'will download' }],
+    }),
+    true
+  );
+});
+
 test('parseSetupCheckOutput returns {allGood, checks} for a good buffer with chatter', () => {
   const out = ['import noise line', JSON.stringify(VALID)].join('\n');
   assert.deepStrictEqual(parseSetupCheckOutput(out), VALID);

--- a/app/setup-check-parse.test.js
+++ b/app/setup-check-parse.test.js
@@ -1,0 +1,74 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  extractSetupCheckPayload,
+  isValidSetupCheckPayload,
+  parseSetupCheckOutput,
+} = require('./setup-check-parse');
+
+const VALID = {
+  allGood: true,
+  checks: [{ name: 'Python', ok: true, status: 'pass', detail: '3.11.5' }],
+};
+
+test('extractSetupCheckPayload reads a clean single JSON line', () => {
+  const out = JSON.stringify(VALID) + '\n';
+  assert.deepStrictEqual(extractSetupCheckPayload(out), VALID);
+});
+
+test('extractSetupCheckPayload tolerates leading stray stdout chatter', () => {
+  // A third-party import printing to stdout before the JSON line must not break
+  // parsing — this is the exact divergence the coordinator flagged.
+  const out = ['ALSA lib pcm.c: some import noise', JSON.stringify(VALID), ''].join('\n');
+  assert.deepStrictEqual(extractSetupCheckPayload(out), VALID);
+});
+
+test('extractSetupCheckPayload picks the JSON line carrying allGood, not other JSON', () => {
+  const out = ['{"unrelated": 1}', JSON.stringify(VALID)].join('\n');
+  assert.deepStrictEqual(extractSetupCheckPayload(out), VALID);
+});
+
+test('extractSetupCheckPayload returns null when no allGood payload exists', () => {
+  assert.strictEqual(extractSetupCheckPayload('no json here\n{"foo":1}\n'), null);
+  assert.strictEqual(extractSetupCheckPayload(''), null);
+  assert.strictEqual(extractSetupCheckPayload(undefined), null);
+});
+
+test('isValidSetupCheckPayload accepts the contract shape', () => {
+  assert.strictEqual(isValidSetupCheckPayload(VALID), true);
+});
+
+test('isValidSetupCheckPayload rejects valid-but-wrong payloads', () => {
+  assert.strictEqual(isValidSetupCheckPayload({}), false); // masks broken backend
+  assert.strictEqual(isValidSetupCheckPayload({ allGood: true, checks: [] }), false);
+  assert.strictEqual(isValidSetupCheckPayload({ allGood: 'yes', checks: VALID.checks }), false);
+  assert.strictEqual(
+    isValidSetupCheckPayload({ allGood: true, checks: [{ name: 'X', ok: true, status: 'bogus', detail: 'd' }] }),
+    false
+  );
+  assert.strictEqual(
+    isValidSetupCheckPayload({ allGood: true, checks: [{ name: '', ok: true, status: 'pass', detail: 'd' }] }),
+    false
+  );
+});
+
+test('parseSetupCheckOutput returns {allGood, checks} for a good buffer with chatter', () => {
+  const out = ['import noise line', JSON.stringify(VALID)].join('\n');
+  assert.deepStrictEqual(parseSetupCheckOutput(out), VALID);
+});
+
+test('parseSetupCheckOutput throws when no payload is present', () => {
+  assert.throws(() => parseSetupCheckOutput('nothing parseable\n'), /no parseable JSON/);
+});
+
+test('parseSetupCheckOutput throws on a valid-but-wrong schema', () => {
+  // {} has no allGood → not even extracted, treated as no payload.
+  assert.throws(() => parseSetupCheckOutput(JSON.stringify({})), /no parseable JSON/);
+  // Extracted (allGood is a boolean) but the checks array is empty → schema fail,
+  // so an empty/broken payload is a failure, not a passing "setup incomplete".
+  assert.throws(
+    () => parseSetupCheckOutput(JSON.stringify({ allGood: false, checks: [] })),
+    /did not match the expected schema/
+  );
+});

--- a/e2e/specs/setup-check.t2.spec.ts
+++ b/e2e/specs/setup-check.t2.spec.ts
@@ -11,7 +11,7 @@ import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
  * deferred to manual /verify + the nightly packaged cold-start.
  */
 
-type Check = [icon: string, label: string];
+type Check = { name: string; ok: boolean; status: 'pass' | 'fail' | 'warn'; detail: string };
 type SetupResult = { success: boolean; allGood?: boolean; checks?: Check[]; error?: string };
 
 type StenoWindow = Window & {
@@ -32,19 +32,30 @@ test('setup.check returns a coherent allGood + checks contract on a clean profil
   // without the LLM model reports false — so we assert the type, not the value).
   expect(typeof res.allGood).toBe('boolean');
 
-  // checks is a non-empty list of [status, detail] pairs the wizard renders. The
-  // handler splits each "<emoji> <label>   <detail>" line on 2+ spaces, so
-  // entry[0] is the emoji-prefixed "<emoji> <label>" and entry[1] is the detail.
+  // checks is a non-empty list of structured records the backend emits as JSON
+  // (setup-check --json) — no emoji-scraping. Each entry is
+  // { name, ok, status, detail } with status in {pass, fail, warn} and ok mirroring
+  // status !== 'fail'.
   expect(Array.isArray(res.checks)).toBe(true);
   expect(res.checks!.length).toBeGreaterThan(0);
   for (const entry of res.checks!) {
-    expect(Array.isArray(entry)).toBe(true);
-    expect(entry).toHaveLength(2);
-    const [status, detail] = entry;
-    expect(['✅', '❌', '⚠️'].some((e) => status.startsWith(e))).toBe(true);
-    expect(status.length).toBeGreaterThan(1); // emoji + a label
-    expect(typeof detail).toBe('string');
+    expect(typeof entry).toBe('object');
+    expect(typeof entry.name).toBe('string');
+    expect(entry.name.length).toBeGreaterThan(0);
+    expect(['pass', 'fail', 'warn']).toContain(entry.status);
+    expect(entry.ok).toBe(entry.status !== 'fail');
+    expect(typeof entry.detail).toBe('string');
   }
+
+  // allGood is exactly "no failing check" — the same verdict the backend computes.
+  expect(res.allGood).toBe(res.checks!.every((c) => c.ok));
+
+  // The Python check is deterministic on any runner (the interpreter is running
+  // the backend), so it must be present and passing.
+  const python = res.checks!.find((c) => c.name === 'Python');
+  expect(python).toBeDefined();
+  expect(python!.status).toBe('pass');
+  expect(python!.ok).toBe(true);
 
   // setup.check is a read — it must not write into the real user-data dir.
   expect(fileSig(realUserDataDir())).toBe(realDirBefore);

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3139,15 +3139,18 @@ def clear_state():
 
 
 @cli.command()
-def setup_check():
+@click.option('--json', 'as_json', is_flag=True,
+              help='Emit a single machine-readable JSON object instead of the human-readable report.')
+def setup_check(as_json):
     """Check system setup and dependencies"""
     import subprocess
     import sys
     import os
-    
-    print("🔧 StenoAI Setup Check")
-    print("=" * 25)
-    
+
+    if not as_json:
+        print("🔧 StenoAI Setup Check")
+        print("=" * 25)
+
     checks = []
     
     # Check Python version
@@ -3294,19 +3297,40 @@ def setup_check():
     else:
         checks.append(("❌ llm-model", "no model installed - needed for summaries"))
 
-    # Print results
+    # Derive a structured, machine-readable view of the checks. This is the
+    # single source of truth for each check's (name, status, detail) and for the
+    # overall verdict; both the JSON output and the human summary below read from
+    # it, so the pass/fail logic is never duplicated. Status is decoded from the
+    # emoji the check-building code above attached to each label:
+    #   ✅ -> pass (ok),  ⚠️ -> warn (ok),  ❌ -> fail (not ok).
+    structured = []
     all_good = True
-    for status, detail in checks:
-        print(f"{status:<20} {detail}")
-        if status.startswith("❌"):
+    for label, detail in checks:
+        if label.startswith("❌"):
+            status, ok = "fail", False
             all_good = False
-    
+        elif label.startswith("⚠"):
+            status, ok = "warn", True
+        else:
+            status, ok = "pass", True
+        # Strip the leading status emoji to get the bare check name.
+        name = label.split(" ", 1)[1] if " " in label else label
+        structured.append({"name": name, "ok": ok, "status": status, "detail": detail})
+
+    if as_json:
+        print(json.dumps({"allGood": all_good, "checks": structured}))
+        return {"success": all_good, "checks": checks}
+
+    # Human-readable summary
+    for label, detail in checks:
+        print(f"{label:<20} {detail}")
+
     print("\n" + "=" * 25)
     if all_good:
         print("🎉 System check passed! Ready to record meetings.")
     else:
         print("⚠️ Setup incomplete. Please install missing dependencies.")
-    
+
     return {"success": all_good, "checks": checks}
 
 

--- a/tests/test_setup_check_cli.py
+++ b/tests/test_setup_check_cli.py
@@ -1,0 +1,87 @@
+# tests/test_setup_check_cli.py
+"""Unit tests for the `setup-check --json` machine-readable output path.
+
+The Electron main process (startup-setup-check) parses this JSON instead of
+scraping emoji out of the human-readable report, so its schema is a contract.
+"""
+import json
+import unittest
+from unittest.mock import patch
+from click.testing import CliRunner
+
+import simple_recorder
+
+
+def _only_json(output):
+    """Extract the single JSON object line from CLI output.
+
+    Logging writes INFO lines to stderr which CliRunner may interleave; the
+    --json path emits exactly one object line, which starts with '{'.
+    """
+    lines = [line for line in output.splitlines() if line.strip().startswith("{")]
+    assert len(lines) == 1, f"expected exactly one JSON line, got: {output!r}"
+    return json.loads(lines[0])
+
+
+class SetupCheckJsonTests(unittest.TestCase):
+    _VALID_STATUS = {"pass", "fail", "warn"}
+
+    def test_json_schema_and_all_good_derivation(self):
+        """--json emits {allGood, checks:[{name, ok, status, detail}]} with allGood
+        == every check ok, and the Python check present and passing."""
+        res = CliRunner().invoke(simple_recorder.setup_check, ["--json"])
+        self.assertEqual(res.exit_code, 0, res.output)
+
+        data = _only_json(res.output)
+        self.assertIsInstance(data["allGood"], bool)
+        self.assertIsInstance(data["checks"], list)
+        self.assertGreater(len(data["checks"]), 0)
+
+        for check in data["checks"]:
+            self.assertIn("name", check)
+            self.assertIsInstance(check["name"], str)
+            self.assertTrue(check["name"])
+            self.assertIn(check["status"], self._VALID_STATUS)
+            self.assertIsInstance(check["ok"], bool)
+            # ok is exactly "not a failure" — warnings are still ok.
+            self.assertEqual(check["ok"], check["status"] != "fail")
+            self.assertIsInstance(check["detail"], str)
+
+        # allGood is exactly "no failing check".
+        self.assertEqual(data["allGood"], all(c["ok"] for c in data["checks"]))
+
+        # The interpreter is running the backend, so Python always passes.
+        python = next((c for c in data["checks"] if c["name"] == "Python"), None)
+        self.assertIsNotNone(python)
+        self.assertEqual(python["status"], "pass")
+        self.assertTrue(python["ok"])
+
+    def test_injected_failure_sets_all_good_false(self):
+        """A failing check (❌) flips its record to status=fail/ok=false and drives
+        allGood to false — the JSON verdict tracks the same emoji logic the human
+        report uses."""
+        with patch("src.ollama_manager.get_ollama_binary", return_value=None):
+            res = CliRunner().invoke(simple_recorder.setup_check, ["--json"])
+        self.assertEqual(res.exit_code, 0, res.output)
+
+        data = _only_json(res.output)
+        ollama = next((c for c in data["checks"] if c["name"] == "Ollama"), None)
+        self.assertIsNotNone(ollama)
+        self.assertEqual(ollama["status"], "fail")
+        self.assertFalse(ollama["ok"])
+        self.assertFalse(data["allGood"])
+
+    def test_human_output_unchanged_without_flag(self):
+        """No flag → the human banner is still printed and no JSON object appears."""
+        res = CliRunner().invoke(simple_recorder.setup_check, [])
+        self.assertEqual(res.exit_code, 0, res.output)
+        self.assertIn("StenoAI Setup Check", res.output)
+        # The human path must not emit a machine-readable JSON object line.
+        self.assertFalse(
+            any(line.strip().startswith("{") for line in res.output.splitlines()),
+            res.output,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #278 item #7 - setup-check emits JSON instead of scraped emoji text

The setup-check result was reconstructed by scraping emoji/whitespace out of the human-oriented CLI text (`result.includes('🎉 System check passed!')` + `line.split(/\s{2,}/)`). This replaces that with a machine-readable JSON contract.

### Backend (`simple_recorder.py`, `setup_check`)
- New additive `--json` flag. Both the human path and the JSON path now build from ONE shared list of `(name, status, detail)` per check, so the two outputs can't drift on what's checked or the verdict. Status is decoded from the existing emoji (✅→pass, ⚠️→warn, ❌→fail); `ok == status != 'fail'`; `allGood == every check ok` - the same condition that printed "System check passed".
- The no-flag human output is unchanged (other tooling still uses it). `--json` emits a single clean JSON line as the final stdout write (INFO logs go to stderr).

Schema:
```json
{"allGood": bool, "checks": [{"name": str, "ok": bool, "status": "pass"|"fail"|"warn", "detail": str}, ...]}
```

### app/main.js
- `startup-setup-check` now calls `setup-check --json` and parses via a new shared `app/setup-check-parse.js` module instead of `JSON.parse` on the raw buffer.
- **Robust extraction** (`setup-check-parse.js`): scan stdout lines from the end, take the first `{`-line that parses to an object with a boolean `allGood`. This tolerates stray stdout chatter from third-party imports (`pywhispercpp`/`sounddevice`/`ollama`) on a startup path - production and the unit tests now use the exact same extraction code, so the test actually guards production.
- **Schema validation**: a valid-but-wrong payload (`{}`, empty `checks`) now throws → returns `{ success: false, error }` instead of masquerading as a passing/empty "setup incomplete".
- The second consumer (`setup-test` at ~4702) parses the separate `test` command's output, not setup-check, so it's correctly left unchanged.

### Contract + e2e
- `ipc.ts` `checks` shape upgraded from `[name, detail]` pairs to `{name, ok, status, detail}` records (no renderer component consumed the old pair shape - only the `useSetupCheck` hook unwraps the result). `ipc.ts` + the t2 spec updated together.
- `setup-check.t2.spec.ts` tightened: validates each entry's types, `status ∈ {pass,fail,warn}`, `ok === status !== 'fail'`, `allGood === checks.every(ok)`, and asserts the `Python` check is present and passing. Still model-free.

### Verification
- `python -m unittest discover tests` → 358 pass (incl. 3 new `test_setup_check_cli` tests: schema + allGood derivation, injected failure flips allGood, human path unchanged).
- `node --test` (incl. new `setup-check-parse.test.js`, 9 cases: clean line, leading stray chatter, allGood-key selection, null/malformed/empty throws) → all pass.
- `python simple_recorder.py setup-check --json` → exactly one clean JSON line.
- `ruff` no new errors; `lint:renderer` 0 errors; `typecheck:renderer` clean.
- Independent Codex review; its two findings (parse robustness + schema validation) are folded in.

**CI note:** the PyInstaller bundle must be rebuilt (CI's build-backend job does this) before `setup-check.t2` sees the `--json` flag - the stale local `dist/` doesn't have it yet.

Part of #278.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches setup-check to a machine-readable `--json` output and replaces emoji-scraping with robust parsing on startup. Tightens schema validation and invariants, updates IPC to structured records, and adds tests. Part of #278.

- **Refactors**
  - Backend (`simple_recorder.py`): add `--json`; build `allGood` and `{name, ok, status, detail}` from one shared list; decode status from existing emoji; human output unchanged.
  - App (`app/main.js`): call `setup-check --json`; parse via `app/setup-check-parse.js` that scans stdout from the end for the JSON line with a boolean `allGood`, validates the schema, re-checks invariants (`ok === status !== 'fail'`, `allGood === checks.every(ok)`), and throws on malformed/inconsistent payloads.
  - IPC/tests (`renderer/src/lib/ipc.ts`, `e2e/specs/setup-check.t2.spec.ts`, `app/setup-check-parse.test.js`, `tests/test_setup_check_cli.py`, `app/package.json`): change `checks` to structured `{name, ok, status, detail}`; e2e asserts types, invariants, and that `Python` is present and passing; add node/CLI unit tests; update `test:unit`.

- **Migration**
  - Rebuild the PyInstaller backend so `--json` is in CI artifacts.
  - Consumers now receive structured `checks`; no renderer component changes required.

<sup>Written for commit 8925b19faec7ea100f82e0a7a33213232fddc5fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

