### PR TITLE
feat: log silence auto-stop decisions to the Developer debug console (#271 diagnostics)

### DIFF
--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ipc } from '@/lib/ipc';
+import { appendDebugLog } from '@/lib/debugLogs';
 import { isMac } from '@/lib/utils';
 import {
   LIVE_RMS_HZ,
@@ -456,6 +457,37 @@ export function useSystemAudioCapture() {
         // flight, and clears on failure so a subsequent sustained silent
         // stretch can retry.
         let stopAttemptInFlight = false;
+        // Observation-only state for the [auto-stop] debug logs below. These
+        // do NOT affect the stop decision - they only track transitions so we
+        // log state changes (not every 1 Hz tick, which would flood the
+        // 1000-line buffer). `idleReason` is the last guard reason we logged,
+        // `wasSilent` the last silence/activity verdict, `lastHeartbeatAtMs`
+        // paces the "still silent" heartbeat.
+        let idleReason = '';
+        let wasSilent = false;
+        let lastHeartbeatAtMs = Date.now();
+
+        // The `[auto-stop]` lines below feed the Settings > Developer debug
+        // console (the renderer ring buffer in @/lib/debugLogs) so #271-class
+        // "silence auto-stop never fired" reports are remotely diagnosable:
+        // the user copies the Developer log and it shows the detector's
+        // decisions, which are otherwise invisible (DevTools-only console).
+        const logAutoStop = (msg: string) => {
+          // Observation-only: logging must never throw into the detector tick,
+          // so a misbehaving debug-log subscriber can't abort the stop
+          // decision. The empty catch is intentional.
+          try {
+            appendDebugLog(`[auto-stop] ${msg}`);
+          } catch {
+            /* logging must not affect the detector */
+          }
+        };
+        {
+          const armedCfg = silenceConfigRef.current;
+          logAutoStop(
+            `armed: enabled=${armedCfg.enabled} minutes=${armedCfg.minutes} systemAudio=${sysAnalyser !== null}`,
+          );
+        }
 
         silenceIntervalRef.current = setInterval(() => {
           const cfg = silenceConfigRef.current;
@@ -465,19 +497,63 @@ export function useSystemAudioCapture() {
           // long pause has to re-accumulate from scratch.
           if (!cfg.enabled || isPausedRef.current || !activeRef.current) {
             lastActiveAtMs = Date.now();
+            // Log the idle transition once (not every tick) so the Developer
+            // log shows WHY the timer keeps resetting.
+            const reason = !cfg.enabled
+              ? 'disabled'
+              : isPausedRef.current
+                ? 'paused'
+                : 'inactive';
+            if (reason !== idleReason) {
+              idleReason = reason;
+              logAutoStop(`idle (${reason}) - timer reset`);
+            }
+            // Reset silence-tracking so a resume re-accumulates from scratch
+            // (mirrors the lastActiveAtMs reset above).
+            wasSilent = false;
             return;
+          }
+          if (idleReason) {
+            logAutoStop('re-armed');
+            idleReason = '';
           }
           if (stopAttemptInFlight) return;
           const micRms = computeRms(micAnalyser, micBuf);
           const sysRms = sysAnalyser && sysBuf ? computeRms(sysAnalyser, sysBuf) : 0;
-          if (micRms > SILENCE_RMS_THRESHOLD || sysRms > SILENCE_RMS_THRESHOLD) {
+          const silent = !(micRms > SILENCE_RMS_THRESHOLD || sysRms > SILENCE_RMS_THRESHOLD);
+          if (!silent) {
+            if (wasSilent) {
+              wasSilent = false;
+              logAutoStop(
+                `activity (mic=${micRms.toFixed(4)} sys=${sysRms.toFixed(4)}) - timer reset`,
+              );
+            }
             lastActiveAtMs = Date.now();
             return;
           }
+          if (!wasSilent) {
+            wasSilent = true;
+            lastHeartbeatAtMs = Date.now();
+            logAutoStop(
+              `silence started (mic=${micRms.toFixed(4)} sys=${sysRms.toFixed(4)})`,
+            );
+          }
           const silenceMs = Date.now() - lastActiveAtMs;
           const limitMs = cfg.minutes * 60 * 1000;
+          // Heartbeat while silence accumulates toward the limit - shows the
+          // detector is running and the window is growing (the missing signal
+          // in #271, where silence never seemed to add up).
+          if (Date.now() - lastHeartbeatAtMs >= 30_000) {
+            lastHeartbeatAtMs = Date.now();
+            const elapsedSec = Math.round((Date.now() - lastActiveAtMs) / 1000);
+            const limitSec = Math.round(limitMs / 1000);
+            logAutoStop(
+              `still silent ${elapsedSec}s / ${limitSec}s (mic=${micRms.toFixed(4)} sys=${sysRms.toFixed(4)})`,
+            );
+          }
           if (silenceMs < limitMs) return;
 
+          logAutoStop(`threshold reached (${Math.round(silenceMs / 1000)}s silent) - stopping`);
           stopAttemptInFlight = true;
           const minutes = cfg.minutes;
           void (async () => {
@@ -491,10 +567,16 @@ export function useSystemAudioCapture() {
               if (!stopResult.success) {
                 // eslint-disable-next-line no-console
                 console.error('[silenceAutoStop] stop failed:', stopResult.error);
+                logAutoStop('stop failed: ' + stopResult.error);
                 // Reset the silence window so the user gets a fresh
                 // duration of silence before we retry the stop — avoids
                 // hammering a failing IPC every second.
                 lastActiveAtMs = Date.now();
+                // Keep the logging-transition state in sync with the reset
+                // window so the next silent stretch logs a clean "silence
+                // started" + fresh heartbeat rather than a stale one.
+                wasSilent = false;
+                lastHeartbeatAtMs = Date.now();
                 stopAttemptInFlight = false;
                 return;
               }
@@ -503,6 +585,7 @@ export function useSystemAudioCapture() {
               // of pre-emptively before the stop call) so a failed stop
               // doesn't permanently disarm auto-stop for the session.
               teardownSilenceDetector();
+              logAutoStop('recording stopped after ' + minutes + 'min of silence');
               const notifResult = await bridge.settings.showSilenceAutoStopNotification({
                 minutes,
                 // Pre-processing name — calendar event title for
@@ -520,7 +603,12 @@ export function useSystemAudioCapture() {
             } catch (e) {
               // eslint-disable-next-line no-console
               console.error('[silenceAutoStop] failed to stop:', e);
+              logAutoStop('stop error: ' + String(e));
               lastActiveAtMs = Date.now();
+              // Keep the logging-transition state in sync with the reset
+              // window (see the !success branch above).
+              wasSilent = false;
+              lastHeartbeatAtMs = Date.now();
               stopAttemptInFlight = false;
             }
           })();


### PR DESCRIPTION
## Make the silence auto-stop detector's decisions visible in the Developer debug console

Groundwork for diagnosing #271 (silence auto-stop never fires; one user got a 5h recording).

### Why
A user shared a repro recording. Running it through the app's exact detector (8-bit `getByteTimeDomainData`, 512-sample window, 1 Hz, threshold 0.01) showed **both channels silent for the full duration** - no system audio at all, and the mic only picking up room noise below threshold (peak 8-bit RMS 0.0083 < 0.01). So the detector *should* have auto-stopped at the configured 2 min, but didn't. The "background noise keeps it awake" theory doesn't hold for that file.

That means the real cause is the detector not firing on genuine silence - and today that is **undiagnosable remotely**: the detector's only logs are `console.error`/`warn` in the renderer, which go to DevTools, not the user-facing debug log. A normal user can't get at them.

### What
Route the silence-auto-stop detector's decisions into the same renderer ring buffer that backs **Settings > Developer > Debug console** (`appendDebugLog`, already copy-able there). It now logs, `[auto-stop]`-prefixed:

- **armed** - once, with `enabled`, `minutes`, and whether a system-audio analyser exists.
- **idle (disabled|paused|inactive) / re-armed** - guard-state transitions (logged on change, not every tick), so the log shows *why* the timer keeps resetting.
- **silence started / activity** - transitions across the RMS threshold, with the `mic`/`sys` RMS values.
- **still silent Ns / limitS** - a 30 s heartbeat while silence accumulates, so you can see the window actually growing (the missing signal in #271).
- **threshold reached / recording stopped / stop failed / stop error** - the fire path and its result.

For a normal 2 min silent stop that is ~5 lines, not 1/s - it logs transitions plus a 30 s heartbeat, so the 1000-line buffer isn't flooded.

### Safety
Observation-only. The stop **decision** is unchanged - the sole logic-touching edit refactors `if (micRms > TH || sysRms > TH)` into `const silent = !(...); if (!silent)`, which is logically identical; thresholds, the `silenceMs < limitMs` window, and the in-flight latch are byte-for-byte the same. `logAutoStop` wraps `appendDebugLog` in try/catch so a misbehaving log subscriber can never throw into the detector tick.

### Verification
- `typecheck:renderer` clean; `lint:renderer` no new warnings; `npm run build` (vite + electron) succeeds.
- Independent Codex review: refactor confirmed logically identical, log volume confirmed transitions+heartbeat (not per-tick); its two low findings (harden the log call, reset log-transition state on the stop-failure path) are folded in.

No e2e spec: asserting these logs needs a real multi-minute silent recording (heavy, model-bearing), out of proportion for an additive logging change.

Once this ships, a #271 reporter can copy the Developer log and we'll see exactly where the detector goes wrong. Part of #271.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log the silence auto-stop detector’s decisions to the Developer debug console so we can diagnose “auto-stop never fires” cases (issue #271). No behavior change; stop logic and thresholds are unchanged.

- **New Features**
  - Send detector transition logs to the renderer debug ring buffer via `appendDebugLog` (`@/lib/debugLogs`), `[auto-stop]`-prefixed.
  - Logs: armed config; idle/paused/inactive and re-armed; silence/activity crossings with RMS; 30s “still silent” heartbeat; threshold reached; stop result/errors.
  - Emits on transitions + 30s heartbeat only, to avoid flooding the 1000-line buffer.
  - Logging is wrapped in try/catch and logging state resets on stop failure to keep output consistent and non-invasive.

<sup>Written for commit f580f8622c2bc85b616eff42e95d7c25fb99d678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

