### PR TITLE
fix: strip reasoning blocks from AI outputs

### DIFF
--- a/app/renderer/src/components/home/PreviousRow.tsx
+++ b/app/renderer/src/components/home/PreviousRow.tsx
@@ -2,6 +2,7 @@ import { Folder as FolderIcon, Loader2 } from 'lucide-react';
 import type { Meeting } from '@/lib/ipc';
 import { navigate } from '@/lib/router';
 import { useMeetingsList } from '@/lib/meetingsListContext';
+import { stripReasoning } from '@/lib/markdown';
 
 interface PreviousRowProps {
   meeting: Meeting;
@@ -166,7 +167,7 @@ function formatDuration(seconds?: number): string | undefined {
 }
 
 function previewText(meeting: Meeting): string | undefined {
-  const summary = meeting.summary?.trim();
+  const summary = meeting.summary ? stripReasoning(meeting.summary).trim() : undefined;
   if (summary) return summary;
   const kp = meeting.key_points?.[0];
   if (typeof kp === 'string' && kp.trim()) return kp.trim();

--- a/app/renderer/src/lib/markdown.test.ts
+++ b/app/renderer/src/lib/markdown.test.ts
@@ -3,7 +3,7 @@ import { stripReasoning } from '@/lib/markdown';
 
 /**
  * Unit coverage for stripReasoning — the guard that removes `<think>` /
- * `<thought>` reasoning blocks emitted by some local models before the text is
+ * `<thought>` / `<thinking>` / `<reasoning>` reasoning blocks emitted by some local models before the text is
  * handed to the markdown renderer. The streaming case (an unclosed tag at the
  * end of a chunk) is the load-bearing edge: a half-streamed reasoning block
  * must not flash into the rendered summary.
@@ -16,9 +16,6 @@ describe('stripReasoning', () => {
 
   test('strips an unclosed reasoning block to the end of a streaming chunk', () => {
     const input = 'visible intro\n<think>still thinking and the chunk cut off here';
-    // The closing tag never arrives, so everything from <think> onward is dropped
-    // (only the trailing newline before the tag survives — strip trims leading,
-    // not trailing, whitespace).
     const result = stripReasoning(input);
     expect(result).toBe('visible intro\n');
     expect(result).not.toContain('still thinking');
@@ -32,5 +29,35 @@ describe('stripReasoning', () => {
   test('returns falsy/empty for empty input', () => {
     expect(stripReasoning('')).toBeFalsy();
     expect(stripReasoning('')).toBe('');
+  });
+
+  test('handles multiple blocks and nested/malformed tags', () => {
+    const input = 'A\n<think>1</think>\nB\n<thinking>2</thinking>\nC';
+    expect(stripReasoning(input)).toBe('A\nB\nC');
+  });
+
+  test('handles reasoning tags', () => {
+    const input = '<reasoning>...</reasoning>content';
+    expect(stripReasoning(input)).toBe('content');
+  });
+
+  test('handles nested tags (outer tag wins)', () => {
+    const input = '<think>outer<thinking>inner</thinking></think>content';
+    expect(stripReasoning(input)).toBe('content');
+  });
+
+  test('preserves spaces and formatting outside blocks', () => {
+    const input = '  # Hello \n\n<think>test</think>\nWorld';
+    expect(stripReasoning(input)).toBe('  # Hello \n\nWorld');
+  });
+
+  test('preserves leading formatting at document start when no reasoning block is present', () => {
+    const input = '  <think>test</think>\n  # Hello';
+    expect(stripReasoning(input)).toBe('  # Hello');
+  });
+
+  test('handles uppercase tags', () => {
+    const input = '<THINK>A</think>B';
+    expect(stripReasoning(input)).toBe('B');
   });
 });

--- a/app/renderer/src/lib/markdown.test.ts
+++ b/app/renderer/src/lib/markdown.test.ts
@@ -41,7 +41,7 @@ describe('stripReasoning', () => {
     expect(stripReasoning(input)).toBe('content');
   });
 
-  test('handles nested tags (outer tag wins)', () => {
+  test('handles different nested tags (outer tag wins)', () => {
     const input = '<think>outer<thinking>inner</thinking></think>content';
     expect(stripReasoning(input)).toBe('content');
   });

--- a/app/renderer/src/lib/markdown.tsx
+++ b/app/renderer/src/lib/markdown.tsx
@@ -10,7 +10,20 @@ import { cn } from '@/lib/utils';
 
 export function stripReasoning(text: string): string {
   if (!text) return text;
-  return text.replace(/<(think|thought)>[\s\S]*?(?:<\/\1>|$)/gi, '').trimStart();
+
+  const startsWithReasoning = /^\s*<(think|thought|thinking|reasoning)>/i.test(text);
+
+  // Consumes optional leading spaces on the line, the block, and one optional trailing newline.
+  let result = text.replace(
+    /(?:^[ \t]*)?<(think|thought|thinking|reasoning)>[\s\S]*?(?:<\/\1>|$(?![\s\S]))\n?/gim,
+    '',
+  );
+
+  if (startsWithReasoning) {
+    result = result.replace(/^\n+/, '');
+  }
+
+  return result;
 }
 
 export function renderMarkdown(text: string): React.ReactNode {

--- a/app/renderer/src/lib/noteSearch.ts
+++ b/app/renderer/src/lib/noteSearch.ts
@@ -1,4 +1,5 @@
 import type { Meeting } from '@/lib/ipc';
+import { stripReasoning } from '@/lib/markdown';
 
 /**
  * Single source of truth for note search. Case-insensitive substring match
@@ -15,7 +16,7 @@ export function searchNotes(meetings: Meeting[], query: string): Meeting[] {
   if (!needle) return [];
   return meetings.filter((m) => {
     const name = m.session_info.name?.toLowerCase() ?? '';
-    const summary = m.summary?.toLowerCase() ?? '';
+    const summary = m.summary ? stripReasoning(m.summary).toLowerCase() : '';
     return name.includes(needle) || summary.includes(needle);
   });
 }
@@ -30,7 +31,7 @@ export function snippet(
   query: string,
   radius = 40,
 ): string {
-  const text = (summary ?? '').replace(/\s+/g, ' ').trim();
+  const text = summary ? stripReasoning(summary).replace(/\s+/g, ' ').trim() : '';
   if (!text) return '';
   const needle = query.trim().toLowerCase();
   const idx = needle ? text.toLowerCase().indexOf(needle) : -1;

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -838,7 +838,7 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
           data-testid="report-content"
           style={{ color: 'var(--fg-1)', maxWidth: '72ch' }}
         >
-          <ReactMarkdown>{activeReport.content}</ReactMarkdown>
+          <ReactMarkdown>{stripReasoning(activeReport.content)}</ReactMarkdown>
         </section>
       ) : (
         <div className="flex flex-col gap-9">
@@ -1699,7 +1699,7 @@ export function pickTranscriptForShare(meeting: Meeting): string {
 export function composeShareBody(meeting: Meeting): string {
   const sections: string[] = [];
 
-  const summary = meeting.summary?.trim();
+  const summary = meeting.summary ? stripReasoning(meeting.summary).trim() : undefined;
   if (summary) {
     sections.push(`## Summary\n\n${summary}`);
   }

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -480,7 +480,7 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
       .filter(Boolean)
       .join(' · ');
     if (meta) lines.push(meta);
-    const summary = meeting.summary?.trim();
+    const summary = meeting.summary ? stripReasoning(meeting.summary).trim() : undefined;
     if (summary) {
       lines.push('', 'SUMMARY', summary);
     }

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -76,7 +76,7 @@ _AUTO_NAMED_PATTERN = re.compile(
 # tags specifically (not any HTML-like tag) so unrelated inline markup in the
 # model's output can't be mistaken for a reasoning block and get a spurious
 # section break inserted ahead of it.
-_REASONING_TAG_HEADER_PATTERN = re.compile(r'(</(?:think|thought)>)\s*(#{1,6}\s)', re.IGNORECASE)
+_REASONING_TAG_HEADER_PATTERN = re.compile(r'(</(?:think|thought|thinking|reasoning)>)\s*(#{1,6}\s)', re.IGNORECASE)
 
 def _normalize_markdown_for_parsing(md_text: str) -> str:
     """Ensure headers immediately following a reasoning tag start on a new line."""


### PR DESCRIPTION
This PR hardens the output sanitization layer to ensure that reasoning blocks (e.g., `<think>...</think>`) from models never leak into user-facing views or exports. It expands support for additional model tags, preserves original Markdown formatting more cleanly, and applies the sanitizer universally across all UI components and features.

**Changes:**
- **Sanitizer Improvements:** `stripReasoning` now supports `<thinking>`, `<thought>`, and `<reasoning>` tags. It preserves legitimate Markdown indentation and cleanly removes blank-line residue after a block is stripped.
- **Backend Parity:** Updated the Markdown normalizer (`simple_recorder.py`) to handle the expanded set of reasoning tags, keeping frontend and backend parsing logic in sync.
- **Universal Application:** Reasoning blocks are now consistently stripped from all user-facing paths. This resolves previous leaks in custom report rendering, shareable note uploads, clipboard copying, search indexing, and list previews.
- **Testing:** Expanded unit tests to cover the newly supported tags, formatting preservation, blank-line cleanup, and relevant streaming edge cases.