### PR TITLE
fix: validate Bedrock region shape to prevent host redirection

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shutil
 import sys
 import tempfile
@@ -20,6 +21,15 @@ from src.whisper_models import SUPPORTED_WHISPER_MODELS as _WHISPER_REGISTRY
 from src import templates as _templates
 
 logger = logging.getLogger(__name__)
+
+# AWS region shape: <code>[-gov]-<name>-<digit(s)>, e.g. us-east-1, eu-west-2,
+# us-gov-west-1, cn-northwest-1. Centralised here (not just format-checked at
+# one call site) because both this config layer and bedrock_converse_url()
+# (src/summarizer.py, which imports this) must agree — a region string
+# crafted to redirect the request via `user@host` URL syntax (e.g.
+# "x@127.0.0.1:8443/") has to be rejected by both, not just whichever one an
+# attacker didn't think to route around. See issue #299.
+BEDROCK_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}$")
 
 
 def _atomic_write_json(path: Path, payload) -> None:
@@ -993,12 +1003,17 @@ class Config:
         return value.strip()
 
     def set_bedrock_region(self, region: str) -> bool:
-        """Persist the AWS region. Accepts any non-empty string — Bedrock
-        validates the region on the wire, so a typo surfaces as a clear
-        404 / DNS error at request time rather than silently here."""
+        """Persist the AWS region. A legitimate typo (e.g. "us-eest-1")
+        still surfaces as a clear 404 / DNS error at request time rather
+        than silently here — but the value must at least be shaped like a
+        real AWS region code, so a string crafted to redirect the request
+        to a different host (`user@host` URL syntax) can't be saved."""
         cleaned = (region or "").strip()
         if not cleaned:
             logger.error("Bedrock region cannot be empty")
+            return False
+        if not BEDROCK_REGION_RE.match(cleaned):
+            logger.error(f"Rejected malformed Bedrock region: {cleaned!r}")
             return False
         self._config["bedrock_region"] = cleaned
         return self._save()

--- a/src/config.py
+++ b/src/config.py
@@ -29,7 +29,11 @@ logger = logging.getLogger(__name__)
 # crafted to redirect the request via `user@host` URL syntax (e.g.
 # "x@127.0.0.1:8443/") has to be rejected by both, not just whichever one an
 # attacker didn't think to route around. See issue #299.
-BEDROCK_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}$")
+#
+# Match with fullmatch() (never match()+"$" — "$" alone still allows a
+# trailing "\n"). Digits are [0-9], not \d — \d is Unicode-aware by default
+# and would accept visually-similar non-ASCII digits (e.g. Arabic-Indic "١").
+BEDROCK_REGION_RE = re.compile(r"[a-z]{2}(-gov)?-[a-z]+-[0-9]{1,2}")
 
 
 def _atomic_write_json(path: Path, payload) -> None:
@@ -1012,7 +1016,7 @@ class Config:
         if not cleaned:
             logger.error("Bedrock region cannot be empty")
             return False
-        if not BEDROCK_REGION_RE.match(cleaned):
+        if not BEDROCK_REGION_RE.fullmatch(cleaned):
             logger.error(f"Rejected malformed Bedrock region: {cleaned!r}")
             return False
         self._config["bedrock_region"] = cleaned

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 from typing import Optional, Dict, Any
 from .models import MeetingTranscript, ActionItem, Decision
-from .config import Config, resolve_runtime_tag
+from .config import Config, resolve_runtime_tag, BEDROCK_REGION_RE
 from . import ollama_manager
 
 logger = logging.getLogger(__name__)
@@ -52,7 +52,16 @@ def bedrock_converse_url(region: str, target_id: str) -> str:
     HTTP 400 "The provided model identifier is invalid". Keeping ``/``
     literal lets ARNs flow through; non-ARN ids (no slashes) are
     unaffected because there's nothing to leave alone.
+
+    ``region`` must be shaped like a real AWS region code — rejected here
+    too (not just in Config.set_bedrock_region()) because this function is
+    the actual network-request sink and must not trust its caller. Without
+    this, a region string like "x@127.0.0.1:8443/" would use `user@host`
+    URL syntax to silently redirect the request (with the real Bedrock
+    bearer credential attached) to a different host. See issue #299.
     """
+    if not BEDROCK_REGION_RE.match(region):
+        raise ValueError(f"Invalid Bedrock region: {region!r}")
     import urllib.parse
     encoded = urllib.parse.quote(target_id, safe=":.-/")
     return f"https://bedrock-runtime.{region}.amazonaws.com/model/{encoded}/converse"

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -60,7 +60,7 @@ def bedrock_converse_url(region: str, target_id: str) -> str:
     URL syntax to silently redirect the request (with the real Bedrock
     bearer credential attached) to a different host. See issue #299.
     """
-    if not BEDROCK_REGION_RE.match(region):
+    if not BEDROCK_REGION_RE.fullmatch(region):
         raise ValueError(f"Invalid Bedrock region: {region!r}")
     import urllib.parse
     encoded = urllib.parse.quote(target_id, safe=":.-/")

--- a/tests/test_bedrock_converse_url.py
+++ b/tests/test_bedrock_converse_url.py
@@ -58,6 +58,19 @@ class BedrockConverseUrlTests(unittest.TestCase):
         url = bedrock_converse_url("ap-southeast-2", "model-x")
         self.assertIn("bedrock-runtime.ap-southeast-2.amazonaws.com", url)
 
+    def test_rejects_region_shaped_to_redirect_the_host(self):
+        # `user@host` URL syntax: an attacker- or accident-crafted region
+        # value that would silently point the request (with the real
+        # Bedrock bearer credential attached) at a different host instead
+        # of AWS. See issue #299 — set_bedrock_region() also guards this,
+        # but the sink itself must not trust its caller either.
+        with self.assertRaises(ValueError):
+            bedrock_converse_url("x@127.0.0.1:8443/", "model-x")
+
+    def test_rejects_non_aws_shaped_region(self):
+        with self.assertRaises(ValueError):
+            bedrock_converse_url("not a region", "model-x")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bedrock_converse_url.py
+++ b/tests/test_bedrock_converse_url.py
@@ -71,6 +71,21 @@ class BedrockConverseUrlTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             bedrock_converse_url("not a region", "model-x")
 
+    def test_rejects_unicode_digit_lookalikes(self):
+        # Python's \d matches non-ASCII decimal digits under re.UNICODE
+        # (the default) — e.g. Arabic-Indic ١ or fullwidth １ — which would
+        # otherwise slip a visually-similar-but-wrong region past the
+        # regex. Region codes are ASCII by definition.
+        with self.assertRaises(ValueError):
+            bedrock_converse_url("us-east-١", "model-x")  # Arabic-Indic 1
+
+    def test_rejects_trailing_newline(self):
+        # `re.match(..., "$")` allows a trailing "\n" ("$" matches just
+        # before it). fullmatch() must be used so a region smuggled with a
+        # trailing newline (e.g. from a config/env value) is rejected too.
+        with self.assertRaises(ValueError):
+            bedrock_converse_url("us-east-1\n", "model-x")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -277,6 +277,25 @@ class ConfigBedrockSettingsTests(unittest.TestCase):
             self.assertFalse(config.set_bedrock_region("   "))
             self.assertEqual(config.get_bedrock_region(), "ap-southeast-2")
 
+    def test_set_bedrock_region_rejects_malformed_values(self):
+        # A region string shaped to redirect the request to a different host
+        # via the `user@host` URL syntax once it's interpolated into
+        # bedrock_converse_url() — see issue #299. Must never persist.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            config.set_bedrock_region("ap-southeast-2")
+            self.assertFalse(config.set_bedrock_region("x@127.0.0.1:8443/"))
+            self.assertFalse(config.set_bedrock_region("us-east-1/../evil"))
+            self.assertFalse(config.set_bedrock_region("not a region"))
+            self.assertEqual(config.get_bedrock_region(), "ap-southeast-2")
+
+    def test_set_bedrock_region_accepts_real_aws_shapes(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            for region in ("us-east-1", "eu-west-2", "us-gov-west-1", "cn-northwest-1", "ca-central-1"):
+                self.assertTrue(config.set_bedrock_region(region), region)
+                self.assertEqual(config.get_bedrock_region(), region)
+
     def test_default_inference_profile_is_empty_string(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -287,7 +287,18 @@ class ConfigBedrockSettingsTests(unittest.TestCase):
             self.assertFalse(config.set_bedrock_region("x@127.0.0.1:8443/"))
             self.assertFalse(config.set_bedrock_region("us-east-1/../evil"))
             self.assertFalse(config.set_bedrock_region("not a region"))
+            self.assertFalse(config.set_bedrock_region("us-east-١"))  # Arabic-Indic 1
             self.assertEqual(config.get_bedrock_region(), "ap-southeast-2")
+
+    def test_set_bedrock_region_strips_trailing_whitespace_before_validating(self):
+        # set_bedrock_region() strips before validating (unlike
+        # bedrock_converse_url(), the sink, which must reject a trailing
+        # "\n" defensively since it can't assume every caller stripped).
+        # A trailing newline here is just whitespace, not a bypass.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertTrue(config.set_bedrock_region("us-east-1\n"))
+            self.assertEqual(config.get_bedrock_region(), "us-east-1")
 
     def test_set_bedrock_region_accepts_real_aws_shapes(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Fixes #299.

`Config.set_bedrock_region()` accepted any non-empty string, and `bedrock_converse_url()` (`src/summarizer.py`) interpolated it directly into the request URL's host segment. A region value using `user@host` URL syntax (e.g. `x@127.0.0.1:8443/`) would silently redirect the Bedrock request — with the real bearer credential attached — to an unintended host, instead of the expected 404/DNS error a genuine typo would produce.

Found while running an adversarial security pass (Codex) on #298, which added a second UI entry point (the setup wizard) to this pre-existing region-config path — the gap predates that PR.

## Fix

Both the config layer (`set_bedrock_region`) and the actual network-request sink (`bedrock_converse_url`) now reject anything not shaped like a real AWS region code, via a shared `BEDROCK_REGION_RE` in `src/config.py` (imported by `src/summarizer.py`) so the two checks can't drift apart — matching the existing pattern in this file for keeping the URL-encoding rules centralised.

A format check rather than an exhaustive region allowlist, so new AWS regions don't need an app update; a format-valid-but-wrong region still surfaces as a normal 404/DNS error, per the original design intent.

## Test plan

- [x] New tests: `set_bedrock_region` rejects malformed values (`x@127.0.0.1:8443/`, path-traversal-shaped, freeform text) and still accepts real AWS region shapes (`us-east-1`, `eu-west-2`, `us-gov-west-1`, `cn-northwest-1`, `ca-central-1`)
- [x] New tests: `bedrock_converse_url` raises `ValueError` on the same malformed inputs, independent of the config-layer guard
- [x] `python -m unittest discover tests` — 359 tests pass
- [x] `ruff check` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate Bedrock region format to block host redirection. Both the config setter and URL builder now enforce real AWS region shapes with ASCII digits and full-match, so typos still fail as normal 404/DNS errors.

- **Bug Fixes**
  - Added shared `BEDROCK_REGION_RE` in `src/config.py`; used by config and URL sink.
  - `Config.set_bedrock_region` trims input and rejects empty or malformed regions.
  - `bedrock_converse_url` validates with `fullmatch` and raises `ValueError` on invalid input.
  - Tests cover valid AWS shapes and reject redirect-shaped, freeform, Unicode-digit, and trailing-newline cases.

<sup>Written for commit f3802c81d81e0a22855cb7b5c599ba1869ec8937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

