### PR TITLE
fix(main): guard app.on('activate') against firing before app.isReady()

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1493,6 +1493,12 @@ if (!gotSingleInstanceLock) {
   });
 
   app.on('activate', () => {
+    // macOS can deliver 'activate' before Electron's own 'ready' event fires
+    // (e.g. cold launch via Dock). The whenReady().then() path below already
+    // creates the initial window once ready, so just no-op here until then -
+    // mirrors the same guard already used in the second-instance/open-url
+    // handlers above.
+    if (!app.isReady()) return;
     rewarmParakeet('activate');
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();


### PR DESCRIPTION
## Problem

Installed Steno.app (v0.5.8, macOS) crashed on launch with:

```
Uncaught Exception: Error: Cannot create BrowserWindow before app is ready
    at createWindow (main.js)
    at EventEmitter.<anonymous> (main.js)  // app.on('activate') handler
```

macOS can deliver the native `activate` event (e.g. cold launch via Dock click) before Electron's own `ready` event resolves. The `activate` handler had no `app.isReady()` guard - unlike the sibling `second-instance` and `open-url` handlers in the same file, which both guard on it - so it called `createWindow()` pre-ready and threw.

## Fix

Early return from the `activate` handler while `!app.isReady()`. No queuing needed: the `app.whenReady().then(...)` path already creates the initial window once ready (unlike `second-instance`/`open-url`, which must preserve an incoming deep-link URL). Skipping `rewarmParakeet` pre-ready is fine too - the startup path does the initial warmup itself.

## Verification

Deterministic repro without triggering a real crash dialog: temporarily appended `app.emit('activate')` at the end of `main.js` (after all top-level state is initialized, before `whenReady()` resolves) and launched via `electron .` with a scratch `STENOAI_USER_DATA_DIR`:

- Without the guard: `isReady=false`, throws the exact production message `Cannot create BrowserWindow before app is ready`
- With the guard: `isReady=false`, no throw; the window is created normally once `whenReady()` resolves

No e2e spec: this is a native-event timing race in the pre-ready window, not practically reachable from Playwright (the app is already past `ready` by the time a test can drive it).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent macOS launch crash by guarding `app.on('activate')` until `app.isReady()`. Window creation now defers to the existing `app.whenReady().then(...)` path.

- **Bug Fixes**
  - Add `if (!app.isReady()) return;` to the `activate` handler; aligns with `second-instance` and `open-url`.
  - Avoids "Cannot create BrowserWindow before app is ready" on cold Dock launch.

<sup>Written for commit 30fc88f578b869a29a1ed143c2fc46436e4535af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

