### PR TITLE
feat: redesign templates settings UI and add provider support

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -129,6 +129,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -498,6 +499,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -521,6 +523,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -787,7 +790,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -809,7 +811,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2985,6 +2986,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3208,6 +3210,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3218,6 +3221,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3291,6 +3295,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -3662,6 +3667,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3695,6 +3701,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4542,6 +4549,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5125,8 +5133,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -5473,7 +5480,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5537,6 +5545,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -5659,6 +5668,7 @@
       "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.0.tgz",
       "integrity": "sha512-in5jnW/Ywy3Rh3FPr4MR80exPEkywKYAmDJRZ/gIKlr8VXEi3zXgiAZbf0Si7KRccHTF2y8euVMRz7M6HqTjMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^5.0.0",
         "@types/node": "^24.9.0",
@@ -5767,7 +5777,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5788,7 +5797,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5804,7 +5812,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5815,7 +5822,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -6161,6 +6167,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8159,6 +8166,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -9197,7 +9205,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9925,6 +9932,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10109,7 +10117,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10127,7 +10134,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10374,6 +10380,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10383,6 +10390,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10764,7 +10772,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11758,7 +11765,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -11892,6 +11898,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12182,6 +12189,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12470,6 +12478,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12976,6 +12985,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -8,6 +8,7 @@ import {
   ExternalLink,
   Loader2,
   Lock,
+  Pin,
   Plus,
   Trash2,
   X,
@@ -778,7 +779,10 @@ export function Settings() {
           className="scrollbar-clean min-h-0 flex-1 overflow-y-auto"
           style={{ padding: '8px 48px 64px' }}
         >
-          <div style={{ maxWidth: 600, paddingTop: 8 }}>
+          <div 
+            className={cn(tab === 'templates' && 'h-full flex flex-col')}
+            style={{ maxWidth: tab === 'templates' ? '100%' : 600, paddingTop: 8 }}
+          >
             {tab === 'general' && <GeneralTab />}
             {tab === 'transcription' && <TranscriptionTab />}
             {tab === 'ai' && <AiTab />}
@@ -1244,154 +1248,166 @@ function TemplatesTab() {
   // Template pending deletion → drives the confirmation dialog.
   const [deleteTarget, setDeleteTarget] = React.useState<Template | null>(null);
 
-  return (
-    <section data-settings-tab="templates">
-      <SettingRow
-        label="Default template"
-        description="The template used for new summaries unless you pick another."
-      >
-        <Select
-          value={defaultId}
-          onValueChange={(v) => setDefault.mutate(v)}
-          disabled={isLoading || templates.length === 0}
-        >
-          <SelectTrigger className={cn(COMPACT_TRIGGER, 'min-w-[180px]')}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent className="w-64">
-            {templates.map((t) => (
-              <SelectItem key={t.id} value={t.id}>
-                {t.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </SettingRow>
-
-      <SectionHeading>Templates</SectionHeading>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        {templates.map((t) => (
-          <div
-            key={t.id}
-            className="flex flex-col gap-3 rounded-[8px] p-4"
-            style={{
-              border: '1px solid var(--border-subtle)',
-              background:
-                t.id === defaultId ? 'var(--surface-raised)' : 'transparent',
-            }}
-          >
-            <div className="flex items-center gap-2">
-              <span
-                className="truncate text-[13px] font-medium"
-                style={{ color: 'var(--fg-1)' }}
-              >
-                {t.name}
-              </span>
-              {t.locked && (
-                <span
-                  className="inline-flex shrink-0 items-center gap-1 text-[11px]"
-                  style={{ color: 'var(--fg-muted)' }}
-                  title="Built-in template — protected from editing and deletion"
-                >
-                  <Lock size={11} aria-hidden="true" />
-                  Locked
-                </span>
-              )}
-              {t.builtin && !t.locked && (
-                <span
-                  className="shrink-0 rounded-[3px] px-1.5 py-px text-[11px]"
-                  style={{
-                    color: 'var(--fg-muted)',
-                    border: '1px solid var(--border-subtle)',
-                  }}
-                >
-                  Built-in
-                </span>
-              )}
-            </div>
-
-            <div 
-              className="text-[12px] leading-relaxed line-clamp-3" 
-              style={{ color: 'var(--fg-muted)' }}
-              title={t.prompt}
-            >
-              {t.prompt || 'No prompt provided.'}
-            </div>
-
-            <div className="mt-auto flex shrink-0 items-center justify-end gap-2">
-              {t.builtin ? (
-                // A locked built-in (Standard) can't be edited, so there is no
-                // override to reset and nothing to edit — show no actions (the
-                // "Locked" badge above already conveys its state). Only an
-                // editable built-in offers Reset + Edit.
-                !t.locked && (
-                  <>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className={COMPACT_BTN}
-                      disabled={reset.isPending}
-                      onClick={() => reset.mutate(t.id)}
-                    >
-                      Reset
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className={COMPACT_BTN}
-                      onClick={() => setEditing(t)}
-                    >
-                      Edit
-                    </Button>
-                  </>
-                )
-              ) : (
-                <>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className={COMPACT_BTN}
-                    onClick={() => setEditing(t)}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className={cn(
-                      COMPACT_BTN,
-                      'text-[color:var(--fg-2)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
-                    )}
-                    onClick={() => setDeleteTarget(t)}
-                    aria-label={`Delete ${t.name}`}
-                  >
-                    <Trash2 size={14} />
-                  </Button>
-                </>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {editing ? (
+  if (editing) {
+    return (
+      <section data-settings-tab="templates" className="flex-1 h-full min-h-0 flex flex-col">
         <TemplateEditor
           key={editing.id ?? 'new'}
-          editing={editing.id ? editing : null}
+          editing={editing.id ? (editing as Template) : null}
           onClose={() => setEditing(null)}
         />
-      ) : (
-        <Button
-          variant="outline"
-          size="sm"
-          className={cn(COMPACT_BTN, 'mt-3')}
+      </section>
+    );
+  }
+
+  return (
+    <section data-settings-tab="templates">
+      <div style={{ maxWidth: 600 }}>
+        <SectionHeading>Templates</SectionHeading>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4">
+        <button
           onClick={() => setEditing({})}
+          className="flex flex-col items-center justify-center gap-2 rounded-[8px] p-4 text-[13px] font-medium transition-colors hover:bg-muted/50 text-center"
+          style={{
+            border: '1px dashed var(--border-subtle)',
+            color: 'var(--fg-muted)',
+            minHeight: '180px'
+          }}
         >
-          <Plus size={14} className="mr-1.5" />
-          New Template
-        </Button>
-      )}
+          <Plus size={16} />
+          <span className="font-semibold" style={{ color: 'var(--fg-1)' }}>New Template</span>
+          <span className="text-[12px] max-w-[200px] leading-relaxed opacity-80 mt-1">
+            Create custom prompts to tailor how your meetings are summarised.
+          </span>
+        </button>
+
+        {[...templates].sort((a, b) => (a.id === defaultId ? -1 : b.id === defaultId ? 1 : 0)).map((t) => {
+          const isDefault = t.id === defaultId;
+          const hasActions = !isDefault || !t.builtin || !t.locked;
+          
+          return (
+            <div
+              key={t.id}
+              className="flex flex-col rounded-[8px] transition-colors min-h-[180px]"
+              style={{
+                border: isDefault ? '1px solid var(--fg-1)' : '1px solid var(--border-subtle)',
+                background:
+                  isDefault ? 'var(--surface-raised)' : 'transparent',
+              }}
+            >
+              <div className="flex flex-col gap-2 p-4 pb-3 flex-1">
+                <div className="flex items-start justify-between gap-2">
+                  <span
+                    className="truncate text-[13px] font-medium"
+                    style={{ color: 'var(--fg-1)' }}
+                  >
+                    {t.name}
+                  </span>
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {isDefault && (
+                      <span
+                        className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider font-semibold"
+                        style={{ color: 'var(--fg-1)' }}
+                      >
+                        <Pin size={10} aria-hidden="true" />
+                        Default
+                      </span>
+                    )}
+                    {t.locked && !isDefault && (
+                      <span
+                        className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider"
+                        style={{ color: 'var(--fg-muted)' }}
+                        title="Built-in template — protected from editing and deletion"
+                      >
+                        <Lock size={10} aria-hidden="true" />
+                        Locked
+                      </span>
+                    )}
+                    {t.builtin && !t.locked && !isDefault && (
+                      <span
+                        className="rounded-[3px] px-1.5 py-px text-[10px] uppercase tracking-wider"
+                        style={{
+                          color: 'var(--fg-muted)',
+                          border: '1px solid var(--border-subtle)',
+                        }}
+                      >
+                        Built-in
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <div 
+                  className={cn(
+                    "text-[12px] leading-relaxed line-clamp-5 mt-1",
+                    !t.prompt && "italic"
+                  )} 
+                  style={{ color: 'var(--fg-muted)', opacity: t.prompt ? 1 : 0.6 }}
+                  title={t.prompt}
+                >
+                  {t.prompt || 'No prompt provided.'}
+                </div>
+              </div>
+
+              {hasActions && (
+                <div 
+                  className="flex shrink-0 items-center justify-end gap-2 px-4 py-3 border-t" 
+                  style={{ borderColor: 'var(--border-subtle)' }}
+                >
+                  {t.builtin ? (
+                    !t.locked && (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className={COMPACT_BTN}
+                          disabled={reset.isPending}
+                          onClick={() => reset.mutate(t.id)}
+                        >
+                          Reset
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className={COMPACT_BTN}
+                          onClick={() => setEditing(t)}
+                        >
+                          Edit
+                        </Button>
+                      </>
+                    )
+                  ) : (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className={COMPACT_BTN}
+                        onClick={() => setEditing(t)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className={cn(
+                          COMPACT_BTN,
+                          'text-[color:var(--fg-2)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
+                        )}
+                        onClick={() => setDeleteTarget(t)}
+                        aria-label={`Delete ${t.name}`}
+                      >
+                        <Trash2 size={14} />
+                      </Button>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
 
       <ConfirmDialog
         open={!!deleteTarget}
@@ -1422,6 +1438,8 @@ function TemplateEditor({
   onClose: () => void;
 }) {
   const save = useSaveTemplate();
+  const { defaultId } = useTemplates();
+  const setDefault = useSetDefaultTemplate();
   const [name, setName] = React.useState(editing?.name ?? '');
   const [prompt, setPrompt] = React.useState(editing?.prompt ?? '');
   const [language, setLanguage] = React.useState(editing?.language ?? 'auto');
@@ -1439,96 +1457,137 @@ function TemplateEditor({
   };
 
   return (
-    <div
-      className="mt-3 rounded-[8px] p-4"
-      style={{
-        border: '1px solid var(--border-subtle)',
-        background: 'var(--surface-raised)',
-      }}
-    >
-      <div
-        className="mb-3 text-[13px] font-medium"
-        style={{ color: 'var(--fg-1)' }}
+    <div className="flex flex-col h-full flex-1 pt-2 animate-in fade-in zoom-in-95 duration-200">
+      {/* Header Area */}
+      <div 
+        className="flex items-center justify-between mb-6 pb-4 border-b shrink-0"
+        style={{ borderColor: 'var(--border-subtle)' }}
       >
-        {editing ? 'Edit template' : 'New template'}
+        <div>
+          <h2 className="text-[20px] font-medium" style={{ color: 'var(--fg-1)' }}>
+            {editing?.id ? 'Edit template' : 'New template'}
+          </h2>
+          <p className="text-[13px] mt-1" style={{ color: 'var(--fg-muted)' }}>
+            Configure how your meetings should be summarized
+          </p>
+        </div>
+        
+        <div className="flex items-center gap-2">
+          {editing?.id && editing.id !== defaultId && (
+            <Button
+              variant="outline"
+              size="sm"
+              className={COMPACT_BTN}
+              onClick={() => {
+                if (editing.id) setDefault.mutate(editing.id);
+              }}
+            >
+              Make Default
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className={COMPACT_BTN}
+            onClick={onClose}
+            disabled={save.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            className={COMPACT_BTN}
+            onClick={onSave}
+            disabled={save.isPending || !name.trim()}
+          >
+            {save.isPending ? (
+              <>
+                <Loader2 className="mr-1.5 size-3 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              'Save Template'
+            )}
+          </Button>
+        </div>
       </div>
 
-      <SettingRow label="Name">
-        <Input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Weekly sync"
-          className="h-[30px] w-[220px] text-[13px]"
-        />
-      </SettingRow>
+      {/* Settings Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 shrink-0">
+        <div className="flex flex-col gap-2">
+          <label className="text-[13px] font-medium" style={{ color: 'var(--fg-1)' }}>
+            Name
+          </label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Weekly Sync, Executive Summary..."
+            className="text-[14px] bg-transparent"
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-[13px] font-medium" style={{ color: 'var(--fg-1)' }}>
+            Language
+          </label>
+          <Select value={language} onValueChange={setLanguage}>
+            <SelectTrigger className="text-[14px] bg-transparent">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TEMPLATE_LANGUAGES.map((l) => (
+                <SelectItem key={l.value} value={l.value}>
+                  {l.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
 
-      <SettingRow label="Language" description="Output language for the summary.">
-        <Select value={language} onValueChange={setLanguage}>
-          <SelectTrigger className={cn(COMPACT_TRIGGER, 'min-w-[180px]')}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {TEMPLATE_LANGUAGES.map((l) => (
-              <SelectItem key={l.value} value={l.value}>
-                {l.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </SettingRow>
-
-      <div className="pt-3">
-        <div
-          className="mb-2 text-[13px] font-medium"
-          style={{ color: 'var(--fg-1)' }}
+      {/* Prompt Area */}
+      <div 
+        className="flex flex-col flex-1 min-h-0 rounded-[8px] overflow-hidden"
+        style={{ 
+          border: '1px solid var(--border-subtle)',
+          background: 'var(--surface-sunken)'
+        }}
+      >
+        <div 
+          className="px-4 py-3 flex items-center justify-between border-b shrink-0"
+          style={{ 
+            borderColor: 'var(--border-subtle)',
+            background: 'var(--surface-raised)'
+          }}
         >
-          Prompt
+          <span className="text-[13px] font-medium" style={{ color: 'var(--fg-1)' }}>
+            System Prompt
+          </span>
+          <span className="text-[12px]" style={{ color: 'var(--fg-muted)' }}>
+            Markdown supported
+          </span>
         </div>
         <Textarea
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
-          placeholder="Summarise the meeting as…"
-          rows={10}
-          className="w-full min-h-[200px] text-[13px] leading-relaxed"
+          placeholder="Write a prompt instructing the AI how to structure the meeting summary..."
+          className="flex-1 w-full p-5 text-[14px] leading-relaxed border-0 focus-visible:ring-0 resize-none bg-transparent shadow-none"
+          style={{ color: 'var(--fg-1)' }}
         />
       </div>
 
       {error && (
         <div
-          className="mt-2 text-[12px]"
-          style={{ color: 'var(--accent-danger, var(--fg-1))' }}
+          className="mt-4 p-3 rounded-[8px] text-[13px] flex items-center shrink-0"
+          style={{ 
+            color: 'var(--accent-danger)', 
+            background: 'var(--danger-bg)',
+            border: '1px solid var(--accent-danger)'
+          }}
           role="alert"
         >
           {error}
         </div>
       )}
-
-      <div className="mt-3 flex justify-end gap-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          className={COMPACT_BTN}
-          onClick={onClose}
-          disabled={save.isPending}
-        >
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          className={COMPACT_BTN}
-          onClick={onSave}
-          disabled={save.isPending || !name.trim()}
-        >
-          {save.isPending ? (
-            <>
-              <Loader2 className="mr-1.5 size-3 animate-spin" />
-              Saving…
-            </>
-          ) : (
-            'Save'
-          )}
-        </Button>
-      </div>
     </div>
   );
 }

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1356,6 +1356,17 @@ function TemplatesTab() {
                   className="flex shrink-0 items-center justify-end gap-2 px-4 py-3 border-t" 
                   style={{ borderColor: 'var(--border-subtle)' }}
                 >
+                  {!isDefault && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className={cn(COMPACT_BTN, "mr-auto")}
+                      disabled={setDefault.isPending}
+                      onClick={() => setDefault.mutate(t.id)}
+                    >
+                      Make Default
+                    </Button>
+                  )}
                   {t.builtin ? (
                     !t.locked && (
                       <>

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1238,7 +1238,7 @@ function AiTab() {
 const TEMPLATE_LANGUAGES: LangOption[] = LANGUAGES_WHISPER;
 
 function TemplatesTab() {
-  const { templates, defaultId, isLoading } = useTemplates();
+  const { templates, defaultId } = useTemplates();
   const setDefault = useSetDefaultTemplate();
   const reset = useResetTemplate();
   const del = useDeleteTemplate();

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1347,7 +1347,7 @@ function TemplatesTab() {
                   style={{ color: 'var(--fg-muted)', opacity: t.prompt ? 1 : 0.6 }}
                   title={t.prompt}
                 >
-                  {t.prompt || 'No prompt provided.'}
+                  {t.prompt || (t.builtin ? 'Uses structured format' : 'No prompt provided.')}
                 </div>
               </div>
 
@@ -1489,6 +1489,7 @@ function TemplateEditor({
               variant="outline"
               size="sm"
               className={COMPACT_BTN}
+              disabled={setDefault.isPending}
               onClick={() => {
                 if (editing.id) setDefault.mutate(editing.id);
               }}

--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -1270,17 +1270,17 @@ function TemplatesTab() {
 
       <SectionHeading>Templates</SectionHeading>
 
-      {templates.map((t) => (
-        <div
-          key={t.id}
-          className="mb-1.5 flex items-center gap-4 rounded-[8px] px-4 py-[13px]"
-          style={{
-            border: '1px solid var(--border-subtle)',
-            background:
-              t.id === defaultId ? 'var(--surface-raised)' : 'transparent',
-          }}
-        >
-          <div className="min-w-0 flex-1">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {templates.map((t) => (
+          <div
+            key={t.id}
+            className="flex flex-col gap-3 rounded-[8px] p-4"
+            style={{
+              border: '1px solid var(--border-subtle)',
+              background:
+                t.id === defaultId ? 'var(--surface-raised)' : 'transparent',
+            }}
+          >
             <div className="flex items-center gap-2">
               <span
                 className="truncate text-[13px] font-medium"
@@ -1290,7 +1290,7 @@ function TemplatesTab() {
               </span>
               {t.locked && (
                 <span
-                  className="inline-flex items-center gap-1 text-[11px]"
+                  className="inline-flex shrink-0 items-center gap-1 text-[11px]"
                   style={{ color: 'var(--fg-muted)' }}
                   title="Built-in template — protected from editing and deletion"
                 >
@@ -1300,7 +1300,7 @@ function TemplatesTab() {
               )}
               {t.builtin && !t.locked && (
                 <span
-                  className="rounded-[3px] px-1.5 py-px text-[11px]"
+                  className="shrink-0 rounded-[3px] px-1.5 py-px text-[11px]"
                   style={{
                     color: 'var(--fg-muted)',
                     border: '1px solid var(--border-subtle)',
@@ -1310,24 +1310,44 @@ function TemplatesTab() {
                 </span>
               )}
             </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {t.builtin ? (
-              // A locked built-in (Standard) can't be edited, so there is no
-              // override to reset and nothing to edit — show no actions (the
-              // "Locked" badge above already conveys its state). Only an
-              // editable built-in offers Reset + Edit.
-              !t.locked && (
+
+            <div 
+              className="text-[12px] leading-relaxed line-clamp-3" 
+              style={{ color: 'var(--fg-muted)' }}
+              title={t.prompt}
+            >
+              {t.prompt || 'No prompt provided.'}
+            </div>
+
+            <div className="mt-auto flex shrink-0 items-center justify-end gap-2">
+              {t.builtin ? (
+                // A locked built-in (Standard) can't be edited, so there is no
+                // override to reset and nothing to edit — show no actions (the
+                // "Locked" badge above already conveys its state). Only an
+                // editable built-in offers Reset + Edit.
+                !t.locked && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className={COMPACT_BTN}
+                      disabled={reset.isPending}
+                      onClick={() => reset.mutate(t.id)}
+                    >
+                      Reset
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className={COMPACT_BTN}
+                      onClick={() => setEditing(t)}
+                    >
+                      Edit
+                    </Button>
+                  </>
+                )
+              ) : (
                 <>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className={COMPACT_BTN}
-                    disabled={reset.isPending}
-                    onClick={() => reset.mutate(t.id)}
-                  >
-                    Reset
-                  </Button>
                   <Button
                     variant="outline"
                     size="sm"
@@ -1336,35 +1356,24 @@ function TemplatesTab() {
                   >
                     Edit
                   </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={cn(
+                      COMPACT_BTN,
+                      'text-[color:var(--fg-2)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
+                    )}
+                    onClick={() => setDeleteTarget(t)}
+                    aria-label={`Delete ${t.name}`}
+                  >
+                    <Trash2 size={14} />
+                  </Button>
                 </>
-              )
-            ) : (
-              <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className={COMPACT_BTN}
-                  onClick={() => setEditing(t)}
-                >
-                  Edit
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    COMPACT_BTN,
-                    'text-[color:var(--fg-2)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
-                  )}
-                  onClick={() => setDeleteTarget(t)}
-                  aria-label={`Delete ${t.name}`}
-                >
-                  <Trash2 size={14} />
-                </Button>
-              </>
-            )}
+              )}
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
 
       {editing ? (
         <TemplateEditor

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -142,15 +142,16 @@ export function Setup() {
   // Wait for the real query to settle — placeholderData (sessionStorage cache)
   // could be stale or empty, and we don't want to seed from it and then ignore
   // the canonical value when it arrives from disk.
-  const seededRef = React.useRef(false);
-  React.useEffect(() => {
-    if (seededRef.current) return;
-    if (userName.isPending || userName.isPlaceholderData) return;
-    if (userName.data !== undefined) {
-      setName(userName.data);
-      seededRef.current = true;
-    }
-  }, [userName.data, userName.isPending, userName.isPlaceholderData]);
+  const [seeded, setSeeded] = React.useState(false);
+  if (
+    !seeded &&
+    !userName.isPending &&
+    !userName.isPlaceholderData &&
+    userName.data !== undefined
+  ) {
+    setName(userName.data);
+    setSeeded(true);
+  }
   const persistName = () => {
     const trimmed = name.trim();
     if (trimmed === (userName.data ?? '')) return;

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -178,7 +178,12 @@ export function Setup() {
   const setBedrockProfile = useSetBedrockInferenceProfile();
   const setCloudUrl = useSetCloudApiUrl();
 
-  const cloudReady = summaryMode === 'cloud' && cloudApiKey.trim().length > 0;
+  const cloudReady = (() => {
+    if (summaryMode !== 'cloud' || !cloudApiKey.trim()) return false;
+    if (cloudProvider === 'bedrock') return bedrockRegion.trim().length > 0;
+    if (cloudProvider === 'custom') return apiUrl.trim().length > 0;
+    return true;
+  })();
   const canBegin = summaryMode === 'local' || cloudReady;
 
   const setStatus = (id: Step['id'], s: StepStatus, detail?: string) => {
@@ -254,10 +259,10 @@ export function Setup() {
         await setAiProvider.mutateAsync('cloud');
         await setCloudProviderMut.mutateAsync(cloudProvider);
         if (cloudProvider === 'bedrock') {
-          if (bedrockRegion) await setBedrockRegion.mutateAsync(bedrockRegion);
+          if (bedrockRegion) await setBedrockRegion.mutateAsync(bedrockRegion.trim());
           if (bedrockProfile) await setBedrockProfile.mutateAsync(bedrockProfile.trim());
         } else if (cloudProvider === 'custom') {
-          if (apiUrl) await setCloudUrl.mutateAsync(apiUrl);
+          if (apiUrl) await setCloudUrl.mutateAsync(apiUrl.trim());
         }
         await setCloudKeyMut.mutateAsync(cloudApiKey.trim());
         setStatus('ollama', 'running', 'Testing connection...');

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -24,6 +24,9 @@ import {
   useSetCloudApiKey,
   useSetCloudProvider,
   useTestCloudApi,
+  useSetBedrockInferenceProfile,
+  useSetBedrockRegion,
+  useSetCloudApiUrl,
 } from '@/hooks/useAi';
 import { ipc, type CloudProvider } from '@/lib/ipc';
 import { cn, isMac } from '@/lib/utils';
@@ -161,10 +164,18 @@ export function Setup() {
   const [summaryMode, setSummaryMode] = React.useState<SummaryMode>('local');
   const [cloudProvider, setCloudProviderChoice] = React.useState<CloudProvider>('openai');
   const [cloudApiKey, setCloudApiKey] = React.useState('');
+  
+  const [bedrockRegion, setBedrockRegionState] = React.useState('');
+  const [bedrockProfile, setBedrockProfileState] = React.useState('');
+  const [apiUrl, setApiUrl] = React.useState('');
+
   const setAiProvider = useSetAiProvider();
   const setCloudProviderMut = useSetCloudProvider();
   const setCloudKeyMut = useSetCloudApiKey();
   const testCloudApi = useTestCloudApi();
+  const setBedrockRegion = useSetBedrockRegion();
+  const setBedrockProfile = useSetBedrockInferenceProfile();
+  const setCloudUrl = useSetCloudApiUrl();
 
   const cloudReady = summaryMode === 'cloud' && cloudApiKey.trim().length > 0;
   const canBegin = summaryMode === 'local' || cloudReady;
@@ -241,6 +252,12 @@ export function Setup() {
         // call so the user gets immediate feedback if the key is bad.
         await setAiProvider.mutateAsync('cloud');
         await setCloudProviderMut.mutateAsync(cloudProvider);
+        if (cloudProvider === 'bedrock') {
+          if (bedrockRegion) await setBedrockRegion.mutateAsync(bedrockRegion);
+          if (bedrockProfile) await setBedrockProfile.mutateAsync(bedrockProfile.trim());
+        } else if (cloudProvider === 'custom') {
+          if (apiUrl) await setCloudUrl.mutateAsync(apiUrl);
+        }
         await setCloudKeyMut.mutateAsync(cloudApiKey.trim());
         setStatus('ollama', 'running', 'Testing connection...');
         // unwrap throws on { success: false } so reaching this line means the
@@ -424,10 +441,66 @@ export function Setup() {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="openai">OpenAI</SelectItem>
-                      <SelectItem value="anthropic">Anthropic</SelectItem>
+                      <SelectItem value="anthropic">Anthropic (Claude)</SelectItem>
+                      <SelectItem value="bedrock">AWS Bedrock (Claude)</SelectItem>
+                      <SelectItem value="custom">Custom (OpenAI-compatible)</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
+                {cloudProvider === 'bedrock' && (
+                  <>
+                    <div>
+                      <label
+                        className="mb-1 block text-[12px] font-medium text-foreground"
+                        htmlFor="setup-bedrock-region"
+                      >
+                        AWS region
+                      </label>
+                      <Input
+                        id="setup-bedrock-region"
+                        value={bedrockRegion}
+                        onChange={(e) => setBedrockRegionState(e.target.value)}
+                        placeholder="us-east-1"
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                    </div>
+                    <div>
+                      <label
+                        className="mb-1 block text-[12px] font-medium text-foreground"
+                        htmlFor="setup-bedrock-profile"
+                      >
+                        Inference profile (optional)
+                      </label>
+                      <Input
+                        id="setup-bedrock-profile"
+                        value={bedrockProfile}
+                        onChange={(e) => setBedrockProfileState(e.target.value)}
+                        placeholder="us.anthropic.claude-…"
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                    </div>
+                  </>
+                )}
+                {cloudProvider === 'custom' && (
+                  <div>
+                    <label
+                      className="mb-1 block text-[12px] font-medium text-foreground"
+                      htmlFor="setup-custom-api"
+                    >
+                      API base URL
+                    </label>
+                    <Input
+                      id="setup-custom-api"
+                      value={apiUrl}
+                      onChange={(e) => setApiUrl(e.target.value)}
+                      placeholder="https://api.example.com/v1"
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                  </div>
+                )}
                 <div>
                   <label
                     className="mb-1 block text-[12px] font-medium text-foreground"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "stenoai",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "stenoai",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -44,7 +44,6 @@ fi
 # Install project dependencies
 echo "Installing project dependencies..."
 pip install -r requirements.txt
-pip install -e .
 echo ""
 
 # Clean previous builds


### PR DESCRIPTION
## Description

This PR redesigns the templates settings UI with a grid layout and improved card visuals, and adds support for Bedrock and custom API providers to the setup flow.

## Type of Change

- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

## Additional Notes

Includes styling changes to the UI for better visual aesthetics when picking a template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Templates settings into a responsive card grid with a full-height editor and clearer default/lock states. Expanded Setup to support AWS Bedrock and custom OpenAI‑compatible providers, with safer validation and more reliable saving.

- New Features
  - Templates grid: cards show name, prompt preview, and badges (Default, Locked, Built‑in) with quick actions and a “New Template” card.
  - Default handling: default template is pinned and can be set from the editor or any non‑default card via “Make Default.”
  - Template editor: full-height view with improved header, language selector, markdown hint, clearer errors, and “Save Template.”
  - Setup: provider choices now include “AWS Bedrock (Claude)” and “Custom (OpenAI‑compatible),” with fields for AWS region, optional inference profile, and API base URL; values are saved before testing the API key.

- Bug Fixes
  - Setup: fixed initial user-name seeding; validate AWS region/API URL before enabling Begin; trim values before saving.
  - Templates: show “Uses structured format” when a built‑in has no prompt; removed an unused isLoading; disable “Make Default” while the request is pending.

<sup>Written for commit a2eba91ab072603a88e93f3753e544aa91e2a029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

