### PR TITLE
chore: gitignore private local notes/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,8 @@ config.json
 CODE_REVIEW.md
 SESSION_LOG.md
 FEATURES.md
+# Private, local-only working notes (design docs, benchmarks, review scratch) - never publish
+notes/
 
 # Bundled Ollama binary (downloaded during build)
 bin/


### PR DESCRIPTION
The repo-root `notes/` dir is used for local-only working material (design docs, benchmarks, review scratch) and shouldn't ever land in the public repo. Right now it's untracked but not ignored, so it's only protected by not wildcard-staging. This adds an explicit `notes/` entry to `.gitignore` so a stray `git add -A` can't publish it.

One-line change, no code impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `notes/` to `.gitignore` to keep private local working notes out of the repo. Prevents accidental commits (e.g., via `git add -A`) and has no code impact.

<sup>Written for commit f79c26e50993ccc8608d6fe6a76ff23b93d6a848. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

