### PR TITLE
Feature/UI enhancement

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -8298,7 +8298,7 @@ function createNotificationWindow(event) {
     resizable: false,
     skipTaskbar: true,
     focusable: false,
-    hasShadow: false, // The React component renders its own shadow
+    hasShadow: false,
     backgroundColor: '#00000000',
     webPreferences: {
       nodeIntegration: false,
@@ -8313,7 +8313,6 @@ function createNotificationWindow(event) {
 
   notificationWindow.once('ready-to-show', () => {
     notificationWindow.showInactive();
-    // Ensure the window floats across all macOS spaces/desktops and full-screen apps
     notificationWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
     notificationWindow.setAlwaysOnTop(true, 'screen-saver', 1);
 
@@ -8329,6 +8328,13 @@ function createNotificationWindow(event) {
 ipcMain.handle('close-notification-window', () => {
   if (notificationWindow && !notificationWindow.isDestroyed()) {
     notificationWindow.close();
+  }
+});
+
+ipcMain.handle('focus-main-window', () => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (!mainWindow.isVisible()) mainWindow.show();
+    mainWindow.focus();
   }
 });
 

--- a/app/main.js
+++ b/app/main.js
@@ -8311,10 +8311,22 @@ function createNotificationWindow(event) {
   const rendererDist = path.join(__dirname, 'renderer', 'dist', 'index.html');
   notificationWindow.loadFile(rendererDist, { hash: '/notification' });
 
+  let autoCloseTimer;
   notificationWindow.once('ready-to-show', () => {
     notificationWindow.showInactive();
     notificationWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
     notificationWindow.setAlwaysOnTop(true, 'screen-saver', 1);
+
+    autoCloseTimer = setTimeout(() => {
+      if (notificationWindow && !notificationWindow.isDestroyed()) {
+        notificationWindow.close();
+      }
+    }, 15000);
+
+    notificationWindow.on('closed', () => {
+      if (autoCloseTimer) clearTimeout(autoCloseTimer);
+      notificationWindow = null;
+    });
 
     notificationWindow.webContents.send('show-notification', {
       title: event.title || 'Meeting starting',
@@ -8328,13 +8340,6 @@ function createNotificationWindow(event) {
 ipcMain.handle('close-notification-window', () => {
   if (notificationWindow && !notificationWindow.isDestroyed()) {
     notificationWindow.close();
-  }
-});
-
-ipcMain.handle('focus-main-window', () => {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    if (!mainWindow.isVisible()) mainWindow.show();
-    mainWindow.focus();
   }
 });
 

--- a/app/main.js
+++ b/app/main.js
@@ -8311,24 +8311,27 @@ function createNotificationWindow(event) {
   const rendererDist = path.join(__dirname, 'renderer', 'dist', 'index.html');
   notificationWindow.loadFile(rendererDist, { hash: '/notification' });
 
+  const win = notificationWindow;
   let autoCloseTimer;
-  notificationWindow.once('ready-to-show', () => {
-    notificationWindow.showInactive();
-    notificationWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
-    notificationWindow.setAlwaysOnTop(true, 'screen-saver', 1);
+  win.once('ready-to-show', () => {
+    win.showInactive();
+    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    win.setAlwaysOnTop(true, 'screen-saver', 1);
 
     autoCloseTimer = setTimeout(() => {
-      if (notificationWindow && !notificationWindow.isDestroyed()) {
-        notificationWindow.close();
+      if (!win.isDestroyed()) {
+        win.close();
       }
     }, 15000);
 
-    notificationWindow.on('closed', () => {
+    win.on('closed', () => {
       if (autoCloseTimer) clearTimeout(autoCloseTimer);
-      notificationWindow = null;
+      if (notificationWindow === win) {
+        notificationWindow = null;
+      }
     });
 
-    notificationWindow.webContents.send('show-notification', {
+    win.webContents.send('show-notification', {
       title: event.title || 'Meeting starting',
       time: event.start ? new Date(event.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '',
       meeting_url: event.meeting_url,

--- a/app/main.js
+++ b/app/main.js
@@ -191,6 +191,7 @@ function getUserDataDir() {
 }
 
 let mainWindow;
+let notificationWindow;
 let pythonProcess;
 let tray = null;
 let isQuitting = false;
@@ -8267,23 +8268,69 @@ async function firePreMeetingNotification(event) {
     sendDebugLog(`[premeeting] suppressed — already recording "${event.title}"`);
     return false;
   }
-  if (!Notification.isSupported()) return false;
-  const notif = new Notification({
-    title: 'Meeting starting',
-    body: `${event.title || 'Your meeting'} starts in 2 minutes`,
-  });
-  notif.on('click', () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      if (!mainWindow.isVisible()) mainWindow.show();
-      mainWindow.focus();
-    }
-  });
-  notif.show();
+  
+  createNotificationWindow(event);
+
   // Mark fired only after we've actually shown it, so an unshowable notif
   // (no OS support) isn't permanently skipped by the scheduler's dedupe.
   premeetingFiredIds.add(event.id);
   return true;
 }
+
+function createNotificationWindow(event) {
+  if (notificationWindow && !notificationWindow.isDestroyed()) {
+    notificationWindow.close();
+  }
+
+  const { screen } = require('electron');
+  const primaryDisplay = screen.getPrimaryDisplay();
+  const { width } = primaryDisplay.workAreaSize;
+  const { x, y } = primaryDisplay.workArea;
+
+  notificationWindow = new BrowserWindow({
+    width: 400,
+    height: 90,
+    x: x + width - 420,
+    y: y + 24,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    resizable: false,
+    skipTaskbar: true,
+    focusable: false,
+    hasShadow: false, // The React component renders its own shadow
+    backgroundColor: '#00000000',
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  const rendererDist = path.join(__dirname, 'renderer', 'dist', 'index.html');
+  notificationWindow.loadFile(rendererDist, { hash: '/notification' });
+
+  notificationWindow.once('ready-to-show', () => {
+    notificationWindow.showInactive();
+    // Ensure the window floats across all macOS spaces/desktops and full-screen apps
+    notificationWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    notificationWindow.setAlwaysOnTop(true, 'screen-saver', 1);
+
+    notificationWindow.webContents.send('show-notification', {
+      title: event.title || 'Meeting starting',
+      time: event.start ? new Date(event.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '',
+      meeting_url: event.meeting_url,
+      attendees: event.attendees ? event.attendees.map(a => a.name || a.email).join(', ') : '',
+    });
+  });
+}
+
+ipcMain.handle('close-notification-window', () => {
+  if (notificationWindow && !notificationWindow.isDestroyed()) {
+    notificationWindow.close();
+  }
+});
 
 function clearPreMeetingTimers() {
   for (const t of premeetingTimers.values()) clearTimeout(t);

--- a/app/main.js
+++ b/app/main.js
@@ -8291,7 +8291,7 @@ function createNotificationWindow(event) {
     width: 400,
     height: 90,
     x: x + width - 420,
-    y: y + 24,
+    y: y + 12,
     frame: false,
     transparent: true,
     alwaysOnTop: true,

--- a/app/main.js
+++ b/app/main.js
@@ -1506,7 +1506,7 @@ function runPythonScript(script, args = [], silent = false, extraEnv = {}, logLa
         reject(new Error(`Python script failed with code ${code}: ${stderr}`));
       }
     });
-    
+
     process.on('error', (error) => {
       sendDebugLog(`Command error: ${error.message}`);
       reject(error);
@@ -1624,11 +1624,11 @@ ipcMain.handle('select-audio-file', async () => {
       { name: 'Audio Files', extensions: IMPORT_AUDIO_EXTENSIONS }
     ]
   });
-  
+
   if (!result.canceled && result.filePaths.length > 0) {
     return { success: true, filePath: result.filePaths[0] };
   }
-  
+
   return { success: false, error: 'No file selected' };
 });
 
@@ -2905,10 +2905,10 @@ ipcMain.handle('delete-meeting', async (event, meetingData) => {
         error: `Blocked ${validationErrors} file deletion(s) due to security validation`
       };
     }
-    
-    return { 
-      success: true, 
-      message: `Deleted meeting and ${deletedCount} associated files` 
+
+    return {
+      success: true,
+      message: `Deleted meeting and ${deletedCount} associated files`
     };
   } catch (error) {
     console.error('Delete meeting error:', error);
@@ -3476,13 +3476,13 @@ async function processNextInQueue() {
   if (isProcessing || processingQueue.length === 0) {
     return;
   }
-  
+
   isProcessing = true;
   currentProcessingJob = processingQueue.shift();
   currentProcessingStartedAtMs = Date.now();
 
   console.log(`🔄 Processing queued job: ${currentProcessingJob.sessionName}`);
-  
+
   try {
     const queueAiEnv = getAiEnv();
     const queueEnv = Object.keys(queueAiEnv).length > 0 ? { ...require('process').env, ...queueAiEnv } : undefined;
@@ -4844,15 +4844,15 @@ ipcMain.handle('setup-test', async () => {
   try {
     sendDebugLog('Running system test...');
     sendDebugLog('$ python simple_recorder.py test');
-    
+
     // Test the complete system
     const result = await runPythonScript('simple_recorder.py', ['test']);
-    
+
     // Log the full result to debug console
     result.split('\n').forEach(line => {
       if (line.trim()) sendDebugLog(line.trim());
     });
-    
+
     if (result.includes('System check passed') || result.includes('SUCCESS')) {
       sendDebugLog('System test completed successfully');
       trackEvent('setup_completed', { step: 'system_test' });
@@ -4871,16 +4871,16 @@ ipcMain.handle('setup-test', async () => {
   }
 });
 
-// Settings window IPC handlers  
+// Settings window IPC handlers
 ipcMain.handle('trigger-setup-wizard', async () => {
   try {
     console.log('🔧 Starting setup wizard from settings...');
-    
+
     // Trigger the main window's setup flow
     if (mainWindow) {
       mainWindow.webContents.send('trigger-setup-flow');
     }
-    
+
     return { success: true, message: 'Setup wizard triggered in main window' };
   } catch (error) {
     console.error('Setup wizard failed:', error);
@@ -5052,13 +5052,13 @@ ipcMain.handle('get-ai-prompts', async () => {
   try {
     // Read the summarization prompt from the Python backend
     const summarizerPath = path.join(__dirname, '..', 'src', 'summarizer.py');
-    
+
     if (fs.existsSync(summarizerPath)) {
       const content = fs.readFileSync(summarizerPath, 'utf8');
-      
+
       // Extract the full prompt from the _create_permissive_prompt method
       const promptMatch = content.match(/def _create_permissive_prompt[\s\S]*?return f"""([\s\S]*?)"""/);
-      
+
       if (promptMatch) {
         return {
           success: true,
@@ -5066,7 +5066,7 @@ ipcMain.handle('get-ai-prompts', async () => {
         };
       }
     }
-    
+
     return {
       success: true,
       summarization: 'Prompt not found in summarizer.py'
@@ -6945,26 +6945,26 @@ async function checkForUpdates() {
 
     const req = https.request(options, (res) => {
       let data = '';
-      
+
       res.on('data', (chunk) => {
         data += chunk;
       });
-      
+
       res.on('end', () => {
         try {
           const release = JSON.parse(data);
           const latestVersion = release.tag_name.replace(/^v/, ''); // Remove 'v' prefix if present
-          
+
           // Get current version from package.json
           const packagePath = path.join(__dirname, 'package.json');
           const packageContent = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
           const currentVersion = packageContent.version;
-          
+
           console.log(`Current version: ${currentVersion}, Latest version: ${latestVersion}`);
-          
+
           // Simple version comparison (works for semantic versioning)
           const isUpdateAvailable = compareVersions(currentVersion, latestVersion) < 0;
-          
+
           resolve({
             success: true,
             updateAvailable: isUpdateAvailable,
@@ -6980,17 +6980,17 @@ async function checkForUpdates() {
         }
       });
     });
-    
+
     req.on('error', (error) => {
       console.error('Error checking for updates:', error);
       resolve({ success: false, error: error.message });
     });
-    
+
     req.setTimeout(10000, () => {
       req.destroy();
       resolve({ success: false, error: 'Update check timeout' });
     });
-    
+
     req.end();
   });
 }
@@ -6998,15 +6998,15 @@ async function checkForUpdates() {
 function compareVersions(current, latest) {
   const currentParts = current.split('.').map(Number);
   const latestParts = latest.split('.').map(Number);
-  
+
   for (let i = 0; i < Math.max(currentParts.length, latestParts.length); i++) {
     const currentPart = currentParts[i] || 0;
     const latestPart = latestParts[i] || 0;
-    
+
     if (currentPart < latestPart) return -1;
     if (currentPart > latestPart) return 1;
   }
-  
+
   return 0;
 }
 
@@ -7014,22 +7014,22 @@ function getDownloadUrl(assets) {
   // Find the appropriate download URL based on platform/architecture
   const platform = process.platform;
   const arch = process.arch;
-  
+
   if (platform === 'darwin') {
     // Look for macOS DMG files
-    const armAsset = assets.find(asset => 
+    const armAsset = assets.find(asset =>
       asset.name.includes('arm64') && asset.name.includes('dmg')
     );
-    const intelAsset = assets.find(asset => 
+    const intelAsset = assets.find(asset =>
       asset.name.includes('x64') && asset.name.includes('dmg')
     );
-    
+
     // Prefer ARM64 for Apple Silicon, fallback to Intel
     if (arch === 'arm64' && armAsset) return armAsset.browser_download_url;
     if (intelAsset) return intelAsset.browser_download_url;
     if (armAsset) return armAsset.browser_download_url;
   }
-  
+
   // Fallback to first asset or releases page
   return assets.length > 0 ? assets[0].browser_download_url : null;
 }
@@ -8268,7 +8268,7 @@ async function firePreMeetingNotification(event) {
     sendDebugLog(`[premeeting] suppressed — already recording "${event.title}"`);
     return false;
   }
-  
+
   createNotificationWindow(event);
 
   // Mark fired only after we've actually shown it, so an unshowable notif
@@ -8289,9 +8289,9 @@ function createNotificationWindow(event) {
 
   notificationWindow = new BrowserWindow({
     width: 400,
-    height: 90,
-    x: x + width - 420,
-    y: y + 12,
+    height: 70,
+    x: x + width - 425,
+    y: y + 1,
     frame: false,
     transparent: true,
     alwaysOnTop: true,

--- a/app/preload.js
+++ b/app/preload.js
@@ -313,6 +313,10 @@ const stenoai = {
     respondQuit: (confirmed) => send('quit-dialog-response', { confirmed }),
   },
 
+  notification: {
+    close: () => invoke('close-notification-window'),
+  },
+
   // All main-driven events. Every subscribe returns an unsubscribe fn.
   on: {
     debugLog: (cb) => subscribe('debug-log', cb),
@@ -350,6 +354,7 @@ const stenoai = {
     navigateToMeeting: (cb) => subscribe('navigate-to-meeting', cb),
     trayOpenSettings: (cb) => subscribe('tray-open-settings', cb),
     showQuitDialog: (cb) => subscribe('show-quit-dialog', cb),
+    showNotification: (cb) => subscribe('show-notification', cb),
   },
 
   subscribeQueryStream,

--- a/app/preload.js
+++ b/app/preload.js
@@ -315,6 +315,7 @@ const stenoai = {
 
   notification: {
     close: () => invoke('close-notification-window'),
+    focusMain: () => invoke('focus-main-window'),
   },
 
   // All main-driven events. Every subscribe returns an unsubscribe fn.

--- a/app/preload.js
+++ b/app/preload.js
@@ -315,7 +315,6 @@ const stenoai = {
 
   notification: {
     close: () => invoke('close-notification-window'),
-    focusMain: () => invoke('focus-main-window'),
   },
 
   // All main-driven events. Every subscribe returns an unsubscribe fn.

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.google.com https://*.gstatic.com https://icons.duckduckgo.com; font-src 'self' data:; media-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" />
     <title>StenoAI</title>
   </head>
   <body>

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.google.com https://*.gstatic.com https://icons.duckduckgo.com; font-src 'self' data:; media-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" />
     <title>StenoAI</title>
   </head>
   <body>

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -49,9 +49,7 @@ export function App() {
     }
   }, []);
 
-  if (route === '/notification') {
-    return <NotificationToast />;
-  }
+
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !window.stenoai) return;
@@ -165,6 +163,10 @@ export function App() {
       }
     })();
   }, [recording.isLoading, recording.status, route]);
+
+  if (route === '/notification') {
+    return <NotificationToast />;
+  }
 
   const isRecordingRoute = route === '/recording';
   const isProcessingRoute = route === '/meetings/processing';

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NotificationToast } from '@/components/NotificationToast';
+
 import { useTheme } from '@/hooks/useTheme';
 import { Sandbox } from '@/routes/Sandbox';
 import { Settings } from '@/routes/Settings';
@@ -163,10 +163,6 @@ export function App() {
       }
     })();
   }, [recording.isLoading, recording.status, route]);
-
-  if (route === '/notification') {
-    return <NotificationToast />;
-  }
 
   const isRecordingRoute = route === '/recording';
   const isProcessingRoute = route === '/meetings/processing';

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { NotificationToast } from '@/components/NotificationToast';
+import { useTheme } from '@/hooks/useTheme';
 import { Sandbox } from '@/routes/Sandbox';
 import { Settings } from '@/routes/Settings';
 import { Setup } from '@/routes/Setup';
@@ -34,6 +36,7 @@ import { ipc } from '@/lib/ipc';
 import { primeDebugLogs } from '@/lib/debugLogs';
 
 export function App() {
+  useTheme();
   const route = useRoute();
 
   React.useLayoutEffect(() => {
@@ -45,6 +48,10 @@ export function App() {
       document.documentElement.dataset.appReady = '1';
     }
   }, []);
+
+  if (route === '/notification') {
+    return <NotificationToast />;
+  }
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !window.stenoai) return;

--- a/app/renderer/src/components/ImportDropZone.tsx
+++ b/app/renderer/src/components/ImportDropZone.tsx
@@ -33,7 +33,9 @@ export function ImportDropZone() {
   const { status } = useRecording();
   const isRecording = status === 'recording' || status === 'paused';
   const isRecordingRef = React.useRef(isRecording);
-  isRecordingRef.current = isRecording;
+  React.useEffect(() => {
+    isRecordingRef.current = isRecording;
+  }, [isRecording]);
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !window.stenoai) return;

--- a/app/renderer/src/components/MeetingsShell.tsx
+++ b/app/renderer/src/components/MeetingsShell.tsx
@@ -398,7 +398,9 @@ function RenamePopover({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const closingRef = React.useRef(false);
   const valueRef = React.useRef(value);
-  valueRef.current = value;
+  React.useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
 
   React.useEffect(() => {
     const id = requestAnimationFrame(() => setVisible(true));

--- a/app/renderer/src/components/NotificationToast.tsx
+++ b/app/renderer/src/components/NotificationToast.tsx
@@ -35,7 +35,7 @@ export function NotificationToast() {
   };
 
   const handleFocusMain = () => {
-    ipc().notification.focusMain();
+    ipc().window.focus();
     handleClose();
   };
 

--- a/app/renderer/src/components/NotificationToast.tsx
+++ b/app/renderer/src/components/NotificationToast.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { ipc } from '@/lib/ipc';
+
+interface NotificationData {
+  title: string;
+  time: string;
+  meeting_url?: string;
+  attendees?: string;
+}
+
+export function NotificationToast() {
+  const [data, setData] = React.useState<NotificationData | null>(null);
+
+  React.useLayoutEffect(() => {
+    const off = ipc().on.showNotification((newData) => {
+      setData(newData);
+    });
+    return off;
+  }, []);
+
+  if (!data) return null;
+
+  const handleClose = () => {
+    ipc().notification.close();
+  };
+
+  const handleJoin = () => {
+    if (data.meeting_url) {
+      ipc().shell.openExternal(data.meeting_url);
+    }
+    handleClose();
+  };
+
+  // Generate a consistent, professional color based on the meeting title
+  const getEventColor = (title: string) => {
+    const colors = ['#10B981', '#3B82F6', '#8B5CF6', '#EC4899', '#F59E0B', '#EF4444', '#06B6D4'];
+    let hash = 0;
+    for (let i = 0; i < title.length; i++) {
+      hash = title.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return colors[Math.abs(hash) % colors.length];
+  };
+
+  const barColor = getEventColor(data.title);
+
+  return (
+    <>
+      <style>{`
+        html, body, #root {
+          background: transparent !important;
+        }
+      `}</style>
+      <div className="flex h-screen w-screen items-center justify-center bg-transparent p-3">
+        <div 
+        className="group relative flex w-full items-center justify-between rounded-[20px] bg-white p-2.5 pr-3 border border-gray-200 dark:bg-[#1E1E1E] dark:border-white/10"
+        style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
+      >
+        {/* Close Button (Hidden until hover) */}
+        <button
+          onClick={handleClose}
+          className="absolute -top-1.5 -left-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow-sm border border-gray-200 text-gray-500 opacity-0 transition-opacity hover:bg-gray-50 hover:text-gray-700 group-hover:opacity-100 dark:bg-[#2C2C2E] dark:border-white/10 dark:text-gray-400 dark:hover:bg-[#3C3C3E] dark:hover:text-gray-200"
+          title="Close"
+        >
+          <svg width="8" height="8" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 1L13 13M1 13L13 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+          </svg>
+        </button>
+
+        {/* Left Side: Status Line + Text */}
+        <div className="flex items-center">
+          <div 
+            className="h-8 w-1 rounded-full ml-1 shrink-0" 
+            style={{ backgroundColor: barColor }}
+          ></div>
+          <div className="flex flex-col justify-center ml-3">
+            <span className="text-[14px] font-medium text-gray-900 tracking-tight leading-tight truncate max-w-[150px] dark:text-gray-100">
+              {data.title}
+            </span>
+            <span className="text-[12px] font-normal text-gray-500 leading-tight mt-0.5 dark:text-gray-400">
+              {data.time}
+            </span>
+          </div>
+        </div>
+
+        {/* Right Side: Action Button */}
+        {data.meeting_url && (
+          <button
+            onClick={handleJoin}
+            className="flex items-center gap-2 rounded-[10px] border border-gray-200 bg-white px-3 py-1.5 text-[13px] font-medium text-gray-900 transition-all hover:bg-gray-50 hover:shadow-sm active:bg-gray-100 active:scale-[0.98] shrink-0 dark:border-white/10 dark:bg-[#2C2C2E] dark:text-gray-100 dark:hover:bg-[#3C3C3E] dark:active:bg-[#1C1C1E]"
+          >
+            <ProfessionalCameraIcon className="h-5 w-5" backgroundColor={barColor} />
+            <span>Join & take notes</span>
+          </button>
+        )}
+      </div>
+    </div>
+    </>
+  );
+}
+
+function ProfessionalCameraIcon({ className, backgroundColor = '#10B981' }: { className?: string, backgroundColor?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="24" height="24" rx="5.5" fill={backgroundColor}/>
+      <path d="M15.5 10.5V8C15.5 7.17157 14.8284 6.5 14 6.5H6C5.17157 6.5 4.5 7.17157 4.5 8V16C4.5 16.8284 5.17157 17.5 6 17.5H14C14.8284 17.5 15.5 16.8284 15.5 16V13.5L19.5 16.5V7.5L15.5 10.5Z" fill="white"/>
+    </svg>
+  );
+}

--- a/app/renderer/src/components/NotificationToast.tsx
+++ b/app/renderer/src/components/NotificationToast.tsx
@@ -30,6 +30,7 @@ export function NotificationToast() {
     if (data.meeting_url) {
       ipc().shell.openExternal(data.meeting_url);
     }
+    ipc().recording.start(data.title);
     handleClose();
   };
 

--- a/app/renderer/src/components/NotificationToast.tsx
+++ b/app/renderer/src/components/NotificationToast.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ipc } from '@/lib/ipc';
+import { useTheme } from '@/hooks/useTheme';
 
 interface NotificationData {
   title: string;
@@ -9,6 +10,7 @@ interface NotificationData {
 }
 
 export function NotificationToast() {
+  useTheme();
   const [data, setData] = React.useState<NotificationData | null>(null);
 
   React.useLayoutEffect(() => {

--- a/app/renderer/src/components/NotificationToast.tsx
+++ b/app/renderer/src/components/NotificationToast.tsx
@@ -20,18 +20,24 @@ export function NotificationToast() {
 
   if (!data) return null;
 
-  const handleClose = () => {
+  const handleClose = (e?: React.MouseEvent) => {
+    e?.stopPropagation();
     ipc().notification.close();
   };
 
-  const handleJoin = () => {
+  const handleJoin = (e?: React.MouseEvent) => {
+    e?.stopPropagation();
     if (data.meeting_url) {
       ipc().shell.openExternal(data.meeting_url);
     }
     handleClose();
   };
 
-  // Generate a consistent, professional color based on the meeting title
+  const handleFocusMain = () => {
+    ipc().notification.focusMain();
+    handleClose();
+  };
+
   const getEventColor = (title: string) => {
     const colors = ['#10B981', '#3B82F6', '#8B5CF6', '#EC4899', '#F59E0B', '#EF4444', '#06B6D4'];
     let hash = 0;
@@ -52,10 +58,10 @@ export function NotificationToast() {
       `}</style>
       <div className="flex h-screen w-screen items-center justify-center bg-transparent p-3">
         <div 
-        className="group relative flex w-full items-center justify-between rounded-[20px] bg-white p-2.5 pr-3 border border-gray-200 dark:bg-[#1E1E1E] dark:border-white/10"
+        className="group relative flex w-full cursor-pointer items-center justify-between rounded-[20px] bg-white p-2.5 pr-3 border border-gray-200 dark:bg-[#1E1E1E] dark:border-white/10"
         style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
+        onClick={handleFocusMain}
       >
-        {/* Close Button (Hidden until hover) */}
         <button
           onClick={handleClose}
           className="absolute -top-1.5 -left-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow-sm border border-gray-200 text-gray-500 opacity-0 transition-opacity hover:bg-gray-50 hover:text-gray-700 group-hover:opacity-100 dark:bg-[#2C2C2E] dark:border-white/10 dark:text-gray-400 dark:hover:bg-[#3C3C3E] dark:hover:text-gray-200"
@@ -66,7 +72,6 @@ export function NotificationToast() {
           </svg>
         </button>
 
-        {/* Left Side: Status Line + Text */}
         <div className="flex items-center">
           <div 
             className="h-8 w-1 rounded-full ml-1 shrink-0" 
@@ -82,7 +87,6 @@ export function NotificationToast() {
           </div>
         </div>
 
-        {/* Right Side: Action Button */}
         {data.meeting_url && (
           <button
             onClick={handleJoin}

--- a/app/renderer/src/components/QuitDialog.tsx
+++ b/app/renderer/src/components/QuitDialog.tsx
@@ -24,15 +24,6 @@ export function QuitDialog() {
     });
   }, []);
 
-  React.useEffect(() => {
-    if (!mounted) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') handleCancel();
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [mounted]);
-
   const dismiss = (confirmed: boolean) => {
     setVisible(false);
     setTimeout(() => setMounted(false), 200);
@@ -41,6 +32,15 @@ export function QuitDialog() {
 
   const handleCancel = () => dismiss(false);
   const handleConfirm = () => dismiss(true);
+
+  React.useEffect(() => {
+    if (!mounted) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleCancel();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [mounted]);
 
   if (!mounted) return null;
 

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -986,7 +986,6 @@ export interface StenoaiBridge {
 
   notification: {
     close: RequestFn<[], void>;
-    focusMain: RequestFn<[], void>;
   };
 
   subscribeQueryStream: (

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -986,6 +986,7 @@ export interface StenoaiBridge {
 
   notification: {
     close: RequestFn<[], void>;
+    focusMain: RequestFn<[], void>;
   };
 
   subscribeQueryStream: (

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -957,6 +957,7 @@ export interface StenoaiBridge {
     navigateToMeeting: Subscribe<{ summaryFile: string }>;
     trayOpenSettings: Subscribe<void>;
     showQuitDialog: Subscribe<{ type: 'recording' | 'processing'; jobCount?: number }>;
+    showNotification: Subscribe<{ title: string; time: string; meeting_url?: string; attendees?: string }>;
   };
 
   org: {
@@ -981,6 +982,10 @@ export interface StenoaiBridge {
 
   dialog: {
     respondQuit: SendFn<[confirmed: boolean]>;
+  };
+
+  notification: {
+    close: RequestFn<[], void>;
   };
 
   subscribeQueryStream: (

--- a/app/renderer/src/main.tsx
+++ b/app/renderer/src/main.tsx
@@ -35,14 +35,26 @@ class ErrorBoundary extends React.Component<
   }
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <ErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider delayDuration={50}>
-          <App />
-        </TooltipProvider>
-      </QueryClientProvider>
-    </ErrorBoundary>
-  </React.StrictMode>
-);
+import { NotificationToast } from './components/NotificationToast';
+
+const isNotification = window.location.hash === '#/notification';
+
+if (isNotification) {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <NotificationToast />
+    </React.StrictMode>
+  );
+} else {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ErrorBoundary>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider delayDuration={50}>
+            <App />
+          </TooltipProvider>
+        </QueryClientProvider>
+      </ErrorBoundary>
+    </React.StrictMode>
+  );
+}

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -80,9 +80,9 @@ export function Chat() {
   const [recentsExpanded, setRecentsExpanded] = React.useState(false);
   const canExpand = allRecents.length > COLLAPSED_LIMIT;
   const recents = recentsExpanded ? allRecents : allRecents.slice(0, COLLAPSED_LIMIT);
-  const [now] = React.useState(() => Date.now());
   const groupedRecents = React.useMemo(() => {
     if (!recentsExpanded) return null;
+    const now = Date.now();
     const groups = new Map<string, typeof allRecents>();
     for (const s of allRecents) {
       const k = bucketKey(s.updatedAt, now);

--- a/app/renderer/src/routes/Chat.tsx
+++ b/app/renderer/src/routes/Chat.tsx
@@ -80,10 +80,10 @@ export function Chat() {
   const [recentsExpanded, setRecentsExpanded] = React.useState(false);
   const canExpand = allRecents.length > COLLAPSED_LIMIT;
   const recents = recentsExpanded ? allRecents : allRecents.slice(0, COLLAPSED_LIMIT);
+  const [now] = React.useState(() => Date.now());
   const groupedRecents = React.useMemo(() => {
     if (!recentsExpanded) return null;
     const groups = new Map<string, typeof allRecents>();
-    const now = Date.now();
     for (const s of allRecents) {
       const k = bucketKey(s.updatedAt, now);
       const arr = groups.get(k) ?? [];

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -207,6 +207,12 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   const [titleRegening, setTitleRegening] = React.useState(() =>
     pendingTitleRegens.has(summaryFile),
   );
+  const [prevSummaryFile, setPrevSummaryFile] = React.useState(summaryFile);
+  if (summaryFile !== prevSummaryFile) {
+    setPrevSummaryFile(summaryFile);
+    setTitleRegening(pendingTitleRegens.has(summaryFile));
+  }
+
   const [isEditingTitle, setIsEditingTitle] = React.useState(false);
   const [titleError, setTitleError] = React.useState<string | null>(null);
   const titleEditRef = React.useRef<HTMLSpanElement>(null);
@@ -214,7 +220,6 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   React.useEffect(() => {
     const pending = pendingTitleRegens.get(summaryFile);
     if (!pending) return;
-    setTitleRegening(true);
     let cancelled = false;
     pending.finally(() => {
       if (!cancelled) setTitleRegening(false);
@@ -262,15 +267,14 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
   const [activeReportId, setActiveReportId] = React.useState<string | null>(
     meeting.active_report ?? null,
   );
+  const [prevMeetingReport, setPrevMeetingReport] = React.useState<string | null>(meeting.active_report ?? null);
+  if (meeting.active_report !== prevMeetingReport) {
+    setPrevMeetingReport(meeting.active_report ?? null);
+    setActiveReportId(meeting.active_report ?? null);
+  }
   const activeReport = activeReportId
     ? reports.find((r) => r.id === activeReportId) ?? null
     : null;
-  // meeting.active_report is the source of truth (the switch persists it). Re-sync
-  // local state whenever it changes so a reprocess (backend clears it to null)
-  // can't leave the UI showing a stale report. Idempotent for user clicks.
-  React.useEffect(() => {
-    setActiveReportId(meeting.active_report ?? null);
-  }, [meeting.active_report]);
   // When a report generation finishes, summaryComplete fires for THIS meeting
   // and we want to land on the freshly-created report. The IPC stream doesn't
   // carry the new report id, so we flag "the active stream is a report" and,
@@ -1307,11 +1311,11 @@ function StreamingView({ text, phase, chunkProgress }: { text: string; phase: St
   const blocks = parseMarkdownBlocks(stripReasoning(text));
   const isStreaming = phase === 'analyzing' || phase === 'generating';
 
-  const prevBlockCountRef = React.useRef(blocks.length);
-  const firstNewIdx = prevBlockCountRef.current;
-  React.useEffect(() => {
-    prevBlockCountRef.current = blocks.length;
-  }, [blocks.length]);
+  const [prevBlockCount, setPrevBlockCount] = React.useState(blocks.length);
+  const firstNewIdx = prevBlockCount;
+  if (blocks.length > prevBlockCount) {
+    setPrevBlockCount(blocks.length);
+  }
 
   const blocksContainerRef = React.useRef<HTMLDivElement>(null);
   const indicatorRef = React.useRef<HTMLDivElement>(null);
@@ -1480,7 +1484,11 @@ function FolderPicker({ summaryFile, assignedFolderIds }: { summaryFile: string;
   const allFolders = folders.data ?? [];
   const serverFolderId = assignedFolderIds[0] ?? null;
   const [localFolderId, setLocalFolderId] = React.useState<string | null>(serverFolderId);
-  React.useEffect(() => { setLocalFolderId(serverFolderId); }, [serverFolderId]);
+  const [prevServerFolderId, setPrevServerFolderId] = React.useState<string | null>(serverFolderId);
+  if (serverFolderId !== prevServerFolderId) {
+    setPrevServerFolderId(serverFolderId);
+    setLocalFolderId(serverFolderId);
+  }
 
   const currentFolder = allFolders.find((f) => f.id === localFolderId) ?? null;
 

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -1311,11 +1311,12 @@ function StreamingView({ text, phase, chunkProgress }: { text: string; phase: St
   const blocks = parseMarkdownBlocks(stripReasoning(text));
   const isStreaming = phase === 'analyzing' || phase === 'generating';
 
-  const [prevBlockCount, setPrevBlockCount] = React.useState(blocks.length);
-  const firstNewIdx = prevBlockCount;
-  if (blocks.length > prevBlockCount) {
-    setPrevBlockCount(blocks.length);
-  }
+  const prevBlockCountRef = React.useRef(blocks.length);
+  // eslint-disable-next-line react-hooks/refs
+  const firstNewIdx = prevBlockCountRef.current;
+  React.useEffect(() => {
+    prevBlockCountRef.current = blocks.length;
+  }, [blocks.length]);
 
   const blocksContainerRef = React.useRef<HTMLDivElement>(null);
   const indicatorRef = React.useRef<HTMLDivElement>(null);

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -268,7 +268,7 @@ function DetailContent({ meeting }: { meeting: Meeting }) {
     meeting.active_report ?? null,
   );
   const [prevMeetingReport, setPrevMeetingReport] = React.useState<string | null>(meeting.active_report ?? null);
-  if (meeting.active_report !== prevMeetingReport) {
+  if ((meeting.active_report ?? null) !== prevMeetingReport) {
     setPrevMeetingReport(meeting.active_report ?? null);
     setActiveReportId(meeting.active_report ?? null);
   }

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -35,11 +35,9 @@ export function Processing() {
   const [activeSession, setActiveSession] = React.useState<string | null>(
     () => recording.sessionName,
   );
-  React.useEffect(() => {
-    if (recording.sessionName && recording.sessionName !== activeSession) {
-      setActiveSession(recording.sessionName);
-    }
-  }, [recording.sessionName, activeSession]);
+  if (recording.sessionName && recording.sessionName !== activeSession) {
+    setActiveSession(recording.sessionName);
+  }
 
   const draft = useLiveDraftStore((s) =>
     activeSession ? s.drafts[activeSession] : undefined,
@@ -48,8 +46,14 @@ export function Processing() {
   // Recordings have a live draft to time from. Imported files don't — fall back
   // to the queue's processing elapsed (get-queue-status), which advances on the
   // poll, so the timer counts up instead of sticking at 0s.
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
   const totalElapsedSeconds = startedAt
-    ? Math.max(0, Math.floor((Date.now() - startedAt.getTime()) / 1000))
+    ? Math.max(0, Math.floor((now - startedAt.getTime()) / 1000))
     : recording.elapsed;
 
   const [stage, setStage] = React.useState<ProcessingStage>('transcribing');
@@ -462,8 +466,14 @@ export function ProcessingDock() {
   // Recordings have a live draft to time from. Imported files don't — fall back
   // to the queue's processing elapsed (get-queue-status), which advances on the
   // poll, so the timer counts up instead of sticking at 0s.
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
   const totalElapsedSeconds = startedAt
-    ? Math.max(0, Math.floor((Date.now() - startedAt.getTime()) / 1000))
+    ? Math.max(0, Math.floor((now - startedAt.getTime()) / 1000))
     : recording.elapsed;
 
   return (


### PR DESCRIPTION
## Description
This PR replaces the standard macOS system notifications with a highly polished, custom floating window. 

### Key Features
- **Premium Aesthetic:** A clean, flat design that floats seamlessly under the macOS menu bar.
- **Smart "Join & Take Notes" Action:** Clicking the action button now simultaneously opens the meeting link in the browser *and* automatically starts a StenoAI recording session.
- **Focus App:** Clicking anywhere on the notification body dismisses it and instantly focuses the main StenoAI window.

### Screenshots


<img width="1509" height="978" alt="CCF6BC9C-FF2D-423E-9F9F-189D5272D6A3" src="https://github.com/user-attachments/assets/f68d929d-bdc3-4bd2-b11e-035b508f715e" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces macOS system notifications with a compact in‑app toast under the menu bar and adds one‑click “Join & take notes.” The toast mounts as its own React root for faster load and tighter focus/close behavior.

- **New Features**
  - Pre‑meeting alerts show in a small, always‑on‑top window; clicking the body focuses the main app and dismisses it.
  - “Join & take notes” opens the meeting URL in the browser, starts a recording, then closes the toast.
  - New `/notification` route with `NotificationToast` rendered at the root and wired to `show-notification`; added `notification.close()` IPC.

- **Bug Fixes**
  - Fixed window focus IPC, rare stuck toasts, and a race in the notification close handler; auto‑close after 15s with proper cleanup.
  - Resolved React Hook/ref issues across the UI (e.g., `ImportDropZone`, `MeetingsShell`, `QuitDialog`, `Processing`, `Chat`); fixed an infinite render loop in `MeetingDetail` and restored streaming text animation by reverting `firstNewIdx` to a ref.
  - Reverted unused CSP img‑src widening and stabilized Processing/Chat timers to prevent stale bucketing and stalled elapsed time.

<sup>Written for commit e18b736608e539c50f1b7ebfbdba5f028af61c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



