### PR TITLE
fix(summarizer): raise on stream failure instead of swallowing it as an empty summary

### DIFF
--- a/e2e/fixtures/mock-ollama.js
+++ b/e2e/fixtures/mock-ollama.js
@@ -23,6 +23,9 @@ const OLLAMA_PORT = 11434;
  * @param {object} [opts]
  * @param {string} [opts.chatReply='ok'] assistant content returned by /api/chat.
  * @param {string[]} [opts.chatReplyQueue=[]] queue of replies to dequeue per call; falls back to chatReply when exhausted.
+ * @param {{status:number, message:string}} [opts.chatError] when set, /api/chat responds with this HTTP
+ *   status and JSON body `{"error": message}` (the real Ollama 404 shape) instead of a reply. Off by
+ *   default so existing specs are unaffected. chatCalls still increments so callers can assert it was hit.
  * @param {string[]} [opts.installedModels=['gemma4:e2b-it-qat','llama3.2:3b']] models /api/tags reports as installed.
  * @param {number} [opts.pullDelayMs=0] hold the /api/pull response open this long before completing it -- gives a
  *   cancel-mid-download test a real window to call cancel-pull before the mock would otherwise finish first.
@@ -31,6 +34,7 @@ const OLLAMA_PORT = 11434;
 function startMockOllama(opts = {}) {
   const chatReply = opts.chatReply ?? 'ok';
   const chatReplyQueue = Array.isArray(opts.chatReplyQueue) ? [...opts.chatReplyQueue] : [];
+  const chatError = opts.chatError ?? null;
   const installedModels = Array.isArray(opts.installedModels)
     ? opts.installedModels
     : ['gemma4:e2b-it-qat', 'llama3.2:3b'];
@@ -110,6 +114,15 @@ function startMockOllama(opts = {}) {
           } catch { /* ignore */ }
           const msgs = Array.isArray(body.messages) ? body.messages : [];
           lastChatPrompt = msgs.length ? String(msgs[msgs.length - 1].content || '') : '';
+
+          // Opt-in failure mode: reply with the configured HTTP error (the real
+          // Ollama 404 "model not found" shape) so the summarizer's stream fails
+          // and must surface it rather than saving an empty summary.
+          if (chatError) {
+            res.writeHead(chatError.status, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: chatError.message }));
+            return;
+          }
 
           // Dequeue reply or fall back to default
           const reply = chatReplyQueue.length > 0 ? chatReplyQueue.shift() : chatReply;

--- a/e2e/specs/summarize-failure.t2.spec.ts
+++ b/e2e/specs/summarize-failure.t2.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
+import { startMockOllama } from '../fixtures/mock-ollama';
+import { readFileSync } from 'fs';
+
+/**
+ * T2 — summarisation FAILURE contract (regression for the swallowed-stream bug /
+ * GH #301). Drives the real `reprocess` path (re-summarise an existing
+ * transcript — NO ASR, NO real model) with a mock Ollama that returns a 404
+ * "model not found" on /api/chat, and asserts the failure is surfaced honestly:
+ *
+ *   1. reprocess reports failure (success:false), NOT a false success.
+ *   2. the pre-existing summary on disk is byte-for-byte UNCHANGED — the failed
+ *      stream must not clobber it with an empty summary.
+ *
+ * Before the fix the streaming generators swallowed the provider error and ended
+ * the stream silently, so the consumer saw an empty-but-"successful" stream, wrote
+ * an empty summary, printed STREAM_COMPLETE and exited 0. Model-free: the mock
+ * never loads a model, so this runs in the model-free t2 lane (no @pipeline tag).
+ */
+
+const TRANSCRIPT =
+  'Alice: we ship the release on Friday. Bob: the budget is fifty thousand dollars.';
+
+const SEEDED_SUMMARY = 'PRE-EXISTING summary that a failed reprocess must NOT clobber';
+
+type ReprocessResult = { success: boolean; error?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      reprocess: (summaryFile: string, regenTitle: boolean, name: string) => Promise<ReprocessResult>;
+    };
+  };
+};
+
+const readSummary = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
+
+test('reprocess surfaces a stream failure and leaves the existing summary untouched', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Local provider so the summarizer talks to the mock Ollama on 11434.
+  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  const summaryFile = writeMeetingSummary(userDataDir, 'failure', {
+    name: 'Failure Meeting',
+    summary: SEEDED_SUMMARY,
+    key_points: ['seeded point'],
+    action_items: ['seeded action'],
+    transcript: TRANSCRIPT,
+  });
+  const summarySigBefore = fileSig(summaryFile);
+
+  // Mock Ollama answers /api/chat with the real Ollama 404 shape so the stream
+  // fails mid-flight instead of returning content.
+  const ollama = await startMockOllama({
+    chatError: { status: 404, message: "model 'gemma4:e2b-it-qat' not found" },
+  });
+  try {
+    const { page } = await launchApp();
+
+    const res = await page.evaluate(
+      (f) => (window as StenoWindow).stenoai.meetings.reprocess(f, false, 'Failure Meeting'),
+      summaryFile,
+    );
+
+    // (1) The operation must report failure, not a false success.
+    expect(res.success).toBe(false);
+
+    // The summariser must have actually attempted the call (proves we exercised
+    // the streaming path, not an earlier bail-out).
+    expect(ollama.chatCalls()).toBeGreaterThanOrEqual(1);
+
+    // (2) The pre-existing summary on disk is byte-for-byte unchanged — a failed
+    // stream must not overwrite it with an empty summary.
+    expect(fileSig(summaryFile)).toBe(summarySigBefore);
+    const after = readSummary(summaryFile);
+    expect(after.summary).toBe(SEEDED_SUMMARY);
+    expect(after.key_points).toEqual(['seeded point']);
+    expect(after.action_items).toEqual(['seeded action']);
+
+    // Keystone: the real user-data dir is byte-for-byte untouched.
+    expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+  } finally {
+    await ollama.close();
+  }
+});

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -853,9 +853,10 @@ class OllamaSummarizer:
             ...
             {"type": "done",  "model": "...", "input_tokens": N, "output_tokens": M}
             or {"type": "error", "error": "..."} on failure.
-        Yields the text portion of each chunk record. Errors are logged
-        and the generator returns silently — matches the streaming-error
-        behaviour of the cloud and ollama paths.
+        Yields the text portion of each chunk record. On any failure (an
+        error record, an HTTP error, or a transport error) it logs and then
+        RAISES so the consumer surfaces the real error via STREAM_ERROR —
+        matching the streaming-error contract of the cloud and ollama paths.
         """
         import urllib.request
         import urllib.error
@@ -890,7 +891,7 @@ class OllamaSummarizer:
                             yield text
                     elif kind == "error":
                         logger.error(f"Adapter stream error: {record.get('error')}")
-                        return
+                        raise RuntimeError(f"Adapter stream error: {record.get('error')}")
                     elif kind == "done":
                         return
         except urllib.error.HTTPError as e:
@@ -898,8 +899,10 @@ class OllamaSummarizer:
                 logger.error("Adapter stream rejected: session expired or unauthorized")
             else:
                 logger.error(f"Adapter streaming failed: HTTP {e.code}")
+            raise
         except Exception as e:
             logger.error(f"Adapter streaming failed: {e}")
+            raise
 
     def _anthropic_chat(self, prompt: str, timeout_seconds: int = 300) -> str:
         """Send a chat request via the Anthropic Messages API."""
@@ -1487,7 +1490,7 @@ TRANSCRIPT:
                             yield text
                 except Exception as e:
                     logger.error(f"Anthropic streaming failed: {e}")
-                    return
+                    raise
             elif self.cloud_provider == "bedrock":
                 # Bedrock's /converse-stream uses amazon eventstream framing
                 # (binary, length-prefixed), which would need a dedicated
@@ -1503,7 +1506,7 @@ TRANSCRIPT:
                         yield text
                 except Exception as e:
                     logger.error(f"Bedrock summarisation failed: {e}")
-                    return
+                    raise
             else:
                 try:
                     response = self.cloud_client.chat.completions.create(
@@ -1519,7 +1522,7 @@ TRANSCRIPT:
                             yield content
                 except Exception as e:
                     logger.error(f"OpenAI streaming failed: {e}")
-                    return
+                    raise
             return
 
         # Ollama (local or remote) — shared with the free-form template path.
@@ -1527,7 +1530,7 @@ TRANSCRIPT:
             yield from self._stream_direct(prompt)
         except Exception as e:
             logger.error(f"Ollama streaming failed: {e}")
-            return
+            raise
 
     def summarize_transcript_streaming(self, transcript: str, duration_minutes: int = 0, language: str = "en", notes: str = None, progress_callback=None, template_prompt: Optional[str] = None):
         """Generator that yields markdown chunks from the LLM.
@@ -1553,15 +1556,28 @@ TRANSCRIPT:
             # ACTIVE provider — not straight to Ollama, which has no client and
             # would crash in cloud/adapter mode.
             prompt = self._create_template_report_prompt(transcript, template_prompt, language, notes)
-            yield from self._stream_completion(prompt)
-            return
+            inner = self._stream_completion(prompt)
+            empty_message = "Model returned an empty report"
+        elif self._needs_chunking(transcript, notes):
+            inner = self._map_reduce_streaming(transcript, language, notes, progress_callback)
+            empty_message = "Model returned an empty summary"
+        else:
+            prompt = self._create_markdown_prompt(transcript, language, notes)
+            inner = self._stream_completion(prompt)
+            empty_message = "Model returned an empty summary"
 
-        if self._needs_chunking(transcript, notes):
-            yield from self._map_reduce_streaming(transcript, language, notes, progress_callback)
-            return
-
-        prompt = self._create_markdown_prompt(transcript, language, notes)
-        yield from self._stream_completion(prompt)
+        # Defense in depth mirroring _map_reduce_streaming's empty-reduce guard: a
+        # provider can complete the stream without raising yet yield nothing (or
+        # only whitespace). Route that through STREAM_ERROR instead of silently
+        # saving an empty summary/report. (_map_reduce_streaming already raises on
+        # an empty reduce, so wrapping it here is harmless.)
+        saw_content = False
+        for chunk in inner:
+            if chunk and chunk.strip():
+                saw_content = True
+            yield chunk
+        if not saw_content:
+            raise ValueError(empty_message)
 
     def test_connection(self) -> bool:
         """

--- a/tests/test_summarizer_stream_errors.py
+++ b/tests/test_summarizer_stream_errors.py
@@ -1,0 +1,205 @@
+"""Regression tests for streaming-summary error propagation.
+
+Before this fix the streaming generators in ``src.summarizer`` swallowed
+provider failures (``logger.error(...); return``): a failed stream (e.g. Ollama
+404 "model not found", a cloud API error, or an adapter error record) ended the
+generator silently, so the consumers in ``simple_recorder`` saw an empty-but-
+"successful" stream and wrote an empty summary + printed STREAM_COMPLETE + exit
+0. These tests pin the corrected contract — a stream failure RAISES so the
+consumer surfaces it via STREAM_ERROR — and add an empty-stream guard mirroring
+``_map_reduce_streaming``'s empty-reduce guard. Fixes GH #301.
+"""
+
+import unittest
+from unittest import mock
+
+from src.config import Config
+from src.summarizer import OllamaSummarizer
+
+
+def _make_summarizer(model="llama3.2:3b"):
+    # Mock the readiness check: __init__ calls _ensure_ollama_ready() for the
+    # local provider, so without this construction would try to start Ollama
+    # (non-hermetic). Mirrors tests/test_summarizer_template.py::_s.
+    with mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready", return_value=True):
+        return OllamaSummarizer(model_name=model, ai_provider="local", config=Config())
+
+
+def _gen_raising(exc):
+    """Return a zero-arg-usable generator function that raises ``exc`` on iteration."""
+
+    def _factory(*args, **kwargs):
+        raise exc
+        yield  # pragma: no cover - makes this a generator
+
+    return _factory
+
+
+def _gen_yielding(chunks):
+    def _factory(*args, **kwargs):
+        for c in chunks:
+            yield c
+
+    return _factory
+
+
+class _FakeResp:
+    """Minimal context-manager stand-in for urllib.request.urlopen()."""
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+class OllamaStreamErrorTests(unittest.TestCase):
+    def test_ollama_stream_error_propagates(self):
+        """Ollama 404 (model not found) must propagate, not yield nothing."""
+        s = _make_summarizer()
+        short = "Speaker: hello.\n" * 3
+        err = RuntimeError("model 'x' not found (404)")
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with mock.patch.object(s, "_stream_direct", side_effect=_gen_raising(err)):
+                with self.assertRaises(RuntimeError) as ctx:
+                    list(s.summarize_transcript_streaming(short))
+        # The ORIGINAL exception surfaces so STREAM_ERROR shows the real message.
+        self.assertIn("not found", str(ctx.exception))
+        self.assertIs(ctx.exception, err)
+
+    def test_empty_stream_raises_valueerror(self):
+        """A stream that completes without raising but yields only whitespace
+        must raise ValueError rather than silently save an empty summary."""
+        s = _make_summarizer()
+        short = "Speaker: hello.\n" * 3
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with mock.patch.object(s, "_stream_direct", side_effect=_gen_yielding(["", "   ", "\n"])):
+                with self.assertRaises(ValueError) as ctx:
+                    list(s.summarize_transcript_streaming(short))
+        self.assertIn("empty", str(ctx.exception).lower())
+
+    def test_successful_stream_yields_chunks_unchanged(self):
+        """Regression guard: a normal successful stream is passed through verbatim."""
+        s = _make_summarizer()
+        short = "Speaker: hello.\n" * 3
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with mock.patch.object(
+                s, "_stream_direct", side_effect=_gen_yielding(["## Summary\n", "ok\n"])
+            ):
+                out = list(s.summarize_transcript_streaming(short))
+        self.assertEqual(out, ["## Summary\n", "ok\n"])
+
+
+class TemplatePathStreamErrorTests(unittest.TestCase):
+    def test_template_path_error_propagates(self):
+        """The free-form template path must also surface provider errors."""
+        s = _make_summarizer()
+        err = RuntimeError("Ollama streaming failed: connection refused")
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with mock.patch.object(s, "_stream_direct", side_effect=_gen_raising(err)):
+                with self.assertRaises(RuntimeError) as ctx:
+                    list(
+                        s.summarize_transcript_streaming(
+                            "Speaker: hi.", template_prompt="Write a status update."
+                        )
+                    )
+        self.assertIs(ctx.exception, err)
+
+    def test_template_path_empty_stream_raises(self):
+        s = _make_summarizer()
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with mock.patch.object(s, "_stream_direct", side_effect=_gen_yielding([""])):
+                with self.assertRaises(ValueError):
+                    list(
+                        s.summarize_transcript_streaming(
+                            "Speaker: hi.", template_prompt="Write a status update."
+                        )
+                    )
+
+
+class CloudStreamErrorTests(unittest.TestCase):
+    def test_openai_compatible_stream_error_propagates(self):
+        """Cloud (openai-compatible) streaming failure must propagate."""
+        s = _make_summarizer()
+        s.ai_provider = "cloud"
+        s.cloud_provider = "openai"
+        s.client = None
+        s.cloud_client = mock.Mock()
+        s.cloud_client.chat.completions.create.side_effect = RuntimeError(
+            "The model `x` does not exist (404)"
+        )
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with self.assertRaises(RuntimeError) as ctx:
+                list(s.summarize_transcript_streaming("Speaker: hi."))
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_anthropic_stream_error_propagates(self):
+        s = _make_summarizer()
+        s.ai_provider = "cloud"
+        s.cloud_provider = "anthropic"
+        s.anthropic_client = mock.Mock()
+        s.anthropic_client.messages.stream.side_effect = RuntimeError("overloaded_error")
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with self.assertRaises(RuntimeError) as ctx:
+                list(s.summarize_transcript_streaming("Speaker: hi."))
+        self.assertIn("overloaded_error", str(ctx.exception))
+
+    def test_bedrock_error_propagates(self):
+        s = _make_summarizer()
+        s.ai_provider = "cloud"
+        s.cloud_provider = "bedrock"
+        with mock.patch.object(s, "_ensure_ollama_ready"):
+            with mock.patch.object(
+                s, "_bedrock_chat", side_effect=RuntimeError("AccessDeniedException")
+            ):
+                with self.assertRaises(RuntimeError) as ctx:
+                    list(s.summarize_transcript_streaming("Speaker: hi."))
+        self.assertIn("AccessDeniedException", str(ctx.exception))
+
+
+class AdapterStreamErrorTests(unittest.TestCase):
+    def _adapter_summarizer(self):
+        s = _make_summarizer()
+        s.ai_provider = "adapter"
+        s.adapter_url = "https://adapter.example.com"
+        s.adapter_token = "fake-token"
+        return s
+
+    def test_adapter_error_record_raises(self):
+        """An NDJSON {"type":"error"} record must raise, not end silently."""
+        s = self._adapter_summarizer()
+        lines = [
+            b'{"type": "chunk", "text": "partial"}\n',
+            b'{"type": "error", "error": "model not found"}\n',
+        ]
+        with mock.patch("urllib.request.urlopen", return_value=_FakeResp(lines)):
+            with self.assertRaises(RuntimeError) as ctx:
+                list(s._adapter_stream("prompt"))
+        self.assertIn("model not found", str(ctx.exception))
+
+    def test_adapter_httperror_raises(self):
+        import urllib.error
+
+        s = self._adapter_summarizer()
+        http_err = urllib.error.HTTPError(
+            "https://adapter.example.com/ai/chat/stream", 500, "Server Error", {}, None
+        )
+        with mock.patch("urllib.request.urlopen", side_effect=http_err):
+            with self.assertRaises(urllib.error.HTTPError):
+                list(s._adapter_stream("prompt"))
+
+    def test_adapter_transport_error_raises(self):
+        s = self._adapter_summarizer()
+        with mock.patch("urllib.request.urlopen", side_effect=OSError("connection reset")):
+            with self.assertRaises(OSError):
+                list(s._adapter_stream("prompt"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

When a summary stream fails (Ollama returning 404 "model not found", a cloud API error, or an adapter error record), the failure was swallowed and reported as success: the user got an empty note ("No summary available for this meeting") with no error surfaced anywhere. Reproduced end-to-end against a real meeting with a broken Ollama: the backend logged `ERROR - Ollama streaming failed: ... 404` but still printed `STREAM_COMPLETE` + `Summary reprocessed successfully` and exited 0.

Root cause: the streaming generators in `src/summarizer.py` logged provider errors and then ended the generator silently (`logger.error(...); return`). Everything downstream was already correct - all five consumer sites in `simple_recorder.py` catch generator exceptions and emit `STREAM_ERROR` + exit 1, and `app/main.js` maps that to failure events. The generators just never raised into that path. This is also the root cause of #301 (cloud streaming failures swallowed).

## Fix

`src/summarizer.py` only - no consumer changes needed:

- `_stream_completion`: all four provider paths (Anthropic, Bedrock, OpenAI-compatible, Ollama) now log and re-raise the original exception, so the real message (e.g. `model 'x' not found (404)`) reaches the UI via `STREAM_ERROR`.
- `_adapter_stream`: an NDJSON error record, an HTTPError, and transport errors now raise after logging. Its second consumer (`query_transcript_streaming`, the chat path) already catches provider errors and yields a visible `[Error: ...]` chunk, so chat via the adapter now shows the error instead of an empty answer.
- `summarize_transcript_streaming`: defense-in-depth empty-stream guard - a stream that completes without raising but yields no non-whitespace content raises `ValueError` instead of saving an empty summary. Mirrors the existing empty-reduce guard in `_map_reduce_streaming`.

A failed regenerate can no longer clobber an existing good summary: the consumers exit before the write.

## Tests

- **Unit** (`tests/test_summarizer_stream_errors.py`, 11 tests, written first and failing before the fix): error propagation for the Ollama, Anthropic, Bedrock, OpenAI-compatible and adapter paths (error record / HTTPError / transport), the empty-stream guard (plain + template path), and a success-passthrough regression guard.
- **e2e** (model-free T2, `e2e/specs/summarize-failure.t2.spec.ts`): drives a real `reprocess` against a mock Ollama answering `/api/chat` with the real 404 shape (new opt-in `chatError` option in `mock-ollama.js`, default off - existing specs unaffected) and asserts the operation reports `success:false` and the pre-existing summary on disk stays byte-for-byte unchanged.
- Full backend suite green, `summarize-contract` e2e re-run green (mock change is non-breaking), backend bundle rebuilt before the e2e run so the spec proves the fix end-to-end.

Fixes #301


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface real errors from summary streaming and stop saving empty notes. Failures (e.g., Ollama 404, cloud API, adapter errors) now trigger `STREAM_ERROR` and never overwrite a good summary.

- **Bug Fixes**
  - All provider streaming paths (Anthropic, Bedrock, OpenAI-compatible, Ollama) now log and re-raise exceptions so the UI gets `STREAM_ERROR`.
  - Adapter stream raises on `{"type":"error"}`, `HTTPError`, and transport errors; chat path shows an inline `[Error: ...]` chunk.
  - Added empty-stream guard: if no non-whitespace is produced, raise `ValueError` instead of saving an empty summary.
  - Prevents failed regenerates from clobbering existing summaries. Fixes #301.

<sup>Written for commit 49e73b4f6bf58486a7dc4ce8e9e8f95957ee3d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

