### PR TITLE
fix(privacy): stop leaking meeting content into the shareable debug log (source reduction)

### DIFF
--- a/app/diagnostics-filter.js
+++ b/app/diagnostics-filter.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// Source-side privacy filters for the shareable debug log (Settings >
+// Developer > Debug console, backed by sendDebugLog). These keep meeting
+// content and PII out of the buffer in the first place, mirroring the on-disk
+// allowlist in main.js's logPipelineStdoutLine. See
+// docs/superpowers/specs/2026-07-04-diagnostics-privacy-design.md (PR1).
+
+// ---------------------------------------------------------------------------
+// Stdout allowlist
+// ---------------------------------------------------------------------------
+
+// Prefixes for the structural, content-free protocol lines that are safe to
+// forward to the debug buffer. Everything else on stdout — settings-command
+// JSON replies, query answers, and the content markers CHUNK:/TITLE:/LIVE_SEG:/
+// CHAT_CHUNK: — is dropped.
+//
+// Deliberately EXCLUDED (accepted diagnostic loss, per the design): STATUS:,
+// SUCCESS:, ERROR:, WARNING: (settings replies / error strings that can quote
+// content) and LIVE_READY: (a config JSON payload). PARAKEET_PULL_STAGE: /
+// LIVE_READY: are consumed by dedicated handlers, never the generic choke
+// points, so they never reach this filter.
+const DIAGNOSTIC_STDOUT_PREFIXES = [
+  'HEARTBEAT:',
+  'PROGRESS:',
+  'TRANSCRIPTION_COMPLETE:',
+  'TRANSCRIPTION_FAILED:',
+  'SAVED:',
+  'STREAM_ERROR:',
+  'CHAT_STREAM_ERROR:',
+  'LIVE_ERROR:',
+];
+
+// STREAM_COMPLETE is an exact-match sentinel (no trailing value), so it is
+// matched on its own rather than as a prefix.
+function isDiagnosticStdoutLine(line) {
+  const l = (line || '').trim();
+  if (!l) return false;
+  if (l === 'STREAM_COMPLETE') return true;
+  return DIAGNOSTIC_STDOUT_PREFIXES.some((p) => l.startsWith(p));
+}
+
+// ---------------------------------------------------------------------------
+// `$ stenoai ...` args-echo sanitizer
+// ---------------------------------------------------------------------------
+
+// Replace everything after the -q flag with a redaction marker (keeps the file
+// and the flag, drops the question text).
+function redactAfterQ(args) {
+  const i = args.indexOf('-q');
+  if (i === -1) return args.slice();
+  return [...args.slice(0, i + 1), '<redacted>'];
+}
+
+// Collapse every value arg after the command into a single marker.
+function redactRest(args) {
+  return args.length > 1 ? [args[0], '<redacted>'] : args.slice();
+}
+
+// Denylist map: commands whose argv carries user content or PII. Each entry
+// rewrites the argv FOR LOGGING ONLY (never the spawned args). API keys are
+// safe here — they travel via env/safeStorage, never argv.
+const ARGS_ECHO_REDACTORS = {
+  // Question text follows -q; keep the file + flag, drop the question.
+  query: redactAfterQ,
+  'query-streaming': redactAfterQ,
+  // The whole template JSON is the user's custom prompt.
+  'save-template': () => ['save-template', '<template json>'],
+  // Single sensitive value arg(s): name, storage path, folder name, or URL
+  // (URLs may embed user:pass@ or an org hostname).
+  'set-user-name': redactRest,
+  'set-storage-path': redactRest,
+  'create-folder': redactRest,
+  'rename-folder': redactRest,
+  'set-remote-ollama-url': redactRest,
+  'test-remote-ollama': redactRest,
+  'set-cloud-api-url': redactRest,
+};
+
+// Return the argv rewritten for the `$ stenoai <...>` debug echo. Non-
+// denylisted commands echo verbatim.
+function sanitizeArgsForLog(args) {
+  if (!Array.isArray(args) || args.length === 0) return '';
+  const redactor = ARGS_ECHO_REDACTORS[args[0]];
+  const out = redactor ? redactor(args) : args;
+  return out.join(' ');
+}
+
+module.exports = { isDiagnosticStdoutLine, sanitizeArgsForLog };

--- a/app/diagnostics-forward.test.js
+++ b/app/diagnostics-forward.test.js
@@ -1,0 +1,104 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { isDiagnosticStdoutLine, sanitizeArgsForLog } = require('./diagnostics-filter');
+
+// isDiagnosticStdoutLine is the predicate behind main.js's
+// forwardDiagnosticStdout: a line reaches the shareable debug buffer only when
+// this returns true.
+
+test('allowlist accepts every diagnostic prefix', () => {
+  const accepted = [
+    'HEARTBEAT:1234',
+    'PROGRESS:summarize:map',
+    'TRANSCRIPTION_COMPLETE:512',
+    'TRANSCRIPTION_FAILED: audio preserved',
+    'SAVED:/Users/x/Library/Application Support/stenoai/output/note.json',
+    'STREAM_COMPLETE',
+    'STREAM_ERROR: model unavailable',
+    'CHAT_STREAM_ERROR: context overflow',
+    'LIVE_ERROR: sidecar died',
+  ];
+  for (const line of accepted) {
+    assert.strictEqual(isDiagnosticStdoutLine(line), true, `should accept: ${line}`);
+  }
+});
+
+test('allowlist tolerates leading/trailing whitespace and CRLF residue', () => {
+  assert.strictEqual(isDiagnosticStdoutLine('  SAVED:/tmp/x.json  '), true);
+  assert.strictEqual(isDiagnosticStdoutLine('STREAM_COMPLETE\r'), true);
+});
+
+test('allowlist drops content markers CHUNK: and TITLE:', () => {
+  assert.strictEqual(isDiagnosticStdoutLine('CHUNK:aGVsbG8gd29ybGQ='), false);
+  assert.strictEqual(isDiagnosticStdoutLine('TITLE:Quarterly budget review'), false);
+  assert.strictEqual(isDiagnosticStdoutLine('LIVE_SEG:{"text":"secret"}'), false);
+  assert.strictEqual(isDiagnosticStdoutLine('CHAT_CHUNK:some answer'), false);
+});
+
+test('allowlist drops JSON replies and free text', () => {
+  assert.strictEqual(isDiagnosticStdoutLine('{"answer": "the meeting decided X"}'), false);
+  assert.strictEqual(isDiagnosticStdoutLine('Some free text about the meeting'), false);
+  assert.strictEqual(isDiagnosticStdoutLine('SUCCESS: Model set to gemma'), false);
+  assert.strictEqual(isDiagnosticStdoutLine('ERROR: Summary file not found: /Users/x/secret.json'), false);
+});
+
+test('allowlist drops empty and whitespace-only lines', () => {
+  assert.strictEqual(isDiagnosticStdoutLine(''), false);
+  assert.strictEqual(isDiagnosticStdoutLine('   '), false);
+  assert.strictEqual(isDiagnosticStdoutLine(null), false);
+});
+
+test('STREAM_COMPLETE only matches exactly, not as a prefix carrying content', () => {
+  // A non-diagnostic line that merely starts with the sentinel text is dropped.
+  assert.strictEqual(isDiagnosticStdoutLine('STREAM_COMPLETEX with trailing content'), false);
+});
+
+// sanitizeArgsForLog rewrites the `$ stenoai <...>` echo for logging only.
+
+test('query and query-streaming strip the question after -q', () => {
+  assert.strictEqual(
+    sanitizeArgsForLog(['query', '/path/note.json', '-q', 'What did we decide about the budget?']),
+    'query /path/note.json -q <redacted>',
+  );
+  assert.strictEqual(
+    sanitizeArgsForLog(['query-streaming', '/path/note.json', '-q', 'private question text']),
+    'query-streaming /path/note.json -q <redacted>',
+  );
+});
+
+test('save-template collapses to a template-json marker', () => {
+  assert.strictEqual(
+    sanitizeArgsForLog(['save-template', '{"name":"Custom","prompt":"my secret prompt"}']),
+    'save-template <template json>',
+  );
+});
+
+test('name / path / folder / URL setters redact their value arg(s)', () => {
+  assert.strictEqual(sanitizeArgsForLog(['set-user-name', 'Jane Doe']), 'set-user-name <redacted>');
+  assert.strictEqual(sanitizeArgsForLog(['set-storage-path', '/Volumes/NAS/meetings']), 'set-storage-path <redacted>');
+  assert.strictEqual(sanitizeArgsForLog(['create-folder', 'Board minutes', '--color', '#ff0000']), 'create-folder <redacted>');
+  assert.strictEqual(sanitizeArgsForLog(['rename-folder', 'folder-id-123', 'Legal matters']), 'rename-folder <redacted>');
+  assert.strictEqual(sanitizeArgsForLog(['set-remote-ollama-url', 'http://user:pass@ollama.corp.internal:11434']), 'set-remote-ollama-url <redacted>');
+  assert.strictEqual(sanitizeArgsForLog(['test-remote-ollama', 'http://ollama.corp.internal']), 'test-remote-ollama <redacted>');
+  assert.strictEqual(sanitizeArgsForLog(['set-cloud-api-url', 'https://api.example.com/v1']), 'set-cloud-api-url <redacted>');
+});
+
+test('set-storage-path with no value (reset) echoes just the command', () => {
+  assert.strictEqual(sanitizeArgsForLog(['set-storage-path']), 'set-storage-path');
+});
+
+test('query with no -q flag passes through unchanged', () => {
+  assert.strictEqual(sanitizeArgsForLog(['query', '/path/note.json']), 'query /path/note.json');
+});
+
+test('non-denylisted commands echo verbatim', () => {
+  assert.strictEqual(sanitizeArgsForLog(['status']), 'status');
+  assert.strictEqual(sanitizeArgsForLog(['reprocess', '/path/note.json']), 'reprocess /path/note.json');
+  assert.strictEqual(sanitizeArgsForLog(['generate-report', '/path/note.json', 'detailed']), 'generate-report /path/note.json detailed');
+});
+
+test('empty or non-array args yield an empty string', () => {
+  assert.strictEqual(sanitizeArgsForLog([]), '');
+  assert.strictEqual(sanitizeArgsForLog(null), '');
+});

--- a/app/main.js
+++ b/app/main.js
@@ -48,6 +48,7 @@ const {
   parseShortcutUrl,
 } = require('./shortcut-url');
 const { parseSetupCheckOutput } = require('./setup-check-parse');
+const { isDiagnosticStdoutLine, sanitizeArgsForLog } = require('./diagnostics-filter');
 
 // Wrap spawn so every backend / ollama launch defaults to windowsHide:true.
 // The PyInstaller backend (stenoai.exe) and bundled ollama.exe are console
@@ -1448,7 +1449,11 @@ function runPythonScript(script, args = [], silent = false, extraEnv = {}, logLa
     // Log the command being executed (unless silent)
     console.log('Running:', `${backendPath} ${args.join(' ')}`);
     if (!silent) {
-      sendDebugLog(`$ stenoai ${args.join(' ')}`);
+      // Sanitize the echoed argv: denylisted commands (query, save-template,
+      // set-user-name/storage-path, folder + URL setters) carry content/PII in
+      // their args. This rewrites the LOGGED string only; the spawned `args`
+      // below are untouched.
+      sendDebugLog(`$ stenoai ${sanitizeArgsForLog(args)}`);
     }
 
     const process = spawn(backendPath, args, {
@@ -1468,10 +1473,12 @@ function runPythonScript(script, args = [], silent = false, extraEnv = {}, logLa
       const output = data.toString();
       stdout += output;
       console.log('Python stdout:', output);
-      // Stream stdout to debug panel in real-time (unless silent)
+      // Stream stdout to debug panel in real-time (unless silent), but only the
+      // structural diagnostic markers — query answers and other content are
+      // dropped so they never reach the shareable buffer.
       if (!silent) {
         output.split('\n').forEach(line => {
-          if (line.trim()) sendDebugLog(line.trim());
+          forwardDiagnosticStdout(line, 'backend');
         });
       }
     });
@@ -1953,8 +1960,9 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
             if (mainWindow && !mainWindow.isDestroyed()) {
               mainWindow.webContents.send('summary-complete', { success: false, sessionName, summaryFile });
             }
-          } else if (line.trim()) {
-            sendDebugLog(line.trim());
+          } else {
+            // Unclassified stdout: forward only diagnostic markers, drop content.
+            forwardDiagnosticStdout(line, 'reprocess');
           }
         }
       });
@@ -2051,12 +2059,13 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
         reject(new Error(`generate-report spawn error: ${err.message}`));
       });
 
+      // Buffer across chunk boundaries (matching reprocess/process-streaming),
+      // so a CHUNK:<base64 summary> line straddling two data events can't lose
+      // its prefix and fall into the diagnostic fallback below.
+      const stdoutReader = makeLineReader();
       proc.stdout.on('data', (data) => {
         watchdog.reset();
-        const text = data.toString();
-        // CRLF-tolerant: Windows stdout is \r\n; exact-match lines (STREAM_COMPLETE)
-        // would otherwise carry a trailing \r and never match.
-        text.split(/\r?\n/).forEach(line => {
+        for (const line of stdoutReader.feed(data)) {
           if (line.startsWith('CHUNK:')) {
             try {
               const encoded = line.slice(6);
@@ -2086,10 +2095,11 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
             }
           } else if (line.startsWith('SAVED:')) {
             sendDebugLog(`Report saved: ${line.slice(6).trim()}`);
-          } else if (line.trim()) {
-            sendDebugLog(line.trim());
+          } else {
+            // Unclassified stdout: forward only diagnostic markers, drop content.
+            forwardDiagnosticStdout(line, 'generate-report');
           }
-        });
+        }
       });
 
       proc.stderr.on('data', (data) => {
@@ -2220,7 +2230,7 @@ ipcMain.handle('regen-meeting-title', async (event, summaryFile, sessionName) =>
 
 ipcMain.handle('query-transcript', async (event, summaryFile, question) => {
   try {
-    sendDebugLog(`🤖 Querying transcript: ${question.substring(0, 50)}...`);
+    sendDebugLog(`🤖 Querying transcript (${String(question || '').length} chars)`);
 
     // Run the query command — getAiEnv supplies the right env for whichever
     // provider is active (cloud key for cloud, adapter url+token for org).
@@ -2285,7 +2295,7 @@ ipcMain.on('query-cancel', (_event, queryId) => {
 
 ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) => {
   console.log(`[QUERY] IPC received: question="${question.substring(0, 50)}" file="${summaryFile}"`);
-  sendDebugLog(`🤖 Streaming query: ${question.substring(0, 50)}...`);
+  sendDebugLog(`🤖 Streaming query (${String(question || '').length} chars)`);
   const env = { ...process.env, ...getAiEnv() };
 
   let proc;
@@ -2379,7 +2389,7 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
 // context window (smaller for local/remote), so a local model answers over
 // fewer recent notes instead of overflowing. No retrieval (RAG) yet.
 ipcMain.on('chat-global-stream', (event, queryId, question, folderId) => {
-  sendDebugLog(`💬 Global chat query: ${String(question || '').slice(0, 80)}... (folder: ${folderId || 'all'})`);
+  sendDebugLog(`💬 Global chat query (${String(question || '').length} chars, folder: ${folderId || 'all'})`);
   const env = { ...process.env, ...getAiEnv() };
 
   const args = ['chat-global-streaming', '-q', question];
@@ -3519,8 +3529,11 @@ async function processNextInQueue() {
               lastHeartbeatLogAt = now;
               sendDebugLog(line.trim());
             }
-          } else if (line.trim()) {
-            sendDebugLog(line.trim());
+          } else {
+            // Unclassified stdout: forward only diagnostic markers (e.g.
+            // STREAM_ERROR:), drop content. HEARTBEAT is handled above with its
+            // own 30s throttle, so it never double-logs here.
+            forwardDiagnosticStdout(line, 'process-streaming');
           }
         }
       });
@@ -3767,7 +3780,7 @@ ipcMain.handle('start-recording-ui', async (_, sessionName) => {
     // process-system-audio-recording IPC. The legacy Python `record`
     // subprocess — signal-controlled and thus unworkable on Windows — is
     // retired, so there is no longer a mic-XOR-system fork here.
-    sendDebugLog(`Starting renderer-driven recording: ${actualSessionName}`);
+    sendDebugLog(`Starting renderer-driven recording (name ${String(actualSessionName || '').length} chars)`);
     currentRecordingSessionName = actualSessionName;
     startRecordingRuntimeState();
     // Flip the active flag immediately so the queue handler reports
@@ -4258,7 +4271,7 @@ async function handleMicEvent(line) {
   sendDebugLog(`[auto-detect] meeting detected: ${appName} (${evt.app_id || 'no-bundle-id'})`);
   const calEvent = await getCalendarEventForNow();
   if (calEvent) {
-    sendDebugLog(`[auto-detect] matched calendar event: ${calEvent.title}`);
+    sendDebugLog(`[auto-detect] matched a calendar event`);
   }
   showMeetingDetectedNotification(appName, evt, calEvent);
 }
@@ -4336,7 +4349,7 @@ function requestAutoRecord(appName, originatingEvt, calEvent) {
   // app-detection string (e.g. "an app — 2026-06-01 17:00") to the user
   // whenever title regeneration produced nothing.
   const sessionName = calEvent?.title || 'Note';
-  sendDebugLog(`[auto-detect] user requested record: ${sessionName}`);
+  sendDebugLog(`[auto-detect] user requested record (calendar-titled: ${calEvent?.title ? 'yes' : 'no'})`);
 
   // Track the originating app so we can pair its mic-stop with this recording
   // and offer a "Summarise" prompt when the meeting ends.
@@ -4463,6 +4476,17 @@ function logPipelineStdoutLine(line, source) {
   ) {
     processingLog.logLine(source, l);
   }
+}
+
+// Forward a backend stdout line to the shareable debug buffer ONLY if it is a
+// structural diagnostic marker (see isDiagnosticStdoutLine). Content — query
+// answers, summary CHUNK:/TITLE:, settings-command JSON replies — is dropped so
+// it never enters the buffer. This is the sendDebugLog counterpart to the
+// on-disk logPipelineStdoutLine allowlist above; `source` is accepted for
+// call-site symmetry with that function (heartbeat throttling stays at the
+// per-handler call site, not here).
+function forwardDiagnosticStdout(line, source) { // eslint-disable-line no-unused-vars
+  if (isDiagnosticStdoutLine(line)) sendDebugLog(line.trim());
 }
 
 ipcMain.handle('setup-ollama-and-model', async () => {
@@ -8525,7 +8549,9 @@ function recordOrgBackupFailure(summaryFile, errorMessage) {
   // Best-effort diagnostic logging (never throws): the persistent processing
   // log on disk for support, plus the in-app debug panel.
   try {
-    const msg = `org backup failed for ${path.basename(summaryFile)}: ${errorMessage || 'unknown error'}`;
+    // Drop the meeting-title basename (content); keep the failure + the
+    // non-content error so both the on-disk log and the debug panel stay useful.
+    const msg = `org backup failed: ${errorMessage || 'unknown error'}`;
     processingLog.logLine('org-backup', msg);
     sendDebugLog(`[org-backup] ${msg}`);
   } catch (_) { /* logging is best-effort */ }

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -881,7 +881,7 @@ class OllamaSummarizer:
                     try:
                         record = _json.loads(line)
                     except _json.JSONDecodeError:
-                        logger.warning(f"Adapter stream: malformed NDJSON line dropped: {line[:120]}")
+                        logger.warning(f"Adapter stream: malformed NDJSON line dropped ({len(line)} chars)")
                         continue
                     kind = record.get("type")
                     if kind == "chunk":
@@ -1340,7 +1340,13 @@ Return ONLY the response in this exact JSON format:
             logger.error(f"Transcript length: {len(transcript)} characters")
             logger.error(f"Error type: {type(e).__name__}")
             if hasattr(e, 'response'):
-                logger.error(f"HTTP response: {e.response}")
+                # Log only the status, never the response object: its str/repr
+                # can embed the response body (model content) or headers.
+                status = getattr(e.response, 'status_code', None)
+                logger.error(
+                    f"HTTP response status: {status}" if status is not None
+                    else f"HTTP response: <{type(e.response).__name__}>"
+                )
             return None
     
     def _create_markdown_prompt(self, transcript: str, language: str = "en", notes: str = None) -> str:

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1227,8 +1227,9 @@ Return ONLY the response in this exact JSON format:
 
             logger.info(f"Received response from {self.ai_provider}")
             logger.info(f"Response length: {len(response_text)} characters")
-            logger.info(f"Response preview: {response_text[:200]}...")
-            
+            # No content preview: the response is meeting-derived and must not
+            # reach the shareable debug log. The length above is the signal.
+
             # Try to parse JSON response with repair functionality
             try:
                 # Remove any markdown formatting
@@ -1251,7 +1252,8 @@ Return ONLY the response in this exact JSON format:
             except json.JSONDecodeError as e:
                 logger.error(f"Ollama returned invalid JSON: {e}")
                 logger.error(f"JSON parse error at position: {e.pos}")
-                logger.error(f"Full Ollama response: {response_text}")
+                # Log the size, not the body: the response is meeting content.
+                logger.error(f"Ollama response unparseable ({len(response_text)} chars)")
                 logger.info("Attempting simple JSON repair for unquoted strings...")
                 
                 # Simple fix for unquoted strings in arrays (the actual issue we encountered)
@@ -1718,7 +1720,7 @@ TITLE:"""
 
             # Only return if we got something meaningful
             if title and len(title) > 2:
-                logger.info(f"Generated meeting title: {title}")
+                logger.info(f"Generated meeting title ({len(title)} chars)")
                 return title
 
             return None
@@ -1834,7 +1836,7 @@ ANSWER:"""
 
             prompt = self._build_query_prompt(transcript, question, language)
 
-            logger.info(f"Querying transcript with question: {question[:50]}...")
+            logger.info(f"Querying transcript with question ({len(question)} chars)")
 
             if self.ai_provider == "adapter":
                 response_text = self._adapter_chat(prompt, 120)

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -832,7 +832,9 @@ class WhisperTranscriber:
                     while run_end < len(segments) and segments[run_end].text.strip() == text:
                         run_end += 1
                     if run_end - i >= 5 and text:
-                        logger.warning("Dropped %d repeated whisper segments: %r", run_end - i, text[:60])
+                        # Log the count, not the text: dropped segments are
+                        # transcript content and must not reach the debug log.
+                        logger.warning("Dropped %d repeated whisper segments (%d chars each)", run_end - i, len(text))
                     else:
                         deduped.extend(segments[i:run_end])
                     i = run_end

--- a/tests/test_summarizer_logging_privacy.py
+++ b/tests/test_summarizer_logging_privacy.py
@@ -1,0 +1,50 @@
+"""Privacy regression: the summarizer's diagnostic log lines must emit
+lengths/counts, not meeting-derived content.
+
+These lines reach the shareable debug console (Settings > Developer) and the
+on-disk processing.log, so a leaked title or question would end up in any log a
+user pastes into Discord/GitHub. See
+docs/superpowers/specs/2026-07-04-diagnostics-privacy-design.md (PR1).
+"""
+
+import unittest
+from unittest import mock
+
+from src.config import Config
+from src.summarizer import OllamaSummarizer
+
+
+def _make_summarizer(model_name="llama3.2:3b", ai_provider="local"):
+    return OllamaSummarizer(model_name=model_name, ai_provider=ai_provider, config=Config())
+
+
+class TitleLoggingPrivacyTests(unittest.TestCase):
+    def test_generated_title_logs_length_not_text(self):
+        s = _make_summarizer()
+        title_text = "Confidential Board Compensation"
+        with mock.patch.object(
+            s, "_chat_no_think", return_value={"message": {"content": title_text}}
+        ):
+            with self.assertLogs("src.summarizer", level="INFO") as cm:
+                out = s.generate_title(summary="Some meeting summary text", transcript="")
+        self.assertEqual(out, title_text)
+        joined = "\n".join(cm.output)
+        self.assertIn(f"Generated meeting title ({len(title_text)} chars)", joined)
+        self.assertNotIn(title_text, joined)
+
+
+class QueryLoggingPrivacyTests(unittest.TestCase):
+    def test_query_logs_question_length_not_text(self):
+        s = _make_summarizer()
+        question = "What did we decide about the confidential acquisition price?"
+        s.client = mock.Mock()
+        s.client.chat.return_value = {"message": {"content": "An answer."}}
+        with self.assertLogs("src.summarizer", level="INFO") as cm:
+            s.query_transcript(transcript="Speaker A: hello.", question=question)
+        joined = "\n".join(cm.output)
+        self.assertIn(f"Querying transcript with question ({len(question)} chars)", joined)
+        self.assertNotIn(question, joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarizer_logging_privacy.py
+++ b/tests/test_summarizer_logging_privacy.py
@@ -46,5 +46,42 @@ class QueryLoggingPrivacyTests(unittest.TestCase):
         self.assertNotIn(question, joined)
 
 
+class _FakeStreamResponse:
+    """Minimal stand-in for the urlopen() context manager: a context manager
+    that iterates the raw NDJSON byte lines the adapter would stream."""
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+class AdapterStreamLoggingPrivacyTests(unittest.TestCase):
+    def test_malformed_ndjson_logs_length_not_content(self):
+        s = _make_summarizer()
+        s.adapter_url = "http://adapter.test"
+        s.adapter_token = "token"
+        secret = "not-json but definitely CONFIDENTIAL response body content"
+        lines = [
+            b'{"type": "chunk", "text": "hi"}\n',
+            (secret + "\n").encode("utf-8"),
+            b'{"type": "done"}\n',
+        ]
+        with mock.patch("urllib.request.urlopen", return_value=_FakeStreamResponse(lines)):
+            with self.assertLogs("src.summarizer", level="WARNING") as cm:
+                list(s._adapter_stream("prompt"))
+        joined = "\n".join(cm.output)
+        self.assertIn(f"malformed NDJSON line dropped ({len(secret)} chars)", joined)
+        self.assertNotIn(secret, joined)
+        self.assertNotIn("CONFIDENTIAL", joined)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Stop leaking meeting content into the shareable debug log (source reduction)

PR1 of a two-part privacy fix. The Settings > Developer "Debug console" (and its Copy button) is meant to be safe to share for remote diagnosis, but today it carries meeting content and PII. This PR removes that **at the source**; a follow-up PR2 adds a shared `redactDiagnostics` + a "Save diagnostics" export for the residual metadata (mainly paths).

### The leak (validated by an independent architecture + security review)
The generic Python runner and three streaming handlers forward raw stdout to `sendDebugLog`, and every stderr line too - so transcript/summary/query-answer content and PII reached the buffer (and the on-disk `processing.log`). The `$ stenoai <args>` echo leaked chat questions, template JSON, the user's name, folder names, storage paths, and URLs.

### What this PR does (reduction only, no UI)
1. **Shared stdout allowlist** (`app/diagnostics-filter.js` `isDiagnosticStdoutLine`, mirroring the existing `logPipelineStdoutLine` privacy idiom), wired via `forwardDiagnosticStdout` at all four forwarders (generic runner, reprocess, generate-report, process-streaming). Only structural protocol lines pass (`HEARTBEAT:`, `PROGRESS:`, `TRANSCRIPTION_COMPLETE:`/`_FAILED:`, `SAVED:`, `STREAM_ERROR:`/`CHAT_STREAM_ERROR:`/`LIVE_ERROR:`, `STREAM_COMPLETE`); JSON replies, `CHUNK:`/`TITLE:` payloads, transcript and summary text are dropped.
2. **generate-report line-reader bugfix**: it split each stdout `data` event independently instead of using `makeLineReader`, so a `CHUNK:<base64 summary>` line straddling two events fell into the raw-forward branch - base64 summary content reached the log. Now uses `makeLineReader` like the other two streaming handlers.
3. **Per-command args-echo sanitizer** (`sanitizeArgsForLog`): `query`/`query-streaming` strip the question after `-q`; `save-template` -> `<template json>`; `set-user-name`/`set-storage-path`/`create-folder`/`rename-folder`/`set-remote-ollama-url`/`test-remote-ollama`/`set-cloud-api-url` redact their value. The actual spawn args are untouched - only the logged echo changes.
4. **Seven Python logger lines** now emit lengths/counts, not content (`summarizer.py` response preview, full-response-on-parse-failure, generated title, query question, adapter malformed-NDJSON line, HTTP response object; `transcriber.py` dropped-segment text). This fixes the debug console AND the persistent `processing.log` in one place.
5. **Curated `main.js` lines** that embedded titles/questions now log lengths or a neutral marker (query/global-chat, recording start, calendar-match, org-backup).

### Invariant
Reduction only - the accumulated/returned stdout that command handlers consume and every `webContents.send` renderer routing (summary chunks, title, progress, completion) are unchanged. The summary still displays, the title still updates, progress still shows; only what's forwarded to the debug log changed.

### Verification
- `node --test` incl. new `app/diagnostics-forward.test.js` (13 cases: allowlist accepts each diagnostic prefix, drops JSON/free text/`CHUNK:`/`TITLE:`; args sanitizer redacts each denylisted command, passes others) -> pass.
- `python -m unittest discover tests` -> 358 pass (new `tests/test_summarizer_logging_privacy.py`).
- `node --check app/main.js`, `ruff check` clean.
- Independent Codex review of the implementation: core confirmed correct (invariant held, no content marker passes the allowlist); its two additional content-bearing stderr lines are folded in. Remaining residual (title-derived path basenames in `SAVED:`/command echoes) is deliberately deferred to PR2's path redaction; error strings that quote content are the documented residual.

Groundwork for #271-class remote diagnosis. PR2 (redaction + Save diagnostics) follows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops meeting content and PII from reaching the shareable debug console and on-disk logs by filtering at the source and sanitizing sensitive log lines, without changing any user-facing behavior.

- **Bug Fixes**
  - Added a stdout allowlist and unified forwarders so only structural markers pass; drops `CHUNK:`/`TITLE:`/`LIVE_SEG:`/`CHAT_CHUNK:`, JSON, and free text.
  - Switched `generate-report` to `makeLineReader` to prevent split `CHUNK:<base64>` lines from leaking across data events.
  - Sanitized `$ stenoai` args echo for sensitive commands: redacts `-q` question text, template JSON, and name/path/URL setters.
  - Replaced content-bearing Python and app logs with lengths/status/counts (e.g., response size, unparseable-response size, HTTP status, generated-title/question lengths, dropped Whisper-segment counts); renderer routing and processing remain unchanged.

<sup>Written for commit 2936d6368595355732b5c18514e6cb462a859996. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

