### PR TITLE
feat: add a curated built-in template gallery

### DIFF
--- a/src/templates.py
+++ b/src/templates.py
@@ -47,12 +47,13 @@ BUILTIN_TEMPLATES = {
         "name": "Product Demo",
         "icon": "presentation",
         "prompt": (
-            "Summarise this call from the perspective of someone evaluating a "
-            "product or service being demonstrated to them. Cover: what was "
-            "demoed and the problem it's meant to solve, key features or "
-            "capabilities shown, pricing or commercial terms if mentioned, how "
-            "it fits (or doesn't fit) the stated needs, concerns or open "
-            "questions raised, and next steps. Write in the language of the "
+            "Summarise this call for someone evaluating a product or service "
+            "being demonstrated to them. Cover: what was demoed and the "
+            "problem it's meant to solve; key features or capabilities shown; "
+            "pricing or commercial terms if mentioned; how well it fits the "
+            "stated needs; concerns or open questions raised; and next steps. "
+            "Structure the report with a short markdown heading per area, and "
+            "omit any area that wasn't discussed. Write in the language of the "
             "meeting."
         ),
         "language": "auto",
@@ -63,12 +64,13 @@ BUILTIN_TEMPLATES = {
         "name": "Sales Call",
         "icon": "handshake",
         "prompt": (
-            "Summarise this call from the perspective of the person running "
-            "the sales conversation. Cover: the prospect's stated needs, pain "
-            "points, and priorities; objections or concerns raised; budget, "
-            "timeline, or decision-process details mentioned; competitors or "
-            "alternatives referenced; and agreed next steps. Write in the "
-            "language of the meeting."
+            "Summarise this call for the person running the sales "
+            "conversation. Cover: the prospect's stated needs, pain points, "
+            "and priorities; objections or concerns raised; budget, timeline, "
+            "or decision-process details mentioned; competitors or "
+            "alternatives referenced; and agreed next steps. Structure the "
+            "report with a short markdown heading per area, and omit any area "
+            "that wasn't discussed. Write in the language of the meeting."
         ),
         "language": "auto",
         "format": "markdown",
@@ -81,8 +83,9 @@ BUILTIN_TEMPLATES = {
             "Summarise this 1:1 conversation. Cover: topics discussed and any "
             "updates shared, feedback given in either direction, concerns or "
             "blockers raised, decisions made, and follow-up actions with who "
-            "owns them. Keep it factual and don't add interpretation beyond "
-            "what was said. Write in the language of the meeting."
+            "owns them. Structure the report with a short markdown heading per "
+            "area, and omit any area that wasn't discussed. Write in the "
+            "language of the meeting."
         ),
         "language": "auto",
         "format": "markdown",
@@ -93,10 +96,10 @@ BUILTIN_TEMPLATES = {
         "icon": "list-checks",
         "prompt": (
             "Summarise this standup/status meeting concisely. For each "
-            "participant or topic, capture what was done, what's planned "
-            "next, and any blockers raised. Keep it brief — this is a quick "
-            "status sync, not a detailed report. Write in the language of "
-            "the meeting."
+            "update, capture what was done, what's planned next, and any "
+            "blockers raised. List updates as brief bullet points, grouped by "
+            "person or topic. Keep it brief - this is a quick status sync, "
+            "not a detailed report. Write in the language of the meeting."
         ),
         "language": "auto",
         "format": "markdown",

--- a/src/templates.py
+++ b/src/templates.py
@@ -1,12 +1,16 @@
 # src/templates.py
 """Built-in report templates + pure template helpers.
 
-A template shapes how a meeting report is generated/exported. The shipped
-lineup is intentionally minimal: STANDARD is the only built-in (locked, drives
-today's structured note). One editable SAMPLE custom template is pre-seeded by
-Config on first run; everything else is user-created. Built-in definitions live
-here (source of truth, like whisper_models.py); custom templates, built-in
-overrides, the seed flag, and the default id live in config.json.
+A template shapes how a meeting report is generated/exported. STANDARD is the
+only *locked* built-in (drives today's structured note); the rest of
+BUILTIN_TEMPLATES is a curated gallery of editable/resettable prompt-driven
+templates for common meeting types (issue #297) — same override/reset
+mechanism as any editable built-in, just shipped with a useful starting
+prompt instead of an empty one. One editable SAMPLE custom template is also
+pre-seeded by Config on first run; everything else is user-created. Built-in
+definitions live here (source of truth, like whisper_models.py); custom
+templates, built-in overrides, the seed flag, and the default id live in
+config.json.
 
 This module is pure — no I/O — so it is unit-testable without a running app.
 """
@@ -20,9 +24,14 @@ MAX_PROMPT_LEN = 8000
 MAX_ICON_LEN = 64
 VALID_FORMATS = {"structured", "markdown"}
 
-# Only STANDARD is a built-in. Locked + structured: its "prompt" is empty
-# because it routes through the existing JSON-schema summary path, not a
-# free-form prompt. PR B reads `format` to pick the render/generation path.
+# STANDARD is locked + structured: its "prompt" is empty because it routes
+# through the existing JSON-schema summary path, not a free-form prompt.
+# `format` picks the render/generation path.
+#
+# The rest are the built-in gallery (issue #297): editable + resettable
+# (locked left unset/False) prompt-driven templates for common meeting
+# types, so most users get a useful default without writing their own
+# prompt — Custom-template CRUD covers anyone who wants more.
 BUILTIN_TEMPLATES = {
     "standard": {
         "id": "standard",
@@ -32,6 +41,65 @@ BUILTIN_TEMPLATES = {
         "language": "auto",
         "format": "structured",
         "locked": True,
+    },
+    "product-demo": {
+        "id": "product-demo",
+        "name": "Product Demo",
+        "icon": "presentation",
+        "prompt": (
+            "Summarise this call from the perspective of someone evaluating a "
+            "product or service being demonstrated to them. Cover: what was "
+            "demoed and the problem it's meant to solve, key features or "
+            "capabilities shown, pricing or commercial terms if mentioned, how "
+            "it fits (or doesn't fit) the stated needs, concerns or open "
+            "questions raised, and next steps. Write in the language of the "
+            "meeting."
+        ),
+        "language": "auto",
+        "format": "markdown",
+    },
+    "sales-call": {
+        "id": "sales-call",
+        "name": "Sales Call",
+        "icon": "handshake",
+        "prompt": (
+            "Summarise this call from the perspective of the person running "
+            "the sales conversation. Cover: the prospect's stated needs, pain "
+            "points, and priorities; objections or concerns raised; budget, "
+            "timeline, or decision-process details mentioned; competitors or "
+            "alternatives referenced; and agreed next steps. Write in the "
+            "language of the meeting."
+        ),
+        "language": "auto",
+        "format": "markdown",
+    },
+    "one-on-one": {
+        "id": "one-on-one",
+        "name": "1:1",
+        "icon": "user-check",
+        "prompt": (
+            "Summarise this 1:1 conversation. Cover: topics discussed and any "
+            "updates shared, feedback given in either direction, concerns or "
+            "blockers raised, decisions made, and follow-up actions with who "
+            "owns them. Keep it factual and don't add interpretation beyond "
+            "what was said. Write in the language of the meeting."
+        ),
+        "language": "auto",
+        "format": "markdown",
+    },
+    "standup": {
+        "id": "standup",
+        "name": "Standup",
+        "icon": "list-checks",
+        "prompt": (
+            "Summarise this standup/status meeting concisely. For each "
+            "participant or topic, capture what was done, what's planned "
+            "next, and any blockers raised. Keep it brief — this is a quick "
+            "status sync, not a detailed report. Write in the language of "
+            "the meeting."
+        ),
+        "language": "auto",
+        "format": "markdown",
     },
 }
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,8 +4,7 @@ from src import templates as T
 
 
 class BuiltinRegistryTests(unittest.TestCase):
-    def test_standard_is_the_only_builtin_and_is_locked_structured(self):
-        self.assertEqual(list(T.BUILTIN_TEMPLATES), ["standard"])
+    def test_standard_is_locked_structured(self):
         std = T.BUILTIN_TEMPLATES["standard"]
         self.assertEqual(std["id"], T.STANDARD_TEMPLATE_ID)
         self.assertTrue(std["locked"])
@@ -103,6 +102,55 @@ class BuiltinRegistryTests(unittest.TestCase):
         self.assertFalse(custom["builtin"])
         # built-ins come first
         self.assertEqual(merged[0]["id"], "standard")
+
+
+class TemplateGalleryTests(unittest.TestCase):
+    """Issue #297 — a curated set of built-in templates beyond just Standard,
+    so users get useful defaults for common meeting types without having to
+    write their own prompt. Unlike Standard, these are editable + resettable
+    built-ins (locked=False) — same UX as OpenOats-style built-in/custom."""
+
+    GALLERY_IDS = {"product-demo", "sales-call", "one-on-one", "standup"}
+
+    def test_gallery_ids_are_registered_builtins(self):
+        self.assertTrue(self.GALLERY_IDS.issubset(set(T.BUILTIN_TEMPLATES)))
+
+    def test_gallery_templates_are_editable_markdown_prompts(self):
+        valid_langs = {"auto"}
+        for tid in self.GALLERY_IDS:
+            t = T.BUILTIN_TEMPLATES[tid]
+            with self.subTest(template=tid):
+                self.assertEqual(t["id"], tid)
+                self.assertFalse(t.get("locked"), "gallery templates must stay editable")
+                self.assertEqual(t["format"], "markdown")
+                self.assertEqual(t["language"], "auto")
+                self.assertTrue(t["prompt"].strip())
+                self.assertLessEqual(len(t["prompt"]), T.MAX_PROMPT_LEN)
+                ok, err = T.validate_template(t, valid_langs)
+                self.assertTrue(ok, err)
+
+    def test_gallery_templates_are_distinct_from_each_other(self):
+        prompts = [T.BUILTIN_TEMPLATES[tid]["prompt"] for tid in self.GALLERY_IDS]
+        names = [T.BUILTIN_TEMPLATES[tid]["name"] for tid in self.GALLERY_IDS]
+        self.assertEqual(len(prompts), len(set(prompts)))
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_merge_tags_gallery_templates_as_editable_builtins(self):
+        merged = T.merge_templates(overrides={}, custom=[])
+        merged_by_id = {m["id"]: m for m in merged}
+        for tid in self.GALLERY_IDS:
+            m = merged_by_id[tid]
+            with self.subTest(template=tid):
+                self.assertTrue(m["builtin"])
+                self.assertFalse(m["locked"])
+
+    def test_gallery_templates_can_be_reset_like_any_editable_builtin(self):
+        # Not a Config test (that lives in test_config_templates.py) — just
+        # pins that these ids aren't special-cased away from the existing
+        # override/reset mechanism editable built-ins already have.
+        for tid in self.GALLERY_IDS:
+            with self.subTest(template=tid):
+                self.assertFalse(T.BUILTIN_TEMPLATES[tid].get("locked"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #297.

Adds a small curated gallery of built-in templates alongside the existing locked `Standard`:

- **Product Demo** — for evaluating a product/service someone is demoing to you (what was shown, pricing, fit, open questions, next steps)
- **Sales Call** — running the sales conversation (prospect needs, objections, budget/timeline, competitors, next steps)
- **1:1** — updates, feedback, blockers, decisions, follow-ups
- **Standup** — quick per-person/topic status: done, next, blockers

Unlike `Standard`, these are **editable + resettable** (`locked` unset), reusing the exact same override/reset mechanism editable built-ins already have — pick one, tweak the prompt for your own needs, reset back to the shipped default whenever.

## Why no renderer changes

`TemplatesTab` already renders whatever `templates.list()` returns generically (name/prompt/builtin/locked, no per-template hardcoding), and `merge_templates()`/`save_template()`/`reset_template()`/`set_default_template()` in `src/config.py` all iterate `BUILTIN_TEMPLATES` generically too. So this is a pure content addition to `src/templates.py` — zero touches to `Settings.tsx`, `main.js`, `ipc.ts`, or anything else.

## Test plan

- [x] New tests in `tests/test_templates.py`: each gallery template registered, editable (not locked), valid markdown prompt, passes `validate_template`, tagged correctly by `merge_templates`
- [x] Updated the one existing test that encoded "Standard is the only built-in" (that invariant is the whole point of this PR)
- [x] Manual end-to-end sanity check via `Config.get_templates()` — correct builtin/locked/format/name for all 5 built-ins plus the pre-seeded sample
- [x] `python -m unittest discover tests` — 360 tests pass
- [x] `ruff check` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a curated gallery of built-in templates (Product Demo, Sales Call, 1:1, Standup) alongside the locked `Standard`, giving users useful starting prompts for common meeting types; fixes #297. Tightens the four prompts for consistent, well-structured output on small models; all remain editable and resettable via the existing override/reset flow.

<sup>Written for commit 22da84f472f09529afd4db4212713651d98f46cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

