### PR TITLE
fix(security): enforce canonical path containment on renderer-supplied meeting paths

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -866,10 +866,39 @@ function validateSafeFilePath(filepath, allowedBaseDirs) {
     // Resolve to absolute path and normalize
     const resolvedPath = path.resolve(filepath);
 
+    // The renderer is untrusted, so a lexical prefix check alone is
+    // symlink-vulnerable: a symlink placed inside an allowed dir but pointing
+    // outside it would slip through. Canonicalize BOTH the target and each base
+    // dir with realpath before the containment check, so an escaping symlink
+    // resolves to its real (out-of-bounds) target and is rejected. realpath also
+    // normalizes platform quirks that must match on both sides — on macOS
+    // /tmp -> /private/tmp, which the e2e temp data dir relies on — which is
+    // exactly why we canonicalize both sides.
+    //
+    // realpath throws if the path doesn't exist yet (e.g. a file being created),
+    // so fall back to canonicalizing the parent directory and re-appending the
+    // basename; if even the parent can't be resolved, use the lexical path so we
+    // don't break create-new-file flows.
+    let canonicalPath;
+    try {
+      canonicalPath = fs.realpathSync(resolvedPath);
+    } catch (_) {
+      try {
+        canonicalPath = path.join(fs.realpathSync(path.dirname(resolvedPath)), path.basename(resolvedPath));
+      } catch (_) {
+        canonicalPath = resolvedPath;
+      }
+    }
+
     // Ensure it's within one of the allowed base directories
     for (const baseDir of allowedBaseDirs) {
-      const resolvedBase = path.resolve(baseDir);
-      if (resolvedPath.startsWith(resolvedBase + path.sep) || resolvedPath === resolvedBase) {
+      let resolvedBase;
+      try {
+        resolvedBase = fs.realpathSync(path.resolve(baseDir));
+      } catch (_) {
+        resolvedBase = path.resolve(baseDir);
+      }
+      if (canonicalPath.startsWith(resolvedBase + path.sep) || canonicalPath === resolvedBase) {
         return true;
       }
     }
@@ -1988,7 +2017,12 @@ function parseMeetingMarkdown(content, mdPath) {
  * used. realpath needs the path to exist; a missing target -> denied.
  */
 async function validateMeetingFilePath(summaryFile) {
-  if (!summaryFile || (!summaryFile.endsWith('.json') && !summaryFile.endsWith('.md'))) {
+  // Reject non-strings up front: the renderer is untrusted and could pass an
+  // object/number, on which `.endsWith` would THROW a TypeError — turning this
+  // async function into a rejected promise that an un-try-wrapped `await` (e.g.
+  // the query-transcript-stream listener) would surface as an unhandled
+  // rejection. Fail closed with the same error shape as any other bad path.
+  if (typeof summaryFile !== 'string' || (!summaryFile.endsWith('.json') && !summaryFile.endsWith('.md'))) {
     return { error: 'Invalid file path' };
   }
   let realPath;
@@ -2399,10 +2433,18 @@ ipcMain.handle('query-transcript', async (event, summaryFile, question) => {
   try {
     sendDebugLog(`🤖 Querying transcript (${String(question || '').length} chars)`);
 
+    // Security: the renderer is untrusted, so containment-check the summary path
+    // (symlink-safe, output/ only) before it reaches the backend, and pass the
+    // canonical realPath — not the original string — as the file arg.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+
     // Run the query command — getAiEnv supplies the right env for whichever
     // provider is active (cloud key for cloud, adapter url+token for org).
     const env = getAiEnv();
-    const result = await runPythonScript('simple_recorder.py', ['query', summaryFile, '-q', question], false, env);
+    const result = await runPythonScript('simple_recorder.py', ['query', validated.realPath, '-q', question], false, env);
 
     // Parse the JSON response
     try {
@@ -2450,12 +2492,30 @@ ipcMain.handle('query-transcript', async (event, summaryFile, question) => {
 
 const activeQueryProcs = new Map();
 
+// Cancellation intent for streaming queries that are still in their pre-spawn
+// async window. query-transcript-stream now `await`s validateMeetingFilePath
+// BEFORE it registers a killable proc in activeQueryProcs, so a query-cancel
+// (or sender-destroy) arriving during that await would otherwise be LOST — the
+// cancel finds nothing to kill, then the backend spawns uncancellable. Each
+// in-flight validation registers a setter here keyed by queryId; query-cancel
+// invokes it to flip the handler's `cancelled` flag, and the handler checks
+// that flag on every exit path so it never spawns-then-orphans a proc.
+const pendingQueryCancels = new Map();
+
 ipcMain.on('query-cancel', (_event, queryId) => {
   const proc = activeQueryProcs.get(queryId);
   if (proc) {
     console.log(`[QUERY] Cancelling queryId=${queryId}`);
     proc.kill();
     activeQueryProcs.delete(queryId);
+  }
+  // Cancel a stream that's still validating (pre-spawn): flip its flag so the
+  // handler bails out instead of spawning after the await resolves.
+  const pending = pendingQueryCancels.get(queryId);
+  if (pending) {
+    console.log(`[QUERY] Cancelling pre-spawn queryId=${queryId}`);
+    pending();
+    pendingQueryCancels.delete(queryId);
   }
   // Org-chat streams use AbortController instead of a child process; share
   // the same query-cancel channel so the renderer doesn't have to know which
@@ -2468,7 +2528,7 @@ ipcMain.on('query-cancel', (_event, queryId) => {
   }
 });
 
-ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) => {
+ipcMain.on('query-transcript-stream', async (event, queryId, summaryFile, question) => {
   console.log(`[QUERY] IPC received: question="${question.substring(0, 50)}" file="${summaryFile}"`);
   sendDebugLog(`🤖 Streaming query (${String(question || '').length} chars)`);
   const env = { ...process.env, ...getAiEnv() };
@@ -2492,21 +2552,92 @@ ipcMain.on('query-transcript-stream', (event, queryId, summaryFile, question) =>
     });
   };
 
+  // Security: the renderer is untrusted, so containment-check the summary path
+  // (symlink-safe, output/ only) BEFORE spawning the backend, and spawn with the
+  // canonical realPath. The handler is async only to await this check — the spawn
+  // still happens synchronously afterwards. The console.log/debug lines above may
+  // keep logging the original string (a label); the spawn arg must be the realPath.
+  //
+  // Cancel-race guard: because we now `await` BEFORE registering a killable proc
+  // in activeQueryProcs, a query-cancel during the await would be lost. Register
+  // cancellation intent via pendingQueryCancels (see the query-cancel handler)
+  // and honour the flag on every exit path so a cancel that lands mid-validation
+  // aborts the query instead of spawning an uncancellable backend.
+  let cancelled = false;
+  pendingQueryCancels.set(queryId, () => { cancelled = true; });
+
+  // Send query-done only if the renderer is still alive — event.sender.send
+  // throws "Object has been destroyed" once the sender is gone. The try/catch is
+  // belt-and-suspenders: isDestroyed() + send() run in the same synchronous tick
+  // (no yield between them), but send can still throw for other reasons (e.g. the
+  // frame went away), and a failure to notify must never crash the main process.
+  const sendDone = (payload) => {
+    try {
+      if (!event.sender.isDestroyed()) event.sender.send('query-done', { queryId, ...payload });
+    } catch (_) { /* renderer gone — nothing to notify */ }
+  };
+  // The renderer can also be destroyed DURING the pre-spawn await (window closed
+  // or navigated away). The `destroyed` listener below is only wired up AFTER
+  // spawn, and `.once('destroyed')` never fires for an event that already
+  // happened — so a destroy mid-validation would spawn an orphaned, unobserved
+  // backend. Treat "sender gone while validating" the same as a cancel: bail on
+  // every pre-spawn exit path, and re-check immediately after spawn.
+  const aborted = () => cancelled || event.sender.isDestroyed();
+
+  let validated;
+  try {
+    validated = await validateMeetingFilePath(summaryFile);
+  } catch (err) {
+    // Defense-in-depth: validateMeetingFilePath is fail-closed and shouldn't
+    // throw, but if it ever does (e.g. a future refactor), don't let it become
+    // an unhandled rejection that can take down the main process.
+    pendingQueryCancels.delete(queryId);
+    sendDone({ success: false, error: 'Invalid file path' });
+    trackChatOnce(false);
+    return;
+  }
+  pendingQueryCancels.delete(queryId);
+
+  if (validated.error) {
+    sendDone({ success: false, error: validated.error });
+    trackChatOnce(false);
+    return;
+  }
+  if (aborted()) {
+    // A cancel landed, or the renderer went away, while we were validating —
+    // bail out before spawning an uncancellable / orphaned backend. A cancelled
+    // query is not a completed "message sent", so (like the killed-proc close
+    // path, code === null) it is deliberately left untracked.
+    sendDone({ success: false, error: 'Cancelled' });
+    return;
+  }
+
   let proc;
   try {
     const backendPath = getBackendPath();
-    proc = require('child_process').spawn(backendPath, ['query-streaming', summaryFile, '-q', question], {
+    proc = require('child_process').spawn(backendPath, ['query-streaming', validated.realPath, '-q', question], {
       env,
       cwd: getBackendCwd(),
       windowsHide: true,
     });
   } catch (err) {
-    event.sender.send('query-done', { queryId, success: false, error: err.message });
+    sendDone({ success: false, error: err.message });
     trackChatOnce(false);
     return;
   }
 
   activeQueryProcs.set(queryId, proc);
+  // Belt-and-suspenders: a cancel or a sender-destroy could have flipped the
+  // abort condition between the pre-spawn check and here. If the query is no
+  // longer wanted, kill the freshly-spawned proc immediately so it can't be
+  // orphaned (the pendingQueryCancels entry is already gone, and a destroy that
+  // already fired won't reach the `destroyed` listener wired up below).
+  if (aborted()) {
+    proc.kill();
+    activeQueryProcs.delete(queryId);
+    sendDone({ success: false, error: 'Cancelled' });
+    return;
+  }
   // Kill the spawned proc if the renderer sender goes away before the query
   // finishes. Keep a reference so we can remove the listener on normal close
   // (otherwise repeated queries on a long-lived sender leak one-time listeners).
@@ -2897,38 +3028,28 @@ ipcMain.handle('save-diagnostics', async (event, defaultFilename, content) => {
 
 ipcMain.handle('update-meeting', async (event, summaryFilePath, updates) => {
   try {
-    const projectRoot = path.join(__dirname, '..');
-
-    // Define allowed base directories for file operations (includes custom storage)
-    const allowedBaseDirs = getAllowedBaseDirs();
-
-    // Convert to absolute path if needed
-    const absolutePath = path.isAbsolute(summaryFilePath)
-      ? summaryFilePath
-      : path.join(projectRoot, summaryFilePath);
-
-    // Security: Validate file path is within allowed directories
-    if (!validateSafeFilePath(absolutePath, allowedBaseDirs)) {
-      console.error(`Security: Blocked attempt to update file outside allowed directories: ${absolutePath}`);
-      return {
-        success: false,
-        error: 'Invalid file path'
-      };
+    // Security: the renderer is untrusted, so containment-check the summary path
+    // (symlink-safe, output/ only) and operate exclusively on the canonical
+    // realPath for every read/write below — never the original renderer string.
+    const validated = await validateMeetingFilePath(summaryFilePath);
+    if (validated.error) {
+      return { success: false, error: validated.error };
     }
+    const { realPath } = validated;
 
     // Read existing data
-    if (!fs.existsSync(absolutePath)) {
+    if (!fs.existsSync(realPath)) {
       return {
         success: false,
         error: 'Meeting file not found'
       };
     }
 
-    const isMarkdown = absolutePath.endsWith('.md');
+    const isMarkdown = realPath.endsWith('.md');
     let data;
 
     if (isMarkdown) {
-      const raw = fs.readFileSync(absolutePath, 'utf8');
+      const raw = fs.readFileSync(realPath, 'utf8');
       // Escape a string for a YAML double-quoted scalar. Backslash MUST be
       // escaped before the quote, and embedded newlines must become literal
       // \n so they don't end the scalar mid-line.
@@ -2996,17 +3117,17 @@ ipcMain.handle('update-meeting', async (event, summaryFilePath, updates) => {
         }
       }
 
-      fs.writeFileSync(absolutePath, updatedRaw, 'utf8');
+      fs.writeFileSync(realPath, updatedRaw, 'utf8');
 
       data = {
         session_info: {
           name: updates.name !== undefined ? updates.name : title,
-          summary_file: absolutePath,
+          summary_file: realPath,
           updated_at: updatedAt,
         },
       };
     } else {
-      data = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+      data = JSON.parse(fs.readFileSync(realPath, 'utf8'));
 
       if (updates.name !== undefined) {
         data.session_info.name = updates.name;
@@ -3025,10 +3146,10 @@ ipcMain.handle('update-meeting', async (event, summaryFilePath, updates) => {
       }
 
       data.session_info.updated_at = new Date().toISOString();
-      fs.writeFileSync(absolutePath, JSON.stringify(data, null, 2), 'utf8');
+      fs.writeFileSync(realPath, JSON.stringify(data, null, 2), 'utf8');
     }
 
-    console.log(`Updated meeting: ${absolutePath}`);
+    console.log(`Updated meeting: ${realPath}`);
 
     return {
       success: true,
@@ -5409,7 +5530,13 @@ ipcMain.handle('reorder-folders', async (event, folderIds) => {
 
 ipcMain.handle('add-meeting-to-folder', async (event, summaryFile, folderId) => {
   try {
-    const result = await runPythonScript('simple_recorder.py', ['add-meeting-to-folder', summaryFile, folderId]);
+    // Security: the renderer is untrusted, so containment-check the summary path
+    // (symlink-safe, output/ only) and pass the canonical realPath to the backend.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+    const result = await runPythonScript('simple_recorder.py', ['add-meeting-to-folder', validated.realPath, folderId]);
     const jsonMatch = result.match(/\{.*\}/s);
     return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
   } catch (error) {
@@ -5419,7 +5546,13 @@ ipcMain.handle('add-meeting-to-folder', async (event, summaryFile, folderId) => 
 
 ipcMain.handle('remove-meeting-from-folder', async (event, summaryFile, folderId) => {
   try {
-    const result = await runPythonScript('simple_recorder.py', ['remove-meeting-from-folder', summaryFile, folderId]);
+    // Security: the renderer is untrusted, so containment-check the summary path
+    // (symlink-safe, output/ only) and pass the canonical realPath to the backend.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+    const result = await runPythonScript('simple_recorder.py', ['remove-meeting-from-folder', validated.realPath, folderId]);
     const jsonMatch = result.match(/\{.*\}/s);
     return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
   } catch (error) {

--- a/e2e/specs/path-validation-security.t2.spec.ts
+++ b/e2e/specs/path-validation-security.t2.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  symlinkSync,
+  rmSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+/**
+ * T2 — path-validation trust boundary (security hardening batch,
+ * fix/path-validation-trust-boundary).
+ *
+ * Threat model: the Electron renderer is UNTRUSTED (XSS / compromised renderer /
+ * DevTools). A renderer-supplied file path must not let the backend or the main
+ * process read / write / delete arbitrary local files. The two seams under test:
+ *
+ *   - validateMeetingFilePath (output/-only, realpath-canonicalized) guards
+ *     query-transcript, add/remove-meeting-to-folder and update-meeting.
+ *   - validateSafeFilePath (recordings/ + transcripts/ + output/, now
+ *     realpath-canonicalized) guards delete-meeting (unlink), reveal and the
+ *     system-audio path.
+ *
+ * These specs drive the real preload bridge and assert BOTH the rejection AND
+ * that the out-of-bounds file on disk is never read / modified / deleted.
+ * Model-free: every rejection happens in the Electron main process BEFORE any
+ * backend spawn, so no Ollama / network is involved.
+ */
+
+type Result = { success: boolean; error?: string; answer?: string };
+type Meeting = { session_info: { name: string; summary_file: string } };
+
+type StenoWindow = Window & {
+  stenoai: {
+    query: { ask: (file: string, q: string) => Promise<Result> };
+    meetings: {
+      update: (summaryFile: string, patch: Record<string, unknown>) => Promise<Result>;
+      delete: (meeting: Meeting) => Promise<Result>;
+    };
+    folders: {
+      addMeeting: (summaryFile: string, folderId: string) => Promise<Result>;
+      removeMeeting: (summaryFile: string, folderId: string) => Promise<Result>;
+    };
+  };
+};
+
+test('meeting-file handlers reject a real .json OUTSIDE output/ and never read/modify it', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // A genuine .json file at the data-dir ROOT (a sibling of output/). It passes
+  // the extension gate, so only the output/-containment check can stop it — this
+  // proves the containment boundary, not merely the ext filter.
+  const evilPath = path.join(userDataDir, 'evil.json');
+  const evilBody = JSON.stringify({ session_info: { name: 'ATTACKER' }, secret: 'keepme' });
+  writeFileSync(evilPath, evilBody, 'utf8');
+  const evilSigBefore = fileSig(evilPath);
+
+  const { page } = await launchApp();
+
+  // 1) query-transcript — arbitrary READ. Rejected before any backend spawn.
+  const q = await page.evaluate(
+    (f) => (window as StenoWindow).stenoai.query.ask(f, 'summarize this'),
+    evilPath,
+  );
+  expect(q.success).toBe(false);
+  expect(q.error).toBeTruthy();
+
+  // 2) add-meeting-to-folder / remove-meeting-from-folder — arbitrary WRITE via
+  //    the backend. Any folder id works: validation rejects before it's used.
+  const add = await page.evaluate(
+    (f) => (window as StenoWindow).stenoai.folders.addMeeting(f, 'dummy-folder-id'),
+    evilPath,
+  );
+  expect(add.success).toBe(false);
+  expect(add.error).toBeTruthy();
+
+  const remove = await page.evaluate(
+    (f) => (window as StenoWindow).stenoai.folders.removeMeeting(f, 'dummy-folder-id'),
+    evilPath,
+  );
+  expect(remove.success).toBe(false);
+  expect(remove.error).toBeTruthy();
+
+  // 3) update-meeting — arbitrary WRITE via fs. Rejected, and the file is byte-
+  //    for-byte unchanged (the rename attempt never touched it).
+  const upd = await page.evaluate(
+    (f) => (window as StenoWindow).stenoai.meetings.update(f, { name: 'HACKED' }),
+    evilPath,
+  );
+  expect(upd.success).toBe(false);
+  expect(upd.error).toBeTruthy();
+
+  // The out-of-bounds file was never modified.
+  expect(fileSig(evilPath)).toBe(evilSigBefore);
+  expect(readFileSync(evilPath, 'utf8')).toBe(evilBody);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('meeting-file handlers reject a NON-STRING / malformed path without crashing', async ({
+  launchApp,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const { page } = await launchApp();
+
+  // The renderer is untrusted, so a compromised/malicious caller can hand the
+  // typed bridge a non-string (object/number). validateMeetingFilePath's ext
+  // check would call `.endsWith` on it and THROW — which, on the async
+  // query-transcript-stream listener, would become an unhandled rejection that
+  // can take down the main process. The source now type-guards, so every caller
+  // resolves gracefully to { success: false } instead. Cast through `unknown`
+  // to smuggle the non-string past the TS bridge types (mirrors a real attacker
+  // who isn't bound by our types at runtime).
+  for (const bad of [42, { path: '/etc/hosts' }, null, undefined] as unknown[]) {
+    const q = await page.evaluate(
+      (f) => (window as StenoWindow).stenoai.query.ask(f as unknown as string, 'read'),
+      bad,
+    );
+    expect(q.success).toBe(false);
+    expect(q.error).toBeTruthy();
+
+    const upd = await page.evaluate(
+      (f) => (window as StenoWindow).stenoai.meetings.update(f as unknown as string, { name: 'x' }),
+      bad,
+    );
+    expect(upd.success).toBe(false);
+    expect(upd.error).toBeTruthy();
+  }
+
+  // The app is still alive and responsive after the malformed inputs (no crash
+  // / no hung main process): a subsequent well-formed-but-rejected call returns.
+  const stillAlive = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.query.ask('/nope/outside.json', 'ping'),
+  );
+  expect(stillAlive.success).toBe(false);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+// Symlink escape: a link that LEXICALLY lives inside output/ but resolves OUTSIDE
+// it. A naive path-prefix check passes; only realpath canonicalization rejects it.
+// Windows symlink creation needs admin / developer mode, unreliable on headless
+// CI runners — skip there. macOS (the signed, primary platform) is the real
+// signal, and validateSafeFilePath deliberately canonicalizes both sides so the
+// e2e /tmp -> /private/tmp normalization keeps working.
+test.describe('symlink escape is canonicalized and rejected', () => {
+  test.skip(
+    process.platform === 'win32',
+    'symlink creation requires admin/developer mode on Windows runners',
+  );
+
+  test('output/ symlink -> outside file is rejected by realpath (read/write + delete seams)', async ({
+    launchApp,
+    userDataDir,
+  }) => {
+    const realDirBefore = fileSig(realUserDataDir());
+
+    // The escape target lives in an UNRELATED temp dir — outside both the app's
+    // project root and the (allowed) user-data dir, so it's out of bounds for
+    // BOTH validators.
+    const outsideDir = mkdtempSync(path.join(tmpdir(), 'stenoai-evil-'));
+    const outsideTarget = path.join(outsideDir, 'secret.json');
+    const outsideBody = JSON.stringify({ secret: 'do-not-touch' });
+    writeFileSync(outsideTarget, outsideBody, 'utf8');
+    const outsideSigBefore = fileSig(outsideTarget);
+
+    // The symlink sits INSIDE output/ (lexically contained) but points out.
+    const outputDir = path.join(userDataDir, 'output');
+    mkdirSync(outputDir, { recursive: true });
+    const linkPath = path.join(outputDir, 'evil_summary.json');
+    symlinkSync(outsideTarget, linkPath);
+
+    try {
+      const { page } = await launchApp();
+
+      // validateMeetingFilePath seam: query READ + update WRITE both rejected.
+      const q = await page.evaluate(
+        (f) => (window as StenoWindow).stenoai.query.ask(f, 'read the secret'),
+        linkPath,
+      );
+      expect(q.success).toBe(false);
+      expect(q.error).toBeTruthy();
+
+      const upd = await page.evaluate(
+        (f) => (window as StenoWindow).stenoai.meetings.update(f, { name: 'HACKED' }),
+        linkPath,
+      );
+      expect(upd.success).toBe(false);
+      expect(upd.error).toBeTruthy();
+
+      // validateSafeFilePath seam: delete-meeting must NOT unlink through the
+      // symlink. It reports the blocked deletion and the target survives.
+      const del = await page.evaluate(
+        (f) =>
+          (window as StenoWindow).stenoai.meetings.delete({
+            session_info: { name: 'Evil', summary_file: f },
+          }),
+        linkPath,
+      );
+      expect(del.success).toBe(false);
+      expect(del.error).toBeTruthy();
+
+      // The escape target was neither modified nor deleted.
+      expect(existsSync(outsideTarget)).toBe(true);
+      expect(fileSig(outsideTarget)).toBe(outsideSigBefore);
+      expect(readFileSync(outsideTarget, 'utf8')).toBe(outsideBody);
+
+      // Keystone: the real user-data dir is byte-for-byte untouched.
+      expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes several path-traversal issues where the untrusted Electron renderer (XSS / compromised renderer / DevTools) could drive the backend or the main process into reading, writing, or deleting arbitrary local files. Enforcement is at the Electron trust boundary; the Python CLI stays intentionally permissive so the documented `query transcript.txt` debug path keeps working.

## Issues fixed

- **Arbitrary file read (+ potential exfiltration)** — `query-transcript` / `query-transcript-stream` passed the renderer's `summaryFile` straight to the backend `query` command, which reads any UTF-8 file (no extension gate on the plain-text path). With a cloud/org provider the contents are also sent to the external AI service.
- **Arbitrary file write** — `add-/remove-meeting-to-folder` passed `summaryFile` straight to the folders backend, which rewrites the target file.
- **Symlink escape** — `update-meeting` used a lexical-only path check, then read/wrote the original (symlink-followed) path across the whole project/storage root.
- **Symlink-followed delete** — `delete-meeting` / `reveal` / system-audio shared the same lexical check.

## Fix

- Route the four meeting-file handlers through `validateMeetingFilePath()` (output/-only, realpath-canonicalized) and pass the canonical `realPath` downstream — never the original renderer string.
- Harden `validateSafeFilePath()` with `realpathSync` canonicalization of both target and base dirs, covering delete/reveal/system-audio with no call-site change.
- Additional hardening on the stream handler this change makes async: guard a `query-cancel` or sender-destroy landing during pre-spawn validation (cancel-race / orphaned backend), type-guard non-string input at the `validateMeetingFilePath` source (avoids an unhandled rejection that could crash main), and make `query-done` delivery exception-safe. The `chat_message_sent` analytics from #323 is preserved.

## Tests

New model-free T2 e2e spec `path-validation-security.t2.spec.ts`: asserts rejection of out-of-`output/` paths, non-string input, and symlink escapes on both validator seams, and that the out-of-bounds file is never read / modified / deleted. `meetings-crud` / `folders-crud` / `chat-sessions` T2 regressions green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces symlink-safe, canonical path containment for renderer-supplied meeting files to block arbitrary local file read/write/delete from the Electron renderer. Validation now happens at the Electron trust boundary; the Python CLI remains permissive for documented debug flows.

- **Bug Fixes**
  - Guard `query-transcript`, `query-transcript-stream`, `update-meeting`, and `add/remove-meeting-to-folder` with `validateMeetingFilePath` (output/ only) and pass the canonical `realPath` downstream.
  - Canonicalize both target and base dirs in `validateSafeFilePath` using `fs.realpathSync`, securing delete/reveal/system-audio without call-site changes.
  - Pre-validate in `query-transcript-stream`, add pending-cancel handling to avoid orphaned backends, and make `query-done` delivery exception-safe.
  - Reject non-string paths early to prevent unhandled rejections and main-process crashes.
  - Add a T2 e2e spec covering out-of-`output/` paths, non-string input, and symlink escapes; asserts no unauthorized disk reads/writes/deletes.

<sup>Written for commit 541654fa0d290d85c90bafe4009577e31a754a8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

