### PR TITLE
fix(settings): OAuth cancel race + name-seed race in GeneralTab (#289 split follow-up)

### DIFF
--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -192,6 +192,37 @@ describe('GeneralTab OAuth connect/cancel race (#306)', () => {
     expect(screen.queryByText("Couldn't connect to Google")).toBeNull();
   });
 
+  test("a stale same-provider retry's late rejection does not overwrite the fresh attempt", async () => {
+    const firstAttempt = h.defer<void>();
+    // First Google attempt gets a controllable promise; the retry falls back to
+    // the default never-resolving mock, so it stays pending.
+    h.google.connect.mutateAsync.mockReturnValueOnce(firstAttempt.promise);
+    render(<GeneralTab />);
+
+    await act(async () => {
+      clickConnect('Google');
+    });
+    await act(async () => {
+      clickCancel();
+    });
+    // Immediately retry the SAME provider — a fresh pending attempt.
+    await act(async () => {
+      clickConnect('Google');
+    });
+    expect(screen.getByText('Connecting to Google')).toBeTruthy();
+
+    // The original (abandoned) attempt rejects late with a non-Cancelled error.
+    // provider + state still superficially match the fresh attempt, so only the
+    // attempt token can tell them apart.
+    await act(async () => {
+      firstAttempt.reject(new Error('Timed out — no response from Google.'));
+      await firstAttempt.promise.catch(() => {});
+    });
+
+    expect(screen.getByText('Connecting to Google')).toBeTruthy();
+    expect(screen.queryByText("Couldn't connect to Google")).toBeNull();
+  });
+
   test('two synchronous Connect clicks fire only one connect mutation', async () => {
     render(<GeneralTab />);
     const btn = screen.getByRole('button', { name: 'Google' });

--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -209,3 +209,23 @@ describe('GeneralTab OAuth connect/cancel race (#306)', () => {
     expect(h.google.connect.mutateAsync).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('GeneralTab name-field seed race (#307)', () => {
+  test('typing before the userName query resolves is not overwritten by the seed', async () => {
+    h.userName = { data: undefined, isPending: true, isPlaceholderData: false };
+    const { rerender } = render(<GeneralTab />);
+
+    const input = screen.getByTestId('user-name-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Ruzin' } });
+    expect(input.value).toBe('Ruzin');
+
+    // The canonical value now arrives from disk.
+    h.userName = { data: 'Old Name', isPending: false, isPlaceholderData: false };
+    await act(async () => {
+      rerender(<GeneralTab />);
+    });
+
+    // The user's in-progress edit must survive the late seed.
+    expect((screen.getByTestId('user-name-input') as HTMLInputElement).value).toBe('Ruzin');
+  });
+});

--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -174,9 +174,8 @@ describe('GeneralTab OAuth connect/cancel race (#306)', () => {
     await act(async () => {
       clickCancel();
     });
-    // Simulate react-query settling Google's pending flag after the cancel so
-    // the in-flight guard lets Outlook start (same window Home.tsx accepts).
-    h.google.connect.isPending = false;
+    // Cancel released the in-flight lock, so a fresh provider can start even
+    // while Google's abandoned mutation is still unsettled.
 
     await act(async () => {
       clickConnect('Outlook');
@@ -193,19 +192,20 @@ describe('GeneralTab OAuth connect/cancel race (#306)', () => {
     expect(screen.queryByText("Couldn't connect to Google")).toBeNull();
   });
 
-  test('double-clicking Connect while pending does not fire a second mutation', async () => {
+  test('two synchronous Connect clicks fire only one connect mutation', async () => {
     render(<GeneralTab />);
-    await act(async () => {
-      clickConnect('Google');
-    });
-    expect(h.google.connect.mutateAsync).toHaveBeenCalledTimes(1);
+    const btn = screen.getByRole('button', { name: 'Google' });
 
-    // react-query flips the connect mutation to pending; a second click within
-    // that window must be dropped by the in-flight guard.
-    h.google.connect.isPending = true;
+    // Fire both clicks inside a SINGLE act with no await/flush between them, so
+    // React has not re-rendered with the mutation's pending=true state yet.
+    // A guard that reads react-query's isPending would see the stale false
+    // snapshot on both and let two mutate()s through; a synchronous ref lock
+    // (set before the first mutate) must drop the second.
     await act(async () => {
-      clickConnect('Google');
+      btn.click();
+      btn.click();
     });
+
     expect(h.google.connect.mutateAsync).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -1,0 +1,211 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+/**
+ * Race coverage for GeneralTab's calendar OAuth flow (#306) and the name-field
+ * seed race (#307). Both are pre-existing behavioural bugs surfaced during the
+ * Settings.tsx split review.
+ *
+ * These are unit tests, not Playwright: the connect/cancel mutations are mocked
+ * so their promises resolve/reject by hand, making each race deterministic (no
+ * real UI timing). The calendar + settings hooks are mocked directly (simpler
+ * than mocking the ipc layer under two hook modules) so mutation pending/error
+ * states can be controlled precisely per test.
+ */
+
+const h = vi.hoisted(() => {
+  function defer<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+  const makeAuth = () => ({
+    status: { data: { connected: false } },
+    connect: {
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(() => new Promise<void>(() => {})),
+      isPending: false,
+      error: null as Error | null,
+      reset: vi.fn(),
+    },
+    cancel: { mutate: vi.fn() },
+    disconnect: { mutate: vi.fn() },
+  });
+  return {
+    defer,
+    google: makeAuth(),
+    outlook: makeAuth(),
+    userName: { data: undefined as string | undefined, isPending: true, isPlaceholderData: false },
+    setUserName: { mutate: vi.fn() },
+  };
+});
+
+vi.mock('@/hooks/useCalendarEvents', () => ({
+  useGoogleCalendarAuth: () => h.google,
+  useOutlookCalendarAuth: () => h.outlook,
+}));
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useSettings', () => {
+  const q = (data: unknown) => ({ data, isPending: false, isPlaceholderData: false });
+  const m = () => ({ mutate: vi.fn() });
+  return {
+    useNotificationsSetting: () => q(true),
+    useSetNotifications: m,
+    useSystemAudioSetting: () => q(true),
+    useSetSystemAudio: m,
+    useSystemAudioSupport: () => q({ supported: true, osVersion: '14.4' }),
+    useAutoDetectMeetingsSetting: () => q(true),
+    useSetAutoDetectMeetings: m,
+    useSilenceAutoStopSetting: () =>
+      q({ enabled: true, minutes: 15, supportedMinutes: [2, 5, 10, 15, 30] }),
+    useSetSilenceAutoStopEnabled: m,
+    useSetSilenceAutoStopMinutes: m,
+    useDockIconSetting: () => q(false),
+    useSetDockIcon: m,
+    useUserName: () => h.userName,
+    useSetUserName: () => h.setUserName,
+  };
+});
+
+// Import after the mocks are registered.
+import { GeneralTab } from './GeneralTab';
+
+function resetAuth(auth: typeof h.google) {
+  auth.status.data = { connected: false };
+  auth.connect.mutate.mockReset();
+  auth.connect.mutateAsync.mockReset();
+  auth.connect.mutateAsync.mockImplementation(() => new Promise<void>(() => {}));
+  auth.connect.isPending = false;
+  auth.connect.error = null;
+  auth.cancel.mutate.mockReset();
+  auth.disconnect.mutate.mockReset();
+}
+
+beforeEach(() => {
+  resetAuth(h.google);
+  resetAuth(h.outlook);
+  h.userName = { data: undefined, isPending: true, isPlaceholderData: false };
+  h.setUserName.mutate.mockReset();
+});
+
+// hidden:true because once the OAuth dialog is open (modal), Radix marks the
+// rest of the page aria-hidden — the settings connect buttons are still in the
+// DOM and clickable, just excluded from the default accessibility query.
+const clickConnect = (name: 'Google' | 'Outlook') =>
+  fireEvent.click(screen.getByRole('button', { name, hidden: true }));
+const clickCancel = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+describe('GeneralTab OAuth connect/cancel race (#306)', () => {
+  test('Cancel while a connect is pending calls the provider cancel mutation', async () => {
+    render(<GeneralTab />);
+    await act(async () => {
+      clickConnect('Google');
+    });
+    // Dialog is showing the pending state.
+    expect(screen.getByText('Connecting to Google')).toBeTruthy();
+
+    await act(async () => {
+      clickCancel();
+    });
+    expect(h.google.cancel.mutate).toHaveBeenCalledTimes(1);
+    expect(h.outlook.cancel.mutate).not.toHaveBeenCalled();
+    // Dialog closed.
+    expect(screen.queryByText('Connecting to Google')).toBeNull();
+  });
+
+  test("a 'Cancelled' rejection after dismiss does not reopen an error dialog", async () => {
+    const d = h.defer<void>();
+    h.google.connect.mutateAsync.mockReturnValueOnce(d.promise);
+    render(<GeneralTab />);
+
+    await act(async () => {
+      clickConnect('Google');
+    });
+    await act(async () => {
+      clickCancel();
+    });
+    // The connect mutation now rejects with the user-cancel contract message.
+    await act(async () => {
+      d.reject(new Error('Cancelled'));
+      await d.promise.catch(() => {});
+    });
+
+    expect(screen.queryByText("Couldn't connect to Google")).toBeNull();
+    expect(screen.queryByText('Connecting to Google')).toBeNull();
+  });
+
+  test('a late rejection after dismiss does not resurrect the dialog', async () => {
+    const d = h.defer<void>();
+    h.google.connect.mutateAsync.mockReturnValueOnce(d.promise);
+    render(<GeneralTab />);
+
+    await act(async () => {
+      clickConnect('Google');
+    });
+    await act(async () => {
+      clickCancel();
+    });
+    await act(async () => {
+      d.reject(new Error('Timed out — no response from Google.'));
+      await d.promise.catch(() => {});
+    });
+
+    expect(screen.queryByText("Couldn't connect to Google")).toBeNull();
+    expect(screen.queryByText('Connecting to Google')).toBeNull();
+  });
+
+  test("a late rejection for provider A does not clobber provider B's pending state", async () => {
+    const dGoogle = h.defer<void>();
+    h.google.connect.mutateAsync.mockReturnValueOnce(dGoogle.promise);
+    render(<GeneralTab />);
+
+    await act(async () => {
+      clickConnect('Google');
+    });
+    await act(async () => {
+      clickCancel();
+    });
+    // Simulate react-query settling Google's pending flag after the cancel so
+    // the in-flight guard lets Outlook start (same window Home.tsx accepts).
+    h.google.connect.isPending = false;
+
+    await act(async () => {
+      clickConnect('Outlook');
+    });
+    expect(screen.getByText('Connecting to Outlook')).toBeTruthy();
+
+    // Google's abandoned attempt now rejects late — must not touch the dialog.
+    await act(async () => {
+      dGoogle.reject(new Error('Timed out — no response from Google.'));
+      await dGoogle.promise.catch(() => {});
+    });
+
+    expect(screen.getByText('Connecting to Outlook')).toBeTruthy();
+    expect(screen.queryByText("Couldn't connect to Google")).toBeNull();
+  });
+
+  test('double-clicking Connect while pending does not fire a second mutation', async () => {
+    render(<GeneralTab />);
+    await act(async () => {
+      clickConnect('Google');
+    });
+    expect(h.google.connect.mutateAsync).toHaveBeenCalledTimes(1);
+
+    // react-query flips the connect mutation to pending; a second click within
+    // that window must be dropped by the in-flight guard.
+    h.google.connect.isPending = true;
+    await act(async () => {
+      clickConnect('Google');
+    });
+    expect(h.google.connect.mutateAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -228,4 +228,27 @@ describe('GeneralTab name-field seed race (#307)', () => {
     // The user's in-progress edit must survive the late seed.
     expect((screen.getByTestId('user-name-input') as HTMLInputElement).value).toBe('Ruzin');
   });
+
+  test('the field re-syncs from userName.data after the edit is committed on blur', async () => {
+    h.userName = { data: undefined, isPending: true, isPlaceholderData: false };
+    const { rerender } = render(<GeneralTab />);
+
+    const input = screen.getByTestId('user-name-input') as HTMLInputElement;
+    // Edit before the query resolves, then clear back to the placeholder ('').
+    fireEvent.change(input, { target: { value: 'X' } });
+    fireEvent.change(input, { target: { value: '' } });
+    // Blur commits: trimmed '' equals the (still-unresolved) placeholder '', so
+    // nothing is persisted — but the editing session is now over.
+    fireEvent.blur(input);
+    expect(h.setUserName.mutate).not.toHaveBeenCalled();
+
+    // The canonical value now arrives from disk. Since the edit was committed
+    // (and saved nothing), the field must re-sync to it rather than stay blank.
+    h.userName = { data: 'Ruzin', isPending: false, isPlaceholderData: false };
+    await act(async () => {
+      rerender(<GeneralTab />);
+    });
+
+    expect((screen.getByTestId('user-name-input') as HTMLInputElement).value).toBe('Ruzin');
+  });
 });

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -107,17 +107,41 @@ export function GeneralTab() {
   }, [oauth, google.status.data?.connected, outlook.status.data?.connected]);
 
   const startConnect = async (provider: 'google' | 'outlook') => {
+    // In-flight guard: drop rapid duplicate clicks before React has flushed
+    // isPending through, so a double-click can't fire two connect mutations
+    // (each starts its own loopback OAuth server in the main process).
+    if (google.connect.isPending || outlook.connect.isPending) return;
     setOauth({ provider, state: 'pending' });
     try {
       if (provider === 'google') await google.connect.mutateAsync();
       else await outlook.connect.mutateAsync();
     } catch (err) {
-      setOauth({
-        provider,
-        state: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      });
+      const message = err instanceof Error ? err.message : String(err);
+      // A user-initiated Cancel rejects the connect mutation with "Cancelled"
+      // (see useGoogleCalendarAuth/useOutlookCalendarAuth) — not an error to
+      // surface back to the user.
+      if (message === 'Cancelled') return;
+      // Only surface the error if the dialog is STILL showing this same
+      // provider as pending. A stale/late rejection (e.g. from a provider the
+      // user cancelled and then switched away from) must not resurrect a
+      // dismissed dialog or clobber a different provider's newer attempt.
+      setOauth((current) =>
+        current?.provider === provider && current.state === 'pending'
+          ? { provider, state: 'error', message }
+          : current,
+      );
     }
+  };
+
+  const cancelConnect = () => {
+    // Abort the in-flight handshake so we don't leak a loopback OAuth server
+    // that could silently complete the connection (and save tokens) after the
+    // user has already backed out of the dialog.
+    if (oauth?.state === 'pending') {
+      if (oauth.provider === 'google') google.cancel.mutate();
+      else outlook.cancel.mutate();
+    }
+    setOauth(null);
   };
 
   return (
@@ -211,7 +235,7 @@ export function GeneralTab() {
 
       <OAuthPrompt
         state={oauth}
-        onClose={() => setOauth(null)}
+        onClose={cancelConnect}
         onRetry={() => oauth && void startConnect(oauth.provider)}
       />
 

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -62,10 +62,10 @@ export function GeneralTab() {
   const setUserName = useSetUserName();
   const [nameDraft, setNameDraft] = React.useState('');
   const nameSeededRef = React.useRef(false);
-  // Tracks whether the user has typed into the field. If they start editing
-  // before the query resolves, a late seed must not clobber their input — and
-  // this stays true even if they clear the field back to empty, so an
-  // intentionally-blanked field isn't re-seeded either.
+  // Tracks in-flight typing so a late initial fetch can't clobber the user's
+  // draft. Set on the first edit, and released again by persistName on blur —
+  // the danger window is only mount → first commit, so once the edit is
+  // committed the seeding effect is free to re-sync from userName.data.
   const nameDirtyRef = React.useRef(false);
   // Wait for the real query (not the sessionStorage placeholder) before
   // seeding — otherwise we lock onto a stale empty string and ignore the
@@ -81,8 +81,16 @@ export function GeneralTab() {
   }, [userName.data, userName.isPending, userName.isPlaceholderData]);
   const persistName = () => {
     const trimmed = nameDraft.trim();
-    if (trimmed === (userName.data ?? '')) return;
-    setUserName.mutate(trimmed);
+    if (trimmed !== (userName.data ?? '')) {
+      setUserName.mutate(trimmed);
+    }
+    // The editing session is over (committed on blur/Enter), so there's no more
+    // in-flight typing to protect. Release the dirty guard so the seeding effect
+    // can re-sync from any later userName.data change — the backend's canonical
+    // value, or a refetch after the mutation invalidates. Otherwise a no-op
+    // commit (draft equal to the not-yet-resolved placeholder) would leave the
+    // guard stuck and the field stranded on a stale/blank draft.
+    nameDirtyRef.current = false;
   };
 
   const calendarConnected =

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -62,11 +62,17 @@ export function GeneralTab() {
   const setUserName = useSetUserName();
   const [nameDraft, setNameDraft] = React.useState('');
   const nameSeededRef = React.useRef(false);
+  // Tracks whether the user has typed into the field. If they start editing
+  // before the query resolves, a late seed must not clobber their input — and
+  // this stays true even if they clear the field back to empty, so an
+  // intentionally-blanked field isn't re-seeded either.
+  const nameDirtyRef = React.useRef(false);
   // Wait for the real query (not the sessionStorage placeholder) before
   // seeding — otherwise we lock onto a stale empty string and ignore the
   // canonical value when it arrives from disk.
   React.useEffect(() => {
     if (nameSeededRef.current) return;
+    if (nameDirtyRef.current) return;
     if (userName.isPending || userName.isPlaceholderData) return;
     if (userName.data !== undefined) {
       setNameDraft(userName.data);
@@ -152,7 +158,10 @@ export function GeneralTab() {
       >
         <Input
           value={nameDraft}
-          onChange={(e) => setNameDraft(e.target.value)}
+          onChange={(e) => {
+            nameDirtyRef.current = true;
+            setNameDraft(e.target.value);
+          }}
           onBlur={persistName}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -112,11 +112,19 @@ export function GeneralTab() {
     }
   }, [oauth, google.status.data?.connected, outlook.status.data?.connected]);
 
+  // Synchronous in-flight lock. react-query's isPending only flips true on the
+  // NEXT render, so two clicks handled in the same tick both read a stale
+  // false and slip past an isPending-based guard; a ref set before the first
+  // mutate closes that exact window. The token distinguishes attempts so a
+  // superseded attempt's settle (a cancel or a newer startConnect took over)
+  // can't release a still-active attempt's lock.
+  const connectingRef = React.useRef(false);
+  const connectTokenRef = React.useRef(0);
+
   const startConnect = async (provider: 'google' | 'outlook') => {
-    // In-flight guard: drop rapid duplicate clicks before React has flushed
-    // isPending through, so a double-click can't fire two connect mutations
-    // (each starts its own loopback OAuth server in the main process).
-    if (google.connect.isPending || outlook.connect.isPending) return;
+    if (connectingRef.current) return;
+    connectingRef.current = true;
+    const token = ++connectTokenRef.current;
     setOauth({ provider, state: 'pending' });
     try {
       if (provider === 'google') await google.connect.mutateAsync();
@@ -136,6 +144,10 @@ export function GeneralTab() {
           ? { provider, state: 'error', message }
           : current,
       );
+    } finally {
+      // Release only if this is still the active attempt — a cancel or a newer
+      // startConnect may have superseded it and now owns the lock.
+      if (connectTokenRef.current === token) connectingRef.current = false;
     }
   };
 
@@ -147,6 +159,9 @@ export function GeneralTab() {
       if (oauth.provider === 'google') google.cancel.mutate();
       else outlook.cancel.mutate();
     }
+    // Release the lock immediately so the user can retry or switch providers
+    // without waiting for the abandoned mutation to reject.
+    connectingRef.current = false;
     setOauth(null);
   };
 

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -143,12 +143,15 @@ export function GeneralTab() {
       // (see useGoogleCalendarAuth/useOutlookCalendarAuth) — not an error to
       // surface back to the user.
       if (message === 'Cancelled') return;
-      // Only surface the error if the dialog is STILL showing this same
-      // provider as pending. A stale/late rejection (e.g. from a provider the
-      // user cancelled and then switched away from) must not resurrect a
-      // dismissed dialog or clobber a different provider's newer attempt.
+      // Only surface the error if THIS attempt is still the active one. The
+      // token check catches a cancel-then-immediate-retry of the same provider,
+      // where a newer attempt is also `pending`/same-provider — provider+state
+      // alone can't tell the stale rejection apart from the fresh dialog. It
+      // also covers a dismissed dialog or a switch to a different provider.
       setOauth((current) =>
-        current?.provider === provider && current.state === 'pending'
+        connectTokenRef.current === token &&
+        current?.provider === provider &&
+        current.state === 'pending'
           ? { provider, state: 'error', message }
           : current,
       );


### PR DESCRIPTION
## What & why

Sibling PR to #311 — same origin: cubic flagged pre-existing bugs during the #289 (Settings.tsx tab split) review, confirmed present identically in `main` before the split. This PR covers the two riskier ones, both in `GeneralTab.tsx`'s calendar OAuth connect flow and name-field seeding, so they got their own PR and extra review passes.

Stacked on `chore/278-settings-split` (#289) — will auto-retarget to `main` once #289 merges.

## What's in this PR

- **#306** — OAuth connect/cancel race:
  - Cancel now actually cancels the in-flight handshake (calls the provider's `cancel` mutation) instead of just closing the dialog — previously the loopback OAuth server kept running and could silently complete the connection after the user backed out.
  - A synchronous ref lock replaces an `isPending`-based in-flight guard that could race on rapid double-clicks (same weakness as the `Home.tsx` reference pattern this was ported from — found by Codex review here and fixed properly).
  - Stale/cancelled rejections (`'Cancelled'` and otherwise) can no longer resurrect a dismissed dialog or overwrite a different/fresher attempt for the same provider — the latter needed an attempt-token check, not just provider/state (also a Codex finding).
- **#307** — the display-name field's seed-from-fetch race:
  - No longer clobbers keystrokes typed before the initial fetch resolves.
  - The dirty guard now releases once the edit is committed (blur), instead of permanently blocking re-sync for the component's whole lifetime — a second Codex finding on the first fix.

Went through 3 rounds of Codex review (`/codex:review` against this branch's base); the last pass reported no actionable findings.

## Test plan

- [x] `npm run typecheck:renderer` clean
- [x] `npm run lint:renderer` clean (no new warnings)
- [x] `npm run test:unit` — 41/41 green, including new deterministic component tests for every race described above (each written test-first, watched fail against the unfixed code)
- [ ] Manual dev-app sanity pass (connect → Cancel → confirm no error reappears) — not run in this environment (needs the PyInstaller-bundled backend); behavior is covered by the component tests instead

Fixes #306, Fixes #307

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two races in Settings → General. Canceling calendar OAuth now aborts the backend handshake and prevents stale errors (including same‑provider retries) or double-connects; the display-name field no longer gets overwritten by a late seed and re-syncs after commit. Fixes #306 and #307.

- **Bug Fixes**
  - Calendar OAuth: Cancel calls the provider `cancel` mutation, immediately releases the in-flight lock, ignores "Cancelled" rejections, and uses an attempt token so late errors can’t resurrect or overwrite a newer attempt. A synchronous ref lock prevents double-click double-connects.
  - Display name: Early typing isn’t clobbered by a late seed. The dirty guard clears on blur/Enter so the field re-syncs from `userName.data` after a committed edit.
  - Added deterministic unit tests in `GeneralTab.test.tsx`.

<sup>Written for commit e0aff13a36dcaef5cf53f80da57258e1f75acded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

