### PR TITLE
fix(meetings): Copy notes copies the open template report, not the Standard note

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -49,6 +49,23 @@ const SEED_MEETING = {
   discussion_areas: [],
 };
 
+// A generated template report attached to SEED_MEETING when
+// STENOAI_E2E_SEED_REPORT=1 (copy-notes-report T1). Gated separately so the
+// transcript-export T1 keeps seeing the report-less meeting it asserts on.
+const SEED_REPORT = {
+  id: 'rep_e2e_1',
+  template_id: 'tpl_e2e_status',
+  template_name: 'Status Report',
+  model: 'mock-model',
+  content: '## Status Report\n\n- Pipeline healthy\n- Next: open the reqs',
+  created_at: '2026-06-19T13:00:00Z',
+};
+
+const seededMeeting = () =>
+  process.env.STENOAI_E2E_SEED_REPORT === '1'
+    ? { ...SEED_MEETING, reports: [SEED_REPORT], active_report: null }
+    : SEED_MEETING;
+
 function install({ ipcMain }) {
   // In-memory stand-in for the org session + provider config that the real
   // handlers persist to disk. Mutated by the org-login / org-logout / set-ai
@@ -95,7 +112,7 @@ function install({ ipcMain }) {
     // channel.
     'list-meetings': async () => {
       if (process.env.STENOAI_E2E_SEED_MEETING === '1') {
-        return { success: true, meetings: [SEED_MEETING] };
+        return { success: true, meetings: [seededMeeting()] };
       }
       return { success: true, meetings: SEEDED_MEETINGS };
     },
@@ -105,7 +122,7 @@ function install({ ipcMain }) {
     // transcript-export detail route resolves and renders the transcript actions.
     'get-meeting': async (_event, summaryFile) => {
       if (process.env.STENOAI_E2E_SEED_MEETING === '1') {
-        return { success: true, meeting: SEED_MEETING };
+        return { success: true, meeting: seededMeeting() };
       }
       const m = SEEDED_MEETINGS.find(
         (x) => x.session_info && x.session_info.summary_file === summaryFile,

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -57,7 +57,10 @@ const SEED_REPORT = {
   template_id: 'tpl_e2e_status',
   template_name: 'Status Report',
   model: 'mock-model',
-  content: '## Status Report\n\n- Pipeline healthy\n- Next: open the reqs',
+  // Leading <think> block: the copy path must strip reasoning like the
+  // rendered view does, so the spec can assert it never reaches the clipboard.
+  content:
+    '<think>secret chain of thought</think>\n## Status Report\n\n- Pipeline healthy\n- Next: open the reqs',
   created_at: '2026-06-19T13:00:00Z',
 };
 

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -61,9 +61,13 @@ const SEED_REPORT = {
   created_at: '2026-06-19T13:00:00Z',
 };
 
+// Mutable so the stateful set-active-report mock below persists the pill
+// switch across the invalidate → get-meeting refetch, like the real sidecar.
+let seedActiveReport = null;
+
 const seededMeeting = () =>
   process.env.STENOAI_E2E_SEED_REPORT === '1'
-    ? { ...SEED_MEETING, reports: [SEED_REPORT], active_report: null }
+    ? { ...SEED_MEETING, reports: [SEED_REPORT], active_report: seedActiveReport }
     : SEED_MEETING;
 
 function install({ ipcMain }) {
@@ -115,6 +119,14 @@ function install({ ipcMain }) {
         return { success: true, meetings: [seededMeeting()] };
       }
       return { success: true, meetings: SEEDED_MEETINGS };
+    },
+
+    // Mirror the real handler just enough for the copy-notes-report T1: persist
+    // the switch so the refetch that follows the mutation doesn't reset the
+    // pill. 'standard' clears it, like src/reports.py set_active.
+    'set-active-report': async (_event, _summaryFile, reportId) => {
+      seedActiveReport = !reportId || reportId === 'standard' ? null : reportId;
+      return { success: true };
     },
 
     // The detail route loads via get-meeting (the lazy per-meeting fetch), not

--- a/app/renderer/src/lib/notesCopy.test.ts
+++ b/app/renderer/src/lib/notesCopy.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'vitest';
+import { buildNotesCopyText, type NotesCopySections } from '@/lib/notesCopy';
+
+/**
+ * Unit coverage for buildNotesCopyText — the builder behind the "Copy notes"
+ * header action. The load-bearing case: when a generated template report is
+ * open, the copy must contain THAT report, not the Standard structured note
+ * (the on-screen content and the clipboard must never disagree).
+ */
+
+const sections: NotesCopySections = {
+  name: 'Weekly sync',
+  meta: 'Mon, Jun 23, 2026, 10:00 AM · 45m',
+  summary: 'We discussed the roadmap.',
+  discussionAreas: [
+    { title: 'Roadmap', analysis: 'Q3 priorities agreed.' },
+    { title: 'Hiring' },
+  ],
+  keyPoints: ['Ship v2 in July'],
+  actionItems: ['Ben: draft the announcement'],
+  participants: ['Ben', 'Ruzin'],
+};
+
+describe('buildNotesCopyText', () => {
+  test('no active report → the Standard structured note, all sections in order', () => {
+    const text = buildNotesCopyText(sections, null);
+    expect(text).toBe(
+      [
+        'Weekly sync',
+        'Mon, Jun 23, 2026, 10:00 AM · 45m',
+        '',
+        'SUMMARY',
+        'We discussed the roadmap.',
+        '',
+        'KEY TOPICS',
+        '- Roadmap: Q3 priorities agreed.',
+        '- Hiring',
+        '',
+        'KEY POINTS',
+        '- Ship v2 in July',
+        '',
+        'ACTION ITEMS',
+        '- Ben: draft the announcement',
+        '',
+        'PARTICIPANTS',
+        'Ben, Ruzin',
+      ].join('\n'),
+    );
+  });
+
+  test('active report → title + meta + the report markdown, no Standard sections', () => {
+    const text = buildNotesCopyText(sections, {
+      content: '## 1:1 Notes\n\n- Roadmap locked\n',
+    });
+    expect(text).toBe(
+      [
+        'Weekly sync',
+        'Mon, Jun 23, 2026, 10:00 AM · 45m',
+        '',
+        '## 1:1 Notes',
+        '',
+        '- Roadmap locked',
+      ].join('\n'),
+    );
+    expect(text).not.toContain('SUMMARY');
+  });
+
+  test('empty sections are omitted entirely (no dangling headers)', () => {
+    const text = buildNotesCopyText(
+      {
+        name: 'Quick call',
+        meta: undefined,
+        summary: '  ',
+        discussionAreas: [],
+        keyPoints: [],
+        actionItems: [],
+        participants: [],
+      },
+      null,
+    );
+    expect(text).toBe('Quick call');
+  });
+
+  test('active report with only-whitespace content still copies just title + meta', () => {
+    const text = buildNotesCopyText(sections, { content: '   \n  ' });
+    expect(text).toBe('Weekly sync\nMon, Jun 23, 2026, 10:00 AM · 45m');
+  });
+});

--- a/app/renderer/src/lib/notesCopy.ts
+++ b/app/renderer/src/lib/notesCopy.ts
@@ -1,0 +1,54 @@
+/**
+ * Builds the plain-text payload for the "Copy notes" header action in
+ * MeetingDetail. Pure so the report-vs-Standard selection is unit-testable:
+ * when a generated template report is open, the clipboard must carry that
+ * report's markdown, not the Standard structured note — the copy always
+ * matches what's on screen.
+ */
+
+export interface NotesCopySections {
+  name: string;
+  meta?: string;
+  summary?: string;
+  discussionAreas: { title: string; analysis?: string }[];
+  keyPoints: string[];
+  actionItems: string[];
+  participants: string[];
+}
+
+export function buildNotesCopyText(
+  sections: NotesCopySections,
+  activeReport: { content: string } | null,
+): string {
+  const lines: string[] = [sections.name];
+  if (sections.meta) lines.push(sections.meta);
+
+  if (activeReport) {
+    const content = activeReport.content.trim();
+    if (content) lines.push('', content);
+    return lines.join('\n');
+  }
+
+  const summary = sections.summary?.trim();
+  if (summary) {
+    lines.push('', 'SUMMARY', summary);
+  }
+  if (sections.discussionAreas.length) {
+    lines.push('', 'KEY TOPICS');
+    sections.discussionAreas.forEach((a) =>
+      lines.push(`- ${a.title}${a.analysis ? `: ${a.analysis}` : ''}`),
+    );
+  }
+  if (sections.keyPoints.length) {
+    lines.push('', 'KEY POINTS');
+    sections.keyPoints.forEach((p) => lines.push(`- ${p}`));
+  }
+  if (sections.actionItems.length) {
+    lines.push('', 'ACTION ITEMS');
+    sections.actionItems.forEach((a) => lines.push(`- ${a}`));
+  }
+  if (sections.participants.length) {
+    lines.push('', 'PARTICIPANTS', sections.participants.join(', '));
+  }
+  return lines.join('\n');
+}

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -535,9 +535,13 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
           <div className="flex items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
+                {/* Disabled while a summary/report stream is on screen — the
+                    clipboard would otherwise get the old note while the body
+                    shows the in-flux streamed text. */}
                 <ActionIconButton
                   label={copied ? 'Copied' : 'Copy notes'}
                   onClick={copyNotes}
+                  disabled={streamPhase !== 'idle'}
                 >
                   {copied ? <Check className="size-[13px]" /> : <Copy className="size-[13px]" />}
                 </ActionIconButton>

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -480,7 +480,9 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   };
 
   // Copies whichever note is on screen: the open template report when one is
-  // selected, otherwise the Standard structured note.
+  // selected, otherwise the Standard structured note. Reasoning blocks are
+  // stripped like the rendered views do, so the clipboard never carries
+  // <think> content the screen hides.
   const copyNotes = () => {
     const meta = [formatDetailDate(info), formatDuration(info.duration_seconds)]
       .filter(Boolean)
@@ -489,13 +491,13 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
       {
         name: info.name,
         meta: meta || undefined,
-        summary: meeting.summary,
+        summary: meeting.summary ? stripReasoning(meeting.summary) : undefined,
         discussionAreas: asDiscussionAreas(meeting.discussion_areas),
         keyPoints: meeting.key_points ?? [],
         actionItems: asStringArray(meeting.action_items),
         participants: asStringArray(meeting.participants),
       },
-      activeReport,
+      activeReport ? { content: stripReasoning(activeReport.content) } : null,
     );
     void navigator.clipboard.writeText(text);
     setCopied(true);

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -72,6 +72,7 @@ import {
 import { useActiveMeeting } from '@/lib/askBarContext';
 import { ipc, type Meeting, type Report, type Template } from '@/lib/ipc';
 import { buildTranscriptBundle, defaultExportFilename } from '@/lib/transcriptBundle';
+import { buildNotesCopyText } from '@/lib/notesCopy';
 import { unwrap } from '@/lib/result';
 import { cn } from '@/lib/utils';
 import { navigate } from '@/lib/router';
@@ -478,36 +479,25 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
     }
   };
 
+  // Copies whichever note is on screen: the open template report when one is
+  // selected, otherwise the Standard structured note.
   const copyNotes = () => {
-    const lines: string[] = [info.name];
     const meta = [formatDetailDate(info), formatDuration(info.duration_seconds)]
       .filter(Boolean)
       .join(' · ');
-    if (meta) lines.push(meta);
-    const summary = meeting.summary ? stripReasoning(meeting.summary).trim() : undefined;
-    if (summary) {
-      lines.push('', 'SUMMARY', summary);
-    }
-    const dAreas = asDiscussionAreas(meeting.discussion_areas);
-    if (dAreas.length) {
-      lines.push('', 'KEY TOPICS');
-      dAreas.forEach((a) => lines.push(`- ${a.title}${a.analysis ? `: ${a.analysis}` : ''}`));
-    }
-    const kp = meeting.key_points ?? [];
-    if (kp.length) {
-      lines.push('', 'KEY POINTS');
-      kp.forEach((p) => lines.push(`- ${p}`));
-    }
-    const ai = asStringArray(meeting.action_items);
-    if (ai.length) {
-      lines.push('', 'ACTION ITEMS');
-      ai.forEach((a) => lines.push(`- ${a}`));
-    }
-    const parts = asStringArray(meeting.participants);
-    if (parts.length) {
-      lines.push('', 'PARTICIPANTS', parts.join(', '));
-    }
-    void navigator.clipboard.writeText(lines.join('\n'));
+    const text = buildNotesCopyText(
+      {
+        name: info.name,
+        meta: meta || undefined,
+        summary: meeting.summary,
+        discussionAreas: asDiscussionAreas(meeting.discussion_areas),
+        keyPoints: meeting.key_points ?? [],
+        actionItems: asStringArray(meeting.action_items),
+        participants: asStringArray(meeting.participants),
+      },
+      activeReport,
+    );
+    void navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/e2e/specs/copy-notes-report.t1.spec.ts
+++ b/e2e/specs/copy-notes-report.t1.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '../fixtures/electron';
+import type { Page } from '@playwright/test';
+
+/**
+ * T1 — renderer-only, mock IPC, no backend. "Copy notes" must copy whichever
+ * note is on screen: with a generated template report open it copies THAT
+ * report's markdown, not the Standard structured note (the regression: the
+ * clipboard silently disagreed with the displayed report).
+ *
+ * Seams (mirrors of the real ones, see app/e2e-mock-ipc.js):
+ *  - STENOAI_E2E_SEED_MEETING=1 + STENOAI_E2E_SEED_REPORT=1 seed one known
+ *    meeting carrying one generated report (rep_e2e_1, "Status Report").
+ *  - the clipboard is captured by replacing navigator.clipboard in-page (no OS
+ *    clipboard dependency in CI), same recorder as transcript-export.t1.
+ */
+
+const SUMMARY_FILE = 'epsilon_summary.json';
+
+async function installClipboardRecorder(page: Page) {
+  await page.evaluate(() => {
+    const w = window as unknown as { __clipboardWrites: string[] };
+    w.__clipboardWrites = [];
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          w.__clipboardWrites.push(text);
+          return Promise.resolve();
+        },
+      },
+    });
+  });
+}
+
+const clipboardWrites = (page: Page) =>
+  page.evaluate(() => (window as unknown as { __clipboardWrites: string[] }).__clipboardWrites);
+
+test('Copy notes copies the open report, and the Standard note when none is open', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_MEETING: '1', STENOAI_E2E_SEED_REPORT: '1' },
+  });
+  await installClipboardRecorder(page);
+
+  await page.evaluate((f) => {
+    window.location.hash = `#/meetings/${encodeURIComponent(f)}`;
+  }, SUMMARY_FILE);
+  await expect(page.getByRole('button', { name: 'Copy notes' })).toBeVisible();
+  // The seeded report shows up as a pill next to Standard.
+  const reportPill = page.getByTestId('report-switch').getByRole('button', {
+    name: /Status Report/,
+  });
+  await expect(reportPill).toBeVisible();
+
+  // Standard note open (active_report is null) → the structured-note copy.
+  await page.getByRole('button', { name: 'Copy notes' }).click();
+  let writes = await clipboardWrites(page);
+  expect(writes).toHaveLength(1);
+  expect(writes[0]).toContain('Epsilon Planning');
+  expect(writes[0]).toContain('PARTICIPANTS');
+  expect(writes[0]).toContain('Alice, Bob');
+  expect(writes[0]).not.toContain('## Status Report');
+
+  // Open the generated report, then copy again → the report's markdown.
+  await reportPill.click();
+  await expect(page.getByText('Pipeline healthy')).toBeVisible();
+  await page.getByRole('button', { name: 'Copy notes' }).click();
+  writes = await clipboardWrites(page);
+  expect(writes).toHaveLength(2);
+  expect(writes[1]).toContain('Epsilon Planning');
+  expect(writes[1]).toContain('- Pipeline healthy');
+  expect(writes[1]).toContain('- Next: open the reqs');
+  expect(writes[1]).not.toContain('PARTICIPANTS');
+
+  // Switching back to Standard restores the structured-note copy.
+  await page.getByTestId('report-switch').getByRole('button', { name: 'Standard' }).click();
+  await page.getByRole('button', { name: 'Copy notes' }).click();
+  writes = await clipboardWrites(page);
+  expect(writes).toHaveLength(3);
+  expect(writes[2]).toContain('PARTICIPANTS');
+  expect(writes[2]).not.toContain('Pipeline healthy');
+});

--- a/e2e/specs/copy-notes-report.t1.spec.ts
+++ b/e2e/specs/copy-notes-report.t1.spec.ts
@@ -73,6 +73,9 @@ test('Copy notes copies the open report, and the Standard note when none is open
   expect(writes[1]).toContain('- Pipeline healthy');
   expect(writes[1]).toContain('- Next: open the reqs');
   expect(writes[1]).not.toContain('PARTICIPANTS');
+  // The seeded report starts with a <think> block; the copy must strip
+  // reasoning like the rendered view does.
+  expect(writes[1]).not.toContain('secret chain of thought');
 
   // Switching back to Standard restores the structured-note copy.
   await page.getByTestId('report-switch').getByRole('button', { name: 'Standard' }).click();


### PR DESCRIPTION
## Problem

With a generated template report open in MeetingDetail, the header "Copy notes" action still copied the **Standard** structured note. The clipboard silently disagreed with what was on screen.

## Fix

- Extract the clipboard builder into `app/renderer/src/lib/notesCopy.ts` (pure, unit-tested): when a report is open it copies title + date/duration + that report's markdown; otherwise the Standard sections exactly as before (byte-identical output for the standard path).
- Disable "Copy notes" while a summary/report stream is on screen (`streamPhase !== 'idle'`, all transient states) — same bug class: the body shows in-flux streamed text while the clipboard would get the old note.

## Coverage

- Vitest unit tests for `buildNotesCopyText` (standard path, report path, empty-section omission, whitespace-only report).
- New T1 e2e spec `copy-notes-report.t1.spec.ts` driving the real pill switch + Copy notes action against a seeded meeting carrying a report. New `STENOAI_E2E_SEED_REPORT` seam in the mock IPC (env-gated so `transcript-export.t1` keeps its report-less meeting), with a stateful `set-active-report` mock so the pill switch survives the post-mutation refetch like the real sidecar.

Full T1 suite 19/19, vitest 78/78, typecheck + lint clean.

## Not changed (by design)

Template reports intentionally live in the `<stem>_reports.json` sidecar, not as standalone `.md` files (`src/report_store.py`) — "view containing folder" not showing a report md is the designed storage model, out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Copy notes” to copy the open template report (not always the Standard note), strips hidden reasoning blocks, and disables the action while streaming to avoid stale copies.

- **Bug Fixes**
  - Copies title + date/duration + the active report’s markdown; otherwise falls back to the Standard structured note.
  - Strips reasoning blocks (e.g., <think>) from both Standard summaries and report content before copying, matching what’s rendered.
  - Disables “Copy notes” when `streamPhase !== 'idle'` to prevent clipboard/display mismatches.

- **Refactors**
  - Extracted builder to `app/renderer/src/lib/notesCopy.ts` with unit tests.
  - Added e2e spec `copy-notes-report.t1.spec.ts`; mock IPC now supports `STENOAI_E2E_SEED_REPORT` and a stateful `set-active-report` (seeded report includes a <think> block to verify stripping).

<sup>Written for commit 37926a71177a04c92f8ee1663afa9fe6906c81bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

