### PR TITLE
fix(settings): four small pre-existing bugs found during the #289 split review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,9 @@ app/playwright-report/
 .claude/
 .github/skills/
 
+# Local git worktrees (agent workspaces, not project content)
+.worktrees/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/app/renderer/src/routes/settings/AdvancedTab.test.tsx
+++ b/app/renderer/src/routes/settings/AdvancedTab.test.tsx
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AdvancedTab } from './AdvancedTab';
+
+// Reset button on the storage-location row must clear the custom override by
+// sending '' to the backend (set-storage-path treats '' as "use default"),
+// NOT the default path itself — which the backend records as a fresh custom
+// override, so "Reset" would visually hide itself while leaving the override
+// in place (#304).
+
+const setStoragePath = vi.fn(async () => ({ success: true }));
+
+vi.mock('@/lib/ipc', () => ({
+  ipc: () => ({
+    settings: {
+      getStoragePath: async () => ({
+        success: true,
+        storage_path: '/custom/path',
+        default_path: '/default/path',
+        custom_path: '/custom/path',
+      }),
+      setStoragePath,
+      pickStorageFolder: async () => ({ success: true, folderPath: null }),
+      getTelemetry: async () => ({
+        success: true,
+        telemetry_enabled: false,
+        anonymous_id: null,
+      }),
+      setTelemetry: async () => ({ success: true }),
+    },
+    system: { clearState: async () => ({ success: true }) },
+  }),
+}));
+
+function renderTab() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AdvancedTab />
+    </QueryClientProvider>,
+  );
+}
+
+describe('AdvancedTab storage reset', () => {
+  beforeEach(() => {
+    setStoragePath.mockClear();
+  });
+
+  test('Reset clears the custom override with an empty string, not the default path', async () => {
+    renderTab();
+
+    // Reset only appears once the storage query resolves with a custom path.
+    const reset = await screen.findByRole('button', { name: 'Reset' });
+    fireEvent.click(reset);
+
+    await waitFor(() => expect(setStoragePath).toHaveBeenCalledTimes(1));
+    expect(setStoragePath).toHaveBeenCalledWith('');
+  });
+});

--- a/app/renderer/src/routes/settings/AdvancedTab.tsx
+++ b/app/renderer/src/routes/settings/AdvancedTab.tsx
@@ -74,11 +74,11 @@ export function AdvancedTab() {
     }
   };
 
-  const resetFolder = () => {
-    if (storage.data?.default_path) {
-      setStorage.mutate(storage.data.default_path);
-    }
-  };
+  // Send '' — the backend treats an empty path as "use the default location"
+  // and clears the custom override. Passing the default *path* instead would
+  // be recorded as a fresh custom override, so Reset would hide itself without
+  // actually resetting anything (#304).
+  const resetFolder = () => setStorage.mutate('');
 
   const custom =
     storage.data?.custom_path &&

--- a/app/renderer/src/routes/settings/OrganisationTab.test.tsx
+++ b/app/renderer/src/routes/settings/OrganisationTab.test.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
 import { describe, test, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { OrganisationTab } from './OrganisationTab';
 import { orgKeys } from '@/hooks/useOrg';
@@ -70,8 +69,11 @@ describe('OrganisationTab', () => {
     // Enter shortcut must respect the same guard and be a no-op.
     fireEvent.keyDown(password, { key: 'Enter' });
 
-    // Give any (incorrect) async login a chance to fire before asserting.
-    await new Promise((r) => setTimeout(r, 0));
+    // Give any (incorrect) async login a chance to fire, and let the
+    // background status/auto-backup queries settle, before asserting.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
     expect(login).not.toHaveBeenCalled();
   });
 

--- a/app/renderer/src/routes/settings/OrganisationTab.test.tsx
+++ b/app/renderer/src/routes/settings/OrganisationTab.test.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { OrganisationTab } from './OrganisationTab';
+import { orgKeys } from '@/hooks/useOrg';
+
+// Two independent bugs in OrganisationTab (#305):
+//   (a) pressing Enter in the password field bypassed the sign-in button's own
+//       disabled/busy guard, firing a login with empty required fields (or
+//       while a sign-in was already in flight).
+//   (b) onSignOut did not clear a stale prior error before mutating, unlike
+//       onSignIn / onGoogleSignIn — so an old failure message reappeared once
+//       the sign-out returned the user to the signed-out card.
+
+const login = vi.fn(async () => ({ success: true }));
+const ssoGoogleStart = vi.fn(async () => ({ success: true }));
+const logout = vi.fn(async () => ({ signedIn: false }));
+const getAutoBackup = vi.fn(async () => ({
+  success: true,
+  org_auto_backup_enabled: true,
+}));
+
+// Mutable so a test can flip the signed-in state and re-invalidate the query.
+let statusValue: Record<string, unknown> = { signedIn: false };
+
+vi.mock('@/lib/ipc', () => ({
+  ipc: () => ({
+    org: {
+      status: async () => statusValue,
+      login,
+      ssoGoogleStart,
+      logout,
+      getAutoBackup,
+    },
+  }),
+}));
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderTab(qc: QueryClient) {
+  return render(
+    <QueryClientProvider client={qc}>
+      <OrganisationTab />
+    </QueryClientProvider>,
+  );
+}
+
+describe('OrganisationTab', () => {
+  beforeEach(() => {
+    login.mockClear();
+    ssoGoogleStart.mockClear();
+    logout.mockClear();
+    statusValue = { signedIn: false };
+  });
+
+  test('(a) Enter in the password field does not sign in while required fields are empty', async () => {
+    const qc = makeClient();
+    renderTab(qc);
+
+    const password = await screen.findByPlaceholderText('••••••');
+    // Email + password are empty, so the Sign-in button is disabled; the
+    // Enter shortcut must respect the same guard and be a no-op.
+    fireEvent.keyDown(password, { key: 'Enter' });
+
+    // Give any (incorrect) async login a chance to fire before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  test('(b) signing out clears a stale sign-in error', async () => {
+    ssoGoogleStart.mockRejectedValueOnce(new Error('google boom'));
+    const qc = makeClient();
+    renderTab(qc);
+
+    // 1. Trigger a Google sign-in failure so an error is shown.
+    const googleBtn = await screen.findByRole('button', {
+      name: /Sign in with Google/i,
+    });
+    fireEvent.click(googleBtn);
+    await screen.findByText('google boom');
+
+    // 2. Flip to signed-in so the Sign out button is reachable.
+    statusValue = {
+      signedIn: true,
+      name: 'Ada',
+      email: 'ada@corp.com',
+      orgId: 'org_1',
+      adapterUrl: 'http://localhost:8000',
+    };
+    await qc.invalidateQueries({ queryKey: orgKeys.status() });
+    const signOut = await screen.findByRole('button', { name: 'Sign out' });
+
+    // 3. Sign out returns us to the signed-out card. logout's onSuccess
+    //    invalidates the status query, which now reports signed-out.
+    statusValue = { signedIn: false };
+    fireEvent.click(signOut);
+
+    // The signed-out card comes back...
+    await screen.findByPlaceholderText('••••••');
+    // ...and the stale error must be gone.
+    await waitFor(() => expect(screen.queryByText('google boom')).toBeNull());
+  });
+});

--- a/app/renderer/src/routes/settings/OrganisationTab.tsx
+++ b/app/renderer/src/routes/settings/OrganisationTab.tsx
@@ -119,6 +119,7 @@ export function OrganisationTab() {
   };
 
   const onSignOut = async () => {
+    setError(null);
     try {
       await logoutMutation.mutateAsync();
     } catch (e) {
@@ -271,7 +272,18 @@ export function OrganisationTab() {
                   className="h-[30px] rounded-[6px] text-[13px]"
                   disabled={busy}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') void onSignIn();
+                    // Mirror the Sign-in button's own disabled guard so the
+                    // Enter shortcut can't fire a login while it's busy or a
+                    // required field is empty (#305).
+                    if (
+                      e.key === 'Enter' &&
+                      !busy &&
+                      adapterUrl &&
+                      email &&
+                      password
+                    ) {
+                      void onSignIn();
+                    }
                   }}
                 />
               </div>

--- a/app/renderer/src/routes/settings/TemplatesTab.test.tsx
+++ b/app/renderer/src/routes/settings/TemplatesTab.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TemplatesTab } from './TemplatesTab';
+
+// A failed template delete must not become an unhandled promise rejection with
+// no user feedback: the dialog stays open and surfaces a visible error so the
+// user can retry (#308).
+
+const remove = vi.fn(async () => ({ success: true }));
+
+vi.mock('@/lib/ipc', () => ({
+  ipc: () => ({
+    templates: {
+      list: async () => ({
+        success: true,
+        default_template_id: 'standard',
+        templates: [
+          {
+            id: 'custom-1',
+            name: 'My Custom',
+            prompt: 'Do the thing',
+            builtin: false,
+            locked: false,
+          },
+        ],
+      }),
+      remove,
+      save: async () => ({ success: true }),
+      setDefault: async () => ({ success: true }),
+      reset: async () => ({ success: true }),
+    },
+  }),
+}));
+
+function renderTab() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TemplatesTab />
+    </QueryClientProvider>,
+  );
+}
+
+describe('TemplatesTab delete failure', () => {
+  beforeEach(() => {
+    remove.mockReset();
+  });
+
+  test('a rejected delete keeps the dialog open and shows an error', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (e: PromiseRejectionEvent) => unhandled.push(e.reason);
+    window.addEventListener('unhandledrejection', onUnhandled);
+
+    remove.mockRejectedValue(new Error('backend exploded'));
+    renderTab();
+
+    // Open the confirm dialog for the custom template.
+    const del = await screen.findByRole('button', { name: 'Delete My Custom' });
+    fireEvent.click(del);
+    const confirm = await screen.findByRole('button', { name: 'Delete' });
+
+    // Confirm the delete — the mutation rejects.
+    fireEvent.click(confirm);
+
+    // A visible error surfaces...
+    await screen.findByText(/backend exploded/i);
+    // ...and the dialog stays open (its title is still present; getByText
+    // throws if absent).
+    expect(screen.getByText('Delete template "My Custom"?')).toBeTruthy();
+
+    // Let any microtasks settle, then assert nothing escaped unhandled.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(unhandled).toEqual([]);
+
+    window.removeEventListener('unhandledrejection', onUnhandled);
+  });
+});

--- a/app/renderer/src/routes/settings/TemplatesTab.tsx
+++ b/app/renderer/src/routes/settings/TemplatesTab.tsx
@@ -48,6 +48,10 @@ export function TemplatesTab() {
   const [editing, setEditing] = React.useState<Partial<Template> | null>(null);
   // Template pending deletion → drives the confirmation dialog.
   const [deleteTarget, setDeleteTarget] = React.useState<Template | null>(null);
+  // Surfaced inside the confirm dialog when a delete fails, so a rejected
+  // mutation isn't a silent unhandled rejection (#308). Cleared whenever the
+  // dialog closes or a new delete starts.
+  const [deleteError, setDeleteError] = React.useState<string | null>(null);
 
   if (editing) {
     return (
@@ -207,7 +211,10 @@ export function TemplatesTab() {
                           COMPACT_BTN,
                           'text-[color:var(--fg-2)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
                         )}
-                        onClick={() => setDeleteTarget(t)}
+                        onClick={() => {
+                          setDeleteError(null);
+                          setDeleteTarget(t);
+                        }}
                         aria-label={`Delete ${t.name}`}
                       >
                         <Trash2 size={14} />
@@ -223,16 +230,46 @@ export function TemplatesTab() {
 
       <ConfirmDialog
         open={!!deleteTarget}
-        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        onOpenChange={(o) => {
+          if (!o) {
+            setDeleteTarget(null);
+            setDeleteError(null);
+          }
+        }}
         title={deleteTarget ? `Delete template "${deleteTarget.name}"?` : ''}
-        description="This permanently deletes the template. Reports already generated from it are not affected."
+        description={
+          <>
+            This permanently deletes the template. Reports already generated
+            from it are not affected.
+            {deleteError && (
+              <span
+                role="alert"
+                style={{
+                  display: 'block',
+                  marginTop: 8,
+                  color: 'var(--accent-danger)',
+                }}
+              >
+                {deleteError}
+              </span>
+            )}
+          </>
+        }
         confirmLabel="Delete"
         destructive
         isPending={del.isPending}
         onConfirm={async () => {
           if (!deleteTarget) return;
-          await del.mutateAsync(deleteTarget.id);
-          setDeleteTarget(null);
+          setDeleteError(null);
+          try {
+            await del.mutateAsync(deleteTarget.id);
+            setDeleteTarget(null);
+          } catch (e) {
+            // Keep the dialog open so the user can retry; surface why.
+            setDeleteError(
+              e instanceof Error ? e.message : 'Failed to delete template.',
+            );
+          }
         }}
       />
     </section>

--- a/app/renderer/src/routes/settings/model-card.test.tsx
+++ b/app/renderer/src/routes/settings/model-card.test.tsx
@@ -1,0 +1,25 @@
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ModelCard } from './model-card';
+
+// The icon-only delete-model button needs an accessible name for screen
+// readers; the sighted-only `title` tooltip is not exposed as the accessible
+// name reliably (#309).
+
+describe('ModelCard delete button', () => {
+  test('the delete-model button has an accessible name', () => {
+    render(
+      <ModelCard
+        name="gemma3:12b"
+        isCurrent={false}
+        isInstalled
+        onSelect={vi.fn()}
+        onDeleteModel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Delete model' }),
+    ).toBeTruthy();
+  });
+});

--- a/app/renderer/src/routes/settings/model-card.tsx
+++ b/app/renderer/src/routes/settings/model-card.tsx
@@ -298,6 +298,7 @@ export function ModelCard({
             <button
               type="button"
               onClick={onDeleteModel}
+              aria-label="Delete model"
               title="Delete this model to free up disk space"
               className="flex size-[28px] cursor-pointer items-center justify-center rounded-[6px] border-0 bg-transparent"
               style={{ color: 'var(--fg-muted)' }}

--- a/e2e/specs/settings-roundtrip.t2.spec.ts
+++ b/e2e/specs/settings-roundtrip.t2.spec.ts
@@ -144,3 +144,50 @@ test('set-storage-path persists the path and provisions its data subdirs', async
   // Keystone: the real user-data dir is byte-for-byte untouched.
   expect(fileSig(realUserDataDir())).toBe(realDirBefore);
 });
+
+// Drives the REAL Advanced-tab "Reset" button through the rendered UI — not the
+// settings bridge — because the #304 bug lived purely in the button's onClick
+// (it passed the default *path* to setStoragePath, which the backend records as
+// a fresh custom override, so Reset hid itself without resetting anything). The
+// bridge itself was always correct, so a `setStoragePath('')` call can't catch
+// this regression; only a real click can.
+test('Advanced-tab Reset button clears the custom storage path (#304); real dir untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // Setup (not under test): seed a custom path via the bridge so the Reset
+  // button is rendered (it only shows when custom_path differs from default).
+  const custom = path.join(userDataDir, 'custom-storage-reset');
+  const res = await page.evaluate(
+    (p) => (window as StenoWindow).stenoai.settings.setStoragePath(p),
+    custom,
+  );
+  expect(res.success).toBe(true);
+  await expect.poll(() => readUserConfig(userDataDir).storage_path).toBe(custom);
+
+  // Navigate the UI to Settings > Advanced (hash-router deep link — same pattern
+  // as org-lock-lifecycle.t2). A fresh mount refetches the storage path so the
+  // Reset button reflects the seeded custom value.
+  await page.evaluate(() => {
+    window.location.hash = '#/settings?tab=advanced';
+  });
+
+  const resetButton = page.getByRole('button', { name: /^reset$/i });
+  await expect(resetButton).toBeVisible();
+
+  // The click under test: fixed handler sends '' (reset), not the default path.
+  await resetButton.click();
+
+  // Backend truth: the custom override is cleared to the empty sentinel — NOT
+  // rewritten as the default path string (the exact shape of the #304 bug).
+  await expect.poll(() => readUserConfig(userDataDir).storage_path).toBe('');
+
+  // UI truth: with no custom override left, the Reset button hides itself.
+  await expect(resetButton).toBeHidden();
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});


### PR DESCRIPTION
## What & why

While reviewing #289 (the mechanical Settings.tsx tab split), cubic flagged 8 behavioral/a11y issues in the extracted code. All 8 were confirmed present identically in `main`'s current monolithic `Settings.tsx` before the split — pre-existing bugs, not introduced by #289. This PR fixes 4 of the 6 follow-up issues filed for them (the small, independent ones); a sibling PR covers the other 2 (OAuth cancel race + name-seed race in `GeneralTab.tsx`).

Stacked on `chore/278-settings-split` (#289) since the code only exists in that shape there — this will auto-retarget to `main` once #289 merges.

## What's in this PR

- **#304** — Settings > Advanced: "Reset" storage-location button now actually clears the custom path (`mutate('')` instead of `mutate(default_path)`), with a UI-driven e2e test proving it (mutation-tested: fails against the old handler, passes against the fix).
- **#305** — Settings > Organisation: Enter-key sign-in now respects the same busy/required-field guard as the button; sign-out clears a stale prior error, matching sign-in.
- **#308** — Settings > Templates: a failed template delete now surfaces a visible error and keeps the dialog open for retry, instead of an unhandled promise rejection.
- **#309** — Settings: the icon-only delete-model button gets an explicit `aria-label` alongside its `title`.

Reviewed by Codex (`/codex:review` against this branch's base) — no actionable findings.

## Test plan

- [x] `npm run typecheck:renderer` clean
- [x] `npm run lint:renderer` clean (no new warnings)
- [x] `npm run test:unit` — all unit/component tests green, including new tests per fix
- [x] New e2e test for #304 (`settings-roundtrip.t2.spec.ts`) — verified locally, including a mutation test (temporarily reverted the fix, confirmed the test fails; restored, confirmed it passes)

Fixes #304, Fixes #305, Fixes #308, Fixes #309

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four pre-existing Settings bugs found during the tab-split review to improve reliability, error handling, and accessibility. Adds focused unit and e2e tests to prevent regressions.

- **Bug Fixes**
  - Advanced: Reset storage location now truly clears the custom path (sends ''), with a real UI e2e test and a unit test.
  - Organisation: Enter-to-sign-in respects disabled/busy guards; sign-out clears stale errors. Tests cover both paths.
  - Templates: Failed delete shows an error and keeps the dialog open for retry (no unhandled rejection), with test coverage.
  - Models: Icon-only delete-model button now has aria-label="Delete model" for screen readers, with an accessibility test.

<sup>Written for commit 4d3592b7653ae7c83fcd45e4756329722e54435e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

