### PR TITLE
feat(privacy): redact the debug log + Save diagnostics export (defense-in-depth)

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -127,6 +127,20 @@ function install({ ipcMain }) {
       return { success: true, path: seamPath };
     },
 
+    // Mirror the real save-diagnostics handler's seam: with
+    // STENOAI_E2E_DIAGNOSTICS_PATH set, write the renderer-built (redacted)
+    // bundle there so a T1 spec can read back exactly what Save passed. Without
+    // the seam there's no dialog here, so report a cancel.
+    'save-diagnostics': async (_event, _defaultFilename, content) => {
+      if (typeof content !== 'string' || content.length === 0) {
+        return { success: false, error: 'No diagnostics content to save.' };
+      }
+      const seamPath = process.env.STENOAI_E2E_DIAGNOSTICS_PATH;
+      if (!seamPath) return { success: false, error: EXPORT_CANCELED };
+      fs.writeFileSync(seamPath, content, 'utf-8');
+      return { success: true, path: seamPath };
+    },
+
     'org-status': async () => {
       if (!state.orgSession) {
         return { signedIn: false, everSignedIn: state.everSignedIn };

--- a/app/main.js
+++ b/app/main.js
@@ -2614,6 +2614,57 @@ ipcMain.handle('export-transcript', async (event, defaultFilename, content) => {
   }
 });
 
+// Save the (already redacted, renderer-built) diagnostics bundle to a file the
+// user picks. Mirrors export-transcript: basename-only defaultPath, atomic
+// tmp+rename, and the e2e save-path seam. The renderer owns redaction + the env
+// header (redactDiagnostics + header build); this handler only writes bytes.
+ipcMain.handle('save-diagnostics', async (event, defaultFilename, content) => {
+  try {
+    if (typeof content !== 'string' || content.length === 0) {
+      return { success: false, error: 'No diagnostics content to save.' };
+    }
+
+    // Test-only seam: only honor it under e2e, so a stray env var in a real
+    // launch can't silently redirect a user's save to an arbitrary path.
+    const seamPath = IS_E2E ? process.env.STENOAI_E2E_DIAGNOSTICS_PATH : undefined;
+    let targetPath = seamPath;
+
+    if (!targetPath) {
+      // The renderer supplies a suggested name only; reduce it to a bare
+      // filename so a malformed value can't steer defaultPath with an absolute
+      // path or traversal components. The user still confirms via the dialog.
+      const suggested =
+        typeof defaultFilename === 'string' && defaultFilename.trim()
+          ? path.basename(defaultFilename).slice(0, 200)
+          : 'stenoai-diagnostics.txt';
+      const result = await dialog.showSaveDialog(mainWindow, {
+        defaultPath: suggested,
+        filters: [{ name: 'Text', extensions: ['txt'] }],
+      });
+      if (result.canceled || !result.filePath) {
+        return { success: false, error: EXPORT_CANCELED };
+      }
+      targetPath = result.filePath;
+    }
+
+    // Atomic write: tmp file in the SAME directory, then rename into place, so a
+    // failed write can't truncate a pre-existing file. Mirrors export-transcript.
+    const dir = path.dirname(targetPath);
+    const base = path.basename(targetPath);
+    const tmpPath = path.join(dir, `.${base}.${require('crypto').randomBytes(6).toString('hex')}.tmp`);
+    try {
+      await fs.promises.writeFile(tmpPath, content, 'utf-8');
+      await fs.promises.rename(tmpPath, targetPath);
+    } catch (writeErr) {
+      try { await fs.promises.unlink(tmpPath); } catch (_) {}
+      throw writeErr;
+    }
+    return { success: true, path: targetPath };
+  } catch (err) {
+    return { success: false, error: String(err && err.message ? err.message : err) };
+  }
+});
+
 ipcMain.handle('update-meeting', async (event, summaryFilePath, updates) => {
   try {
     const projectRoot = path.join(__dirname, '..');

--- a/app/preload.js
+++ b/app/preload.js
@@ -241,6 +241,8 @@ const stenoai = {
     setStoragePath: (p) => invoke('set-storage-path', p),
     pickStorageFolder: () => invoke('select-storage-folder'),
     getAiPrompts: () => invoke('get-ai-prompts'),
+    saveDiagnostics: (defaultFilename, content) =>
+      invoke('save-diagnostics', defaultFilename, content),
   },
 
   ai: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -878,6 +878,7 @@ export interface StenoaiBridge {
     setStoragePath: RequestFn<[p: string], Result<Record<string, never>>>;
     pickStorageFolder: RequestFn<[], PickStorageFolderResponse>;
     getAiPrompts: RequestFn<[], GetAiPromptsResponse>;
+    saveDiagnostics: RequestFn<[defaultFilename: string, content: string], Result<{ path: string }>>;
   };
 
   ai: {

--- a/app/renderer/src/lib/redactDiagnostics.test.ts
+++ b/app/renderer/src/lib/redactDiagnostics.test.ts
@@ -53,6 +53,15 @@ describe('redactDiagnostics - custom storage root', () => {
   test('empty storage root is a no-op', () => {
     expect(redact('nothing here', '')).toBe('nothing here');
   });
+
+  test('trailing-slash storage root still lets the data-dir rule redact', () => {
+    // Without stripping the trailing slash the literal replace yields
+    // `~output/Board.md` (no separator) and the basename survives.
+    const root = '/Volumes/Client Acme/steno/';
+    expect(redact(`SAVED:${root}output/Board.md`, root)).toBe(
+      'SAVED:~/output/<redacted>.md',
+    );
+  });
 });
 
 describe('redactDiagnostics - data-dir basename', () => {
@@ -81,8 +90,26 @@ describe('redactDiagnostics - data-dir basename', () => {
   });
 
   test('no-extension single-token basename is redacted to <redacted>', () => {
-    expect(redact('SAVED:/Users/a/x/recordings/rawclip end')).toBe(
-      'SAVED:~/x/recordings/<redacted> end',
+    expect(redact('SAVED:/Users/a/x/recordings/rawclip')).toBe(
+      'SAVED:~/x/recordings/<redacted>',
+    );
+  });
+
+  test('no-extension basename WITH spaces redacts whole (end-of-line)', () => {
+    expect(redact('SAVED:/Users/a/x/output/Weekly Sync')).toBe(
+      'SAVED:~/x/output/<redacted>',
+    );
+  });
+
+  test('no-extension basename WITH spaces redacts whole (quoted)', () => {
+    expect(redact('reprocess "/Users/a/x/output/Weekly Sync"')).toBe(
+      'reprocess "~/x/output/<redacted>"',
+    );
+  });
+
+  test('no-extension basename WITH spaces redacts whole (followed by ;)', () => {
+    expect(redact('path=/Users/a/x/transcripts/Board Meeting Q3;next')).toBe(
+      'path=~/x/transcripts/<redacted>;next',
     );
   });
 
@@ -109,6 +136,28 @@ describe('redactDiagnostics - URLs', () => {
       'remote https://ollama.corp.internal:11434',
     );
   });
+
+  test('URL inside JSON does not swallow the following field or path', () => {
+    expect(
+      redact('{"url":"https://u:p@host/api","path":"/Users/a/x/output/Board.md"}'),
+    ).toBe('{"url":"https://host","path":"~/x/output/<redacted>.md"}');
+  });
+});
+
+describe('redactDiagnostics - scheme-less credentials', () => {
+  test('strips user:pass@ before a host:port even without a scheme', () => {
+    expect(redact('connecting alice:secret@ollama.corp:11434/x')).toBe(
+      'connecting ollama.corp:11434/x',
+    );
+  });
+
+  test('strips user@ before a dotted host without a port', () => {
+    expect(redact('login bob@ollama.corp.internal/api')).toBe('login ollama.corp.internal/api');
+  });
+
+  test('leaves ordinary word@word prose untouched (no host-shape after @)', () => {
+    expect(redact('see foo@bar in the log')).toBe('see foo@bar in the log');
+  });
 });
 
 describe('redactDiagnostics - idempotence + no over-redaction', () => {
@@ -118,8 +167,11 @@ describe('redactDiagnostics - idempotence + no over-redaction', () => {
       'POST https://alice:secret@ollama.corp.internal:11434/api/x',
       'SAVED:C:\\Users\\Alice\\x\\recordings\\Board Meeting.webm',
       'SAVED:/Volumes/NAS/steno/transcripts/Standup.txt',
+      'SAVED:/Volumes/NAS/steno/output/Weekly Sync',
+      'connecting alice:secret@ollama.corp:11434/x',
+      '{"url":"https://u:p@host/api","path":"/Volumes/NAS/steno/output/Board.md"}',
     ];
-    const opts = { storageRoot: '/Volumes/NAS/steno' };
+    const opts = { storageRoot: '/Volumes/NAS/steno/' };
     const once = redactDiagnostics(lines, opts);
     const twice = redactDiagnostics(once, opts);
     expect(twice).toEqual(once);

--- a/app/renderer/src/lib/redactDiagnostics.test.ts
+++ b/app/renderer/src/lib/redactDiagnostics.test.ts
@@ -145,14 +145,22 @@ describe('redactDiagnostics - URLs', () => {
 });
 
 describe('redactDiagnostics - scheme-less credentials', () => {
-  test('strips user:pass@ before a host:port even without a scheme', () => {
-    expect(redact('connecting alice:secret@ollama.corp:11434/x')).toBe(
-      'connecting ollama.corp:11434/x',
+  test('strips user:pass@ AND the trailing path/query, keeping host[:port]', () => {
+    // The path/query can carry a secret (?token=...), so - like the scheme'd URL
+    // rule - the scheme-less rule keeps only host[:port].
+    expect(redact('connecting alice:secret@ollama.corp:11434/api/tags?token=SECRET')).toBe(
+      'connecting ollama.corp:11434',
     );
   });
 
-  test('strips user@ before a dotted host without a port', () => {
-    expect(redact('login bob@ollama.corp.internal/api')).toBe('login ollama.corp.internal/api');
+  test('strips user@ and the path before a dotted host without a port', () => {
+    expect(redact('login bob@ollama.corp.internal/api')).toBe('login ollama.corp.internal');
+  });
+
+  test('does not swallow across a delimiter (JSON) when stripping the path', () => {
+    expect(redact('{"dsn":"alice:secret@ollama.corp:11434/api","k":"v"}')).toBe(
+      '{"dsn":"ollama.corp:11434","k":"v"}',
+    );
   });
 
   test('leaves ordinary word@word prose untouched (no host-shape after @)', () => {

--- a/app/renderer/src/lib/redactDiagnostics.test.ts
+++ b/app/renderer/src/lib/redactDiagnostics.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from 'vitest';
+import { redactDiagnostics } from '@/lib/redactDiagnostics';
+
+// Redaction is defense-in-depth on top of PR1's source reduction. These tests
+// pin the four rules (home dir both platforms, custom storage root, data-dir
+// basename, URL host-masking), idempotence, and - just as important - that
+// ordinary prose is left untouched. Each `redact` helper redacts a single line.
+const redact = (line: string, storageRoot?: string): string =>
+  redactDiagnostics([line], { storageRoot })[0];
+
+describe('redactDiagnostics - home dir', () => {
+  test('macOS /Users/<name>/ -> ~/ (any username, generically)', () => {
+    expect(redact('SAVED:/Users/alice/Documents/notes.txt')).toBe('SAVED:~/Documents/notes.txt');
+    expect(redact('opened /Users/bob.smith/thing')).toBe('opened ~/thing');
+  });
+
+  test('the default app-support path collapses under home', () => {
+    expect(
+      redact('SAVED:/Users/alice/Library/Application Support/stenoai/output/x.md'),
+    ).toBe('SAVED:~/Library/Application Support/stenoai/output/<redacted>.md');
+  });
+
+  test('Windows C:\\Users\\<name>\\ -> ~\\ (case-insensitive drive)', () => {
+    expect(redact('SAVED:C:\\Users\\Alice\\Documents\\notes.txt')).toBe(
+      'SAVED:~\\Documents\\notes.txt',
+    );
+    expect(redact('path d:\\Users\\bob\\thing')).toBe('path ~\\thing');
+  });
+});
+
+describe('redactDiagnostics - custom storage root', () => {
+  test('literal storage root outside home -> ~', () => {
+    const root = '/Volumes/NAS/steno';
+    expect(redact(`SAVED:${root}/recordings/Weekly Sync.webm`, root)).toBe(
+      'SAVED:~/recordings/<redacted>.webm',
+    );
+  });
+
+  test('storage root is regex-escaped (special chars are literal)', () => {
+    const root = '/Volumes/My (Backup)/steno+data';
+    expect(redact(`at ${root}/output/report.md end`, root)).toBe(
+      'at ~/output/<redacted>.md end',
+    );
+  });
+
+  test('storage root under home is hidden whole (root rule runs before home)', () => {
+    const root = '/Users/alice/steno-data';
+    expect(redact(`SAVED:${root}/transcripts/Board Meeting.txt`, root)).toBe(
+      'SAVED:~/transcripts/<redacted>.txt',
+    );
+  });
+
+  test('empty storage root is a no-op', () => {
+    expect(redact('nothing here', '')).toBe('nothing here');
+  });
+});
+
+describe('redactDiagnostics - data-dir basename', () => {
+  test('basename with spaces, extension preserved (output)', () => {
+    expect(redact('SAVED:/Users/alice/x/output/Weekly Team Sync_report.md')).toBe(
+      'SAVED:~/x/output/<redacted>.md',
+    );
+  });
+
+  test('basename with spaces + unicode (recordings)', () => {
+    expect(redact('SAVED:/Users/alice/x/recordings/sysaudio-1783-Wöchentliche Besprechung.webm')).toBe(
+      'SAVED:~/x/recordings/<redacted>.webm',
+    );
+  });
+
+  test('transcripts dir, quoted command echo', () => {
+    expect(redact('$ stenoai reprocess "/Users/alice/x/transcripts/Board Meeting Q3.txt"')).toBe(
+      '$ stenoai reprocess "~/x/transcripts/<redacted>.txt"',
+    );
+  });
+
+  test('multi-dot basename keeps only the final extension', () => {
+    expect(redact('SAVED:/Users/a/x/output/report.v2.final.json')).toBe(
+      'SAVED:~/x/output/<redacted>.json',
+    );
+  });
+
+  test('no-extension single-token basename is redacted to <redacted>', () => {
+    expect(redact('SAVED:/Users/a/x/recordings/rawclip end')).toBe(
+      'SAVED:~/x/recordings/<redacted> end',
+    );
+  });
+
+  test('does not touch a similarly-named word without a leading separator', () => {
+    expect(redact('the throughput/output ratio')).toBe('the throughput/output ratio');
+  });
+});
+
+describe('redactDiagnostics - URLs', () => {
+  test('strips user:pass@ credentials and path, keeps scheme+host+port', () => {
+    expect(redact('POST https://alice:secret@ollama.corp.internal:11434/api/x')).toBe(
+      'POST https://ollama.corp.internal:11434',
+    );
+  });
+
+  test('host-only URL with a path is reduced to scheme+host', () => {
+    expect(redact('GET http://ollama.corp.internal/api/tags?x=1')).toBe(
+      'GET http://ollama.corp.internal',
+    );
+  });
+
+  test('plain host+port with no path is preserved as-is', () => {
+    expect(redact('remote https://ollama.corp.internal:11434')).toBe(
+      'remote https://ollama.corp.internal:11434',
+    );
+  });
+});
+
+describe('redactDiagnostics - idempotence + no over-redaction', () => {
+  test('redact(redact(x)) === redact(x)', () => {
+    const lines = [
+      'SAVED:/Users/alice/Library/Application Support/stenoai/output/Weekly Team Sync_report.md',
+      'POST https://alice:secret@ollama.corp.internal:11434/api/x',
+      'SAVED:C:\\Users\\Alice\\x\\recordings\\Board Meeting.webm',
+      'SAVED:/Volumes/NAS/steno/transcripts/Standup.txt',
+    ];
+    const opts = { storageRoot: '/Volumes/NAS/steno' };
+    const once = redactDiagnostics(lines, opts);
+    const twice = redactDiagnostics(once, opts);
+    expect(twice).toEqual(once);
+  });
+
+  test('ordinary prose is left completely untouched', () => {
+    expect(redact('the quick brown fox jumps over the lazy dog')).toBe(
+      'the quick brown fox jumps over the lazy dog',
+    );
+    expect(redact('HEARTBEAT: 42s elapsed, exit code 0')).toBe(
+      'HEARTBEAT: 42s elapsed, exit code 0',
+    );
+  });
+
+  test('returns a new array, does not mutate the input', () => {
+    const input = ['/Users/alice/x'];
+    const out = redactDiagnostics(input);
+    expect(input).toEqual(['/Users/alice/x']);
+    expect(out).toEqual(['~/x']);
+  });
+});

--- a/app/renderer/src/lib/redactDiagnostics.ts
+++ b/app/renderer/src/lib/redactDiagnostics.ts
@@ -1,0 +1,108 @@
+// Pure, side-effect-free redaction for the shareable debug log.
+//
+// This is defense-in-depth on top of PR1's source reduction: even the
+// allowlisted diagnostic lines still carry paths (the `SAVED:<path>` lines and
+// the reprocess/report command echoes embed a title-derived filename) and URLs
+// (remote-ollama / cloud-api / org-adapter hostnames, possibly with
+// `user:pass@` credentials). `redactDiagnostics` scrubs those at egress so both
+// the Copy button and the "Save diagnostics" export are safe to share.
+//
+// Design: we redact by matching OUR OWN controlled directory structure
+// (`recordings/`, `transcripts/`, `output/`) and well-formed URLs, not by
+// guessing which free-text token is a meeting title. Rules are applied per line
+// in an order chosen so each stage can't re-expose what a later stage would
+// hide, and the whole function is idempotent
+// (`redact(redact(x)) === redact(x)`).
+
+export interface RedactOptions {
+  /**
+   * The user's custom storage root, when configured (`custom_path` from
+   * `get-storage-path`). It may live outside the home dir (e.g.
+   * `/Volumes/NAS/steno`), so the home-dir rule can't catch it - we replace the
+   * literal string with `~`. Empty/undefined means the default (under home),
+   * which the home-dir rule already handles.
+   */
+  storageRoot?: string;
+}
+
+// The three data sub-directories we own under the storage root. A path segment
+// under any of these has a meeting-title-derived basename we must redact.
+const DATA_DIRS = ['recordings', 'transcripts', 'output'];
+const DATA_DIR_ALT = DATA_DIRS.join('|');
+
+// Characters that terminate a path token in free text (whitespace, quotes,
+// closing brackets, and common trailing punctuation). Used as a lookahead so a
+// path embedded mid-line is bounded without consuming the delimiter.
+const TOKEN_END = `[\\s"'\`)\\]},;]`;
+
+// scheme://[user:pass@]host[:port][/path...] -> scheme://host[:port]
+// Keeps the scheme + host (+ port) for diagnosis, strips credentials and the
+// path/query that could carry identifiers. Requires a real host char after
+// `://` so `file:///Users/...` (triple slash) is left for the path rules.
+const URL_RE = /\b([a-z][a-z0-9+.-]*):\/\/(?:[^/@\s]*@)?([^/\s:]+(?::\d+)?)[^\s]*/gi;
+
+// macOS home: /Users/<name>/ -> ~/   (any username)
+const MAC_HOME_RE = /\/Users\/[^/\\]+\//gi;
+// Windows home: C:\Users\<name>\ -> ~\   (case-insensitive drive + "Users")
+const WIN_HOME_RE = /[A-Za-z]:\\Users\\[^\\]+\\/gi;
+
+// A data-dir path segment with a file extension, possibly containing spaces and
+// unicode in the basename: `.../output/Weekly Team Sync_report.md`. We anchor on
+// a preceding separator + the known dir, redact the basename (no separators),
+// and keep the final `.<ext>`. Lazy basename so the extension is the LAST dotted
+// group before a token boundary.
+const DATA_DIR_WITH_EXT_RE = new RegExp(
+  `([/\\\\](?:${DATA_DIR_ALT})[/\\\\])([^/\\\\]*?)(\\.[A-Za-z0-9]+)(?=$|${TOKEN_END})`,
+  'gi',
+);
+
+// A data-dir path segment with NO extension and NO spaces: `.../recordings/foo`.
+// The basename excludes separators, whitespace, token-enders AND dots, and the
+// lookahead forbids a following dot - so this never touches an already-extension
+// redaction (`.../recordings/<redacted>.webm`) and keeps it idempotent. A
+// space-containing basename with no extension is the documented, accepted
+// residual (best-effort): matching it here would only redact its first word, so
+// we deliberately leave it whole rather than partially mangle it.
+const DATA_DIR_NO_EXT_RE = new RegExp(
+  `([/\\\\](?:${DATA_DIR_ALT})[/\\\\])([^/\\\\\\s"'\`)\\]},;.]+)(?=$|${TOKEN_END})`,
+  'gi',
+);
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function redactLine(line: string, storageRoot?: string): string {
+  let out = line;
+
+  // 1. URLs first: strip credentials + path so the path rules below never see a
+  //    URL's internals (and can't mistake a URL path for a filesystem path).
+  out = out.replace(URL_RE, (_m, scheme: string, host: string) => `${scheme}://${host}`);
+
+  // 2. Custom storage root literal -> ~ (before home, so a root that itself
+  //    lives under home is hidden whole rather than left as ~/<folder>).
+  if (typeof storageRoot === 'string' && storageRoot.length > 0) {
+    out = out.replace(new RegExp(escapeRegExp(storageRoot), 'g'), '~');
+  }
+
+  // 3. Home dir -> ~ (both platforms). Covers the default app-support path too.
+  out = out.replace(MAC_HOME_RE, '~/');
+  out = out.replace(WIN_HOME_RE, '~\\');
+
+  // 4. Data-dir basenames -> <redacted>.<ext>. Extension case first, then the
+  //    no-extension single-token case (mutually exclusive by construction).
+  out = out.replace(DATA_DIR_WITH_EXT_RE, '$1<redacted>$3');
+  out = out.replace(DATA_DIR_NO_EXT_RE, '$1<redacted>');
+
+  return out;
+}
+
+/**
+ * Redact each line for safe sharing. Pure - returns a new array, mutates
+ * nothing. Idempotent: `redactDiagnostics(redactDiagnostics(x))` equals
+ * `redactDiagnostics(x)`.
+ */
+export function redactDiagnostics(lines: string[], opts: RedactOptions = {}): string[] {
+  const storageRoot = opts.storageRoot;
+  return lines.map((line) => redactLine(line, storageRoot));
+}

--- a/app/renderer/src/lib/redactDiagnostics.ts
+++ b/app/renderer/src/lib/redactDiagnostics.ts
@@ -63,13 +63,19 @@ const URL_RE = new RegExp(
   'gi',
 );
 
-// Scheme-less credentials: `user[:pass]@host[:port]` with NO `scheme://`, as the
-// Python summarizer can log on stderr. We strip the `user[:pass]@` and keep the
-// host. To avoid eating ordinary `word@word` prose, the part after `@` must look
-// like a host: either a dotted domain (`host.tld`, optional `:port`) or a bare
-// host WITH a port (`host:11434`). A bare dot-less/port-less host is left alone.
-const SCHEMELESS_CREDS_RE =
-  /([A-Za-z0-9._%+-]+(?::[^\s@/]+)?)@((?:[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+(?::\d+)?|[A-Za-z0-9-]+:\d+))/g;
+// Scheme-less credentials: `user[:pass]@host[:port][/path?query]` with NO
+// `scheme://`, as the Python summarizer can log on stderr. We strip the
+// `user[:pass]@` AND the trailing path/query (symmetric with the scheme'd URL
+// rule, which keeps only scheme://host - so a `?token=SECRET` can't leak),
+// keeping just `host[:port]`. To avoid eating ordinary `word@word` prose, the
+// part after `@` must look like a host: either a dotted domain (`host.tld`,
+// optional `:port`) or a bare host WITH a port (`host:11434`). A bare
+// dot-less/port-less host is left alone. The trailing match is bounded by the
+// token-end set so it can't swallow across a quote/JSON delimiter.
+const SCHEMELESS_CREDS_RE = new RegExp(
+  `([A-Za-z0-9._%+-]+(?::[^\\s@/]+)?)@((?:[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)+(?::\\d+)?|[A-Za-z0-9-]+:\\d+))[^${TOKEN_END_CHARS}]*`,
+  'g',
+);
 
 // macOS home: /Users/<name>/ -> ~/   (any username)
 const MAC_HOME_RE = /\/Users\/[^/\\]+\//gi;

--- a/app/renderer/src/lib/redactDiagnostics.ts
+++ b/app/renderer/src/lib/redactDiagnostics.ts
@@ -13,6 +13,17 @@
 // in an order chosen so each stage can't re-expose what a later stage would
 // hide, and the whole function is idempotent
 // (`redact(redact(x)) === redact(x)`).
+//
+// Accepted residuals (documented, out of scope for regex):
+//  - A scheme-less BARE hostname with no credentials (e.g. `ollama.corp:11434`)
+//    is left as-is: it's an internal hostname, not a secret, and fully hiding it
+//    would need the Python source to stop logging it (deferred out of this PR).
+//  - Nested sub-directories under a data dir (`.../output/Team/Sync.md`) are NOT
+//    matched: stenoai writes FLAT data dirs so this isn't currently produced,
+//    but it's a known limitation of the separator-anchored basename rules.
+//  - A space-containing data-dir path with NO extension that runs mid-line into
+//    following prose with no delimiter is best-effort: the common end-of-line /
+//    quoted / delimited forms fully redact.
 
 export interface RedactOptions {
   /**
@@ -30,16 +41,35 @@ export interface RedactOptions {
 const DATA_DIRS = ['recordings', 'transcripts', 'output'];
 const DATA_DIR_ALT = DATA_DIRS.join('|');
 
-// Characters that terminate a path token in free text (whitespace, quotes,
-// closing brackets, and common trailing punctuation). Used as a lookahead so a
-// path embedded mid-line is bounded without consuming the delimiter.
-const TOKEN_END = `[\\s"'\`)\\]},;]`;
+// Characters (inside a char class) that terminate a path token in free text:
+// whitespace, quotes, closing brackets, and common trailing punctuation.
+const TOKEN_END_CHARS = `\\s"'\`)\\]},;`;
+// Used as a lookahead so a path embedded mid-line is bounded without consuming
+// the delimiter.
+const TOKEN_END = `[${TOKEN_END_CHARS}]`;
+// The same terminators EXCLUDING whitespace. A data-dir basename may legitimately
+// contain spaces (meeting titles do), so for the no-extension case only these
+// strong terminators (or a separator / end-of-line) end the basename.
+const STRONG_TERM = `"'\`)\\]},;`;
 
 // scheme://[user:pass@]host[:port][/path...] -> scheme://host[:port]
 // Keeps the scheme + host (+ port) for diagnosis, strips credentials and the
 // path/query that could carry identifiers. Requires a real host char after
-// `://` so `file:///Users/...` (triple slash) is left for the path rules.
-const URL_RE = /\b([a-z][a-z0-9+.-]*):\/\/(?:[^/@\s]*@)?([^/\s:]+(?::\d+)?)[^\s]*/gi;
+// `://` so `file:///Users/...` (triple slash) is left for the path rules. The
+// trailing path match is bounded by the token-end set (not `[^\s]*`) so a URL
+// embedded in JSON/quoted text can't swallow the following field or path.
+const URL_RE = new RegExp(
+  `\\b([a-z][a-z0-9+.-]*):\\/\\/(?:[^/@${TOKEN_END_CHARS}]*@)?([^/:${TOKEN_END_CHARS}]+(?::\\d+)?)[^${TOKEN_END_CHARS}]*`,
+  'gi',
+);
+
+// Scheme-less credentials: `user[:pass]@host[:port]` with NO `scheme://`, as the
+// Python summarizer can log on stderr. We strip the `user[:pass]@` and keep the
+// host. To avoid eating ordinary `word@word` prose, the part after `@` must look
+// like a host: either a dotted domain (`host.tld`, optional `:port`) or a bare
+// host WITH a port (`host:11434`). A bare dot-less/port-less host is left alone.
+const SCHEMELESS_CREDS_RE =
+  /([A-Za-z0-9._%+-]+(?::[^\s@/]+)?)@((?:[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+(?::\d+)?|[A-Za-z0-9-]+:\d+))/g;
 
 // macOS home: /Users/<name>/ -> ~/   (any username)
 const MAC_HOME_RE = /\/Users\/[^/\\]+\//gi;
@@ -56,15 +86,16 @@ const DATA_DIR_WITH_EXT_RE = new RegExp(
   'gi',
 );
 
-// A data-dir path segment with NO extension and NO spaces: `.../recordings/foo`.
-// The basename excludes separators, whitespace, token-enders AND dots, and the
-// lookahead forbids a following dot - so this never touches an already-extension
-// redaction (`.../recordings/<redacted>.webm`) and keeps it idempotent. A
-// space-containing basename with no extension is the documented, accepted
-// residual (best-effort): matching it here would only redact its first word, so
-// we deliberately leave it whole rather than partially mangle it.
+// A data-dir path segment with NO extension: `.../recordings/Weekly Sync`. The
+// basename is GREEDY and INCLUDES internal spaces, stopping only at a separator,
+// a strong terminator (quote/bracket/`,`/`;`) or end-of-line - so a space-
+// containing title is redacted WHOLE (not just its first word). Dots are
+// excluded from the basename and the lookahead has no dot, so this never touches
+// an already-extension redaction (`.../recordings/<redacted>.webm`) nor a real
+// extensioned file (both handled by DATA_DIR_WITH_EXT_RE, which runs first),
+// keeping the pass idempotent.
 const DATA_DIR_NO_EXT_RE = new RegExp(
-  `([/\\\\](?:${DATA_DIR_ALT})[/\\\\])([^/\\\\\\s"'\`)\\]},;.]+)(?=$|${TOKEN_END})`,
+  `([/\\\\](?:${DATA_DIR_ALT})[/\\\\])([^/\\\\${STRONG_TERM}.]+)(?=$|${TOKEN_END})`,
   'gi',
 );
 
@@ -79,10 +110,21 @@ function redactLine(line: string, storageRoot?: string): string {
   //    URL's internals (and can't mistake a URL path for a filesystem path).
   out = out.replace(URL_RE, (_m, scheme: string, host: string) => `${scheme}://${host}`);
 
+  // 1b. Scheme-less credentials (`user:pass@host[:port]`) the URL rule can't see
+  //     because there's no scheme. Runs after the URL rule (which already
+  //     stripped scheme'd creds, leaving no `@`), so the two never overlap.
+  out = out.replace(SCHEMELESS_CREDS_RE, (_m, _creds: string, host: string) => host);
+
   // 2. Custom storage root literal -> ~ (before home, so a root that itself
-  //    lives under home is hidden whole rather than left as ~/<folder>).
+  //    lives under home is hidden whole rather than left as ~/<folder>). Strip
+  //    any trailing separator first: replacing `/Volumes/x/steno/` wholesale
+  //    would yield `~output/...` (no separator), which the data-dir rule can't
+  //    match - stripping it leaves `~/output/...` so the basename still redacts.
   if (typeof storageRoot === 'string' && storageRoot.length > 0) {
-    out = out.replace(new RegExp(escapeRegExp(storageRoot), 'g'), '~');
+    const root = storageRoot.replace(/[/\\]+$/, '');
+    if (root.length > 0) {
+      out = out.replace(new RegExp(escapeRegExp(root), 'g'), '~');
+    }
   }
 
   // 3. Home dir -> ~ (both platforms). Covers the default app-support path too.

--- a/app/renderer/src/routes/settings/DeveloperTab.tsx
+++ b/app/renderer/src/routes/settings/DeveloperTab.tsx
@@ -5,6 +5,17 @@ import {
   getDebugLogs,
   subscribeDebugLogs,
 } from '@/lib/debugLogs';
+import { ipc } from '@/lib/ipc';
+import { redactDiagnostics } from '@/lib/redactDiagnostics';
+import {
+  useStoragePath,
+  useAppVersion,
+  useSystemAudioSupport,
+  useSystemAudioSetting,
+  useSilenceAutoStopSetting,
+} from '@/hooks/useSettings';
+import { useAiProvider } from '@/hooks/useAi';
+import { useTranscriptionEngine } from '@/hooks/useModels';
 
 export function DeveloperTab() {
   // Read from the global store so we get the full session backlog, not just
@@ -22,8 +33,52 @@ export function DeveloperTab() {
     if (el) el.scrollTop = el.scrollHeight;
   }, [logs]);
 
+  // Data for redaction (custom storage root) + the anonymized env header. All
+  // already cached by other Settings surfaces, so these reads are free here.
+  const storage = useStoragePath();
+  const version = useAppVersion();
+  const systemAudioSupport = useSystemAudioSupport();
+  const systemAudio = useSystemAudioSetting();
+  const silenceAutoStop = useSilenceAutoStopSetting();
+  const engine = useTranscriptionEngine();
+  const aiProvider = useAiProvider();
+
+  // The custom storage root (only set when the user moved storage off the
+  // default under-home location). It may live outside home, so redaction needs
+  // the literal string; undefined means the home-dir rule already covers it.
+  const storageRoot = storage.data?.custom_path ?? undefined;
+
   const copyLogs = () => {
-    void navigator.clipboard.writeText(logs.join('\n'));
+    void navigator.clipboard.writeText(
+      redactDiagnostics(logs, { storageRoot }).join('\n'),
+    );
+  };
+
+  // Build the anonymized env header (no PII: provider TYPE not URL/key, no
+  // telemetry id) + a blank line + the redacted buffer, and save it to a file
+  // the user picks. Header values come from the same hooks the Settings/About
+  // surfaces already use.
+  const saveLogs = async () => {
+    const platform = systemAudioSupport.data?.platform ?? '(unknown)';
+    const osVersion = systemAudioSupport.data?.osVersion ?? '(unknown)';
+    const header = [
+      '# stenoai diagnostics',
+      '# Paths, URLs and meeting titles are redacted. No account/telemetry id.',
+      `app version: ${version.data?.version ?? '(unknown)'}`,
+      `platform: ${platform}`,
+      `os version: ${osVersion}`,
+      `transcription engine: ${engine.data ?? '(unknown)'}`,
+      `ai provider: ${aiProvider.data?.ai_provider ?? '(unknown)'}`,
+      `system audio enabled: ${systemAudio.data ? 'yes' : 'no'}`,
+      `silence auto-stop enabled: ${silenceAutoStop.data?.enabled ? 'yes' : 'no'}`,
+      `silence auto-stop minutes: ${silenceAutoStop.data?.minutes ?? '(unknown)'}`,
+    ];
+    const body = redactDiagnostics(logs, { storageRoot });
+    const content = [...header, '', ...body].join('\n');
+
+    const now = new Date();
+    const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
+    await ipc().settings.saveDiagnostics(`stenoai-diagnostics-${stamp}.txt`, content);
   };
 
   const placeholder =
@@ -60,6 +115,15 @@ export function DeveloperTab() {
             disabled={!logs.length}
           >
             Copy
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2.5 text-[13px]"
+            onClick={() => void saveLogs()}
+            disabled={!logs.length}
+          >
+            Save
           </Button>
         </div>
       </div>

--- a/app/renderer/src/routes/settings/DeveloperTab.tsx
+++ b/app/renderer/src/routes/settings/DeveloperTab.tsx
@@ -17,6 +17,12 @@ import {
 import { useAiProvider } from '@/hooks/useAi';
 import { useTranscriptionEngine } from '@/hooks/useModels';
 
+// Cross-process sentinel: the save-diagnostics handler (and its e2e mock) return
+// this exact error string when the user dismisses the save dialog. Kept in sync
+// with app/ipc-sentinels.js (EXPORT_CANCELED); the renderer can't require that
+// CJS module, so it mirrors the literal (same as MeetingDetail's copy).
+const DIAGNOSTICS_CANCELED = 'canceled';
+
 export function DeveloperTab() {
   // Read from the global store so we get the full session backlog, not just
   // lines emitted after this tab mounted.
@@ -48,6 +54,10 @@ export function DeveloperTab() {
   // the literal string; undefined means the home-dir rule already covers it.
   const storageRoot = storage.data?.custom_path ?? undefined;
 
+  // Surfaced when a Save genuinely fails (disk error / rejection). A cancelled
+  // save dialog is not an error and stays silent.
+  const [saveError, setSaveError] = React.useState<string | null>(null);
+
   const copyLogs = () => {
     void navigator.clipboard.writeText(
       redactDiagnostics(logs, { storageRoot }).join('\n'),
@@ -78,7 +88,25 @@ export function DeveloperTab() {
 
     const now = new Date();
     const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
-    await ipc().settings.saveDiagnostics(`stenoai-diagnostics-${stamp}.txt`, content);
+
+    // Save writes a file, which can genuinely fail. A user-cancelled dialog
+    // resolves with error === DIAGNOSTICS_CANCELED and stays silent; a real
+    // failure (or a rejection) is surfaced inline. Mirrors MeetingDetail's
+    // save-transcript consumer.
+    setSaveError(null);
+    try {
+      const res = await ipc().settings.saveDiagnostics(
+        `stenoai-diagnostics-${stamp}.txt`,
+        content,
+      );
+      if (!res.success && res.error !== DIAGNOSTICS_CANCELED) {
+        setSaveError(`Couldn't save diagnostics: ${res.error || 'unknown error'}`);
+      }
+    } catch (err) {
+      setSaveError(
+        `Couldn't save diagnostics: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   };
 
   const placeholder =
@@ -127,6 +155,15 @@ export function DeveloperTab() {
           </Button>
         </div>
       </div>
+      {saveError && (
+        <div
+          className="mb-2 text-[12px]"
+          style={{ color: 'var(--accent-danger, var(--fg-1))' }}
+          role="alert"
+        >
+          {saveError}
+        </div>
+      )}
       <textarea
         ref={textareaRef}
         readOnly

--- a/e2e/specs/save-diagnostics.t2.spec.ts
+++ b/e2e/specs/save-diagnostics.t2.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readFileSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+/**
+ * T2 — the real `save-diagnostics` main-process handler. Drives the preload
+ * bridge (`window.stenoai.settings.saveDiagnostics`) and asserts the handler
+ * atomic-writes exactly the string it's handed, and rejects empty content.
+ * Model-free, no backend subprocess (the handler is pure Electron dialog + fs).
+ *
+ * The redaction + env-header build live in the renderer and are unit-tested
+ * (`renderer/src/lib/redactDiagnostics.test.ts`); this spec covers the IPC
+ * wiring + the on-disk write. The save-path dialog is bypassed by the
+ * `STENOAI_E2E_DIAGNOSTICS_PATH` seam (mirrors export-transcript), so the
+ * handler's target is observable byte-for-byte.
+ */
+
+type DiagBridge = {
+  settings: {
+    saveDiagnostics: (
+      defaultFilename: string,
+      content: string,
+    ) => Promise<{ success?: boolean; error?: string; path?: string }>;
+  };
+};
+type StenoWindow = Window & { stenoai: DiagBridge };
+
+const CONTENT = [
+  '# stenoai diagnostics',
+  '# Paths, URLs and meeting titles are redacted. No account/telemetry id.',
+  'app version: 0.5.7',
+  'platform: darwin',
+  '',
+  'SAVED:~/x/output/<redacted>.md',
+  'HEARTBEAT: 42s elapsed',
+].join('\n');
+
+test('save-diagnostics writes the handed content byte-for-byte; real dir untouched', async ({
+  launchApp,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const outDir = mkdtempSync(path.join(tmpdir(), 'steno-diag-t2-'));
+  const outFile = path.join(outDir, 'stenoai-diagnostics-20260704.txt');
+  const { page } = await launchApp({ env: { STENOAI_E2E_DIAGNOSTICS_PATH: outFile } });
+
+  try {
+    const res = await page.evaluate(
+      (c) =>
+        (window as StenoWindow).stenoai.settings.saveDiagnostics(
+          'stenoai-diagnostics-20260704.txt',
+          c,
+        ),
+      CONTENT,
+    );
+    expect(res.success).toBe(true);
+    expect(res.path).toBe(outFile);
+    expect(readFileSync(outFile, 'utf8')).toBe(CONTENT);
+
+    // Empty content is rejected without touching disk.
+    const empty = await page.evaluate(
+      () => (window as StenoWindow).stenoai.settings.saveDiagnostics('x.txt', ''),
+    );
+    expect(empty.success).toBe(false);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Redact the debug log + a "Save diagnostics" export (defense-in-depth)

PR2 of the diagnostics-privacy pair. #293 removes meeting content/PII at the source; this adds the egress-side redaction and a shareable export, so what a user copies or saves is safe to post. The two land independently (no file overlap - #293 is `main.js`/Python, this is the renderer + one IPC) and the full guarantee holds once both are in.

### `redactDiagnostics` (`app/renderer/src/lib/redactDiagnostics.ts`)
A pure, idempotent per-line redactor. It matches on OUR OWN controlled structure (data dirs, well-formed URLs), not by guessing which token is a meeting title. Rules, in an order chosen so no stage re-exposes what a later one hides:
1. **URLs** `scheme://[user:pass@]host[:port]/path` -> `scheme://host[:port]` (strip credentials + path), token-bounded so it can't eat across quotes/JSON.
2. **Scheme-less credentials** `user:pass@host[:port]` -> `host[:port]`, host-shape-gated so benign `foo@bar` prose is untouched.
3. **Custom storage root** (fetched via `get-storage-path` at export time, trailing separators stripped) -> `~`.
4. **Home dir** `/Users/<name>/` and `C:\Users\<name>\` -> `~`.
5. **Data-dir basenames** under `recordings/`/`transcripts/`/`output/` -> `<redacted>.<ext>` (keeps dir + extension), handling spaces and unicode in the title.

Documented accepted residuals (safe direction - over-redacts rather than leaks): a scheme-less bare hostname with no credentials (internal hostname, no secret; full fix needs the deferred Python-source change), nested data-dir subdirs (stenoai writes flat dirs), and a space-containing no-extension path that runs into undelimited prose mid-line.

### Wiring
- **Copy** now copies `redactDiagnostics(logs, { storageRoot })` - closes the existing clipboard leak vector.
- **"Save diagnostics"** button (third in the Developer-tab header, matching the Clear/Copy ghost style) writes a single `.txt`: a non-PII env header (app version, OS/platform, engine, AI provider *type*, system-audio + silence-auto-stop booleans; no URL, no key, no telemetry ID) + the redacted buffer. Saving goes through a new `save-diagnostics` IPC that mirrors `export-transcript` (basename-sanitized filename, user-confirmed save dialog, atomic tmp+rename), wired consistently across main.js / preload.js / `ipc.ts` / the T1 mock.

### Verification
- `typecheck:renderer` clean; `lint:renderer` no new warnings; `test:unit` 60 pass incl. 27 `redactDiagnostics` cases (both platforms, credential stripping scheme'd + scheme-less, data-dir basenames with spaces/unicode, JSON-embedded URL + path, trailing-slash storage root, idempotence, no-op prose).
- `save-diagnostics.t2.spec.ts` - a model-free T2 driving the real save handler through the preload bridge + seam (byte-for-byte write, empty-content rejection, real-dir-untouched keystone).
- Independent Codex security review (design + implementation); its four redaction-bypass findings (trailing storage root, space no-ext partial redaction, URL over-consumption, scheme-less credentials) are all folded in with tests.

Complements #293. Together they make the Developer debug console safe to share for #271-class remote diagnosis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sensitive data from the Developer debug log on copy/export and adds a “Save diagnostics” export with an anonymized header, making logs safe to share. Adds a new `save-diagnostics` IPC with atomic writes, basename-only defaults, and end-to-end coverage.

- **New Features**
  - Copy runs a pure, idempotent `redactDiagnostics` to scrub logs per line.
  - Redaction covers: URL credentials and paths; scheme-less `user[:pass]@host` with trailing path/query; home dir and custom storage root to `~`; and title-derived basenames in `recordings/`, `transcripts/`, `output/` to `<redacted>` (keeps extension).
  - “Save diagnostics” writes one `.txt` with a non-PII header (version, platform/OS, engine, AI provider type, system audio, silence auto-stop) plus the redacted log, via `save-diagnostics` (basename-only default, user dialog, atomic tmp+rename, `STENOAI_E2E_DIAGNOSTICS_PATH` seam).

- **Bug Fixes**
  - Handle saves: cancelled dialog is silent; empty content is rejected; real failures show inline; no unhandled rejections.
  - Strip trailing separators from `storageRoot` so data-dir redaction still triggers.
  - Bound URL matching to avoid over-consuming JSON/quoted text.
  - Redact scheme-less credentials and their path/query while leaving `word@word` prose.
  - Fully redact no-extension basenames with spaces up to a strong terminator/EOL.

<sup>Written for commit 271b132a52d61880cb7698a2aaab9e6cc850852c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

