### PR TITLE
feat(website): /vs/ competitor comparison pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">Steno is the privacy first AI notepad for all your confidential conversations. No cloud, no usage limits and full control of your private data. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
+<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and full control of your private data. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
 
 <p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and full control of your private data. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
+<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
 
 <p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">Steno is the AI powered intelligence layer for all your confidential workflows, your private data never leaves anywhere. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
+<p align="center">Steno is the privacy first AI notepad for all your confidential conversations. No cloud, no usage limits and full control of your private data. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
 
 <p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, healthcare, defence, legal and CXO professionals.</p>
+<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, finance, legal and C-suite professionals with confidential data needs.</p>
 
 <p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, legal and C-suite professionals with confidential data needs.</p>
+<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, healthcare, defence, legal and CXO professionals.</p>
 
 <p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 

--- a/website/index.html
+++ b/website/index.html
@@ -5,23 +5,23 @@
     <link rel="icon" type="image/svg+xml" href="/stenoai-logo.svg" />
     <link rel="icon" type="image/png" href="/favicon-64.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Free AI meeting notes with full privacy. Steno transcribes and summarizes meetings entirely on your device — no cloud, no bots joining calls, no usage limits." />
-    <title>Steno — Free, Private AI Meeting Notes (No Cloud)</title>
+    <meta name="description" content="Steno is the privacy-first AI notepad and meeting assistant. It records, transcribes, and summarizes meetings entirely on your device — a free, open-source AI notetaker with no cloud, no bots joining calls, and no usage limits." />
+    <title>Steno — Privacy-First AI Notepad & Meeting Notetaker (Free, No Cloud)</title>
     <link rel="canonical" href="https://stenoai.co/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://stenoai.co/" />
-    <meta property="og:title" content="Steno — Free, Private AI Meeting Notes (No Cloud)" />
-    <meta property="og:description" content="Free AI meeting notes with full privacy. Steno transcribes and summarizes meetings entirely on your device — no cloud, no bots joining calls, no usage limits." />
+    <meta property="og:title" content="Steno — Privacy-First AI Notepad & Meeting Notetaker (Free, No Cloud)" />
+    <meta property="og:description" content="Steno is the privacy-first AI notepad and meeting assistant. It records, transcribes, and summarizes meetings entirely on your device — a free, open-source AI notetaker with no cloud, no bots joining calls, and no usage limits." />
     <meta property="og:image" content="https://stenoai.co/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Steno — Free, Private AI Meeting Notes (No Cloud)" />
-    <meta name="twitter:description" content="Free AI meeting notes with full privacy. Steno transcribes and summarizes meetings entirely on your device — no cloud, no bots joining calls, no usage limits." />
+    <meta name="twitter:title" content="Steno — Privacy-First AI Notepad & Meeting Notetaker (Free, No Cloud)" />
+    <meta name="twitter:description" content="Steno is the privacy-first AI notepad and meeting assistant. It records, transcribes, and summarizes meetings entirely on your device — a free, open-source AI notetaker with no cloud, no bots joining calls, and no usage limits." />
     <meta name="twitter:image" content="https://stenoai.co/og-image.png" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -53,7 +53,7 @@
         "@type": "SoftwareApplication",
         "name": "Steno",
         "url": "https://stenoai.co/",
-        "description": "Free AI meeting notes with full privacy. Steno transcribes and summarizes meetings entirely on your device — no cloud, no bots joining calls, no usage limits.",
+        "description": "Steno is the privacy-first AI notepad and meeting assistant. It records, transcribes, and summarizes meetings entirely on your device — a free, open-source AI notetaker with no cloud, no bots joining calls, and no usage limits.",
         "applicationCategory": "BusinessApplication",
         "operatingSystem": "macOS, Windows",
         "offers": {

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -6,6 +6,31 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://stenoai.co/vs/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://stenoai.co/vs/granola/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://stenoai.co/vs/otter/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://stenoai.co/vs/fireflies/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://stenoai.co/vs/meetily/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://stenoai.co/privacy.html</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/website/src/components/AppWindowDemo.jsx
+++ b/website/src/components/AppWindowDemo.jsx
@@ -207,7 +207,7 @@ function NotesScreen() {
           <div
             style={{ fontFamily: "var(--font-serif)", fontWeight: 400, fontSize: 34, lineHeight: 1.15, letterSpacing: "-0.02em", color: "var(--fg-1)", marginBottom: 10 }}
           >
-            Q1 Budget Planning
+            Defence Budget Planning
           </div>
 
           <div className="flex flex-wrap items-center gap-1.5 mb-6">
@@ -364,7 +364,7 @@ function GeneratingScreen() {
           </button>
 
           <div style={{ fontFamily: "var(--font-serif)", fontWeight: 400, fontSize: 34, lineHeight: 1.15, letterSpacing: "-0.02em", color: "var(--fg-1)", margin: "0 0 10px" }}>
-            Q1 Budget Planning
+            Defence Budget Planning
           </div>
 
           <div className="flex flex-wrap items-center gap-1.5 mb-6">
@@ -424,7 +424,7 @@ function SummaryScreen() {
           </button>
 
           <div style={{ fontFamily: "var(--font-serif)", fontWeight: 400, fontSize: 36, lineHeight: 1.1, letterSpacing: "-0.025em", color: "var(--fg-1)", margin: "0 0 10px" }}>
-            Q1 Budget Planning
+            Defence Budget Planning
           </div>
 
           <div className="flex flex-wrap items-center gap-1.5 pb-5 mb-5" style={{ borderBottom: "1px solid var(--border-subtle)" }}>
@@ -555,7 +555,7 @@ function ChatScreen() {
           <ChevronLeft size={13} /> Work
         </div>
         <div style={{ fontFamily: "var(--font-serif)", fontSize: 30, fontWeight: 400, letterSpacing: "-0.02em", color: "var(--fg-1)", marginBottom: 10 }}>
-          Q1 Budget Planning
+          Defence Budget Planning
         </div>
         <div style={{ display: "flex", gap: 6, marginBottom: 16 }}>
           <span style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 10px", background: "var(--surface-hover)", borderRadius: 20, fontSize: 12, color: "var(--fg-2)" }}>
@@ -591,7 +591,7 @@ function ChatScreen() {
             <div style={{ background: "color-mix(in srgb, var(--surface-raised) 92%, transparent)", backdropFilter: "saturate(160%) blur(10px)", WebkitBackdropFilter: "saturate(160%) blur(10px)", border: "1px solid var(--border-subtle)", borderRadius: 14, boxShadow: "var(--shadow-md)", overflow: "hidden" }}>
               <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", borderBottom: "1px solid var(--border-subtle)" }}>
                 <span style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-1)", flex: 1 }}>
-                  Q1 Budget Planning
+                  Defence Budget Planning
                   <ChevronDown size={11} style={{ display: "inline", marginLeft: 3, color: "var(--fg-2)", verticalAlign: "middle" }} />
                 </span>
                 <button style={{ border: "1px solid var(--border-subtle)", borderRadius: 6, padding: "2px 8px", fontSize: 12, color: "var(--fg-2)", background: "transparent", cursor: "default" }}>

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -369,3 +369,65 @@
   from { transform: translateX(0); }
   to   { transform: translateX(-50%); }
 }
+
+/* ═══════════════════════════════════════════════════
+   /vs/ comparison pages — ledger-style table
+   ═══════════════════════════════════════════════════ */
+.vs-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.vs-table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.vs-table thead th {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--fg-2);
+  text-align: left;
+  padding: 0 16px 12px;
+  border-bottom: 2px solid var(--fg-1);
+}
+
+.vs-table tbody th {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg-2);
+  text-align: left;
+  vertical-align: top;
+  padding: 14px 16px 14px 0;
+  width: 22%;
+}
+
+.vs-table tbody td {
+  color: var(--fg-1);
+  vertical-align: top;
+  padding: 14px 16px;
+  width: 39%;
+}
+
+.vs-table tbody tr {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+/* Steno's column reads as the highlighted ledger entry */
+.vs-table .vs-col-steno {
+  background: var(--surface-sunken);
+}
+.vs-table thead .vs-col-steno {
+  color: var(--fg-1);
+}
+
+/* /vs/ index rows */
+.vs-index-row { display: block; }
+.vs-index-row:hover span:first-child { text-decoration: none; }

--- a/website/src/sections/Features.jsx
+++ b/website/src/sections/Features.jsx
@@ -133,7 +133,7 @@ function NotesPane() {
             lineHeight: 1.15, letterSpacing: "-0.02em", color: "var(--fg-1)", marginBottom: 10,
           }}
         >
-          Q1 Budget Planning
+          Defence Budget Planning
         </div>
         <div className="flex flex-wrap items-center gap-1.5 mb-6">
           {[
@@ -272,7 +272,7 @@ function ChatWithNotesImage() {
           <ChevronLeft size={9} /> Work
         </div>
         <div style={{ fontFamily: "var(--font-serif)", fontSize: 18, color: "var(--fg-1)", marginBottom: 8, letterSpacing: "-0.02em" }}>
-          Q1 Budget Planning
+          Defence Budget Planning
         </div>
         <div style={{ display: "flex", gap: 4 }}>
           {[
@@ -324,7 +324,7 @@ function ChatWithNotesImage() {
           >
             <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 12px", borderBottom: "1px solid var(--border-subtle)", flexShrink: 0 }}>
               <span style={{ fontSize: 12, fontWeight: 600, color: "var(--fg-1)", flex: 1 }}>
-                Q1 Budget Planning
+                Defence Budget Planning
                 <ChevronDown size={10} style={{ display: "inline", marginLeft: 2, color: "var(--fg-2)", verticalAlign: "middle" }} />
               </span>
               <button style={{ border: "1px solid var(--border-subtle)", borderRadius: 5, padding: "1px 7px", fontSize: 10, color: "var(--fg-2)", background: "transparent", cursor: "default" }}>

--- a/website/src/sections/Footer.jsx
+++ b/website/src/sections/Footer.jsx
@@ -21,9 +21,23 @@ export function Footer() {
           </div>
           <div className="text-fg-2 text-[13px]">© 2026 Steno</div>
         </div>
-        <p className="mt-14 text-fg-muted text-[13px] leading-[1.55]" style={{ maxWidth: "70ch" }}>
+        <div className="mt-10 flex gap-x-4 gap-y-2 flex-wrap items-center">
+          <span className="text-fg-muted text-[13px]">Compare:</span>
+          {[
+            { slug: "granola", name: "Granola" },
+            { slug: "otter", name: "Otter.ai" },
+            { slug: "fireflies", name: "Fireflies" },
+            { slug: "meetily", name: "Meetily" },
+          ].map(({ slug, name }) => (
+            <a key={slug} href={`/vs/${slug}/`} className="text-fg-muted text-[13px] no-underline hover:text-fg-1 transition-colors">
+              Steno vs {name}
+            </a>
+          ))}
+        </div>
+        <p className="mt-8 text-fg-muted text-[13px] leading-[1.55]" style={{ maxWidth: "70ch" }}>
           Independent open-source project for private meeting notes. Not affiliated with any similarly named company.
-          Product names (Whisper, Llama, Gemma, Qwen, DeepSeek) are trademarks of their respective owners.
+          Product names (Whisper, Llama, Gemma, Qwen, DeepSeek, Granola, Otter, Fireflies, Meetily) are trademarks
+          of their respective owners; comparisons are independent editorial content.
         </p>
       </div>
     </footer>

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -96,7 +96,7 @@ export function Hero() {
           style={{ maxWidth: "64ch" }}
         >
           Steno is the privacy first AI notepad for all your confidential conversations.
-          No cloud, no usage limits and full control of your data.
+          No cloud, no usage limits and full control of your private data.
         </Motion.p>
 
         <Motion.div

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -95,7 +95,7 @@ export function Hero() {
           className="text-fg-2 text-lg leading-[1.55] mt-6 mb-8 mx-auto"
           style={{ maxWidth: "64ch" }}
         >
-          Steno is the privacy first AI notepad for all your confidential conversations.
+          Steno is the privacy-first AI notepad for all your confidential conversations.
           No cloud, no usage limits and full control of your private data.
         </Motion.p>
 

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -95,7 +95,7 @@ export function Hero() {
           className="text-fg-2 text-lg leading-[1.55] mt-6 mb-8 mx-auto"
           style={{ maxWidth: "64ch" }}
         >
-          Steno is the AI powered intelligence layer for all your confidential workflows.
+          Steno is the privacy first AI notepad for all your confidential conversations.
           No cloud, no usage limits and full control of your data.
         </Motion.p>
 

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -97,6 +97,7 @@ export function Hero() {
         >
           Steno is the privacy-first AI notepad for all your confidential conversations.
           No cloud, no usage limits and your private data never leaves your premises.
+          Perfect for government, healthcare, defence, legal and CXO professionals.
         </Motion.p>
 
         <Motion.div

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -96,7 +96,7 @@ export function Hero() {
           style={{ maxWidth: "64ch" }}
         >
           Steno is the privacy-first AI notepad for all your confidential conversations.
-          No cloud, no usage limits and full control of your private data.
+          No cloud, no usage limits and your private data never leaves your premises.
         </Motion.p>
 
         <Motion.div

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -97,7 +97,6 @@ export function Hero() {
         >
           Steno is the privacy-first AI notepad for all your confidential conversations.
           No cloud, no usage limits and your private data never leaves your premises.
-          Perfect for government, healthcare, defence, legal and CXO professionals.
         </Motion.p>
 
         <Motion.div

--- a/website/src/sections/Nav.jsx
+++ b/website/src/sections/Nav.jsx
@@ -90,7 +90,6 @@ function CompareMenu() {
       <a
         href="/vs/"
         aria-expanded={open}
-        aria-haspopup="menu"
         onFocus={() => setOpen(true)}
         className="inline-flex items-center gap-1 text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
       >
@@ -104,8 +103,12 @@ function CompareMenu() {
 
       <AnimatePresence>
         {open && (
+          // Plain links in a labelled group, not role="menu": a nav dropdown of
+          // page links doesn't need the application-menu keyboard model (arrow
+          // keys, roving focus). Tab/Shift-Tab through the links + Escape is the
+          // correct, expected interaction here.
           <Motion.div
-            role="menu"
+            aria-label="Compare Steno with other tools"
             initial={{ opacity: 0, y: 4, x: "-50%" }}
             animate={{ opacity: 1, y: 0, x: "-50%" }}
             exit={{ opacity: 0, y: 4, x: "-50%" }}
@@ -125,7 +128,6 @@ function CompareMenu() {
                 <a
                   key={href}
                   href={href}
-                  role="menuitem"
                   className="px-4 py-2 text-fg-2 text-sm no-underline hover:text-fg-1 hover:bg-surface-hover transition-colors whitespace-nowrap"
                 >
                   {label}
@@ -134,7 +136,6 @@ function CompareMenu() {
               <div className="my-2" style={{ borderTop: "1px solid var(--border-subtle)" }} />
               <a
                 href="/vs/"
-                role="menuitem"
                 className="px-4 py-2 text-fg-2 text-sm no-underline hover:text-fg-1 hover:bg-surface-hover transition-colors whitespace-nowrap"
               >
                 All comparisons
@@ -275,9 +276,14 @@ export function Nav({ subpage = false }) {
                 </a>
               ))}
               <div className="mt-2 pt-2" style={{ borderTop: "1px solid var(--border-subtle)" }}>
-                <span className="block text-fg-muted text-[12px] py-2" style={{ fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.12em" }}>
+                <a
+                  href="/vs/"
+                  onClick={() => setMenuOpen(false)}
+                  className="block text-fg-muted text-[12px] py-2 no-underline hover:text-fg-1 transition-colors"
+                  style={{ fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.12em" }}
+                >
                   Compare
-                </span>
+                </a>
                 {COMPARE_LINKS.map(({ href, label }) => (
                   <a
                     key={href}

--- a/website/src/sections/Nav.jsx
+++ b/website/src/sections/Nav.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { Github, Download, Menu, X } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { Github, Download, Menu, X, ChevronDown } from "lucide-react";
 import { m as Motion, AnimatePresence } from "framer-motion";
 import { StenoMark, Wordmark } from "../components/Brand";
 import { ThemeToggle } from "../components/ThemeToggle";
@@ -11,8 +11,16 @@ const NAV_LINKS = [
   { href: "#how", label: "How it works" },
   { href: "#features", label: "Features" },
   { href: "#industries", label: "Enterprise" },
-  { href: "/vs/", label: "Compare" },
   { href: "#faq", label: "FAQ" },
+];
+
+// Kept as a small local list (mirrors src/vs/competitors.js) so the nav
+// doesn't pull the full comparison copy into the homepage bundle.
+const COMPARE_LINKS = [
+  { href: "/vs/granola/", label: "Steno vs Granola" },
+  { href: "/vs/otter/", label: "Steno vs Otter.ai" },
+  { href: "/vs/fireflies/", label: "Steno vs Fireflies" },
+  { href: "/vs/meetily/", label: "Steno vs Meetily" },
 ];
 
 function formatStars(n) {
@@ -39,6 +47,104 @@ function scrollToHash(e, href) {
     if (Date.now() < deadline) requestAnimationFrame(tryScroll);
   };
   tryScroll();
+}
+
+// Desktop-only Compare dropdown: opens on hover or click, closes on leave,
+// outside click, or Escape. The trigger itself navigates to /vs/ so the
+// hub page stays reachable even without interacting with the menu.
+function CompareMenu() {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef(null);
+  const closeTimer = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false);
+    };
+    const onKeyDown = (e) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const scheduleClose = () => {
+    closeTimer.current = setTimeout(() => setOpen(false), 120);
+  };
+  const cancelClose = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+  };
+
+  return (
+    <div
+      ref={wrapRef}
+      className="relative"
+      onMouseEnter={() => { cancelClose(); setOpen(true); }}
+      onMouseLeave={scheduleClose}
+    >
+      <a
+        href="/vs/"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onFocus={() => setOpen(true)}
+        className="inline-flex items-center gap-1 text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
+      >
+        Compare
+        <ChevronDown
+          size={12}
+          aria-hidden="true"
+          style={{ transform: open ? "rotate(180deg)" : "none", transition: "transform var(--dur-fast) var(--ease)" }}
+        />
+      </a>
+
+      <AnimatePresence>
+        {open && (
+          <Motion.div
+            role="menu"
+            initial={{ opacity: 0, y: 4, x: "-50%" }}
+            animate={{ opacity: 1, y: 0, x: "-50%" }}
+            exit={{ opacity: 0, y: 4, x: "-50%" }}
+            transition={{ duration: 0.15, ease: [0.33, 1, 0.68, 1] }}
+            className="absolute left-1/2 top-full pt-3"
+          >
+            <div
+              className="flex flex-col py-2 min-w-[200px]"
+              style={{
+                background: "var(--surface-raised)",
+                border: "1px solid var(--border-subtle)",
+                borderRadius: "var(--radius)",
+                boxShadow: "var(--shadow-md)",
+              }}
+            >
+              {COMPARE_LINKS.map(({ href, label }) => (
+                <a
+                  key={href}
+                  href={href}
+                  role="menuitem"
+                  className="px-4 py-2 text-fg-2 text-sm no-underline hover:text-fg-1 hover:bg-surface-hover transition-colors whitespace-nowrap"
+                >
+                  {label}
+                </a>
+              ))}
+              <div className="my-2" style={{ borderTop: "1px solid var(--border-subtle)" }} />
+              <a
+                href="/vs/"
+                role="menuitem"
+                className="px-4 py-2 text-fg-2 text-sm no-underline hover:text-fg-1 hover:bg-surface-hover transition-colors whitespace-nowrap"
+              >
+                All comparisons
+              </a>
+            </div>
+          </Motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
 }
 
 // `subpage` renders the nav for pages other than the homepage (/vs/*):
@@ -88,19 +194,27 @@ export function Nav({ subpage = false }) {
         </a>
 
         <div className="hidden md:flex gap-7 items-center">
-          {NAV_LINKS.map(({ href, label }) => {
-            const isHash = href.startsWith("#");
-            return (
-              <a
-                key={href}
-                href={isHash && subpage ? `/${href}` : href}
-                onClick={isHash && !subpage ? (e) => scrollToHash(e, href) : undefined}
-                className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
-              >
-                {label}
-              </a>
-            );
-          })}
+          {NAV_LINKS.slice(0, 3).map(({ href, label }) => (
+            <a
+              key={href}
+              href={subpage ? `/${href}` : href}
+              onClick={subpage ? undefined : (e) => scrollToHash(e, href)}
+              className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
+            >
+              {label}
+            </a>
+          ))}
+          <CompareMenu />
+          {NAV_LINKS.slice(3).map(({ href, label }) => (
+            <a
+              key={href}
+              href={subpage ? `/${href}` : href}
+              onClick={subpage ? undefined : (e) => scrollToHash(e, href)}
+              className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
+            >
+              {label}
+            </a>
+          ))}
         </div>
 
         <div className="flex gap-1 items-center">
@@ -149,20 +263,33 @@ export function Nav({ subpage = false }) {
             style={{ borderTop: "1px solid var(--border-subtle)" }}
           >
             <div className="container-site flex flex-col py-3">
-              {NAV_LINKS.map(({ href, label }) => {
-                const isHash = href.startsWith("#");
-                return (
+              {NAV_LINKS.map(({ href, label }) => (
+                <a
+                  key={href}
+                  href={subpage ? `/${href}` : href}
+                  onClick={(e) => { if (!subpage) scrollToHash(e, href); setMenuOpen(false); }}
+                  className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
+                  style={{ padding: "10px 0" }}
+                >
+                  {label}
+                </a>
+              ))}
+              <div className="mt-2 pt-2" style={{ borderTop: "1px solid var(--border-subtle)" }}>
+                <span className="block text-fg-muted text-[12px] py-2" style={{ fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.12em" }}>
+                  Compare
+                </span>
+                {COMPARE_LINKS.map(({ href, label }) => (
                   <a
                     key={href}
-                    href={isHash && subpage ? `/${href}` : href}
-                    onClick={(e) => { if (isHash && !subpage) scrollToHash(e, href); setMenuOpen(false); }}
-                    className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
+                    href={href}
+                    onClick={() => setMenuOpen(false)}
+                    className="block text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
                     style={{ padding: "10px 0" }}
                   >
                     {label}
                   </a>
-                );
-              })}
+                ))}
+              </div>
               <a
                 href={GITHUB_URL}
                 target="_blank"

--- a/website/src/sections/Nav.jsx
+++ b/website/src/sections/Nav.jsx
@@ -11,6 +11,7 @@ const NAV_LINKS = [
   { href: "#how", label: "How it works" },
   { href: "#features", label: "Features" },
   { href: "#industries", label: "Enterprise" },
+  { href: "/vs/", label: "Compare" },
   { href: "#faq", label: "FAQ" },
 ];
 
@@ -87,9 +88,19 @@ export function Nav({ subpage = false }) {
         </a>
 
         <div className="hidden md:flex gap-7 items-center">
-          {NAV_LINKS.map(({ href, label }) => (
-            <a key={href} href={subpage ? `/${href}` : href} onClick={subpage ? undefined : (e) => scrollToHash(e, href)} className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors">{label}</a>
-          ))}
+          {NAV_LINKS.map(({ href, label }) => {
+            const isHash = href.startsWith("#");
+            return (
+              <a
+                key={href}
+                href={isHash && subpage ? `/${href}` : href}
+                onClick={isHash && !subpage ? (e) => scrollToHash(e, href) : undefined}
+                className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
+              >
+                {label}
+              </a>
+            );
+          })}
         </div>
 
         <div className="flex gap-1 items-center">
@@ -138,17 +149,20 @@ export function Nav({ subpage = false }) {
             style={{ borderTop: "1px solid var(--border-subtle)" }}
           >
             <div className="container-site flex flex-col py-3">
-              {NAV_LINKS.map(({ href, label }) => (
-                <a
-                  key={href}
-                  href={subpage ? `/${href}` : href}
-                  onClick={(e) => { if (!subpage) scrollToHash(e, href); setMenuOpen(false); }}
-                  className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
-                  style={{ padding: "10px 0" }}
-                >
-                  {label}
-                </a>
-              ))}
+              {NAV_LINKS.map(({ href, label }) => {
+                const isHash = href.startsWith("#");
+                return (
+                  <a
+                    key={href}
+                    href={isHash && subpage ? `/${href}` : href}
+                    onClick={(e) => { if (isHash && !subpage) scrollToHash(e, href); setMenuOpen(false); }}
+                    className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
+                    style={{ padding: "10px 0" }}
+                  >
+                    {label}
+                  </a>
+                );
+              })}
               <a
                 href={GITHUB_URL}
                 target="_blank"

--- a/website/src/sections/Nav.jsx
+++ b/website/src/sections/Nav.jsx
@@ -40,7 +40,10 @@ function scrollToHash(e, href) {
   tryScroll();
 }
 
-export function Nav() {
+// `subpage` renders the nav for pages other than the homepage (/vs/*):
+// section links become absolute (/#how) so they navigate home, and the
+// lazy-chunk scroll polyfill is skipped — it only applies to same-page ids.
+export function Nav({ subpage = false }) {
   const [scrolled, setScrolled] = useState(false);
   const [stars, setStars] = useState(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -78,14 +81,14 @@ export function Nav() {
       }}
     >
       <div className="container-site flex items-center justify-between py-[18px]">
-        <a href="#" className="flex items-center gap-[10px] text-fg-1 no-underline hover:no-underline">
+        <a href={subpage ? "/" : "#"} className="flex items-center gap-[10px] text-fg-1 no-underline hover:no-underline">
           <StenoMark size={26} />
           <Wordmark size={21} />
         </a>
 
         <div className="hidden md:flex gap-7 items-center">
           {NAV_LINKS.map(({ href, label }) => (
-            <a key={href} href={href} onClick={(e) => scrollToHash(e, href)} className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors">{label}</a>
+            <a key={href} href={subpage ? `/${href}` : href} onClick={subpage ? undefined : (e) => scrollToHash(e, href)} className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors">{label}</a>
           ))}
         </div>
 
@@ -138,8 +141,8 @@ export function Nav() {
               {NAV_LINKS.map(({ href, label }) => (
                 <a
                   key={href}
-                  href={href}
-                  onClick={(e) => { scrollToHash(e, href); setMenuOpen(false); }}
+                  href={subpage ? `/${href}` : href}
+                  onClick={(e) => { if (!subpage) scrollToHash(e, href); setMenuOpen(false); }}
                   className="text-fg-2 text-sm no-underline hover:text-fg-1 transition-colors"
                   style={{ padding: "10px 0" }}
                 >

--- a/website/src/vs/ComparisonPage.jsx
+++ b/website/src/vs/ComparisonPage.jsx
@@ -1,0 +1,275 @@
+import { useState } from "react";
+import { Check, Minus, X, Download, Plus, ArrowRight } from "lucide-react";
+import { AnimatePresence, m as Motion } from "framer-motion";
+import { Nav } from "../sections/Nav";
+import { Footer } from "../sections/Footer";
+import { CTAFooter } from "../sections/CTAFooter";
+import { trackDownload } from "../analytics";
+import { ALL, VERIFIED } from "./competitors";
+
+const DOWNLOAD_ARM = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+const DOWNLOAD_WIN = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
+
+const H2_STYLE = {
+  fontFamily: "var(--font-serif)",
+  fontWeight: 400,
+  fontSize: "clamp(28px, 3.6vw, 40px)",
+  lineHeight: 1.1,
+  letterSpacing: "-0.02em",
+  color: "var(--fg-1)",
+};
+
+function ToneIcon({ tone }) {
+  if (tone === "good") return <Check size={15} strokeWidth={2.2} aria-hidden="true" style={{ color: "var(--fg-1)", flexShrink: 0, marginTop: 2 }} />;
+  if (tone === "bad") return <X size={15} strokeWidth={2} aria-hidden="true" style={{ color: "var(--fg-muted)", flexShrink: 0, marginTop: 2 }} />;
+  return <Minus size={15} strokeWidth={2} aria-hidden="true" style={{ color: "var(--fg-muted)", flexShrink: 0, marginTop: 2 }} />;
+}
+
+function Cell({ value }) {
+  return (
+    <div className="flex items-start gap-2">
+      <ToneIcon tone={value.tone} />
+      <span>{value.text}</span>
+    </div>
+  );
+}
+
+function FaqItem({ faq, open, onToggle, last }) {
+  return (
+    <div style={{ borderTop: "1px solid var(--border-subtle)", borderBottom: last ? "1px solid var(--border-subtle)" : "none" }}>
+      <button
+        onClick={onToggle}
+        className="w-full bg-transparent border-0 py-6 flex justify-between items-center gap-5 cursor-pointer text-left text-fg-1 text-base md:text-[17px]"
+        style={{ fontFamily: "var(--font-sans)", fontWeight: 500 }}
+      >
+        <span>{faq.q}</span>
+        <span className="text-fg-2 flex-shrink-0">
+          {open ? <Minus size={16} aria-hidden="true" /> : <Plus size={16} aria-hidden="true" />}
+        </span>
+      </button>
+      <AnimatePresence>
+        {open && (
+          <Motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <p className="text-fg-2 text-[15px] leading-[1.6] pb-6" style={{ maxWidth: "62ch" }}>{faq.a}</p>
+          </Motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export function ComparisonPage({ data }) {
+  const [openFaq, setOpenFaq] = useState(null);
+  const others = ALL.filter((c) => c.slug !== data.slug);
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: data.faqs.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+
+  return (
+    <>
+      <Nav subpage />
+
+      <main>
+        {/* Header */}
+        <section className="pt-[48px] pb-[24px] md:pt-[72px]">
+          <div className="container-site" style={{ maxWidth: 880 }}>
+            <Motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              className="text-fg-2 text-[12px] mb-5"
+              style={{ fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.14em" }}
+            >
+              {data.eyebrow}
+            </Motion.p>
+            <Motion.h1
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.05 }}
+              style={{
+                fontFamily: "var(--font-serif)",
+                fontWeight: 400,
+                fontSize: "clamp(36px, 5vw, 58px)",
+                lineHeight: 1.05,
+                letterSpacing: "-0.025em",
+                color: "var(--fg-1)",
+                maxWidth: "24ch",
+              }}
+            >
+              {data.h1}
+            </Motion.h1>
+            <Motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+              className="text-fg-2 text-lg leading-[1.6] mt-6"
+              style={{ maxWidth: "66ch" }}
+            >
+              {data.intro}
+            </Motion.p>
+            <Motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.15 }}
+              className="flex gap-[10px] flex-wrap mt-8"
+            >
+              <a
+                href={DOWNLOAD_ARM}
+                onClick={() => trackDownload(`vs_${data.slug}`, "arm64")}
+                className="btn-base btn-primary inline-flex items-center gap-2 no-underline hover:no-underline"
+              >
+                <Download size={15} aria-hidden="true" /> Download for macOS
+              </a>
+              <a
+                href={DOWNLOAD_WIN}
+                onClick={() => trackDownload(`vs_${data.slug}`, "win-x64")}
+                className="btn-base btn-ghost inline-flex items-center gap-2 no-underline hover:no-underline"
+              >
+                <Download size={15} aria-hidden="true" /> Windows (alpha)
+              </a>
+            </Motion.div>
+          </div>
+        </section>
+
+        {/* Ledger table */}
+        <section className="pt-[40px] pb-[24px]">
+          <div className="container-site" style={{ maxWidth: 880 }}>
+            <div className="vs-table-wrap">
+              <table className="vs-table">
+                <caption className="sr-only">Feature comparison between Steno and {data.name}</caption>
+                <thead>
+                  <tr>
+                    <th scope="col" aria-label="Feature"></th>
+                    <th scope="col" className="vs-col-steno">Steno</th>
+                    <th scope="col">{data.name}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.rows.map((row) => (
+                    <tr key={row.label}>
+                      <th scope="row">{row.label}</th>
+                      <td className="vs-col-steno"><Cell value={row.steno} /></td>
+                      <td><Cell value={row.them} /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-fg-muted text-[13px] mt-4" style={{ maxWidth: "70ch" }}>
+              {data.name} details taken from its public website and documentation, verified {VERIFIED}. Pricing
+              and features change — check their site for current terms.
+            </p>
+          </div>
+        </section>
+
+        {/* Verdict */}
+        <section className="pt-[48px] pb-[8px]">
+          <div className="container-site" style={{ maxWidth: 880 }}>
+            <blockquote
+              className="m-0 py-2 pl-6 md:pl-8"
+              style={{ borderLeft: "2px solid var(--fg-1)" }}
+            >
+              <p
+                style={{
+                  fontFamily: "var(--font-serif)",
+                  fontWeight: 400,
+                  fontSize: "clamp(20px, 2.6vw, 26px)",
+                  lineHeight: 1.4,
+                  letterSpacing: "-0.01em",
+                  color: "var(--fg-1)",
+                  maxWidth: "52ch",
+                }}
+              >
+                {data.verdict}
+              </p>
+            </blockquote>
+          </div>
+        </section>
+
+        {/* Choose lists */}
+        <section className="pt-[64px] pb-[16px]">
+          <div className="container-site" style={{ maxWidth: 880 }}>
+            <div className="grid md:grid-cols-2 gap-10 md:gap-14">
+              <div>
+                <h2 className="mb-6" style={H2_STYLE}>Choose Steno if</h2>
+                <ul className="m-0 p-0 flex flex-col gap-4" style={{ listStyle: "none" }}>
+                  {data.chooseSteno.map((item) => (
+                    <li key={item} className="flex items-start gap-3 text-fg-2 text-[15px] leading-[1.6]">
+                      <Check size={15} strokeWidth={2.2} aria-hidden="true" style={{ color: "var(--fg-1)", flexShrink: 0, marginTop: 4 }} />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h2 className="mb-6" style={H2_STYLE}>Choose {data.name} if</h2>
+                <ul className="m-0 p-0 flex flex-col gap-4" style={{ listStyle: "none" }}>
+                  {data.chooseThem.map((item) => (
+                    <li key={item} className="flex items-start gap-3 text-fg-2 text-[15px] leading-[1.6]">
+                      <ArrowRight size={15} strokeWidth={2} aria-hidden="true" style={{ color: "var(--fg-muted)", flexShrink: 0, marginTop: 4 }} />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="sect" style={{ paddingBottom: 48 }}>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd).replace(/</g, "\\u003c") }}
+          />
+          <div className="container-site" style={{ maxWidth: 820 }}>
+            <h2 className="mb-10" style={H2_STYLE}>Questions</h2>
+            <div className="flex flex-col">
+              {data.faqs.map((f, i) => (
+                <FaqItem
+                  key={f.q}
+                  faq={f}
+                  open={openFaq === i}
+                  onToggle={() => setOpenFaq(openFaq === i ? null : i)}
+                  last={i === data.faqs.length - 1}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Cross-links */}
+        <section className="pb-[16px]">
+          <div className="container-site" style={{ maxWidth: 820 }}>
+            <p className="text-fg-2 text-sm">
+              More comparisons:{" "}
+              {others.map((c, i) => (
+                <span key={c.slug}>
+                  <a href={`/vs/${c.slug}/`}>Steno vs {c.name}</a>
+                  {i < others.length - 1 ? " · " : ""}
+                </span>
+              ))}
+            </p>
+          </div>
+        </section>
+
+        <CTAFooter />
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/website/src/vs/ComparisonPage.jsx
+++ b/website/src/vs/ComparisonPage.jsx
@@ -69,15 +69,9 @@ export function ComparisonPage({ data }) {
   const [openFaq, setOpenFaq] = useState(null);
   const others = ALL.filter((c) => c.slug !== data.slug);
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: data.faqs.map((f) => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  // The FAQ JSON-LD is emitted into each page's static HTML at build time
+  // (see faqJsonLdPlugin in vite.config.js) so crawlers see it without JS —
+  // not injected here, to avoid duplicate FAQPage structured data.
 
   return (
     <>
@@ -230,12 +224,8 @@ export function ComparisonPage({ data }) {
           </div>
         </section>
 
-        {/* FAQ */}
+        {/* FAQ (FAQPage JSON-LD is injected into the static HTML at build) */}
         <section className="sect" style={{ paddingBottom: 48 }}>
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd).replace(/</g, "\\u003c") }}
-          />
           <div className="container-site" style={{ maxWidth: 820 }}>
             <h2 className="mb-10" style={H2_STYLE}>Questions</h2>
             <div className="flex flex-col">

--- a/website/src/vs/ComparisonPage.jsx
+++ b/website/src/vs/ComparisonPage.jsx
@@ -39,6 +39,7 @@ function FaqItem({ faq, open, onToggle, last }) {
     <div style={{ borderTop: "1px solid var(--border-subtle)", borderBottom: last ? "1px solid var(--border-subtle)" : "none" }}>
       <button
         onClick={onToggle}
+        aria-expanded={open}
         className="w-full bg-transparent border-0 py-6 flex justify-between items-center gap-5 cursor-pointer text-left text-fg-1 text-base md:text-[17px]"
         style={{ fontFamily: "var(--font-sans)", fontWeight: 500 }}
       >

--- a/website/src/vs/VsIndex.jsx
+++ b/website/src/vs/VsIndex.jsx
@@ -1,0 +1,111 @@
+import { ArrowRight } from "lucide-react";
+import { m as Motion } from "framer-motion";
+import { Nav } from "../sections/Nav";
+import { Footer } from "../sections/Footer";
+import { CTAFooter } from "../sections/CTAFooter";
+import { ALL, VERIFIED } from "./competitors";
+
+const ONE_LINERS = {
+  granola: "The cloud notetaker without a bot — Steno does the same job without the cloud either.",
+  otter: "The incumbent: a bot in your calls, recordings on their servers, minute caps below Business.",
+  fireflies: "Team conversation intelligence in the cloud, metered by storage and AI credits.",
+  meetily: "The other open-source local notetaker — with a $120/year Pro tier for what Steno ships free.",
+};
+
+export function VsIndex() {
+  return (
+    <>
+      <Nav subpage />
+
+      <main>
+        <section className="pt-[48px] pb-[24px] md:pt-[72px]">
+          <div className="container-site" style={{ maxWidth: 880 }}>
+            <Motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              className="text-fg-2 text-[12px] mb-5"
+              style={{ fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.14em" }}
+            >
+              Comparisons
+            </Motion.p>
+            <Motion.h1
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.05 }}
+              style={{
+                fontFamily: "var(--font-serif)",
+                fontWeight: 400,
+                fontSize: "clamp(36px, 5vw, 58px)",
+                lineHeight: 1.05,
+                letterSpacing: "-0.025em",
+                color: "var(--fg-1)",
+                maxWidth: "22ch",
+              }}
+            >
+              How Steno compares.
+            </Motion.h1>
+            <Motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+              className="text-fg-2 text-lg leading-[1.6] mt-6"
+              style={{ maxWidth: "66ch" }}
+            >
+              Steno transcribes and summarizes meetings entirely on your device — free, open source,
+              no bot, no account. Here is how that stacks up against the tools you might be using
+              instead, stated as fairly as we can. Competitor details verified {VERIFIED}.
+            </Motion.p>
+          </div>
+        </section>
+
+        <section className="pt-[40px] pb-[24px]">
+          <div className="container-site" style={{ maxWidth: 880 }}>
+            <div className="flex flex-col">
+              {ALL.map((c, i) => (
+                <a
+                  key={c.slug}
+                  href={`/vs/${c.slug}/`}
+                  className="vs-index-row group no-underline hover:no-underline"
+                  style={{
+                    borderTop: "1px solid var(--border-subtle)",
+                    borderBottom: i === ALL.length - 1 ? "1px solid var(--border-subtle)" : "none",
+                  }}
+                >
+                  <div className="flex items-center justify-between gap-5 py-7">
+                    <div>
+                      <span
+                        className="block text-fg-1"
+                        style={{
+                          fontFamily: "var(--font-serif)",
+                          fontWeight: 400,
+                          fontSize: "clamp(22px, 2.8vw, 28px)",
+                          letterSpacing: "-0.015em",
+                          lineHeight: 1.2,
+                        }}
+                      >
+                        Steno vs {c.name}
+                      </span>
+                      <span className="block text-fg-2 text-[15px] leading-[1.6] mt-2" style={{ maxWidth: "58ch" }}>
+                        {ONE_LINERS[c.slug]}
+                      </span>
+                    </div>
+                    <ArrowRight
+                      size={18}
+                      aria-hidden="true"
+                      className="flex-shrink-0 text-fg-muted transition-transform group-hover:translate-x-1 group-hover:text-fg-1"
+                    />
+                  </div>
+                </a>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <CTAFooter />
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/website/src/vs/VsIndex.jsx
+++ b/website/src/vs/VsIndex.jsx
@@ -5,13 +5,6 @@ import { Footer } from "../sections/Footer";
 import { CTAFooter } from "../sections/CTAFooter";
 import { ALL, VERIFIED } from "./competitors";
 
-const ONE_LINERS = {
-  granola: "The cloud notetaker without a bot — Steno does the same job without the cloud either.",
-  otter: "The incumbent: a bot in your calls, recordings on their servers, minute caps below Business.",
-  fireflies: "Team conversation intelligence in the cloud, metered by storage and AI credits.",
-  meetily: "The other open-source local notetaker — with a $120/year Pro tier for what Steno ships free.",
-};
-
 export function VsIndex() {
   return (
     <>
@@ -87,7 +80,7 @@ export function VsIndex() {
                         Steno vs {c.name}
                       </span>
                       <span className="block text-fg-2 text-[15px] leading-[1.6] mt-2" style={{ maxWidth: "58ch" }}>
-                        {ONE_LINERS[c.slug]}
+                        {c.oneLiner}
                       </span>
                     </div>
                     <ArrowRight

--- a/website/src/vs/boot.jsx
+++ b/website/src/vs/boot.jsx
@@ -1,0 +1,21 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { LazyMotion, domMax } from "framer-motion";
+import "../index.css";
+import { initAnalytics } from "../analytics";
+
+// Shared bootstrap for the /vs/ entry points — mirrors main.jsx (idle-deferred
+// analytics, LazyMotion so the reused Nav/CTAFooter `m` components animate).
+export function mount(node) {
+  createRoot(document.getElementById("root")).render(
+    <StrictMode>
+      <LazyMotion features={domMax}>{node}</LazyMotion>
+    </StrictMode>,
+  );
+
+  if ("requestIdleCallback" in window) {
+    requestIdleCallback(initAnalytics);
+  } else {
+    setTimeout(initAnalytics, 1);
+  }
+}

--- a/website/src/vs/competitors.js
+++ b/website/src/vs/competitors.js
@@ -4,6 +4,12 @@
 // website or repo. When pricing or features change, update the copy AND
 // the `verified` date. Keep the tone factual — the honest "choose them if"
 // section is deliberate: it's what makes the rest credible.
+//
+// NOTE: `metaTitle`/`metaDescription` below are NOT read at runtime — each
+// page's <title>/<meta> live in its static HTML entry under website/vs/*,
+// which is the source of truth for SEO heads. The fields are kept here only
+// as human-readable documentation of the intended per-page copy; if you edit
+// them, edit the matching website/vs/<slug>/index.html too (or they drift).
 
 export const VERIFIED = "July 2026";
 
@@ -78,7 +84,7 @@ export const granola = {
   faqs: [
     {
       q: "Is Granola private?",
-      a: "Granola avoids the meeting bot, which is a real privacy improvement over Otter-style tools. But your audio is still streamed to cloud servers for transcription, and cloud LLMs process your transcripts. Steno removes that layer entirely: after install it makes no network requests, and audio never leaves the device.",
+      a: "Granola avoids the meeting bot, which is a real privacy improvement over Otter-style tools. But your audio is still streamed to cloud servers for transcription, and cloud LLMs process your transcripts. Steno removes that layer entirely: transcription and summarization run locally, and your recordings, transcripts, and notes never leave your device. (Steno makes no network calls with your meeting content; anonymous usage telemetry is on by default and can be switched off in Settings.)",
     },
     {
       q: "Does Steno work the same way as Granola — no bot in the call?",
@@ -94,7 +100,7 @@ export const granola = {
     },
     {
       q: "Are Steno's local summaries as good as Granola's cloud ones?",
-      a: "Steno ships five open-weight models (up to GPT-OSS 20B) that run on your machine, and you can optionally plug in your own cloud API key if you want a frontier model. For meeting summaries and action items, well-prompted local models are strong — and you can verify the results because you keep the full transcript.",
+      a: "Steno ships a lineup of open-weight models (up to GPT-OSS 20B) that run on your machine, and you can optionally plug in your own cloud API key if you want a frontier model. For meeting summaries and action items, well-prompted local models are strong — and you can verify the results because you keep the full transcript.",
     },
   ],
 };
@@ -111,7 +117,7 @@ export const otter = {
     "Otter is the incumbent cloud transcription service: an OtterPilot bot joins your call as a participant, recordings live on Otter's servers, and every plan below Business has minute caps. Steno takes the opposite approach — it captures system audio on your own machine, transcribes and summarizes locally, and never uploads anything.",
   rows: [
     ROW("Price", STENO.price, {
-      text: "Free: 300 min/month (30 min per conversation); Pro from $8.49/user/month; Business from $19.99",
+      text: "Free: 300 min/month (30 min per conversation); Pro from $8.33/user/month billed annually; Business from $19.99",
       tone: "bad",
     }),
     ROW("Open source", STENO.openSource, { text: "No — proprietary", tone: "bad" }),
@@ -160,7 +166,7 @@ export const otter = {
     },
     {
       q: "Where do my recordings go?",
-      a: "With Otter, recordings and transcripts are stored in Otter's cloud, under Otter's terms. With Steno, they're ordinary files in local app storage on your device. Steno makes no network requests after install.",
+      a: "With Otter, recordings and transcripts are stored in Otter's cloud, under Otter's terms. With Steno, they're ordinary files in local app storage on your device — your meeting content is never uploaded. (Steno does make some network calls unrelated to your content: update checks, first-run model downloads, and anonymous usage telemetry that's on by default and can be switched off in Settings.)",
     },
     {
       q: "Is Steno's accuracy comparable to Otter's?",
@@ -168,7 +174,7 @@ export const otter = {
     },
     {
       q: "What's the catch — why is Steno free?",
-      a: "There's no hosted infrastructure to pay for: your machine does the work. Steno is an open-source project (MIT), so you can read the code, build it yourself, and verify the no-network claim.",
+      a: "There's no hosted infrastructure to pay for: your machine does the work. Steno is an open-source project (MIT), so you can read the code, build it yourself, and verify exactly what it does and doesn't send.",
     },
   ],
 };
@@ -255,10 +261,10 @@ export const meetily = {
   eyebrow: "Steno vs Meetily",
   h1: "Same privacy philosophy. But Steno offers a whole lot more.",
   intro:
-    "Meetily deserves credit: like Steno, it's open source and transcribes meetings on your own machine. The comparison here isn't about privacy — both projects take it seriously. It's about what's actually in the box. Steno ships features Meetily either doesn't have or holds behind its $120/year-per-device Pro tier: chat with your meetings, speaker attribution, meeting auto-detect, and local AI models bundled in so there's nothing to set up. Steno has one tier, and it's free.",
+    "Meetily deserves credit: like Steno, it's open source and transcribes meetings on your own machine. The comparison here isn't about privacy — both projects take it seriously. It's about what's actually in the box. Steno ships features free that Meetily reserves for its $120/year Pro tier: chat with your meetings, speaker attribution, meeting auto-detect, and local AI models bundled in so there's nothing to set up. Steno has one tier, and it's free.",
   rows: [
     ROW("Price", STENO.price, {
-      text: "Community edition free; Pro $120/year, licensed per device; Enterprise custom",
+      text: "Community edition free; Pro $10/user/month billed annually ($120/year); Enterprise custom",
       tone: "bad",
     }),
     ROW("Open source", STENO.openSource, {
@@ -279,21 +285,21 @@ export const meetily = {
       text: "Live [You] / [Others] labels — included free",
       tone: "good",
     }, {
-      text: "“Coming soon”, planned as a Pro feature",
+      text: "Paid Pro feature (diarization)",
       tone: "bad",
     }),
     ROW("Meeting auto-detect", {
       text: "Included free (calendar integration)",
       tone: "good",
     }, {
-      text: "Pro feature; calendar integration “coming soon”",
+      text: "Paid Pro feature",
       tone: "bad",
     }),
     ROW("Chat with your meetings", {
       text: "Included free — ask questions across any note or recording",
       tone: "good",
     }, {
-      text: "“Coming soon”, planned as a Pro feature",
+      text: "Paid Pro feature",
       tone: "bad",
     }),
     ROW("Usage limits", STENO.limits, { text: "None", tone: "good" }),
@@ -303,7 +309,7 @@ export const meetily = {
     }),
   ],
   verdict:
-    "If you're choosing between the two open-source local notetakers, the question is simple: Steno ships the whole product free — bundled models, speaker attribution, meeting auto-detect, chat with your meetings — while Meetily reserves its enhanced accuracy, exports, auto-detect, and chat for a $120/year Pro license tied to one device, with several of those still marked coming soon.",
+    "If you're choosing between the two open-source local notetakers, the question is simple: Steno ships the whole product free — bundled models, speaker attribution, meeting auto-detect, chat with your meetings — while Meetily reserves its enhanced accuracy, exports, auto-detect, and chat for a $120/year Pro tier.",
   chooseSteno: [
     "You want local summaries working out of the box — Steno bundles Ollama and downloads models in-app, no separate install",
     "You want speaker attribution, meeting auto-detect, and chat with your meetings today, free",
@@ -325,7 +331,7 @@ export const meetily = {
     },
     {
       q: "What does Meetily Pro cost, and what's the Steno equivalent?",
-      a: "Meetily Pro is $120/year, and each license is valid for one device. The Steno equivalent is the free download: there is no Pro tier, and features like speaker attribution and meeting auto-detect — paid or “coming soon” in Meetily — are included.",
+      a: "Meetily Pro is $10/user/month billed annually ($120/year); per their FAQ, each license is valid for one device. The Steno equivalent is the free download: there is no Pro tier, and features Meetily charges Pro for — speaker attribution, meeting auto-detect, chat — are included.",
     },
     {
       q: "Which is more accurate?",

--- a/website/src/vs/competitors.js
+++ b/website/src/vs/competitors.js
@@ -31,7 +31,7 @@ export const granola = {
   metaDescription:
     "Granola processes your meeting audio in the cloud and costs from $14/user/month. Steno does the same job — no bot, AI meeting notes — entirely on your device, free and open source.",
   eyebrow: "Steno vs Granola",
-  h1: "Like Granola, but nothing leaves your Mac.",
+  h1: "Like Granola, but data never leaves your premises.",
   intro:
     "Granola popularised the bot-free meeting notetaker — it captures system audio instead of sending a bot into your call. Steno works the same way, with one structural difference: Granola transcribes and summarizes your audio on cloud servers, while Steno runs the entire pipeline on your own device. No audio upload, no account, no subscription.",
   rows: [

--- a/website/src/vs/competitors.js
+++ b/website/src/vs/competitors.js
@@ -33,6 +33,7 @@ const ROW = (label, steno, them) => ({ label, steno, them });
 export const granola = {
   slug: "granola",
   name: "Granola",
+  oneLiner: "The cloud notetaker without a bot — Steno does the same job without the cloud either.",
   metaTitle: "Steno vs Granola — Free, Fully Local Alternative to Granola",
   metaDescription:
     "Granola processes your meeting audio in the cloud and costs from $14/user/month. Steno does the same job — no bot, AI meeting notes — entirely on your device, free and open source.",
@@ -108,6 +109,7 @@ export const granola = {
 export const otter = {
   slug: "otter",
   name: "Otter.ai",
+  oneLiner: "The incumbent: a bot in your calls, recordings on their servers, minute caps below Business.",
   metaTitle: "Steno vs Otter.ai — Private, Unlimited Alternative to Otter",
   metaDescription:
     "Otter sends a bot into your meetings, stores recordings in the cloud, and caps free transcription at 300 minutes a month. Steno transcribes unlimited meetings entirely on your device — free, no bot, no account.",
@@ -182,6 +184,7 @@ export const otter = {
 export const fireflies = {
   slug: "fireflies",
   name: "Fireflies.ai",
+  oneLiner: "Team conversation intelligence in the cloud, metered by storage and AI credits.",
   metaTitle: "Steno vs Fireflies.ai — No-Bot, On-Device Alternative to Fireflies",
   metaDescription:
     "Fireflies sends its Fred bot into your calls and stores everything in its cloud, with AI-credit caps per tier. Steno keeps meetings on your device: unlimited local transcription and AI notes, free and open source.",
@@ -255,6 +258,7 @@ export const fireflies = {
 export const meetily = {
   slug: "meetily",
   name: "Meetily",
+  oneLiner: "The other open-source local notetaker — with a $120/year Pro tier for what Steno ships free.",
   metaTitle: "Steno vs Meetily — What Meetily Pro Charges For, Free",
   metaDescription:
     "Steno and Meetily are both open-source, local-first meeting notetakers. The difference: Meetily moves accuracy, exports, and auto-detect behind a $120/year-per-device Pro license — Steno ships everything free, with models bundled in.",

--- a/website/src/vs/competitors.js
+++ b/website/src/vs/competitors.js
@@ -253,9 +253,9 @@ export const meetily = {
   metaDescription:
     "Steno and Meetily are both open-source, local-first meeting notetakers. The difference: Meetily moves accuracy, exports, and auto-detect behind a $120/year-per-device Pro license — Steno ships everything free, with models bundled in.",
   eyebrow: "Steno vs Meetily",
-  h1: "Same privacy philosophy. Nothing held back.",
+  h1: "Same privacy philosophy. But Steno offers a whole lot more.",
   intro:
-    "Meetily deserves credit: like Steno, it's open source and transcribes meetings on your own machine. The comparison here isn't about privacy — both projects take it seriously. It's about what's actually included. Meetily's Community edition is a base tier under a $120/year-per-device Pro product; Steno has one tier, it's free, and the local AI models are bundled so there's nothing to set up.",
+    "Meetily deserves credit: like Steno, it's open source and transcribes meetings on your own machine. The comparison here isn't about privacy — both projects take it seriously. It's about what's actually in the box. Steno ships features Meetily either doesn't have or holds behind its $120/year-per-device Pro tier: chat with your meetings, speaker attribution, meeting auto-detect, and local AI models bundled in so there's nothing to set up. Steno has one tier, and it's free.",
   rows: [
     ROW("Price", STENO.price, {
       text: "Community edition free; Pro $120/year, licensed per device; Enterprise custom",
@@ -289,6 +289,13 @@ export const meetily = {
       text: "Pro feature; calendar integration “coming soon”",
       tone: "bad",
     }),
+    ROW("Chat with your meetings", {
+      text: "Included free — ask questions across any note or recording",
+      tone: "good",
+    }, {
+      text: "“Coming soon”, planned as a Pro feature",
+      tone: "bad",
+    }),
     ROW("Usage limits", STENO.limits, { text: "None", tone: "good" }),
     ROW("Platforms", STENO.platforms, {
       text: "macOS, Windows; Linux build-from-source",
@@ -296,10 +303,10 @@ export const meetily = {
     }),
   ],
   verdict:
-    "If you're choosing between the two open-source local notetakers, the question is simple: Steno ships the whole product free — bundled models, speaker attribution, meeting auto-detect — while Meetily reserves its enhanced accuracy, exports, and auto-detect for a $120/year Pro license tied to one device, with several Pro features still marked coming soon.",
+    "If you're choosing between the two open-source local notetakers, the question is simple: Steno ships the whole product free — bundled models, speaker attribution, meeting auto-detect, chat with your meetings — while Meetily reserves its enhanced accuracy, exports, auto-detect, and chat for a $120/year Pro license tied to one device, with several of those still marked coming soon.",
   chooseSteno: [
     "You want local summaries working out of the box — Steno bundles Ollama and downloads models in-app, no separate install",
-    "You want speaker attribution and meeting auto-detect today, free",
+    "You want speaker attribution, meeting auto-detect, and chat with your meetings today, free",
     "You'd rather not manage per-device licenses",
     "You want one codebase you can read end to end — no separate Pro fork",
   ],
@@ -310,7 +317,7 @@ export const meetily = {
   faqs: [
     {
       q: "Aren't Steno and Meetily basically the same app?",
-      a: "They share a philosophy — open source, on-device transcription, no meeting bot — and even similar engines (Whisper, Parakeet). They differ in what's free: Steno's single free tier includes everything, while Meetily's Community edition sits under a paid Pro product that holds back enhanced accuracy models, advanced exports, custom templates, and meeting auto-detect.",
+      a: "They share a philosophy — open source, on-device transcription, no meeting bot — and even similar engines (Whisper, Parakeet). They differ in what's free: Steno's single free tier includes everything, while Meetily's Community edition sits under a paid Pro product that holds back enhanced accuracy models, advanced exports, custom templates, meeting auto-detect, and chat with your meetings.",
     },
     {
       q: "Do I need to install Ollama to get local AI summaries?",

--- a/website/src/vs/competitors.js
+++ b/website/src/vs/competitors.js
@@ -1,0 +1,334 @@
+// Data for the /vs/ comparison pages.
+//
+// Every claim about a competitor must be verifiable from their public
+// website or repo. When pricing or features change, update the copy AND
+// the `verified` date. Keep the tone factual — the honest "choose them if"
+// section is deliberate: it's what makes the rest credible.
+
+export const VERIFIED = "July 2026";
+
+// Steno's side of the table. Shared rows reuse these so the four pages
+// can't drift out of sync about our own product.
+const STENO = {
+  price: { text: "Free — everything included", tone: "good" },
+  openSource: { text: "Yes — MIT license", tone: "good" },
+  transcription: { text: "100% on your device (Parakeet, Whisper)", tone: "good" },
+  summaries: { text: "On your device — bundled local models, no setup", tone: "good" },
+  audio: { text: "Never", tone: "good" },
+  bot: { text: "No bot — captures system audio directly", tone: "good" },
+  worksWith: { text: "Any meeting app, plus in-person", tone: "good" },
+  limits: { text: "None — unlimited meetings and minutes", tone: "good" },
+  account: { text: "No account, no sign-up", tone: "good" },
+  platforms: { text: "macOS (Apple Silicon) · Windows (alpha)", tone: "neutral" },
+};
+
+const ROW = (label, steno, them) => ({ label, steno, them });
+
+export const granola = {
+  slug: "granola",
+  name: "Granola",
+  metaTitle: "Steno vs Granola — Free, Fully Local Alternative to Granola",
+  metaDescription:
+    "Granola processes your meeting audio in the cloud and costs from $14/user/month. Steno does the same job — no bot, AI meeting notes — entirely on your device, free and open source.",
+  eyebrow: "Steno vs Granola",
+  h1: "Like Granola, but nothing leaves your Mac.",
+  intro:
+    "Granola popularised the bot-free meeting notetaker — it captures system audio instead of sending a bot into your call. Steno works the same way, with one structural difference: Granola transcribes and summarizes your audio on cloud servers, while Steno runs the entire pipeline on your own device. No audio upload, no account, no subscription.",
+  rows: [
+    ROW("Price", STENO.price, {
+      text: "Free plan with limited meeting history; paid from $14/user/month",
+      tone: "bad",
+    }),
+    ROW("Open source", STENO.openSource, { text: "No — proprietary", tone: "bad" }),
+    ROW("Transcription", STENO.transcription, {
+      text: "In the cloud — audio is streamed to Granola's servers",
+      tone: "bad",
+    }),
+    ROW("AI summaries", STENO.summaries, {
+      text: "Cloud LLMs run on your transcripts",
+      tone: "bad",
+    }),
+    ROW("Audio leaves your device", STENO.audio, { text: "Yes — for cloud transcription", tone: "bad" }),
+    ROW("Bot joins your meetings", STENO.bot, {
+      text: "No bot — also captures system audio",
+      tone: "good",
+    }),
+    ROW("Works with", STENO.worksWith, { text: "Any meeting app", tone: "good" }),
+    ROW("Usage limits", STENO.limits, {
+      text: "Free plan caps meeting history",
+      tone: "bad",
+    }),
+    ROW("Account required", STENO.account, { text: "Yes", tone: "bad" }),
+    ROW("Platforms", STENO.platforms, { text: "macOS, Windows, iOS", tone: "neutral" }),
+  ],
+  verdict:
+    "Granola is a polished cloud notetaker without the bot. Steno is the same idea taken to its conclusion: if the notes can be made without a bot, they can be made without a server too. Everything — recording, transcription, summaries, chat — runs on your device, free.",
+  chooseSteno: [
+    "Your meetings involve confidential, legal, medical, or client material that shouldn't transit third-party servers",
+    "You want unlimited meetings without a per-user subscription",
+    "You need it to work offline — planes, secure sites, flaky Wi-Fi",
+    "You (or your security team) want to audit the code that touches your audio",
+  ],
+  chooseThem: [
+    "You want an iPhone app for in-person meetings on the go",
+    "You rely on cloud sync across several devices",
+    "Your team lives in its integrations — Notion, Slack, HubSpot, Zapier",
+    "You're comfortable with cloud processing and want the most polished template ecosystem",
+  ],
+  faqs: [
+    {
+      q: "Is Granola private?",
+      a: "Granola avoids the meeting bot, which is a real privacy improvement over Otter-style tools. But your audio is still streamed to cloud servers for transcription, and cloud LLMs process your transcripts. Steno removes that layer entirely: after install it makes no network requests, and audio never leaves the device.",
+    },
+    {
+      q: "Does Steno work the same way as Granola — no bot in the call?",
+      a: "Yes. Steno captures system audio and microphone simultaneously, so both sides of a Zoom, Teams, or Meet call are transcribed without anything joining the meeting. It also works for in-person conversations.",
+    },
+    {
+      q: "How much does Granola cost compared to Steno?",
+      a: "Granola's paid plans start at $14/user/month ($168/user/year), with a free plan that limits meeting history. Steno is free and open source (MIT) — there is no paid tier, and nothing is held back.",
+    },
+    {
+      q: "Can I use Steno on my phone?",
+      a: "No — Steno is a desktop app for macOS (Apple Silicon) and Windows (alpha). If phone-first capture matters more to you than on-device privacy, Granola's iPhone app is the better fit today.",
+    },
+    {
+      q: "Are Steno's local summaries as good as Granola's cloud ones?",
+      a: "Steno ships five open-weight models (up to GPT-OSS 20B) that run on your machine, and you can optionally plug in your own cloud API key if you want a frontier model. For meeting summaries and action items, well-prompted local models are strong — and you can verify the results because you keep the full transcript.",
+    },
+  ],
+};
+
+export const otter = {
+  slug: "otter",
+  name: "Otter.ai",
+  metaTitle: "Steno vs Otter.ai — Private, Unlimited Alternative to Otter",
+  metaDescription:
+    "Otter sends a bot into your meetings, stores recordings in the cloud, and caps free transcription at 300 minutes a month. Steno transcribes unlimited meetings entirely on your device — free, no bot, no account.",
+  eyebrow: "Steno vs Otter.ai",
+  h1: "Everything Otter does, without the bot or the cloud.",
+  intro:
+    "Otter is the incumbent cloud transcription service: an OtterPilot bot joins your call as a participant, recordings live on Otter's servers, and every plan below Business has minute caps. Steno takes the opposite approach — it captures system audio on your own machine, transcribes and summarizes locally, and never uploads anything.",
+  rows: [
+    ROW("Price", STENO.price, {
+      text: "Free: 300 min/month (30 min per conversation); Pro from $8.49/user/month; Business from $19.99",
+      tone: "bad",
+    }),
+    ROW("Open source", STENO.openSource, { text: "No — proprietary", tone: "bad" }),
+    ROW("Transcription", STENO.transcription, { text: "In the cloud", tone: "bad" }),
+    ROW("AI summaries", STENO.summaries, { text: "In the cloud", tone: "bad" }),
+    ROW("Audio leaves your device", STENO.audio, {
+      text: "Yes — recordings are stored on Otter's servers",
+      tone: "bad",
+    }),
+    ROW("Bot joins your meetings", STENO.bot, {
+      text: "Yes — OtterPilot appears as a participant in your calls",
+      tone: "bad",
+    }),
+    ROW("Works with", STENO.worksWith, {
+      text: "Zoom, Meet, Teams via the bot; mobile recording",
+      tone: "neutral",
+    }),
+    ROW("Usage limits", STENO.limits, {
+      text: "Minute caps on every plan below Business",
+      tone: "bad",
+    }),
+    ROW("Account required", STENO.account, { text: "Yes", tone: "bad" }),
+    ROW("Platforms", STENO.platforms, { text: "Web browser, iOS, Android", tone: "neutral" }),
+  ],
+  verdict:
+    "Otter charges a subscription to run your audio through its servers, with a bot sitting visibly in your meetings. Steno removes the bot, the server, the account, and the bill — the whole pipeline runs on hardware you already own.",
+  chooseSteno: [
+    "You don't want a bot appearing in client or internal calls",
+    "Your recordings shouldn't live on a third party's servers",
+    "You keep hitting minute caps — Steno has no limits at any length",
+    "You record in-person conversations and don't want them uploaded",
+  ],
+  chooseThem: [
+    "You need to record from a phone, or work entirely in a browser",
+    "Your team collaborates inside a shared cloud workspace of transcripts",
+    "You want Otter's live shared highlights during large webinars",
+  ],
+  faqs: [
+    {
+      q: "Does Steno need a bot like OtterPilot?",
+      a: "No. Steno captures system audio and microphone on your machine, so both sides of any call are transcribed without a participant joining. Nothing announces itself in your meeting, because nothing enters the meeting.",
+    },
+    {
+      q: "Is Steno really unlimited?",
+      a: "Yes. Transcription and summarization run on your own hardware, so there's no metering — no monthly minutes, no per-conversation cap, no file-import quota. Otter's free plan allows 300 minutes a month with a 30-minute cap per conversation.",
+    },
+    {
+      q: "Where do my recordings go?",
+      a: "With Otter, recordings and transcripts are stored in Otter's cloud, under Otter's terms. With Steno, they're ordinary files in local app storage on your device. Steno makes no network requests after install.",
+    },
+    {
+      q: "Is Steno's accuracy comparable to Otter's?",
+      a: "Steno uses Parakeet TDT v3 for live transcription and Whisper for the long tail of 99 languages — current open models that benchmark competitively with commercial cloud ASR. As with any transcription, quiet rooms and decent microphones matter more than the engine.",
+    },
+    {
+      q: "What's the catch — why is Steno free?",
+      a: "There's no hosted infrastructure to pay for: your machine does the work. Steno is an open-source project (MIT), so you can read the code, build it yourself, and verify the no-network claim.",
+    },
+  ],
+};
+
+export const fireflies = {
+  slug: "fireflies",
+  name: "Fireflies.ai",
+  metaTitle: "Steno vs Fireflies.ai — No-Bot, On-Device Alternative to Fireflies",
+  metaDescription:
+    "Fireflies sends its Fred bot into your calls and stores everything in its cloud, with AI-credit caps per tier. Steno keeps meetings on your device: unlimited local transcription and AI notes, free and open source.",
+  eyebrow: "Steno vs Fireflies.ai",
+  h1: "Meeting notes without Fred in the room.",
+  intro:
+    "Fireflies is a cloud conversation-intelligence platform: its bot (Fred) joins your calls, recordings are stored and analyzed in Fireflies' cloud, and plans are metered by storage and AI credits. Steno is the private counterpart — it records on your machine, transcribes and summarizes locally, and nothing is uploaded, metered, or credited.",
+  rows: [
+    ROW("Price", STENO.price, {
+      text: "Free (400 min storage, AI-credit caps); Pro $10/seat/month billed annually; Business $19; Enterprise $39",
+      tone: "bad",
+    }),
+    ROW("Open source", STENO.openSource, { text: "No — proprietary", tone: "bad" }),
+    ROW("Transcription", STENO.transcription, { text: "In the cloud", tone: "bad" }),
+    ROW("AI summaries", STENO.summaries, {
+      text: "In the cloud, metered by AI credits",
+      tone: "bad",
+    }),
+    ROW("Audio leaves your device", STENO.audio, {
+      text: "Yes — stored in Fireflies' cloud",
+      tone: "bad",
+    }),
+    ROW("Bot joins your meetings", STENO.bot, {
+      text: "Yes — the Fireflies notetaker joins as a participant",
+      tone: "bad",
+    }),
+    ROW("Works with", STENO.worksWith, {
+      text: "Meeting platforms via the bot; uploads for other audio",
+      tone: "neutral",
+    }),
+    ROW("Usage limits", STENO.limits, {
+      text: "Storage minutes, AI credits, and recording-length caps per tier",
+      tone: "bad",
+    }),
+    ROW("Account required", STENO.account, { text: "Yes", tone: "bad" }),
+    ROW("Platforms", STENO.platforms, { text: "Web browser, iOS, Android", tone: "neutral" }),
+  ],
+  verdict:
+    "Fireflies is built for teams that want a cloud archive of every call, analyzed and integrated with their CRM. If what you actually need is accurate, private notes from your own meetings, Steno does that with no bot, no credits, and no data leaving your machine.",
+  chooseSteno: [
+    "A bot in the participant list isn't acceptable for your calls",
+    "Compliance or client confidentiality rules out cloud storage of recordings",
+    "You'd rather not budget storage minutes and AI credits — Steno has neither",
+    "You want notes from in-person meetings, not just scheduled video calls",
+  ],
+  chooseThem: [
+    "You want conversation analytics across a whole sales or support team",
+    "You need deep CRM integrations — Salesforce, HubSpot — fed automatically",
+    "A searchable cloud archive shared across the team is the point",
+  ],
+  faqs: [
+    {
+      q: "How does Steno record without a bot?",
+      a: "Steno captures system audio and your microphone directly on your machine, so both sides of a Zoom, Teams, or Meet call are transcribed without anything joining the meeting. It works for in-person conversations too.",
+    },
+    {
+      q: "Does Steno have AI credits or storage limits like Fireflies?",
+      a: "No. Everything runs on your own hardware, so nothing is metered. Unlimited meetings, unlimited length, unlimited summaries — the only resource used is your machine's disk and compute.",
+    },
+    {
+      q: "Can my team share notes with Steno?",
+      a: "Steno is built around local-first, per-person notes; you can copy and share summaries wherever your team works. If your core need is a shared, always-on cloud archive with CRM automation, Fireflies is honestly the better match — at the cost of every call living in its cloud.",
+    },
+    {
+      q: "Is Fireflies' free plan enough?",
+      a: "Fireflies' free tier caps storage at 400 minutes per team, limits AI credits, and holds back downloads and several AI features. Steno's free tier is the entire product — it's the only tier.",
+    },
+  ],
+};
+
+export const meetily = {
+  slug: "meetily",
+  name: "Meetily",
+  metaTitle: "Steno vs Meetily — What Meetily Pro Charges For, Free",
+  metaDescription:
+    "Steno and Meetily are both open-source, local-first meeting notetakers. The difference: Meetily moves accuracy, exports, and auto-detect behind a $120/year-per-device Pro license — Steno ships everything free, with models bundled in.",
+  eyebrow: "Steno vs Meetily",
+  h1: "Same privacy philosophy. Nothing held back.",
+  intro:
+    "Meetily deserves credit: like Steno, it's open source and transcribes meetings on your own machine. The comparison here isn't about privacy — both projects take it seriously. It's about what's actually included. Meetily's Community edition is a base tier under a $120/year-per-device Pro product; Steno has one tier, it's free, and the local AI models are bundled so there's nothing to set up.",
+  rows: [
+    ROW("Price", STENO.price, {
+      text: "Community edition free; Pro $120/year, licensed per device; Enterprise custom",
+      tone: "bad",
+    }),
+    ROW("Open source", STENO.openSource, {
+      text: "Community edition is MIT; Pro is a separate paid product on a different codebase",
+      tone: "neutral",
+    }),
+    ROW("Transcription", STENO.transcription, {
+      text: "On-device (Whisper, Parakeet)",
+      tone: "good",
+    }),
+    ROW("AI summaries", STENO.summaries, {
+      text: "Local via an Ollama you install and configure yourself, or your own cloud API key",
+      tone: "neutral",
+    }),
+    ROW("Audio leaves your device", STENO.audio, { text: "Never (local setup)", tone: "good" }),
+    ROW("Bot joins your meetings", STENO.bot, { text: "No bot", tone: "good" }),
+    ROW("Speaker attribution", {
+      text: "Live [You] / [Others] labels — included free",
+      tone: "good",
+    }, {
+      text: "“Coming soon”, planned as a Pro feature",
+      tone: "bad",
+    }),
+    ROW("Meeting auto-detect", {
+      text: "Included free (calendar integration)",
+      tone: "good",
+    }, {
+      text: "Pro feature; calendar integration “coming soon”",
+      tone: "bad",
+    }),
+    ROW("Usage limits", STENO.limits, { text: "None", tone: "good" }),
+    ROW("Platforms", STENO.platforms, {
+      text: "macOS, Windows; Linux build-from-source",
+      tone: "neutral",
+    }),
+  ],
+  verdict:
+    "If you're choosing between the two open-source local notetakers, the question is simple: Steno ships the whole product free — bundled models, speaker attribution, meeting auto-detect — while Meetily reserves its enhanced accuracy, exports, and auto-detect for a $120/year Pro license tied to one device, with several Pro features still marked coming soon.",
+  chooseSteno: [
+    "You want local summaries working out of the box — Steno bundles Ollama and downloads models in-app, no separate install",
+    "You want speaker attribution and meeting auto-detect today, free",
+    "You'd rather not manage per-device licenses",
+    "You want one codebase you can read end to end — no separate Pro fork",
+  ],
+  chooseThem: [
+    "You're on Linux — Meetily can be built from source there; Steno is macOS/Windows only",
+    "You want a paid support relationship with the vendor",
+  ],
+  faqs: [
+    {
+      q: "Aren't Steno and Meetily basically the same app?",
+      a: "They share a philosophy — open source, on-device transcription, no meeting bot — and even similar engines (Whisper, Parakeet). They differ in what's free: Steno's single free tier includes everything, while Meetily's Community edition sits under a paid Pro product that holds back enhanced accuracy models, advanced exports, custom templates, and meeting auto-detect.",
+    },
+    {
+      q: "Do I need to install Ollama to get local AI summaries?",
+      a: "With Steno, no — Ollama is bundled inside the app and the models download during first-run setup. With Meetily, local summaries require setting up your own Ollama (or supplying a cloud API key).",
+    },
+    {
+      q: "What does Meetily Pro cost, and what's the Steno equivalent?",
+      a: "Meetily Pro is $120/year, and each license is valid for one device. The Steno equivalent is the free download: there is no Pro tier, and features like speaker attribution and meeting auto-detect — paid or “coming soon” in Meetily — are included.",
+    },
+    {
+      q: "Which is more accurate?",
+      a: "Both build on the same open ASR family — Whisper and NVIDIA's Parakeet — so baseline accuracy is comparable. Meetily sells “enhanced accuracy models” as a Pro feature; Steno's best models are simply the defaults.",
+    },
+    {
+      q: "Is this comparison fair? You're a competitor.",
+      a: `We've tried to be. Every claim here comes from Meetily's public website, pricing page, or GitHub repository as of ${VERIFIED}, and the things Meetily does well — genuine local-first design, open source Community edition, Linux buildability — are stated plainly. If something is out of date, tell us and we'll fix it.`,
+    },
+  ],
+};
+
+export const ALL = [granola, otter, fireflies, meetily];

--- a/website/src/vs/entries/fireflies.jsx
+++ b/website/src/vs/entries/fireflies.jsx
@@ -1,0 +1,5 @@
+import { mount } from "../boot";
+import { ComparisonPage } from "../ComparisonPage";
+import { fireflies } from "../competitors";
+
+mount(<ComparisonPage data={fireflies} />);

--- a/website/src/vs/entries/granola.jsx
+++ b/website/src/vs/entries/granola.jsx
@@ -1,0 +1,5 @@
+import { mount } from "../boot";
+import { ComparisonPage } from "../ComparisonPage";
+import { granola } from "../competitors";
+
+mount(<ComparisonPage data={granola} />);

--- a/website/src/vs/entries/index.jsx
+++ b/website/src/vs/entries/index.jsx
@@ -1,0 +1,4 @@
+import { mount } from "../boot";
+import { VsIndex } from "../VsIndex";
+
+mount(<VsIndex />);

--- a/website/src/vs/entries/meetily.jsx
+++ b/website/src/vs/entries/meetily.jsx
@@ -1,0 +1,5 @@
+import { mount } from "../boot";
+import { ComparisonPage } from "../ComparisonPage";
+import { meetily } from "../competitors";
+
+mount(<ComparisonPage data={meetily} />);

--- a/website/src/vs/entries/otter.jsx
+++ b/website/src/vs/entries/otter.jsx
@@ -1,0 +1,5 @@
+import { mount } from "../boot";
+import { ComparisonPage } from "../ComparisonPage";
+import { otter } from "../competitors";
+
+mount(<ComparisonPage data={otter} />);

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -1,5 +1,9 @@
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -7,6 +11,18 @@ export default defineConfig({
   base: '/',
   build: {
     outDir: 'dist',
-    assetsDir: 'assets'
-  }
+    assetsDir: 'assets',
+    rollupOptions: {
+      // Multi-page build: each /vs/ page is its own HTML entry so it ships
+      // with static per-page meta tags (title/canonical/OG) for SEO.
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        vs: resolve(__dirname, 'vs/index.html'),
+        vsGranola: resolve(__dirname, 'vs/granola/index.html'),
+        vsOtter: resolve(__dirname, 'vs/otter/index.html'),
+        vsFireflies: resolve(__dirname, 'vs/fireflies/index.html'),
+        vsMeetily: resolve(__dirname, 'vs/meetily/index.html'),
+      },
+    },
+  },
 })

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -2,12 +2,41 @@ import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { ALL } from './src/vs/competitors.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
+const COMPETITOR_BY_SLUG = Object.fromEntries(ALL.map((c) => [c.slug, c]))
+
+// Emit each /vs/<slug>/ page's FAQ structured data into its STATIC HTML at
+// build time, sourced from competitors.js (single source of truth). This is
+// what non-JS crawlers read — the pages are SEO surfaces, so the JSON-LD must
+// exist without executing React. ComparisonPage no longer injects it client-side.
+function faqJsonLdPlugin() {
+  return {
+    name: 'inject-vs-faq-jsonld',
+    transformIndexHtml(html, ctx) {
+      const match = (ctx.path || '').match(/\/vs\/([^/]+)\/index\.html$/)
+      const data = match && COMPETITOR_BY_SLUG[match[1]]
+      if (!data) return html
+      const jsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: data.faqs.map((f) => ({
+          '@type': 'Question',
+          name: f.q,
+          acceptedAnswer: { '@type': 'Answer', text: f.a },
+        })),
+      }
+      const tag = `<script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>`
+      return html.replace('</head>', `  ${tag}\n</head>`)
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), faqJsonLdPlugin()],
   base: '/',
   build: {
     outDir: 'dist',

--- a/website/vs/fireflies/index.html
+++ b/website/vs/fireflies/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/stenoai-logo.svg" />
+    <link rel="icon" type="image/png" href="/favicon-64.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Fireflies sends its bot into your calls and stores everything in its cloud, with AI-credit caps per tier. Steno keeps meetings on your device: unlimited local transcription and AI notes, free and open source." />
+    <title>Steno vs Fireflies.ai — No-Bot, On-Device Alternative to Fireflies</title>
+    <link rel="canonical" href="https://stenoai.co/vs/fireflies/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://stenoai.co/vs/fireflies/" />
+    <meta property="og:title" content="Steno vs Fireflies.ai — No-Bot, On-Device Alternative to Fireflies" />
+    <meta property="og:description" content="Fireflies sends its bot into your calls and stores everything in its cloud, with AI-credit caps per tier. Steno keeps meetings on your device: unlimited local transcription and AI notes, free and open source." />
+    <meta property="og:image" content="https://stenoai.co/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Steno vs Fireflies.ai — No-Bot, On-Device Alternative to Fireflies" />
+    <meta name="twitter:description" content="Fireflies sends its bot into your calls and stores everything in its cloud. Steno keeps meetings on your device: unlimited local transcription and AI notes, free and open source." />
+    <meta name="twitter:image" content="https://stenoai.co/og-image.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://us.i.posthog.com" />
+    <link rel="preconnect" href="https://us-assets.i.posthog.com" />
+    <!-- Non-blocking font load: fetch in parallel, apply once ready, no render-blocking round trip -->
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
+    <!-- No-flash dark mode: apply class before React renders -->
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'dark' || (!stored && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/vs/entries/fireflies.jsx"></script>
+  </body>
+</html>

--- a/website/vs/granola/index.html
+++ b/website/vs/granola/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/stenoai-logo.svg" />
+    <link rel="icon" type="image/png" href="/favicon-64.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Granola processes your meeting audio in the cloud and costs from $14/user/month. Steno does the same job — no bot, AI meeting notes — entirely on your device, free and open source." />
+    <title>Steno vs Granola — Free, Fully Local Alternative to Granola</title>
+    <link rel="canonical" href="https://stenoai.co/vs/granola/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://stenoai.co/vs/granola/" />
+    <meta property="og:title" content="Steno vs Granola — Free, Fully Local Alternative to Granola" />
+    <meta property="og:description" content="Granola processes your meeting audio in the cloud and costs from $14/user/month. Steno does the same job — no bot, AI meeting notes — entirely on your device, free and open source." />
+    <meta property="og:image" content="https://stenoai.co/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Steno vs Granola — Free, Fully Local Alternative to Granola" />
+    <meta name="twitter:description" content="Granola processes your meeting audio in the cloud and costs from $14/user/month. Steno does the same job entirely on your device, free and open source." />
+    <meta name="twitter:image" content="https://stenoai.co/og-image.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://us.i.posthog.com" />
+    <link rel="preconnect" href="https://us-assets.i.posthog.com" />
+    <!-- Non-blocking font load: fetch in parallel, apply once ready, no render-blocking round trip -->
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
+    <!-- No-flash dark mode: apply class before React renders -->
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'dark' || (!stored && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/vs/entries/granola.jsx"></script>
+  </body>
+</html>

--- a/website/vs/index.html
+++ b/website/vs/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/stenoai-logo.svg" />
+    <link rel="icon" type="image/png" href="/favicon-64.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="How Steno's free, on-device meeting transcription compares with Granola, Otter.ai, Fireflies, and Meetily — pricing, privacy, bots, and usage limits, stated as fairly as we can." />
+    <title>Steno vs Granola, Otter, Fireflies & Meetily — Compare AI Meeting Notetakers</title>
+    <link rel="canonical" href="https://stenoai.co/vs/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://stenoai.co/vs/" />
+    <meta property="og:title" content="Steno vs Granola, Otter, Fireflies & Meetily — Compare AI Meeting Notetakers" />
+    <meta property="og:description" content="How Steno's free, on-device meeting transcription compares with Granola, Otter.ai, Fireflies, and Meetily — pricing, privacy, bots, and usage limits, stated as fairly as we can." />
+    <meta property="og:image" content="https://stenoai.co/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Steno vs Granola, Otter, Fireflies & Meetily — Compare AI Meeting Notetakers" />
+    <meta name="twitter:description" content="How Steno's free, on-device meeting transcription compares with Granola, Otter.ai, Fireflies, and Meetily." />
+    <meta name="twitter:image" content="https://stenoai.co/og-image.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://us.i.posthog.com" />
+    <link rel="preconnect" href="https://us-assets.i.posthog.com" />
+    <!-- Non-blocking font load: fetch in parallel, apply once ready, no render-blocking round trip -->
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
+    <!-- No-flash dark mode: apply class before React renders -->
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'dark' || (!stored && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/vs/entries/index.jsx"></script>
+  </body>
+</html>

--- a/website/vs/meetily/index.html
+++ b/website/vs/meetily/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/stenoai-logo.svg" />
+    <link rel="icon" type="image/png" href="/favicon-64.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Steno and Meetily are both open-source, local-first meeting notetakers. The difference: Meetily moves accuracy, exports, and auto-detect behind a $120/year-per-device Pro license — Steno ships everything free, with models bundled in." />
+    <title>Steno vs Meetily — What Meetily Pro Charges For, Free</title>
+    <link rel="canonical" href="https://stenoai.co/vs/meetily/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://stenoai.co/vs/meetily/" />
+    <meta property="og:title" content="Steno vs Meetily — What Meetily Pro Charges For, Free" />
+    <meta property="og:description" content="Steno and Meetily are both open-source, local-first meeting notetakers. The difference: Meetily moves accuracy, exports, and auto-detect behind a $120/year-per-device Pro license — Steno ships everything free, with models bundled in." />
+    <meta property="og:image" content="https://stenoai.co/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Steno vs Meetily — What Meetily Pro Charges For, Free" />
+    <meta name="twitter:description" content="Both are open-source, local-first meeting notetakers. Meetily moves key features behind a $120/year-per-device Pro license — Steno ships everything free, with models bundled in." />
+    <meta name="twitter:image" content="https://stenoai.co/og-image.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://us.i.posthog.com" />
+    <link rel="preconnect" href="https://us-assets.i.posthog.com" />
+    <!-- Non-blocking font load: fetch in parallel, apply once ready, no render-blocking round trip -->
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
+    <!-- No-flash dark mode: apply class before React renders -->
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'dark' || (!stored && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/vs/entries/meetily.jsx"></script>
+  </body>
+</html>

--- a/website/vs/otter/index.html
+++ b/website/vs/otter/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/stenoai-logo.svg" />
+    <link rel="icon" type="image/png" href="/favicon-64.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Otter sends a bot into your meetings, stores recordings in the cloud, and caps free transcription at 300 minutes a month. Steno transcribes unlimited meetings entirely on your device — free, no bot, no account." />
+    <title>Steno vs Otter.ai — Private, Unlimited Alternative to Otter</title>
+    <link rel="canonical" href="https://stenoai.co/vs/otter/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://stenoai.co/vs/otter/" />
+    <meta property="og:title" content="Steno vs Otter.ai — Private, Unlimited Alternative to Otter" />
+    <meta property="og:description" content="Otter sends a bot into your meetings, stores recordings in the cloud, and caps free transcription at 300 minutes a month. Steno transcribes unlimited meetings entirely on your device — free, no bot, no account." />
+    <meta property="og:image" content="https://stenoai.co/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Steno vs Otter.ai — Private, Unlimited Alternative to Otter" />
+    <meta name="twitter:description" content="Otter sends a bot into your meetings and caps free transcription at 300 minutes a month. Steno transcribes unlimited meetings entirely on your device — free, no bot, no account." />
+    <meta name="twitter:image" content="https://stenoai.co/og-image.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://us.i.posthog.com" />
+    <link rel="preconnect" href="https://us-assets.i.posthog.com" />
+    <!-- Non-blocking font load: fetch in parallel, apply once ready, no render-blocking round trip -->
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
+    <!-- No-flash dark mode: apply class before React renders -->
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'dark' || (!stored && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/vs/entries/otter.jsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## What

Adds SEO comparison pages to stenoai.co, modeled on the highest-leverage part of Meetily's site structure (they run 7 such pages; we had none):

- `/vs/` — hub page listing all comparisons
- `/vs/granola/` — vs Granola (closest UX comp: bot-free, but cloud processing, $14/user/mo)
- `/vs/otter/` — vs Otter.ai (bot + cloud + minute caps)
- `/vs/fireflies/` — vs Fireflies.ai (bot + cloud + AI credits)
- `/vs/meetily/` — vs Meetily incl. Meetily Pro ($120/yr/device for what Steno ships free)

## How

- **Multi-entry Vite build**: each page is a real static HTML file with its own title/description/canonical/OG tags (crawlable without JS), mounting a shared React `ComparisonPage` that reuses the existing design system (Nav, Footer, CTAFooter, paper+ink tokens).
- **Content**: ledger-style comparison table, verdict pull-quote, an honest "Choose {them} if" section (credibility), page-specific FAQ with `FAQPage` JSON-LD.
- **Fairness/accuracy**: every competitor claim sourced from their public pricing/marketing pages, stamped "verified July 2026" on-page with a note that pricing changes. Trademark disclaimer extended in the footer.
- `Nav` gains a `subpage` prop (section links become `/#how` etc.); footer gains compare links; sitemap.xml updated.

## Testing

- `npm run build` + `npm run lint` clean.
- All six URLs verified serving with correct heads via `vite preview`.
- Screenshots (light, dark, mobile 390px) checked — table scrolls in its own container on mobile, dark tokens carry through.
- No e2e spec: the Playwright suite covers the Electron app, not the website (no website lane exists).

## Notes for review

- Competitor pricing was taken from live pricing pages on 2026-07-10; worth a second pair of eyes on the Meetily Pro framing since they're the direct competitor.
- The homepage is untouched except the footer compare row and the Nav prop (default unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SEO-focused competitor pages under `/vs/` (Granola, Otter, Fireflies, Meetily) with static heads and build-time FAQ JSON‑LD, plus a Compare dropdown in the nav. Also standardizes copy to “privacy‑first AI notepad,” fixes pricing/claims, and improves accessibility.

- **New Features**
  - `/vs/` hub and pages with per-page heads (title/description/canonical/OG) and FAQ `FAQPage` JSON‑LD emitted into the static HTML.
  - Shared ComparisonPage (ledger table, verdict, “Choose … if,” cross‑links); nav adds a Compare dropdown (hover/click, Escape/outside‑click close) and mobile menu list; `sitemap.xml` includes all `/vs/*`.

- **Refactors**
  - `Vite` multi-entry build plus a plugin that injects FAQ JSON‑LD at build; removed client-side injection to avoid duplicates; `Nav` adds `subpage` for absolute section links on `/vs/*`; VsIndex one‑liners now live in `competitors.js`.
  - Copy/a11y/accuracy: standardized homepage/README (“privacy‑first AI notepad/meeting notetaker”), reframed to “meeting content never leaves your device” with telemetry opt‑out; corrected competitor details (e.g., Otter Pro $8.33); Compare dropdown uses plain links; demo meeting renamed “Defence Budget Planning.”

<sup>Written for commit 9033de0d083944110067c4b86cbff340e74b32d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

