### PR TITLE
fix: #278 - close the config.json cross-process lost-update race

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,13 @@ pywhispercpp>=1.2.0
 # TypeError on it, which the streaming path would swallow into an empty summary.
 ollama>=0.5.0
 click>=8.1.0
+# Cross-process file lock guarding config.json's read-modify-write in
+# src/config.py (_save). The app spawns a fresh CLI subprocess per operation,
+# so concurrent writers would otherwise revert each other's unrelated keys
+# (lost update). Already present transitively via huggingface_hub; pinned
+# explicitly since we now import it directly. Pure Python (fcntl / msvcrt),
+# so PyInstaller picks it up via normal import analysis.
+filelock>=3.13
 pydantic>=2.5.0
 python-dateutil>=2.8.0
 openai>=1.0.0

--- a/src/config.py
+++ b/src/config.py
@@ -466,29 +466,59 @@ class Config:
             return None
         return data if isinstance(data, dict) else None
 
+    @classmethod
+    def _apply_changes(
+        cls, base: Dict[str, Any], current: Dict[str, Any], snapshot: Any
+    ) -> Dict[str, Any]:
+        """Overlay onto `base` (fresh from disk) only the changes between
+        `snapshot` (what we loaded) and `current` (our in-memory dict).
+
+        Recurses into dict-valued keys so two processes editing DIFFERENT
+        sub-keys of the SAME nested dict (e.g. per-provider `cloud_models`, or
+        `template_overrides`) don't clobber each other — we assert only the
+        sub-keys THIS process actually touched and keep the concurrent writer's
+        sub-keys straight from disk. Scalars and lists are overlaid wholesale
+        (a list has no clean per-element three-way merge, so last-writer-wins,
+        matching the design's genuine-conflict stance). A key whose type
+        changed between dict and non-dict also falls back to a wholesale
+        overlay. Nested deletions (config's only deletion path, reset_template
+        dropping a `template_overrides` entry) are propagated too.
+
+        Returns a new dict; does not mutate `base`, `current`, or `snapshot`."""
+        result = dict(base)
+        snap = snapshot if isinstance(snapshot, dict) else {}
+        for key, cur_val in current.items():
+            if key in snap and snap[key] == cur_val:
+                continue  # unchanged by us — keep disk's (possibly newer) value
+            base_val = result.get(key)
+            if isinstance(cur_val, dict) and isinstance(base_val, dict):
+                result[key] = cls._apply_changes(base_val, cur_val, snap.get(key))
+            else:
+                result[key] = cur_val
+        # Propagate keys we removed since load (present in our load snapshot,
+        # gone from current). Our removal wins over a concurrent edit, symmetric
+        # with how our edits overlay theirs.
+        for key in snap:
+            if key not in current:
+                result.pop(key, None)
+        return result
+
     def _merge_for_save(self) -> Dict[str, Any]:
-        """Build the dict to persist: a fresh on-disk read overlaid with only
-        the top-level keys this process changed since load.
+        """Build the dict to persist: a fresh on-disk read with only the
+        changes this process made since load overlaid on top (recursively for
+        nested dicts — see _apply_changes).
 
         Diffing against self._snapshot (what we loaded) rather than writing
         self._config wholesale is what prevents the lost update — a concurrent
-        writer's unrelated keys, which are present in the fresh read but absent
-        from (or unchanged in) our in-memory copy, survive. config.py never
-        deletes a top-level key (only nested dict entries, e.g.
-        template_overrides), so a value diff captures every change; no removed-
-        key tracking is needed. Must be called under the file lock."""
+        writer's unrelated keys, present in the fresh read but untouched by us,
+        survive. Must be called under the file lock."""
         base = self._read_disk_for_merge()
         if base is None:
             # Missing / corrupt / non-dict on disk: write our own config
             # wholesale. Preserves the corrupt-file recovery semantics — a
             # set() after a corrupt load still lays down a valid file.
             return dict(self._config)
-        changed = {
-            k: v for k, v in self._config.items()
-            if k not in self._snapshot or self._snapshot[k] != v
-        }
-        base.update(changed)
-        return base
+        return self._apply_changes(base, self._config, self._snapshot)
 
     def _save(self) -> bool:
         """Save configuration to disk without clobbering concurrent writers.
@@ -506,6 +536,8 @@ class Config:
         """
         lock_path = str(self.config_path) + ".lock"
         try:
+            # filelock is NOT reentrant: _save() must never be called while
+            # already holding this lock (no current path does).
             with filelock.FileLock(lock_path, timeout=self._SAVE_LOCK_TIMEOUT):
                 merged = self._merge_for_save()
                 _atomic_write_json(self.config_path, merged)
@@ -522,6 +554,9 @@ class Config:
             )
             try:
                 _atomic_write_json(self.config_path, self._config)
+                # Keep the snapshot consistent with what we just wrote so a
+                # later save on this instance diffs correctly.
+                self._snapshot = copy.deepcopy(self._config)
                 return True
             except Exception as e:
                 logger.error(f"Error saving config: {e}")

--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,7 @@ Configuration management for StenoAI.
 Handles storing and loading user preferences like model selection.
 """
 
+import copy
 import json
 import logging
 import os
@@ -15,6 +16,8 @@ import time
 import uuid
 from pathlib import Path
 from typing import Optional, Dict, Any
+
+import filelock
 
 from src.whisper_models import SUPPORTED_WHISPER_MODELS as _WHISPER_REGISTRY
 from src import templates as _templates
@@ -271,6 +274,11 @@ class Config:
         # gets its in-memory defaults persisted over the recoverable file.
         self._load_failed = False
         self._config: Dict[str, Any] = self._load()
+        # Snapshot of exactly what was read from disk (or the defaults on a
+        # fresh/corrupt load). _save() diffs self._config against this to write
+        # back ONLY the keys this process actually changed, so a concurrent
+        # writer's unrelated keys aren't clobbered (the lost-update fix).
+        self._snapshot: Dict[str, Any] = copy.deepcopy(self._config)
         self._migrate_cloud_model_map()
         self._migrate_whisper_model()
         self._migrate_summary_model()
@@ -437,12 +445,87 @@ class Config:
             )
         return self._get_default_config()
 
-    def _save(self) -> bool:
-        """Save configuration to file (atomic tempfile + os.replace)."""
+    # Seconds to wait for the cross-process config lock before giving up and
+    # falling back to an unlocked write. Generous enough to cover a normal
+    # save on a busy disk, short enough that a truly stuck lock never blocks
+    # the CLI for long.
+    _SAVE_LOCK_TIMEOUT = 10
+
+    def _read_disk_for_merge(self) -> Optional[Dict[str, Any]]:
+        """Re-read config.json fresh for use as the merge base. Returns the
+        parsed dict, or None if the file is missing / unparseable / not a dict
+        (in which case the caller writes its own config wholesale). Must be
+        called under the file lock so the read reflects any concurrent writer's
+        just-completed atomic replace."""
+        if not self.config_path.exists():
+            return None
         try:
-            _atomic_write_json(self.config_path, self._config)
-            logger.info(f"Saved config to {self.config_path}")
-            return True
+            with open(self.config_path, 'r') as f:
+                data = json.load(f)
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _merge_for_save(self) -> Dict[str, Any]:
+        """Build the dict to persist: a fresh on-disk read overlaid with only
+        the top-level keys this process changed since load.
+
+        Diffing against self._snapshot (what we loaded) rather than writing
+        self._config wholesale is what prevents the lost update — a concurrent
+        writer's unrelated keys, which are present in the fresh read but absent
+        from (or unchanged in) our in-memory copy, survive. config.py never
+        deletes a top-level key (only nested dict entries, e.g.
+        template_overrides), so a value diff captures every change; no removed-
+        key tracking is needed. Must be called under the file lock."""
+        base = self._read_disk_for_merge()
+        if base is None:
+            # Missing / corrupt / non-dict on disk: write our own config
+            # wholesale. Preserves the corrupt-file recovery semantics — a
+            # set() after a corrupt load still lays down a valid file.
+            return dict(self._config)
+        changed = {
+            k: v for k, v in self._config.items()
+            if k not in self._snapshot or self._snapshot[k] != v
+        }
+        base.update(changed)
+        return base
+
+    def _save(self) -> bool:
+        """Save configuration to disk without clobbering concurrent writers.
+
+        The app spawns a fresh CLI subprocess per operation (no daemon), so two
+        near-simultaneous writers each do load-whole-config -> mutate one key ->
+        write-whole-file and silently revert each other's unrelated keys
+        (classic lost update). _atomic_write_json fixes torn files but not this.
+
+        Fix: under a cross-process file lock (filelock: fcntl on POSIX / msvcrt
+        on Windows, auto-released if a holder crashes) re-read config.json fresh
+        as the merge base and overlay only the top-level keys this process
+        changed. On lock timeout, degrade to a plain unlocked atomic write of
+        our own config — a stuck lock must never block saves or raise.
+        """
+        lock_path = str(self.config_path) + ".lock"
+        try:
+            with filelock.FileLock(lock_path, timeout=self._SAVE_LOCK_TIMEOUT):
+                merged = self._merge_for_save()
+                _atomic_write_json(self.config_path, merged)
+                # Adopt the merged result so a second _save() in this process
+                # diffs against what we just wrote, not the stale load snapshot.
+                self._config = merged
+                self._snapshot = copy.deepcopy(merged)
+                logger.info(f"Saved config to {self.config_path}")
+                return True
+        except filelock.Timeout:
+            logger.warning(
+                f"Timed out acquiring config lock at {lock_path}; "
+                f"falling back to an unlocked atomic write"
+            )
+            try:
+                _atomic_write_json(self.config_path, self._config)
+                return True
+            except Exception as e:
+                logger.error(f"Error saving config: {e}")
+                return False
         except Exception as e:
             logger.error(f"Error saving config: {e}")
             return False

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -20,10 +20,15 @@ from unittest.mock import patch
 from src.config import Config
 
 
-def _worker_set_key(path_str: str, key: str, value) -> None:
-    """Top-level (picklable) worker for the multiprocess stress test: each
-    process loads the shared config and writes one distinct key via set()."""
-    Config(config_path=Path(path_str)).set(key, value)
+def _worker_set_key(path_str: str, key: str, value, barrier) -> None:
+    """Top-level (picklable) worker for the multiprocess stress test: load the
+    shared config, wait at the barrier so every worker has loaded the SAME
+    baseline, then write one distinct key. The barrier forces the concurrent
+    read-modify-write the race needs — without it the workers would serialize
+    and even the old whole-file save would pass."""
+    cfg = Config(config_path=Path(path_str))
+    barrier.wait(timeout=30)
+    cfg.set(key, value)
 
 
 class AtomicSaveTests(unittest.TestCase):
@@ -191,6 +196,48 @@ class LostUpdateTests(unittest.TestCase):
             self.assertIs(on_disk["keep_recordings"], True)
 
 
+    def test_concurrent_edits_to_same_nested_dict_both_survive(self):
+        # Two processes editing DIFFERENT sub-keys of the SAME top-level dict
+        # (per-provider cloud_models) must not clobber each other. A top-level-
+        # only merge would overlay the whole cloud_models dict and lose the
+        # other provider's entry; the recursive merge keeps both.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            Config(config_path=path)  # baseline with cloud_models = {}
+
+            c1 = Config(config_path=path)
+            c1.set_cloud_provider("openai")
+            c2 = Config(config_path=path)
+            c2.set_cloud_provider("anthropic")
+
+            # Each writes its own provider's model into the shared cloud_models.
+            self.assertTrue(c1.set_cloud_model("gpt-4o"))
+            self.assertTrue(c2.set_cloud_model("claude-x"))
+
+            on_disk = json.loads(path.read_text())
+            self.assertEqual(on_disk["cloud_models"]["openai"], "gpt-4o")
+            self.assertEqual(on_disk["cloud_models"]["anthropic"], "claude-x")
+
+    def test_nested_deletion_still_propagates(self):
+        # The recursive merge must not resurrect a nested key this process
+        # deleted (reset_template drops a template_overrides entry — config's
+        # only nested-deletion path). Guards against the recursion silently
+        # keeping disk's stale sub-key.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({
+                "template_overrides": {"brief": {"name": "B", "prompt": "p"}},
+                "templates_seeded": True,
+            }))
+
+            config = Config(config_path=path)
+            self.assertIn("brief", config._config["template_overrides"])
+
+            self.assertTrue(config.reset_template("brief"))
+            on_disk = json.loads(path.read_text())
+            self.assertNotIn("brief", on_disk.get("template_overrides", {}))
+
+
 class MigrationVsSetterTests(unittest.TestCase):
     def test_load_time_migration_and_concurrent_setter_both_survive(self):
         # A pre-migration config: legacy flat cloud_model triggers the
@@ -236,17 +283,28 @@ class MultiprocessStressTests(unittest.TestCase):
             Config(config_path=path)
 
             n = 6
+            barrier = ctx.Barrier(n)
             procs = [
                 ctx.Process(
                     target=_worker_set_key,
-                    args=(str(path), f"stress_key_{i}", i),
+                    args=(str(path), f"stress_key_{i}", i, barrier),
                 )
                 for i in range(n)
             ]
             for p in procs:
                 p.start()
+            try:
+                for p in procs:
+                    p.join(timeout=60)
+            finally:
+                # Never leave live children behind (CI/Windows cleanup) if a
+                # worker hung on the barrier or the lock.
+                for p in procs:
+                    if p.is_alive():
+                        p.terminate()
+                        p.join(timeout=10)
+
             for p in procs:
-                p.join(timeout=60)
                 self.assertEqual(p.exitcode, 0)
 
             on_disk = json.loads(path.read_text())

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -11,12 +11,19 @@ settings wipe (the "org user silently reset to local llama" bug):
 """
 
 import json
+import multiprocessing
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 from src.config import Config
+
+
+def _worker_set_key(path_str: str, key: str, value) -> None:
+    """Top-level (picklable) worker for the multiprocess stress test: each
+    process loads the shared config and writes one distinct key via set()."""
+    Config(config_path=Path(path_str)).set(key, value)
 
 
 class AtomicSaveTests(unittest.TestCase):
@@ -133,6 +140,118 @@ class MigrationStillRunsOnHealthyLoadTests(unittest.TestCase):
             self.assertEqual(config._config["cloud_models"], {"openai": "gpt-4o-mini"})
             on_disk = json.loads(path.read_text())
             self.assertEqual(on_disk["cloud_models"], {"openai": "gpt-4o-mini"})
+
+
+class LostUpdateTests(unittest.TestCase):
+    """Two writers changing DIFFERENT keys must not revert each other.
+
+    The app has no daemon — every operation is a fresh CLI subprocess doing
+    load-whole-config -> mutate one key -> write-whole-file. Without the
+    snapshot-diff merge under a file lock, the second writer's whole-file
+    write reverts the first writer's unrelated key (classic lost update).
+    """
+
+    def test_two_writers_different_keys_both_survive(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            # Seed a baseline file both writers load from.
+            Config(config_path=path)
+
+            c1 = Config(config_path=path)
+            c2 = Config(config_path=path)
+            # Two live handles that both loaded the same starting config, then
+            # each change a different key (the interleaving a real double-write
+            # produces). Pre-fix, c2's save reverted c1's language back to "en".
+            self.assertTrue(c1.set_language("de"))
+            self.assertTrue(c2.set_notifications_enabled(False))
+
+            on_disk = json.loads(path.read_text())
+            self.assertEqual(on_disk["language"], "de")
+            self.assertIs(on_disk["notifications_enabled"], False)
+
+    def test_second_save_in_same_process_diffs_correctly(self):
+        # After a save adopts the merged result, a second save on the SAME
+        # handle must still overlay only its own new change, not resurrect the
+        # pre-first-save snapshot.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            Config(config_path=path)
+
+            c1 = Config(config_path=path)
+            c2 = Config(config_path=path)
+
+            self.assertTrue(c1.set_language("de"))
+            self.assertTrue(c2.set_notifications_enabled(False))
+            # c1 writes a second, unrelated key after c2 already wrote.
+            self.assertTrue(c1.set_keep_recordings(True))
+
+            on_disk = json.loads(path.read_text())
+            self.assertEqual(on_disk["language"], "de")
+            self.assertIs(on_disk["notifications_enabled"], False)
+            self.assertIs(on_disk["keep_recordings"], True)
+
+
+class MigrationVsSetterTests(unittest.TestCase):
+    def test_load_time_migration_and_concurrent_setter_both_survive(self):
+        # A pre-migration config: legacy flat cloud_model triggers the
+        # cloud_models migration (a load-time _save) in c1's __init__. A second
+        # handle changes an unrelated key; neither write may clobber the other.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({
+                "cloud_model": "gpt-4o-mini",
+                "cloud_provider": "openai",
+                "language": "en",
+            }))
+
+            # c2 loads the pre-migration file first (its snapshot has no
+            # cloud_models), then c1's construction migrates + saves.
+            c2 = Config(config_path=path)
+            c1 = Config(config_path=path)  # __init__ migrates cloud_models + saves
+
+            # c2 now writes an unrelated key on top of the migrated file.
+            self.assertTrue(c2.set_language("de"))
+
+            on_disk = json.loads(path.read_text())
+            # Migration result survives c2's later write.
+            self.assertEqual(on_disk["cloud_models"], {"openai": "gpt-4o-mini"})
+            # And c2's setter survives.
+            self.assertEqual(on_disk["language"], "de")
+            del c1  # keep linters quiet; construction was the point
+
+
+class MultiprocessStressTests(unittest.TestCase):
+    def test_concurrent_processes_each_key_survives(self):
+        # Real OS processes prove the file lock serializes cross-process, not
+        # just cross-handle in one interpreter. spawn matches the frozen app's
+        # subprocess model and is the only portable start method on macOS/Windows.
+        try:
+            ctx = multiprocessing.get_context("spawn")
+        except ValueError:  # pragma: no cover - spawn is available on mac/win/linux
+            self.skipTest("spawn start method unavailable")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            # Seed a baseline so every worker loads the same starting file.
+            Config(config_path=path)
+
+            n = 6
+            procs = [
+                ctx.Process(
+                    target=_worker_set_key,
+                    args=(str(path), f"stress_key_{i}", i),
+                )
+                for i in range(n)
+            ]
+            for p in procs:
+                p.start()
+            for p in procs:
+                p.join(timeout=60)
+                self.assertEqual(p.exitcode, 0)
+
+            on_disk = json.loads(path.read_text())
+            for i in range(n):
+                self.assertEqual(on_disk[f"stress_key_{i}"], i)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## #278 item #2 - fix the config.json cross-process lost-update race

### The bug
The app spawns a fresh `simple_recorder.py` subprocess per operation (no daemon). `Config._save()` did whole-file read-modify-write per process with no cross-process coordination, so two near-simultaneous writers each did (load whole config -> mutate one key -> write whole file) and silently reverted each other's unrelated keys. `_atomic_write_json` already prevents torn files, but not the lost UPDATE across the read-modify-write cycle.

main.js is **not** the only writer, so serialising there can't fix it: config.json is also written by load-time migrations in `Config.__init__` (fired from any subprocess, including pure readers like `get-status`), `get_anonymous_id()` telemetry, the seed-org-auto-backup subprocess, and direct terminal CLI use. The fix therefore lives at the Python write site.

### The fix - snapshot-diff merge under a cross-process file lock
- **Snapshot on load:** `__init__` captures `self._snapshot = copy.deepcopy(self._config)` - exactly what was read from disk.
- **`_save()` under a `filelock.FileLock`** (fcntl on POSIX / msvcrt on Windows; auto-released if a holder crashes): re-read config.json fresh as the merge base, overlay only the keys this process changed since load, atomic-write the result inside the lock, then adopt it and refresh the snapshot.
- **Recursive merge** (`_apply_changes`): recurses into dict-valued keys so two processes editing *different* sub-keys of the same nested dict (per-provider `cloud_models`, `template_overrides`) both survive - we assert only the sub-keys we actually touched and keep the concurrent writer's sub-keys straight from disk. Scalars/lists overlay wholesale (last-writer-wins; no clean per-element merge). Nested deletions (the `reset_template` path) propagate.
- **Timeout fallback:** on `filelock.Timeout` it degrades to today's plain unlocked atomic write (a stuck lock must never block saves) and refreshes the snapshot so later saves stay consistent. Non-`Timeout` errors inside the lock keep the existing `-> False` contract.
- `filelock>=3.13` pinned in `requirements.txt` (already transitively present via `huggingface_hub`; no PyInstaller spec change needed - normal import analysis bundles it).

### Design
Chosen over a main.js serialisation queue after an architecture review: only the Python-side lock covers migration/telemetry/seed/terminal-CLI writers. Granularity is per (possibly nested) key; two writes to the *same* leaf remain last-writer-wins, which is a genuine conflict.

### Tests (model-free, `tests/test_config_persistence.py`)
- `test_two_writers_different_keys_both_survive` - the keystone: two `Config` instances load the same baseline, set different top-level keys; both survive on disk (fails on the old whole-file `_save`, passes now).
- `test_concurrent_edits_to_same_nested_dict_both_survive` + `test_nested_deletion_still_propagates` - the recursive-merge cases.
- `test_load_time_migration_and_concurrent_setter_both_survive`, `test_second_save_in_same_process_diffs_correctly`.
- `test_concurrent_processes_each_key_survives` - a real `multiprocessing` (spawn) stress test with a `Barrier` so all N workers load the same baseline then save simultaneously, forcing the race; proven to catch the old behaviour (1/6 keys survive old vs 6/6 fixed). Terminates timed-out children.
- All pre-existing atomic-write / corrupt-file recovery tests still pass unchanged.

### Verification
- `python -m unittest discover tests` -> 361 pass (13 in test_config_persistence). Stress test run 5x, no flake.
- `ruff check` clean.
- Independent Codex review of the recursive merge across 6 interleaving edge cases (nested concurrent add, untouched-dict disk additions, deletion vs concurrent sibling add, type changes, aliasing, missing snapshot key): no defects.

Part of #278.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cross-process lost-update race in config.json by saving under a file lock and merging only the keys changed by the current process. Addresses #278 and makes writes safe across CLI subprocesses, migrations, and telemetry.

- **Bug Fixes**
  - Save under a cross-process `filelock` with a 10s timeout; on timeout, fall back to an unlocked atomic write to avoid blocking.
  - Re-read disk and snapshot-diff merge only this process’s changes; recursive for dicts so nested keys from concurrent writers survive; scalars/lists remain last-writer-wins; deletions propagate.
  - After saving, adopt the merged result and refresh the snapshot so subsequent saves diff correctly.

- **Dependencies**
  - Add `filelock>=3.13` (already transitive via `huggingface_hub`).

<sup>Written for commit 1272fa88f120d8f5a1565df11c13e586356861c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

