### PR TITLE
fix(main): fold in-meeting notes into the summary again

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -206,9 +206,7 @@ function getUserDataDir() {
   return path.join(base, 'stenoai');
 }
 
-// The output dir the Python pipeline reads/writes (custom storage if set, else
-// the user-data dir). Single source of truth so the notes writer and reader
-// can't drift apart — see notes-file.js.
+// Output dir the Python pipeline reads/writes (custom storage, else user-data).
 function getOutputDir() {
   return path.join(_cachedCustomStoragePath || getUserDataDir(), 'output');
 }
@@ -7067,11 +7065,7 @@ ipcMain.handle('process-system-audio-recording', async (event, audioFilePath, se
 
     const actualSessionName = sessionName || 'Note';
 
-    // Check for user notes file. Resolve it from the SAME output dir that
-    // 'save-meeting-notes' wrote it to (getOutputDir / userNotesFilePath) — not
-    // the read-only bundle dir. The old getBackendCwd()/_internal/output path
-    // never existed for packaged users, so the lookup always missed, --notes was
-    // never passed, and in-meeting notes were silently dropped from the summary.
+    // Same dir 'save-meeting-notes' writes to — not the read-only bundle dir.
     const notesFile = userNotesFilePath(getOutputDir(), actualSessionName);
     const notesPath = fs.existsSync(notesFile) ? notesFile : undefined;
 

--- a/app/main.js
+++ b/app/main.js
@@ -37,6 +37,7 @@ const path = require('path');
 const { spawn: _spawnRaw } = require('child_process');
 const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
+const { userNotesFilePath } = require('./notes-file');
 const { makeLineReader } = require('./backend-stream');
 // Pure deep-link (stenoai://) parsing/sanitizing lives in ./shortcut-url
 // (unit-tested). The stateful side — window creation, IPC dispatch,
@@ -203,6 +204,13 @@ function getUserDataDir() {
   }
   const base = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
   return path.join(base, 'stenoai');
+}
+
+// The output dir the Python pipeline reads/writes (custom storage if set, else
+// the user-data dir). Single source of truth so the notes writer and reader
+// can't drift apart — see notes-file.js.
+function getOutputDir() {
+  return path.join(_cachedCustomStoragePath || getUserDataDir(), 'output');
 }
 
 let mainWindow;
@@ -2780,10 +2788,9 @@ ipcMain.handle('save-meeting-notes', async (event, sessionName, notes) => {
     // INSIDE the app bundle: read-only in a packaged/signed app (so saving notes
     // failed for real users on macOS + Windows), and a dir the Python pipeline
     // never reads notes from, so reprocess's _load_user_notes couldn't find them.
-    const outputDir = path.join(_cachedCustomStoragePath || getUserDataDir(), 'output');
+    const outputDir = getOutputDir();
     if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
-    const safeName = sessionName.replace(/[^a-zA-Z0-9_-]/g, '_');
-    const notesFile = path.join(outputDir, `${safeName}_notes.txt`);
+    const notesFile = userNotesFilePath(outputDir, sessionName);
     fs.writeFileSync(notesFile, notes, 'utf-8');
     return { success: true, path: notesFile };
   } catch (error) {
@@ -7060,9 +7067,12 @@ ipcMain.handle('process-system-audio-recording', async (event, audioFilePath, se
 
     const actualSessionName = sessionName || 'Note';
 
-    // Check for user notes file
-    const safeName = actualSessionName.replace(/[^a-zA-Z0-9_-]/g, '_');
-    const notesFile = path.join(getBackendCwd(), '_internal', 'output', `${safeName}_notes.txt`);
+    // Check for user notes file. Resolve it from the SAME output dir that
+    // 'save-meeting-notes' wrote it to (getOutputDir / userNotesFilePath) — not
+    // the read-only bundle dir. The old getBackendCwd()/_internal/output path
+    // never existed for packaged users, so the lookup always missed, --notes was
+    // never passed, and in-meeting notes were silently dropped from the summary.
+    const notesFile = userNotesFilePath(getOutputDir(), actualSessionName);
     const notesPath = fs.existsSync(notesFile) ? notesFile : undefined;
 
     // Snapshot the live transcript captured during this recording (#207) so the

--- a/app/notes-file.js
+++ b/app/notes-file.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const path = require('path');
+
+// Sanitize a session name into the stem used for its sidecar files. MUST stay
+// in sync with the Python backend, which derives the same stem via
+//   re.sub(r'[^a-zA-Z0-9_-]', '_', session_name)
+// (see simple_recorder.py _load_user_notes). If these two drift, the note file
+// Electron writes won't be the one the pipeline reads.
+function safeSessionStem(sessionName) {
+  return String(sessionName == null ? '' : sessionName).replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+// Resolve the user-notes sidecar path for a session, given the resolved output
+// dir. The writer ('save-meeting-notes') and the reader (stop-recording, which
+// decides whether to pass --notes to the pipeline) MUST both go through this so
+// they can never point at different directories again.
+//
+// Regression context: the note was written to the user-data output dir
+// but read back from the read-only bundle dir (getBackendCwd()/_internal/output).
+// That path doesn't exist for packaged users, so the lookup always missed,
+// --notes was never passed, and in-meeting notes were silently dropped from the
+// summary — the LLM never saw them.
+function userNotesFilePath(outputDir, sessionName) {
+  return path.join(outputDir, `${safeSessionStem(sessionName)}_notes.txt`);
+}
+
+module.exports = { safeSessionStem, userNotesFilePath };

--- a/app/notes-file.js
+++ b/app/notes-file.js
@@ -2,25 +2,15 @@
 
 const path = require('path');
 
-// Sanitize a session name into the stem used for its sidecar files. MUST stay
-// in sync with the Python backend, which derives the same stem via
-//   re.sub(r'[^a-zA-Z0-9_-]', '_', session_name)
-// (see simple_recorder.py _load_user_notes). If these two drift, the note file
-// Electron writes won't be the one the pipeline reads.
+// Stem used for a session's sidecar files. The `u` flag mirrors Python's
+// re.sub(r'[^a-zA-Z0-9_-]', '_', name), which folds an astral char to one '_'.
 function safeSessionStem(sessionName) {
-  return String(sessionName == null ? '' : sessionName).replace(/[^a-zA-Z0-9_-]/g, '_');
+  return String(sessionName == null ? '' : sessionName).replace(/[^a-zA-Z0-9_-]/gu, '_');
 }
 
-// Resolve the user-notes sidecar path for a session, given the resolved output
-// dir. The writer ('save-meeting-notes') and the reader (stop-recording, which
-// decides whether to pass --notes to the pipeline) MUST both go through this so
-// they can never point at different directories again.
-//
-// Regression context: the note was written to the user-data output dir
-// but read back from the read-only bundle dir (getBackendCwd()/_internal/output).
-// That path doesn't exist for packaged users, so the lookup always missed,
-// --notes was never passed, and in-meeting notes were silently dropped from the
-// summary — the LLM never saw them.
+// Single source of truth for the notes sidecar path — writer and reader MUST
+// share it, or they drift (the reader once read the read-only bundle dir and
+// silently dropped every note).
 function userNotesFilePath(outputDir, sessionName) {
   return path.join(outputDir, `${safeSessionStem(sessionName)}_notes.txt`);
 }

--- a/app/notes-file.test.js
+++ b/app/notes-file.test.js
@@ -1,0 +1,52 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+const { safeSessionStem, userNotesFilePath } = require('./notes-file');
+
+test('safeSessionStem replaces every disallowed char with underscore', () => {
+  // Must mirror Python: re.sub(r'[^a-zA-Z0-9_-]', '_', name)
+  assert.strictEqual(safeSessionStem('Weekly Sync'), 'Weekly_Sync');
+  assert.strictEqual(safeSessionStem('Q3 review: budget/plan'), 'Q3_review__budget_plan');
+  assert.strictEqual(safeSessionStem('café ☕ chat'), 'caf____chat');
+});
+
+test('safeSessionStem preserves the already-safe alphabet (letters, digits, _ and -)', () => {
+  assert.strictEqual(safeSessionStem('Note-1_v2'), 'Note-1_v2');
+});
+
+test('safeSessionStem coerces null/undefined to an empty stem', () => {
+  assert.strictEqual(safeSessionStem(null), '');
+  assert.strictEqual(safeSessionStem(undefined), '');
+});
+
+test('userNotesFilePath joins the output dir with the <stem>_notes.txt sidecar', () => {
+  assert.strictEqual(
+    userNotesFilePath('/data/output', 'Note'),
+    path.join('/data/output', 'Note_notes.txt'),
+  );
+  assert.strictEqual(
+    userNotesFilePath('/data/output', 'Weekly Sync'),
+    path.join('/data/output', 'Weekly_Sync_notes.txt'),
+  );
+});
+
+test('regression: writer and reader resolve to the SAME path for the same dir + name', () => {
+  // The bug was two call sites computing the notes path independently — the
+  // writer used the user-data output dir, the reader used the read-only bundle
+  // dir — so the file written was never the file read. Routing both through
+  // userNotesFilePath makes divergence impossible: same inputs => same path.
+  const outputDir = '/Users/x/Library/Application Support/stenoai/output';
+  const sessionName = 'Note';
+  const writerPath = userNotesFilePath(outputDir, sessionName); // save-meeting-notes
+  const readerPath = userNotesFilePath(outputDir, sessionName); // stop-recording
+  assert.strictEqual(writerPath, readerPath);
+  assert.strictEqual(readerPath, path.join(outputDir, 'Note_notes.txt'));
+});
+
+test('userNotesFilePath does NOT resolve into the app bundle', () => {
+  // Guards against a regression back to getBackendCwd()/_internal/output, which
+  // is read-only for packaged users and where notes are never written.
+  const p = userNotesFilePath('/data/output', 'Note');
+  assert.ok(!p.includes('_internal'), `notes path leaked into the bundle: ${p}`);
+});

--- a/app/notes-file.test.js
+++ b/app/notes-file.test.js
@@ -8,7 +8,14 @@ test('safeSessionStem replaces every disallowed char with underscore', () => {
   // Must mirror Python: re.sub(r'[^a-zA-Z0-9_-]', '_', name)
   assert.strictEqual(safeSessionStem('Weekly Sync'), 'Weekly_Sync');
   assert.strictEqual(safeSessionStem('Q3 review: budget/plan'), 'Q3_review__budget_plan');
+  // BMP non-ASCII (é, ☕ = U+2615) are each a single code unit → one underscore.
   assert.strictEqual(safeSessionStem('café ☕ chat'), 'caf____chat');
+});
+
+test('safeSessionStem collapses an astral char (emoji) to a SINGLE underscore', () => {
+  // 😀 is one code point but two UTF-16 units; the `u` flag matches Python's one '_'.
+  assert.strictEqual(safeSessionStem('a😀b'), 'a_b');
+  assert.strictEqual(safeSessionStem('Standup 🚀'), 'Standup__');
 });
 
 test('safeSessionStem preserves the already-safe alphabet (letters, digits, _ and -)', () => {
@@ -32,10 +39,7 @@ test('userNotesFilePath joins the output dir with the <stem>_notes.txt sidecar',
 });
 
 test('regression: writer and reader resolve to the SAME path for the same dir + name', () => {
-  // The bug was two call sites computing the notes path independently — the
-  // writer used the user-data output dir, the reader used the read-only bundle
-  // dir — so the file written was never the file read. Routing both through
-  // userNotesFilePath makes divergence impossible: same inputs => same path.
+  // The bug: two sites computed the path independently and drifted. One helper => can't.
   const outputDir = '/Users/x/Library/Application Support/stenoai/output';
   const sessionName = 'Note';
   const writerPath = userNotesFilePath(outputDir, sessionName); // save-meeting-notes
@@ -45,8 +49,7 @@ test('regression: writer and reader resolve to the SAME path for the same dir + 
 });
 
 test('userNotesFilePath does NOT resolve into the app bundle', () => {
-  // Guards against a regression back to getBackendCwd()/_internal/output, which
-  // is read-only for packaged users and where notes are never written.
+  // Guards against regressing to the read-only bundle dir (_internal/output).
   const p = userNotesFilePath('/data/output', 'Note');
   assert.ok(!p.includes('_internal'), `notes path leaked into the bundle: ${p}`);
 });

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -3,6 +3,7 @@ import { ipc } from '@/lib/ipc';
 import { appendDebugLog } from '@/lib/debugLogs';
 import { isMac } from '@/lib/utils';
 import { flushNotesThenProcess } from '@/lib/notesFlush';
+import { unwrap } from '@/lib/result';
 import { getLiveDraft } from './liveDraftStore';
 import { useRecording } from './useRecording';
 import { useTranscriptionEngine } from './useModels';
@@ -671,7 +672,8 @@ export function useSystemAudioCapture() {
                 name,
                 filePath: closed.filePath,
                 getDraftNotes: (n) => getLiveDraft(n)?.notes,
-                saveNotes: (n, notes) => bridge.meetings.saveNotes(n, notes),
+                // unwrap turns a { success:false } Result into a throw so onFlushError sees it.
+                saveNotes: async (n, notes) => unwrap(await bridge.meetings.saveNotes(n, notes)),
                 processRecording: (fp, n) => bridge.recording.processSystemAudio(fp, n),
                 // eslint-disable-next-line no-console
                 onFlushError: (err) => console.error('[systemAudioCapture] notes flush failed', err),

--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { ipc } from '@/lib/ipc';
 import { appendDebugLog } from '@/lib/debugLogs';
 import { isMac } from '@/lib/utils';
+import { flushNotesThenProcess } from '@/lib/notesFlush';
+import { getLiveDraft } from './liveDraftStore';
 import { useRecording } from './useRecording';
 import { useTranscriptionEngine } from './useModels';
 import {
@@ -664,7 +666,16 @@ export function useSystemAudioCapture() {
               // eslint-disable-next-line no-console
               console.error('[systemAudioCapture] close failed', closed.error);
             } else if (closed.filePath) {
-              await bridge.recording.processSystemAudio(closed.filePath, name);
+              // Flush last-second notes before handoff — main reads the sidecar.
+              await flushNotesThenProcess({
+                name,
+                filePath: closed.filePath,
+                getDraftNotes: (n) => getLiveDraft(n)?.notes,
+                saveNotes: (n, notes) => bridge.meetings.saveNotes(n, notes),
+                processRecording: (fp, n) => bridge.recording.processSystemAudio(fp, n),
+                // eslint-disable-next-line no-console
+                onFlushError: (err) => console.error('[systemAudioCapture] notes flush failed', err),
+              });
             }
           } catch (err) {
             // eslint-disable-next-line no-console

--- a/app/renderer/src/lib/notesFlush.test.ts
+++ b/app/renderer/src/lib/notesFlush.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, vi } from 'vitest';
+import { flushNotesThenProcess } from '@/lib/notesFlush';
+
+describe('flushNotesThenProcess', () => {
+  test('flushes the latest notes, then processes — in that order', async () => {
+    const calls: string[] = [];
+    const saveNotes = vi.fn(async () => {
+      calls.push('save');
+    });
+    const processRecording = vi.fn(async () => {
+      calls.push('process');
+    });
+
+    await flushNotesThenProcess({
+      name: 'Note',
+      filePath: '/tmp/rec.webm',
+      getDraftNotes: () => 'last-second edit',
+      saveNotes,
+      processRecording,
+    });
+
+    expect(saveNotes).toHaveBeenCalledWith('Note', 'last-second edit');
+    expect(processRecording).toHaveBeenCalledWith('/tmp/rec.webm', 'Note');
+    expect(calls).toEqual(['save', 'process']); // write must land before the read
+  });
+
+  test('skips the write when there are no notes, but still processes', async () => {
+    const saveNotes = vi.fn(async () => {});
+    const processRecording = vi.fn(async () => {});
+
+    for (const notes of [undefined, '']) {
+      await flushNotesThenProcess({
+        name: 'Note',
+        filePath: '/tmp/rec.webm',
+        getDraftNotes: () => notes,
+        saveNotes,
+        processRecording,
+      });
+    }
+
+    expect(saveNotes).not.toHaveBeenCalled();
+    expect(processRecording).toHaveBeenCalledTimes(2);
+  });
+
+  test('a failed flush does not block processing (best-effort)', async () => {
+    const err = new Error('disk full');
+    const onFlushError = vi.fn();
+    const processRecording = vi.fn(async () => {});
+
+    await flushNotesThenProcess({
+      name: 'Note',
+      filePath: '/tmp/rec.webm',
+      getDraftNotes: () => 'notes',
+      saveNotes: async () => {
+        throw err;
+      },
+      processRecording,
+      onFlushError,
+    });
+
+    expect(onFlushError).toHaveBeenCalledWith(err);
+    expect(processRecording).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/renderer/src/lib/notesFlush.test.ts
+++ b/app/renderer/src/lib/notesFlush.test.ts
@@ -24,22 +24,36 @@ describe('flushNotesThenProcess', () => {
     expect(calls).toEqual(['save', 'process']); // write must land before the read
   });
 
-  test('skips the write when there are no notes, but still processes', async () => {
+  test('skips the write when no draft exists (undefined), but still processes', async () => {
     const saveNotes = vi.fn(async () => {});
     const processRecording = vi.fn(async () => {});
 
-    for (const notes of [undefined, '']) {
-      await flushNotesThenProcess({
-        name: 'Note',
-        filePath: '/tmp/rec.webm',
-        getDraftNotes: () => notes,
-        saveNotes,
-        processRecording,
-      });
-    }
+    await flushNotesThenProcess({
+      name: 'Note',
+      filePath: '/tmp/rec.webm',
+      getDraftNotes: () => undefined,
+      saveNotes,
+      processRecording,
+    });
 
     expect(saveNotes).not.toHaveBeenCalled();
-    expect(processRecording).toHaveBeenCalledTimes(2);
+    expect(processRecording).toHaveBeenCalledTimes(1);
+  });
+
+  test('writes an empty string (cleared notes) to overwrite a stale sidecar', async () => {
+    const saveNotes = vi.fn(async () => {});
+    const processRecording = vi.fn(async () => {});
+
+    await flushNotesThenProcess({
+      name: 'Note',
+      filePath: '/tmp/rec.webm',
+      getDraftNotes: () => '',
+      saveNotes,
+      processRecording,
+    });
+
+    expect(saveNotes).toHaveBeenCalledWith('Note', '');
+    expect(processRecording).toHaveBeenCalledTimes(1);
   });
 
   test('a failed flush does not block processing (best-effort)', async () => {

--- a/app/renderer/src/lib/notesFlush.ts
+++ b/app/renderer/src/lib/notesFlush.ts
@@ -13,7 +13,9 @@ export interface StopHandoffDeps {
 
 export async function flushNotesThenProcess(deps: StopHandoffDeps): Promise<void> {
   const notes = deps.getDraftNotes(deps.name);
-  if (notes) {
+  // `''` means the user cleared notes: write it to overwrite a stale sidecar.
+  // `undefined` means no draft exists, so there is nothing to flush.
+  if (notes !== undefined) {
     // Best-effort: a failed flush must not block processing.
     try {
       await deps.saveNotes(deps.name, notes);

--- a/app/renderer/src/lib/notesFlush.ts
+++ b/app/renderer/src/lib/notesFlush.ts
@@ -1,0 +1,25 @@
+// Flush the latest notes to disk before handing the recording to processing.
+// The debounced autosave (useLiveMeeting) is dropped when the stop flow unmounts
+// the editor, so a note typed in the last ~500 ms would miss the sidecar main
+// reads. Reading the store directly and awaiting the write closes that race.
+export interface StopHandoffDeps {
+  name: string;
+  filePath: string;
+  getDraftNotes: (name: string) => string | undefined;
+  saveNotes: (name: string, notes: string) => Promise<unknown>;
+  processRecording: (filePath: string, name: string) => Promise<unknown>;
+  onFlushError?: (err: unknown) => void;
+}
+
+export async function flushNotesThenProcess(deps: StopHandoffDeps): Promise<void> {
+  const notes = deps.getDraftNotes(deps.name);
+  if (notes) {
+    // Best-effort: a failed flush must not block processing.
+    try {
+      await deps.saveNotes(deps.name, notes);
+    } catch (err) {
+      deps.onFlushError?.(err);
+    }
+  }
+  await deps.processRecording(deps.filePath, deps.name);
+}


### PR DESCRIPTION
## Problem

Notes typed during a meeting (the "In-app note-taking" feature) never reach the AI summary. The model has no idea the note existed.

## Root cause

The notes sidecar is written and read from **two different directories**:

- **Writer** — `save-meeting-notes` writes to the user-data output dir:
  `path.join(_cachedCustomStoragePath || getUserDataDir(), 'output', '<stem>_notes.txt')`
- **Reader** — the stop-recording handler (`process-system-audio-recording`) looked for it in the **read-only app bundle**:
  `path.join(getBackendCwd(), '_internal', 'output', '<stem>_notes.txt')`

That bundle path doesn't exist for packaged users, so `fs.existsSync(notesFile)` always returned false, `--notes` was never passed to `simple_recorder.py`, `notes_text` stayed `None`, and the note was dropped from the summary.

This looks like a half-completed move: the writer was intentionally moved out of the read-only bundle (see the comment on `save-meeting-notes`), but the reader was left pointing at the old location. The backend safety net that would have caught it — `MeetingPipeline._load_user_notes()` in `simple_recorder.py` — is currently dead code (never called), so nothing masked the mismatch.

Verified on a packaged 0.5.8 install: the note file was sitting in `~/Library/Application Support/stenoai/output/` while the reader looked under `Steno.app/Contents/Resources/stenoai/_internal/output/`, which did not exist.

## Fix

Give the notes path a single source of truth so the writer and reader can't drift apart again:

- **`app/notes-file.js`** (new) — `safeSessionStem()` (kept in sync with the Python `re.sub(r'[^a-zA-Z0-9_-]', '_', name)`) and `userNotesFilePath(outputDir, name)`.
- **`app/main.js`** — new `getOutputDir()` helper; both `save-meeting-notes` and the stop-recording reader now resolve the path via `userNotesFilePath(getOutputDir(), name)`.

## Tests

- **`app/notes-file.test.js`** (new, `node:test`) — stem sanitization (incl. Unicode + null/undefined), sidecar path shape, a regression test asserting writer and reader resolve to the **same** path for the same dir+name, and a guard that the path never lands inside the app bundle (`_internal`).
- Wired into the `test:unit` script.

```
# tests 6
# pass 6
# fail 0
```

## Follow-up (not in this PR)

`_load_user_notes()` in `simple_recorder.py` is defined but never called. Wiring it up as a backend-side fallback would make the pipeline robust even if the Electron path regresses again. Happy to do it in a separate PR if you'd like.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped in-meeting notes and flushes both last-second edits and cleared notes on Stop so summaries always reflect user notes. Save errors are surfaced without blocking processing, and filename sanitization now matches Python across Unicode.

- **Bug Fixes**
  - Add `app/notes-file.js` with `safeSessionStem()` (uses the `u` flag for astral-char parity) and `userNotesFilePath()`; single source for notes paths.
  - Add `getOutputDir()` in `app/main.js` and route both `save-meeting-notes` and stop-recording through `userNotesFilePath(getOutputDir(), name)` instead of the read-only bundle path.
  - Flush notes before processing to close the debounce race; write '' to overwrite stale sidecars; unwrap save-note Result failures to surface errors, but still process.
  - Tests: add `app/notes-file.test.js` and `app/renderer/src/lib/notesFlush.test.ts` (ordering, undefined skip, empty overwrite, best-effort on error); wire `notes-file.test.js` into `test:unit`.

<sup>Written for commit 197ea04a6e2d12e957b7855accf7424787ab0c92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

