### PR TITLE
fix(release): Steno naming in release copy + download guidance (#244)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -239,31 +239,33 @@ jobs:
     - name: Create Release with Assets
       uses: softprops/action-gh-release@v1
       with:
-        name: StenoAI ${{ github.event.inputs.version || steps.package_version.outputs.version }}
+        name: Steno ${{ github.event.inputs.version || steps.package_version.outputs.version }}
         body: |
-          ## StenoAI v${{ github.event.inputs.version || steps.package_version.outputs.version }}
+          ## Steno v${{ github.event.inputs.version || steps.package_version.outputs.version }}
 
           ${{ steps.tag_body.outputs.text }}
 
           ### Downloads
 
-          - **Apple Silicon (M1-M5)**: `stenoAI-macos-arm64.dmg`
+          - **Apple Silicon (M1-M5)**: [`stenoAI-macos-arm64.dmg`](https://github.com/${{ github.repository }}/releases/download/v${{ github.event.inputs.version || steps.package_version.outputs.version }}/stenoAI-macos-arm64.dmg)
+
+          The `.zip` and `.yml` assets below are used by the in-app auto-updater - no need to download them manually.
 
           ### First Time Setup
           1. Download the DMG
-          2. Install by dragging StenoAI to Applications
+          2. Install by dragging Steno to Applications
           3. Launch app - setup wizard runs automatically
           4. Grant microphone permissions when prompted
           5. Start recording meetings!
 
           ### Requirements
-          - **Apple Silicon Mac (M1 or later)** — Intel Macs are no longer supported as of v0.4.0
+          - **Apple Silicon Mac (M1 or later)** - Intel Macs are not supported (since v0.4.0)
           - macOS 12 (Monterey) or later
           - Internet connection for initial setup
           - Microphone access permissions
 
           ### Intel Mac users
-          v0.4.0 is **Apple Silicon only**. Intel users should stay on [v0.3.8](https://github.com/ruzin/stenoai/releases/tag/v0.3.8), which is the last release supporting Intel Macs. Auto-update on existing Intel installs is gated and will not push v0.4.0 to those machines.
+          Steno is **Apple Silicon only** (since v0.4.0). Intel users should stay on [v0.3.8](https://github.com/ruzin/stenoai/releases/tag/v0.3.8), the last release supporting Intel Macs. Auto-update on existing Intel installs is gated and will not offer newer versions to those machines.
         files: |
           release/*.dmg
           release/*.zip


### PR DESCRIPTION
Takes the low-risk **copy + UX** slice suggested in #244 - no artifact filename changes (the stable-URL `stenoAI-macos-arm64.dmg` alias is linked from the website, and `latest-mac.yml` drives auto-update, so renames need coordinated changes and stay out of scope; `appId`/URL scheme are intentionally untouched per the issue).

What changes on the next release page:

- Release title and body header say **Steno** instead of StenoAI (v0.5.8 just went out as "StenoAI 0.5.8" again).
- The Downloads entry is a **clickable link** to the stable-URL DMG instead of plain code text, and a one-liner explains that the `.zip`/`.yml` assets belong to the in-app auto-updater - the release page currently shows 4 macOS assets with no guidance.
- "dragging StenoAI to Applications" -> Steno.
- The Intel paragraph no longer hardcodes "v0.4.0 is Apple Silicon only" as if v0.4.0 were the current release - it now reads version-independently ("since v0.4.0") so it stops going staler with every release.

Verified: YAML parses; the download URL pattern matches the existing alias step (`cp "$dmg" stenoAI-macos-arm64.dmg`) and softprops/action-gh-release uploads it under exactly that name.

Leaves #244's artifact-rename part open - suggest keeping the issue open (or splitting) until someone wants to coordinate the website + workflow alias renames.

Fixes nothing automatically: intentionally NOT tagged with a closing keyword since it covers only part of #244. Refs #244.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the release workflow to use the Steno name and make the DMG download clear and clickable. Part of #244; copy/UX only—no artifact renames, `appId`, or URL scheme changes.

- **Refactors**
  - Release title and header: StenoAI → Steno.
  - DMG entry now links to stable `stenoAI-macos-arm64.dmg`; note clarifies `.zip`/`.yml` are for auto-update.
  - Setup step says “dragging Steno to Applications.”
  - Intel support note is version-independent (not supported since v0.4.0).

<sup>Written for commit 816b7478d66233966c4c265ab8455291f3a8b213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

