### PR TITLE
chore(release): v0.5.8 — version bump + What's New

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
-- **2026-07-02** ⏱️ Transcript timestamps — every turn of your live and saved transcripts now shows a `[MM:SS]` timestamp, so you can see (and cite) when things were said.
-- **2026-07-02** ⚡ Faster on Apple Silicon — opt into Ollama's native MLX model builds for quicker summaries (Settings → "Switch to faster build"); your model choice and settings are preserved.
-- **2026-07-02** 🌍 Pin your meeting language — Parakeet users can now pin a European language (French, German, Spanish, Dutch, Portuguese) so summaries and notes come out in it, not English.
-- **2026-07-02** 🧹 Cleaner summaries — reasoning-model "thinking" blocks are stripped before your notes render, so scratchpad text never leaks into a summary.
+- **2026-07-05** 🔓 Notes on demand — turn off "Generate notes automatically" (Settings) and a recording stops at a transcript-only note; generate the AI summary whenever you're ready.
+- **2026-07-05** 🗣️ Sharper speaker labels — the live transcript now uses true per-channel attribution, so `[You]` vs `[Others]` is far more accurate.
+- **2026-07-04** 🎨 Template gallery — pick from a curated set of built-in note templates, with a redesigned Templates settings and cloud-provider support.
+- **2026-07-04** 🔒 Privacy hardening — the shareable debug log no longer carries meeting content, and a new redacted "Save diagnostics" export keeps paths and PII out.
 
 
 ## Features

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",


### PR DESCRIPTION
Release prep for v0.5.8: bump app/package.json 0.5.7 → 0.5.8 and refresh the README 'What's New' marquee (notes-on-demand #276, per-channel speaker labels #284, template gallery #302/#298, privacy hardening #293/#294). The release gate runs on the `release/v0.5.8` branch next.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v0.5.8 release by bumping the version in `app/package.json` and updating README "What's New" to include notes on demand, per-channel speaker labels, a template gallery, and privacy hardening. This keeps docs current and unblocks the `release/v0.5.8` gate.

<sup>Written for commit 92e3f006956beb1e687f5d02fa052e3ea6dbb070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

