### PR TITLE
chore: gitignore the dev-only recordings/, transcripts/ and output/ dirs entirely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ eggs/
 lib/
 !app/renderer/src/lib/
 
-# Superpowers skill scratch — agent working notes, not project content.
-docs/
 lib64/
 parts/
 sdist/
@@ -185,6 +183,9 @@ SESSION_LOG.md
 FEATURES.md
 # Private, local-only working notes (design docs, benchmarks, review scratch) - never publish
 notes/
+# Local agent scratch (skill working notes, task specs) - never publish
+.superpowers/
+.specs/
 
 # Bundled Ollama binary (downloaded during build)
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -132,10 +132,13 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# StenoAI specific
-recordings/*.wav
-transcripts/*.txt
-output/*.json
+# StenoAI specific — dev-only scratch dirs (real user data lives in the app
+# data dir, see src.config.get_data_dirs()); ignore them entirely so meeting
+# audio/transcripts in subdirs or other formats (.m4a, .md, ...) can never be
+# staged by a broad git add
+recordings/
+transcripts/
+output/
 recorder_state*.json
 audio_buffer.npy
 


### PR DESCRIPTION
Follow-up to #296 (which did this for `notes/`). Two commits:

**1. Ignore the dev-only `recordings/`, `transcripts/` and `output/` dirs entirely**

The existing patterns only matched a single extension at the top level (`recordings/*.wav`, `transcripts/*.txt`, `output/*.json`), so meeting audio or transcripts in subdirectories or other formats - e.g. a local `recordings/archive/demo-meeting.m4a` - were still stageable by a broad `git add`. These dirs are dev-only scratch (real user data lives in the app data dir via `src.config.get_data_dirs()`), and nothing under them has ever been tracked (verified with `git log --all` over all three).

**2. Ignore agent scratch dirs, un-ignore the tracked `docs/` site**

- `.specs/` - a local spec file from this dir was accidentally committed and had to be reverted in #313; adding the ignore here so it can't happen again.
- `.superpowers/` - local agent working notes, previously only protected by a tool-written `.gitignore` inside one subdir.
- Drop the blanket `docs/` ignore (added in #95, pre-dating the Mintlify site): `docs/` is a fully tracked docs site now, and the stale entry made `git add` silently skip any **new** docs page - only already-tracked files were immune. Verified locally that a fresh `docs/*.mdx` shows up in `git status` again after the change.