### PR TITLE
fix: sanitize analytics crash and model values

### DIFF
--- a/app/analytics-helpers.js
+++ b/app/analytics-helpers.js
@@ -246,6 +246,39 @@ function sanitizeErrorForCrashReport(err) {
   return safe;
 }
 
+function captureSanitizedException(posthogClient, err, distinctId) {
+  if (!posthogClient || !distinctId) return;
+  posthogClient.captureException(sanitizeErrorForCrashReport(err), distinctId);
+}
+
+// Only fixed, public model identifiers are safe to send as analytics values.
+// User-entered model names, fine-tuned ids, local paths, and self-pulled tags
+// can carry customer/project names, so they collapse to the fixed "custom".
+const ANALYTICS_MODEL_ALLOWLIST = new Set([
+  'gemma4:e2b-it-qat',
+  'gemma4:e4b-it-qat',
+  'gemma4:12b-it-qat',
+  'gemma4:e2b-nvfp4',
+  'gemma4:e4b-nvfp4',
+  'gemma4:12b-nvfp4',
+  'parakeet',
+  'large-v3-turbo',
+  'gpt-4o-mini',
+  'gpt-4o',
+  'gpt-4.1-mini',
+  'claude-3-5-haiku-latest',
+  'claude-3-5-sonnet-latest',
+  'claude-3-7-sonnet-latest',
+  'claude-haiku-4-5-20251001',
+  'anthropic.claude-haiku-4-5-20251001-v1:0',
+]);
+
+function sanitizeModelForAnalytics(model) {
+  if (typeof model !== 'string' || model.trim() === '') return 'unknown';
+  const trimmed = model.trim();
+  return ANALYTICS_MODEL_ALLOWLIST.has(trimmed) ? trimmed : 'custom';
+}
+
 // Content-free per-window summary for calendar_snapshot: counts + a
 // provider breakdown, never titles/attendees/URLs.
 function summarizeCalendarWindow(windowEvents) {
@@ -324,7 +357,9 @@ module.exports = {
   sanitizeTrackProperties,
   calendarMeetingProvider,
   classifyErrorReason,
+  captureSanitizedException,
   redactLocalPaths,
+  sanitizeModelForAnalytics,
   sanitizeErrorForCrashReport,
   summarizeCalendarWindow,
   summarizeCalendarSnapshot,

--- a/app/analytics-helpers.js
+++ b/app/analytics-helpers.js
@@ -255,14 +255,20 @@ function captureSanitizedException(posthogClient, err, distinctId) {
 // User-entered model names, fine-tuned ids, local paths, and self-pulled tags
 // can carry customer/project names, so they collapse to the fixed "custom".
 const ANALYTICS_MODEL_ALLOWLIST = new Set([
+  // Curated local registry (SUPPORTED_MODELS in src/config.py) + MLX tags
   'gemma4:e2b-it-qat',
   'gemma4:e4b-it-qat',
   'gemma4:12b-it-qat',
   'gemma4:e2b-nvfp4',
   'gemma4:e4b-nvfp4',
   'gemma4:12b-nvfp4',
+  'llama3.2:3b',
+  'qwen3.5:9b',
+  'gpt-oss:20b',
+  // Transcription engines (SUPPORTED_WHISPER_MODELS + the parakeet path)
   'parakeet',
   'large-v3-turbo',
+  // Common public cloud ids (cloud model fields are free-form per provider)
   'gpt-4o-mini',
   'gpt-4o',
   'gpt-4.1-mini',
@@ -270,7 +276,12 @@ const ANALYTICS_MODEL_ALLOWLIST = new Set([
   'claude-3-5-sonnet-latest',
   'claude-3-7-sonnet-latest',
   'claude-haiku-4-5-20251001',
+  // Bedrock dropdown (SUPPORTED_BEDROCK_MODELS in src/config.py)
+  'anthropic.claude-sonnet-4-5-20250929-v2:0',
   'anthropic.claude-haiku-4-5-20251001-v1:0',
+  'anthropic.claude-opus-4-1-20250805-v1:0',
+  'anthropic.claude-3-5-sonnet-20241022-v2:0',
+  'anthropic.claude-3-5-haiku-20241022-v1:0',
 ]);
 
 function sanitizeModelForAnalytics(model) {

--- a/app/analytics-helpers.test.js
+++ b/app/analytics-helpers.test.js
@@ -11,7 +11,9 @@ const {
   sanitizeTrackProperties,
   calendarMeetingProvider,
   classifyErrorReason,
+  captureSanitizedException,
   redactLocalPaths,
+  sanitizeModelForAnalytics,
   sanitizeErrorForCrashReport,
   summarizeCalendarWindow,
   summarizeCalendarSnapshot,
@@ -341,6 +343,39 @@ test('sanitizeErrorForCrashReport does not leak the real dev-checkout path when 
   const safe2 = sanitizeErrorForCrashReport('a bare string, not an Error');
   assert.ok(!safe2.stack.includes(appDir));
   assert.strictEqual(safe2.stack, 'Error: unknown');
+});
+
+test('captureSanitizedException sends only the sanitized crash object to PostHog', () => {
+  let captured = null;
+  const fakePosthog = {
+    captureException(err, distinctId) {
+      captured = { err, distinctId };
+    },
+  };
+  const err = new Error("ENOENT: open '/Users/alice/Secret Client/meeting.wav'");
+  err.stack =
+    "Error: ENOENT: open '/Users/alice/Secret Client/meeting.wav'\n" +
+    '    at fail (/Users/alice/Secret Client/steno/app/main.js:10:2)';
+
+  captureSanitizedException(fakePosthog, err, 'anon-123');
+
+  assert.strictEqual(captured.distinctId, 'anon-123');
+  assert.strictEqual(captured.err.message, 'not_found');
+  assert.ok(!captured.err.stack.includes('alice'));
+  assert.ok(!captured.err.stack.includes('Secret Client'));
+  assert.ok(captured.err.stack.includes('<redacted-path>/main.js:10:2'));
+});
+
+test('sanitizeModelForAnalytics keeps known public model ids but collapses custom/free-form names', () => {
+  assert.strictEqual(sanitizeModelForAnalytics('gemma4:e2b-it-qat'), 'gemma4:e2b-it-qat');
+  assert.strictEqual(sanitizeModelForAnalytics('gpt-4o-mini'), 'gpt-4o-mini');
+  assert.strictEqual(sanitizeModelForAnalytics('claude-3-5-haiku-latest'), 'claude-3-5-haiku-latest');
+
+  assert.strictEqual(sanitizeModelForAnalytics('/Users/alice/Secret Client/model.gguf'), 'custom');
+  assert.strictEqual(sanitizeModelForAnalytics('acme-board-meeting-private-model'), 'custom');
+  assert.strictEqual(sanitizeModelForAnalytics('ft:gpt-4o-mini:acme-corp:board:abc123'), 'custom');
+  assert.strictEqual(sanitizeModelForAnalytics(''), 'unknown');
+  assert.strictEqual(sanitizeModelForAnalytics(null), 'unknown');
 });
 
 test('redactLocalPaths never exposes the username itself when nothing follows it in the match (adversarial regression)', () => {

--- a/app/analytics-helpers.test.js
+++ b/app/analytics-helpers.test.js
@@ -367,21 +367,37 @@ test('captureSanitizedException sends only the sanitized crash object to PostHog
 });
 
 test('sanitizeModelForAnalytics keeps known public model ids but collapses custom/free-form names', () => {
-  assert.strictEqual(sanitizeModelForAnalytics('gemma4:e2b-it-qat'), 'gemma4:e2b-it-qat');
-  assert.strictEqual(sanitizeModelForAnalytics('gpt-4o-mini'), 'gpt-4o-mini');
-  assert.strictEqual(sanitizeModelForAnalytics('claude-3-5-haiku-latest'), 'claude-3-5-haiku-latest');
-  // Every curated built-in must pass through un-collapsed: the full Bedrock
-  // dropdown and the non-Gemma local registry entries are fixed public ids.
-  assert.strictEqual(
-    sanitizeModelForAnalytics('anthropic.claude-sonnet-4-5-20250929-v2:0'),
-    'anthropic.claude-sonnet-4-5-20250929-v2:0'
-  );
-  assert.strictEqual(
-    sanitizeModelForAnalytics('anthropic.claude-3-5-haiku-20241022-v1:0'),
-    'anthropic.claude-3-5-haiku-20241022-v1:0'
-  );
-  assert.strictEqual(sanitizeModelForAnalytics('qwen3.5:9b'), 'qwen3.5:9b');
-  assert.strictEqual(sanitizeModelForAnalytics('gpt-oss:20b'), 'gpt-oss:20b');
+  // Every curated built-in must pass through un-collapsed. This list is a
+  // deliberate literal duplicate of ANALYTICS_MODEL_ALLOWLIST so that an
+  // accidental removal or typo in the allowlist fails here.
+  const curatedPublicIds = [
+    'gemma4:e2b-it-qat',
+    'gemma4:e4b-it-qat',
+    'gemma4:12b-it-qat',
+    'gemma4:e2b-nvfp4',
+    'gemma4:e4b-nvfp4',
+    'gemma4:12b-nvfp4',
+    'llama3.2:3b',
+    'qwen3.5:9b',
+    'gpt-oss:20b',
+    'parakeet',
+    'large-v3-turbo',
+    'gpt-4o-mini',
+    'gpt-4o',
+    'gpt-4.1-mini',
+    'claude-3-5-haiku-latest',
+    'claude-3-5-sonnet-latest',
+    'claude-3-7-sonnet-latest',
+    'claude-haiku-4-5-20251001',
+    'anthropic.claude-sonnet-4-5-20250929-v2:0',
+    'anthropic.claude-haiku-4-5-20251001-v1:0',
+    'anthropic.claude-opus-4-1-20250805-v1:0',
+    'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    'anthropic.claude-3-5-haiku-20241022-v1:0',
+  ];
+  for (const id of curatedPublicIds) {
+    assert.strictEqual(sanitizeModelForAnalytics(id), id);
+  }
 
   assert.strictEqual(sanitizeModelForAnalytics('/Users/alice/Secret Client/model.gguf'), 'custom');
   assert.strictEqual(sanitizeModelForAnalytics('acme-board-meeting-private-model'), 'custom');

--- a/app/analytics-helpers.test.js
+++ b/app/analytics-helpers.test.js
@@ -370,6 +370,18 @@ test('sanitizeModelForAnalytics keeps known public model ids but collapses custo
   assert.strictEqual(sanitizeModelForAnalytics('gemma4:e2b-it-qat'), 'gemma4:e2b-it-qat');
   assert.strictEqual(sanitizeModelForAnalytics('gpt-4o-mini'), 'gpt-4o-mini');
   assert.strictEqual(sanitizeModelForAnalytics('claude-3-5-haiku-latest'), 'claude-3-5-haiku-latest');
+  // Every curated built-in must pass through un-collapsed: the full Bedrock
+  // dropdown and the non-Gemma local registry entries are fixed public ids.
+  assert.strictEqual(
+    sanitizeModelForAnalytics('anthropic.claude-sonnet-4-5-20250929-v2:0'),
+    'anthropic.claude-sonnet-4-5-20250929-v2:0'
+  );
+  assert.strictEqual(
+    sanitizeModelForAnalytics('anthropic.claude-3-5-haiku-20241022-v1:0'),
+    'anthropic.claude-3-5-haiku-20241022-v1:0'
+  );
+  assert.strictEqual(sanitizeModelForAnalytics('qwen3.5:9b'), 'qwen3.5:9b');
+  assert.strictEqual(sanitizeModelForAnalytics('gpt-oss:20b'), 'gpt-oss:20b');
 
   assert.strictEqual(sanitizeModelForAnalytics('/Users/alice/Secret Client/model.gguf'), 'custom');
   assert.strictEqual(sanitizeModelForAnalytics('acme-board-meeting-private-model'), 'custom');

--- a/app/main.js
+++ b/app/main.js
@@ -59,7 +59,8 @@ const {
   sanitizeTrackProperties,
   calendarMeetingProvider,
   classifyErrorReason,
-  sanitizeErrorForCrashReport,
+  captureSanitizedException,
+  sanitizeModelForAnalytics,
   summarizeCalendarSnapshot,
   withTimeout,
 } = require('./analytics-helpers');
@@ -679,7 +680,7 @@ const CAPTURE_EXCEPTION_ENQUEUE_DELAY_MS = 50;
 
 async function captureExceptionAndFlush(err) {
   if (!telemetryEnabled || !posthogClient || !anonymousId) return;
-  posthogClient.captureException(sanitizeErrorForCrashReport(err), anonymousId);
+  captureSanitizedException(posthogClient, err, anonymousId);
   await new Promise((resolve) => setTimeout(resolve, CAPTURE_EXCEPTION_ENQUEUE_DELAY_MS));
   await withTimeout(posthogClient.flush(), 1000);
 }
@@ -1516,7 +1517,8 @@ if (!gotSingleInstanceLock) {
   app.on('render-process-gone', (_event, _webContents, details) => {
     try {
       if (telemetryEnabled && posthogClient && anonymousId) {
-        posthogClient.captureException(
+        captureSanitizedException(
+          posthogClient,
           new Error(`render-process-gone: ${details?.reason || 'unknown'}`),
           anonymousId
         );
@@ -1527,7 +1529,8 @@ if (!gotSingleInstanceLock) {
   app.on('child-process-gone', (_event, details) => {
     try {
       if (telemetryEnabled && posthogClient && anonymousId) {
-        posthogClient.captureException(
+        captureSanitizedException(
+          posthogClient,
           new Error(`child-process-gone: ${details?.type || 'unknown'} (${details?.reason || 'unknown'})`),
           anonymousId
         );
@@ -3484,7 +3487,7 @@ function loadTranscriptionContext() {
       engine,
       // Parakeet has no separate user-selectable model today (single bundled
       // default) -- report the engine name rather than guess a variant id.
-      model: engine === 'whisper' ? (cfg.whisper_model || 'unknown') : 'parakeet',
+      model: engine === 'whisper' ? sanitizeModelForAnalytics(cfg.whisper_model) : 'parakeet',
       language: cfg.language || 'auto',
     };
   } catch (_) {
@@ -3504,7 +3507,9 @@ function loadSummarizationContext() {
     const provider = cfg.ai_provider || 'local';
     return {
       provider,
-      model: provider === 'cloud' ? (cfg.cloud_model || 'unknown') : (cfg.model || 'unknown'),
+      model: provider === 'cloud'
+        ? sanitizeModelForAnalytics(cfg.cloud_model)
+        : sanitizeModelForAnalytics(cfg.model),
     };
   } catch (_) {
     return { provider: 'local', model: 'unknown' };
@@ -5577,11 +5582,11 @@ ipcMain.handle('set-model', async (event, modelName) => {
     const jsonMatch = result.match(/\{.*\}/s);
     if (jsonMatch) {
       const jsonData = JSON.parse(jsonMatch[0]);
-      trackEvent('model_changed', { model: modelName, kind: 'summarization' });
+      trackEvent('model_changed', { model: sanitizeModelForAnalytics(modelName), kind: 'summarization' });
       return jsonData;
     }
 
-    trackEvent('model_changed', { model: modelName, kind: 'summarization' });
+    trackEvent('model_changed', { model: sanitizeModelForAnalytics(modelName), kind: 'summarization' });
     return { success: true, model: modelName };
   } catch (error) {
     sendDebugLog(`Error setting model: ${error.message}`);
@@ -5709,7 +5714,7 @@ ipcMain.handle('set-whisper-model', async (event, modelSize) => {
   try {
     const result = await runPythonScript('simple_recorder.py', ['set-whisper-model', modelSize]);
     const jsonData = JSON.parse(result.trim());
-    trackEvent('model_changed', { model: modelSize, kind: 'transcription' });
+    trackEvent('model_changed', { model: sanitizeModelForAnalytics(modelSize), kind: 'transcription' });
     return { success: true, ...jsonData };
   } catch (e) { return { success: false, error: e.message }; }
 });


### PR DESCRIPTION
## Summary
- route renderer/child-process crash capture through the existing sanitized exception path
- collapse custom/free-form model names to fixed analytics labels before tracking
- add regression tests for both privacy boundaries

## Verification
- npm run test:unit
- npm run typecheck:renderer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes analytics crash reports and model values to prevent leaking local paths or private model names. Fixes curated built-in models being mislabeled as "custom" in analytics.

- **Bug Fixes**
  - Route renderer/child-process and queued errors through `captureSanitizedException` so only redacted errors reach PostHog.
  - Expand model allowlist to include all curated built-ins; collapse others to `custom`. Apply in summarization/transcription contexts and for `model_changed` events.
  - Add unit tests for crash redaction and to assert every curated public model id passes the allowlist.

<sup>Written for commit 861cb7c95028da66006f04344cd57367fc5aeaf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

