### PR TITLE
fix(language): detect transcript language so auto output-language stops defaulting to English (#283)

### DIFF
--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -516,6 +516,8 @@ Summary output language: {config.get_language_name(output_language)}
             'date': processed_at,
             'duration_seconds': int(duration_seconds) if duration_seconds else None,
             'language': transcript_data.get("configured_language"),
+            'configured_language': transcript_data.get("configured_language"),
+            'detected_language': transcript_data.get("detected_language"),
             'is_diarised': False,
             'transcription_failed': True,
             'reprocessable': True,
@@ -619,6 +621,8 @@ Summary output language: {config.get_language_name(output_language)}
                 'date': processed_at,
                 'duration_seconds': int(duration_seconds) if duration_seconds else None,
                 'language': output_language,
+                'configured_language': gate_config.get_language(),
+                'detected_language': transcript_data.get('detected_language'),
                 'is_diarised': transcript_data.get('is_diarised', False),
                 'notes_generated': False,
             }
@@ -709,6 +713,8 @@ Summary output language: {config.get_language_name(output_language)}
             'date': processed_at,
             'duration_seconds': int(duration_seconds) if duration_seconds else None,
             'language': output_language,
+            'configured_language': configured_language,
+            'detected_language': transcript_data.get('detected_language'),
             'is_diarised': transcript_data.get('is_diarised', False),
         }
         md_lines = _render_frontmatter(md_meta)
@@ -975,6 +981,8 @@ def process_streaming(audio_file, name, notes, live_transcript):
                 'date': processed_at,
                 'duration_seconds': int(duration_seconds) if duration_seconds else None,
                 'language': output_language,
+                'configured_language': gate_config.get_language(),
+                'detected_language': transcript_data.get('detected_language'),
                 'is_diarised': transcript_data.get('is_diarised', False),
                 'notes_generated': False,
             }
@@ -1079,6 +1087,8 @@ def process_streaming(audio_file, name, notes, live_transcript):
             'date': processed_at,
             'duration_seconds': int(duration_seconds) if duration_seconds else None,
             'language': output_language,
+            'configured_language': configured_language,
+            'detected_language': transcript_data.get('detected_language'),
             'is_diarised': transcript_data.get('is_diarised', False),
         }
         # Mark live-sourced meetings (#207) so the UI and future code know this
@@ -2308,6 +2318,13 @@ def _parse_meeting_markdown(md_path):
         'duration_seconds': meta.get('duration_seconds'),
         'summary_file': str(md_path),
         'output_language': meta.get('language'),
+        # Provenance of the output language, so recovery paths (reprocess /
+        # generate-report / regen-title / chat) can tell a real user pin or
+        # Whisper engine detection from a bare Parakeet fallback (#283). Old .md
+        # files predating these keys read as None -> treated as no provenance
+        # (re-detect), preserving prior behaviour.
+        'configured_language': meta.get('configured_language'),
+        'detected_language': meta.get('detected_language'),
     }
     # A meeting whose transcription crashed carries these markers so the UI
     # can render an honest failure state (and a future retry) rather than a
@@ -2575,6 +2592,11 @@ def reprocess(summary_file, regenerate_title):
                 'date': existing_data.get('session_info', {}).get('processed_at', datetime.now().isoformat()),
                 'duration_seconds': existing_data.get('session_info', {}).get('duration_seconds'),
                 'language': output_language,
+                # Carry the ORIGINAL provenance forward, not the re-resolved
+                # output_language: a text-detected value must not masquerade as a
+                # pin/engine detection (it stays re-detectable, idempotently).
+                'configured_language': existing_session_info.get('configured_language'),
+                'detected_language': existing_session_info.get('detected_language'),
                 'is_diarised': existing_data.get('is_diarised', False),
                 # Carry forward folder membership so a regenerate never silently
                 # removes the meeting from its folders (matches _parse_meeting_markdown's
@@ -2856,7 +2878,10 @@ def query(transcript_file, question):
     from pathlib import Path
 
     transcript_path = Path(transcript_file)
-    language = None
+    # Collected from the meeting file (if any) so the language resolver can weigh
+    # the note's persisted output_language against its provenance (#283). Plain
+    # .txt transcripts leave this empty -> pure text-detection / config fallback.
+    session_info = {}
 
     # Handle summary JSON files (extract transcript from them)
     if transcript_file.endswith('.json'):
@@ -2872,7 +2897,6 @@ def query(transcript_file, question):
                     print(json.dumps({"success": False, "error": "No transcript found in summary file"}))
                     return
                 session_info = data.get("session_info", {})
-                language = session_info.get("output_language")
         except Exception as e:
             print(json.dumps({"success": False, "error": f"Failed to read summary file: {e}"}))
             return
@@ -2899,7 +2923,6 @@ def query(transcript_file, question):
                 parts.append(f"TRANSCRIPT:\n{raw_transcript}")
             transcript_text = '\n\n'.join(parts)
             session_info = meeting_data.get("session_info", {})
-            language = session_info.get("output_language")
         except Exception as e:
             print(json.dumps({"success": False, "error": f"Failed to read summary file: {e}"}))
             return
@@ -2924,12 +2947,14 @@ def query(transcript_file, question):
     try:
         from src.config import get_config
         config = get_config()
-        if not language:
-            language = config.get_language()
-        # Same priority as summaries: a stored/pinned language wins; otherwise
-        # detect from the transcript so an auto-mode Parakeet meeting is chatted
-        # in its own language instead of defaulting to English (#283).
-        language = resolve_output_language(language, transcript_text=transcript_text)
+        # The note's saved output_language is only a real pin when provenance-
+        # backed (a user pin or a Whisper detection). A stale Parakeet auto-mode
+        # "en" fallback (#283) must not lock chat to English, so re-detect from
+        # the transcript in that case. CLI contract is unchanged: the caller
+        # still passes only <file> -q <question>; provenance comes from the note.
+        language = resolve_persisted_output_language(
+            session_info, transcript_text, config.get_language()
+        )
         summarizer = OllamaSummarizer()
         answer = summarizer.query_transcript(transcript_text, question, language=language)
 
@@ -2951,7 +2976,10 @@ def query_streaming(transcript_file, question):
     from pathlib import Path
 
     transcript_path = Path(transcript_file)
-    language = None
+    # Collected from the meeting file (if any) so the language resolver can weigh
+    # the note's persisted output_language against its provenance (#283). Plain
+    # .txt transcripts leave this empty -> pure text-detection / config fallback.
+    session_info = {}
 
     if transcript_file.endswith('.json'):
         if not transcript_path.exists():
@@ -2965,7 +2993,6 @@ def query_streaming(transcript_file, question):
                     print("STREAM_ERROR:No transcript found in summary file", flush=True)
                     return
                 session_info = data.get("session_info", {})
-                language = session_info.get("output_language")
         except Exception as e:
             print(f"STREAM_ERROR:Failed to read file: {e}", flush=True)
             return
@@ -2988,7 +3015,6 @@ def query_streaming(transcript_file, question):
                 parts.append(f"TRANSCRIPT:\n{meeting_data['transcript']}")
             transcript_text = '\n\n'.join(parts)
             session_info = meeting_data.get("session_info", {})
-            language = session_info.get("output_language")
         except Exception as e:
             print(f"STREAM_ERROR:Failed to read file: {e}", flush=True)
             return
@@ -3002,12 +3028,13 @@ def query_streaming(transcript_file, question):
             print(f"STREAM_ERROR:Failed to read file: {e}", flush=True)
             return
 
-    if not language:
-        from src.config import get_config
-        language = get_config().get_language()
-    # Detect from the transcript when unpinned so auto-mode Parakeet meetings
-    # are chatted in their own language, not English (#283).
-    language = resolve_output_language(language, transcript_text=transcript_text)
+    from src.config import get_config
+    # Provenance-aware: honour the note's saved language only when it was a real
+    # pin or a Whisper detection, else re-detect so a stale Parakeet "en" (#283)
+    # doesn't lock chat to English. CLI contract unchanged (<file> -q <question>).
+    language = resolve_persisted_output_language(
+        session_info, transcript_text, get_config().get_language()
+    )
 
     try:
         summarizer = OllamaSummarizer()

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -57,9 +57,47 @@ try:
 except ImportError:
     OllamaSummarizer = None
 
+from src.language_detect import detect_transcript_language
+
 # Setup logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+def resolve_output_language(
+    configured_language: str,
+    detected_language: Optional[str] = None,
+    transcript_text: Optional[str] = None,
+) -> str:
+    """Resolve the summary/title/query output language, in strict priority order.
+
+    1. an explicit user pin (``configured_language != "auto"``) always wins;
+    2. an engine-detected language — whisper.cpp reports one; Parakeet never
+       does (#283);
+    3. a text-based detection over the transcript body, filling Parakeet's gap
+       so an auto-mode German/French/… meeting isn't summarised in English;
+    4. ``"en"`` as the final fallback when nothing above is conclusive.
+
+    Kept module-level (the ``MeetingPipeline`` method delegates here) so the
+    resolution logic is unit-testable without constructing the pipeline.
+    """
+    if configured_language and configured_language != "auto":
+        return configured_language
+
+    if detected_language:
+        return detected_language
+
+    if transcript_text:
+        detected = detect_transcript_language(transcript_text)
+        if detected:
+            # Privacy: log the code only, never the transcript content.
+            logger.info(
+                "Detected transcript language: %s (auto mode, engine gave none)",
+                detected,
+            )
+            return detected
+
+    return "en"
+
 
 # Session names that should trigger AI title regeneration after summarization.
 # Covers manual placeholders (Meeting / Note / Meeting-ABC123 / Note-ABC123) and
@@ -186,17 +224,21 @@ class MeetingPipeline:
         # through get_data_dirs(), which honors that env var).
         self.state_file = Path("recorder_state.json")
 
-    def _resolve_output_language(self, configured_language: str, detected_language: Optional[str] = None) -> str:
-        """Resolve which language should be used for summary/title/query output."""
-        from src.config import get_config
+    def _resolve_output_language(
+        self,
+        configured_language: str,
+        detected_language: Optional[str] = None,
+        transcript_text: Optional[str] = None,
+    ) -> str:
+        """Resolve which language should be used for summary/title/query output.
 
-        if configured_language != "auto":
-            return configured_language
-
-        if detected_language:
-            return detected_language
-
-        return "en"
+        Thin delegate to the module-level ``resolve_output_language`` so the
+        priority (pin > engine-detected > text-detected > "en") lives in one
+        unit-testable place.
+        """
+        return resolve_output_language(
+            configured_language, detected_language, transcript_text
+        )
 
     def _transcript_file_path(self, audio_path: Path) -> Path:
         """Canonical on-disk path for a meeting's transcript text file.
@@ -224,7 +266,9 @@ class MeetingPipeline:
         config = get_config()
 
         if output_language is None:
-            output_language = self._resolve_output_language(configured_language, detected_language)
+            output_language = self._resolve_output_language(
+                configured_language, detected_language, transcript_text=transcript_body
+            )
         detected_language_name = (
             config.get_language_name(detected_language) if detected_language else "Unknown"
         )
@@ -374,7 +418,9 @@ Summary output language: {config.get_language_name(output_language)}
             is_diarised = transcript_result.get("is_diarised", False)
             diarised_text = transcript_result.get("diarised_text")
 
-        output_language = self._resolve_output_language(configured_language, detected_language)
+        output_language = self._resolve_output_language(
+            configured_language, detected_language, transcript_text=diarised_text or transcript_text
+        )
 
         # Save transcript (use diarised text if available for the saved file)
         saved_transcript = diarised_text if diarised_text else transcript_text
@@ -528,7 +574,9 @@ Summary output language: {config.get_language_name(output_language)}
         gate_config = get_config()
         if not gate_config.get_auto_summarize_enabled():
             output_language = self._resolve_output_language(
-                gate_config.get_language(), transcript_data.get("detected_language")
+                gate_config.get_language(),
+                transcript_data.get("detected_language"),
+                transcript_text=text_for_summary,
             )
             summary_path = self.output_dir / f"{audio_path.stem}_summary.md"
             processed_at = datetime.now().isoformat()
@@ -574,7 +622,9 @@ Summary output language: {config.get_language_name(output_language)}
         config = get_config()
         configured_language = config.get_language()
         output_language = self._resolve_output_language(
-            configured_language, transcript_data.get("detected_language")
+            configured_language,
+            transcript_data.get("detected_language"),
+            transcript_text=text_for_summary,
         )
 
         print("🧠 Generating summary...", flush=True)
@@ -879,7 +929,9 @@ def process_streaming(audio_file, name, notes, live_transcript):
         gate_config = get_config()
         if not gate_config.get_auto_summarize_enabled():
             output_language = recorder._resolve_output_language(
-                gate_config.get_language(), transcript_data.get("detected_language")
+                gate_config.get_language(),
+                transcript_data.get("detected_language"),
+                transcript_text=text_for_summary,
             )
             audio_path = Path(audio_file)
             summary_path = recorder.output_dir / f"{audio_path.stem}_summary.md"
@@ -924,7 +976,9 @@ def process_streaming(audio_file, name, notes, live_transcript):
         config = get_config()
         configured_language = config.get_language()
         output_language = recorder._resolve_output_language(
-            configured_language, transcript_data.get("detected_language")
+            configured_language,
+            transcript_data.get("detected_language"),
+            transcript_text=text_for_summary,
         )
 
         import base64
@@ -2399,7 +2453,8 @@ def reprocess(summary_file, regenerate_title):
                 configured_language = get_config().get_language()
             output_language = recorder._resolve_output_language(
                 configured_language,
-                existing_session_info.get("detected_language")
+                existing_session_info.get("detected_language"),
+                transcript_text=transcript,
             )
 
         # Use streaming summarization (same as new recordings)
@@ -2637,7 +2692,7 @@ def generate_report(summary_file, template_id):
         output_language = meeting["language"]
         if not output_language:
             output_language = recorder._resolve_output_language(
-                config.get_language(), None
+                config.get_language(), None, transcript_text=transcript
             )
 
     if recorder.summarizer is None:
@@ -2827,8 +2882,10 @@ def query(transcript_file, question):
         config = get_config()
         if not language:
             language = config.get_language()
-        if language == "auto":
-            language = "en"
+        # Same priority as summaries: a stored/pinned language wins; otherwise
+        # detect from the transcript so an auto-mode Parakeet meeting is chatted
+        # in its own language instead of defaulting to English (#283).
+        language = resolve_output_language(language, transcript_text=transcript_text)
         summarizer = OllamaSummarizer()
         answer = summarizer.query_transcript(transcript_text, question, language=language)
 
@@ -2904,8 +2961,9 @@ def query_streaming(transcript_file, question):
     if not language:
         from src.config import get_config
         language = get_config().get_language()
-    if language == "auto":
-        language = "en"
+    # Detect from the transcript when unpinned so auto-mode Parakeet meetings
+    # are chatted in their own language, not English (#283).
+    language = resolve_output_language(language, transcript_text=transcript_text)
 
     try:
         summarizer = OllamaSummarizer()

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -99,6 +99,40 @@ def resolve_output_language(
     return "en"
 
 
+def resolve_persisted_output_language(
+    session_info: dict,
+    transcript_text: Optional[str],
+    fallback_configured: str,
+) -> str:
+    """Resolve output language for a note that already has a persisted value.
+
+    Recovery paths (reprocess / generate-report / regen-title) reopen a saved
+    note whose ``session_info`` carries an ``output_language`` from when it was
+    first processed. That persisted value is only trustworthy when we can prove
+    its *provenance*: it was written from a real user pin
+    (``configured_language != "auto"``) or from an engine detection
+    (``detected_language``, i.e. Whisper). Old Parakeet auto-mode notes instead
+    persisted ``"en"`` purely from the buggy fallback (#283) with no pin and no
+    engine language behind it - trusting that value would re-pin every such note
+    to English forever, defeating this fix.
+
+    So: honour the persisted value only when pin- or engine-backed; otherwise
+    fall through to ``resolve_output_language`` (which re-detects from the
+    transcript, then lands on "en" if inconclusive). Re-detecting a
+    previously text-detected note is idempotent, so this is safe to re-run.
+
+    ``fallback_configured`` is the caller's current configured language, used
+    when the note never stored its own ``configured_language`` (e.g. markdown
+    notes, whose front matter only persists the resolved output language).
+    """
+    configured = session_info.get("configured_language") or fallback_configured
+    detected = session_info.get("detected_language")
+    persisted = session_info.get("output_language")
+    if persisted and ((configured and configured != "auto") or detected):
+        return persisted
+    return resolve_output_language(configured, detected, transcript_text)
+
+
 # Session names that should trigger AI title regeneration after summarization.
 # Covers manual placeholders (Meeting / Note / Meeting-ABC123 / Note-ABC123) and
 # the auto-detect-meetings shape "<AppName> — YYYY-MM-DD HH:MM" produced by
@@ -2443,19 +2477,14 @@ def reprocess(summary_file, regenerate_title):
         if notes_text:
             print(f"User notes: {len(notes_text)} characters")
 
-        # Resolve output language
+        # Resolve output language. A persisted value is only trusted when it was
+        # pin- or engine-backed; a stale Parakeet auto-mode "en" (buggy fallback,
+        # #283) is re-detected from the transcript instead of re-pinning English.
+        from src.config import get_config
         existing_session_info = existing_data.get("session_info", {})
-        output_language = existing_session_info.get("output_language")
-        if not output_language:
-            configured_language = existing_session_info.get("configured_language")
-            if not configured_language:
-                from src.config import get_config
-                configured_language = get_config().get_language()
-            output_language = recorder._resolve_output_language(
-                configured_language,
-                existing_session_info.get("detected_language"),
-                transcript_text=transcript,
-            )
+        output_language = resolve_persisted_output_language(
+            existing_session_info, transcript, get_config().get_language()
+        )
 
         # Use streaming summarization (same as new recordings)
         if recorder.summarizer is None:
@@ -2689,11 +2718,18 @@ def generate_report(summary_file, template_id):
     if tmpl.get("language") and tmpl["language"] != "auto":
         output_language = tmpl["language"]
     else:
-        output_language = meeting["language"]
-        if not output_language:
-            output_language = recorder._resolve_output_language(
-                config.get_language(), None, transcript_text=transcript
-            )
+        # Trust the meeting's persisted language only when pin-/engine-backed;
+        # otherwise re-detect from the transcript so a stale Parakeet auto-mode
+        # "en" (#283) doesn't force English reports. read_meeting surfaces the
+        # provenance fields (None for markdown, which never stored them).
+        persisted_info = {
+            "output_language": meeting["language"],
+            "configured_language": meeting.get("configured_language"),
+            "detected_language": meeting.get("detected_language"),
+        }
+        output_language = resolve_persisted_output_language(
+            persisted_info, transcript, config.get_language()
+        )
 
     if recorder.summarizer is None:
         from src.summarizer import OllamaSummarizer
@@ -2768,11 +2804,19 @@ def regen_title(summary_file):
         transcript = existing_data.get('transcript', '')
         summary = existing_data.get('summary', '')
         session_info = existing_data.get('session_info', {})
-        output_language = session_info.get('output_language') or session_info.get('configured_language') or 'en'
 
         if not transcript and not summary:
             print("ERROR: No transcript or summary found in file")
             sys.exit(1)
+
+        # Trust the persisted language only when pin-/engine-backed; otherwise
+        # re-detect so a stale Parakeet auto-mode "en" (#283) doesn't force an
+        # English title. Fall back to the summary text when there's no
+        # transcript (summary is already in the note's language).
+        from src.config import get_config
+        output_language = resolve_persisted_output_language(
+            session_info, transcript or summary, get_config().get_language()
+        )
 
         if recorder.summarizer is None:
             from src.summarizer import OllamaSummarizer

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -121,16 +121,25 @@ def resolve_persisted_output_language(
     transcript, then lands on "en" if inconclusive). Re-detecting a
     previously text-detected note is idempotent, so this is safe to re-run.
 
-    ``fallback_configured`` is the caller's current configured language, used
-    when the note never stored its own ``configured_language`` (e.g. markdown
-    notes, whose front matter only persists the resolved output language).
+    Only STORED provenance may authenticate the persisted value: the caller's
+    current pin must NOT retroactively legitimise a stale value it never
+    produced. So a legacy note {output_language: "en"} with no stored provenance
+    does not become trustworthy just because config is now pinned to "fr" - the
+    current "fr" pin wins instead. ``fallback_configured`` (the caller's current
+    configured language) therefore feeds ONLY the untrusted-path resolve, never
+    the trust check.
     """
-    configured = session_info.get("configured_language") or fallback_configured
+    stored_configured = session_info.get("configured_language")
     detected = session_info.get("detected_language")
     persisted = session_info.get("output_language")
-    if persisted and ((configured and configured != "auto") or detected):
+    if persisted and ((stored_configured and stored_configured != "auto") or detected):
         return persisted
-    return resolve_output_language(configured, detected, transcript_text)
+    # Untrusted persisted value: resolve fresh. Prefer a real stored pin (which
+    # only reaches here when no output_language was persisted), then the
+    # caller's current pin, then engine/text detection.
+    return resolve_output_language(
+        stored_configured or fallback_configured, detected, transcript_text
+    )
 
 
 # Session names that should trigger AI title regeneration after summarization.
@@ -2882,6 +2891,12 @@ def query(transcript_file, question):
     # the note's persisted output_language against its provenance (#283). Plain
     # .txt transcripts leave this empty -> pure text-detection / config fallback.
     session_info = {}
+    # Language detection must run over the RAW transcript only, not the combined
+    # summary+topics+transcript context below: detection samples the first ~8000
+    # chars, so a legacy English summary would flip a German meeting to "en"
+    # before the transcript is ever reached. Falls back to transcript_text when a
+    # note has no separate transcript body.
+    detect_text = None
 
     # Handle summary JSON files (extract transcript from them)
     if transcript_file.endswith('.json'):
@@ -2922,6 +2937,7 @@ def query(transcript_file, question):
             if raw_transcript:
                 parts.append(f"TRANSCRIPT:\n{raw_transcript}")
             transcript_text = '\n\n'.join(parts)
+            detect_text = raw_transcript
             session_info = meeting_data.get("session_info", {})
         except Exception as e:
             print(json.dumps({"success": False, "error": f"Failed to read summary file: {e}"}))
@@ -2950,10 +2966,10 @@ def query(transcript_file, question):
         # The note's saved output_language is only a real pin when provenance-
         # backed (a user pin or a Whisper detection). A stale Parakeet auto-mode
         # "en" fallback (#283) must not lock chat to English, so re-detect from
-        # the transcript in that case. CLI contract is unchanged: the caller
+        # the RAW transcript in that case. CLI contract is unchanged: the caller
         # still passes only <file> -q <question>; provenance comes from the note.
         language = resolve_persisted_output_language(
-            session_info, transcript_text, config.get_language()
+            session_info, detect_text or transcript_text, config.get_language()
         )
         summarizer = OllamaSummarizer()
         answer = summarizer.query_transcript(transcript_text, question, language=language)
@@ -2980,6 +2996,10 @@ def query_streaming(transcript_file, question):
     # the note's persisted output_language against its provenance (#283). Plain
     # .txt transcripts leave this empty -> pure text-detection / config fallback.
     session_info = {}
+    # Detect language over the RAW transcript only (not the combined context
+    # below), so a legacy English summary in the first ~8000 chars can't flip a
+    # German meeting to "en". Falls back to transcript_text when absent.
+    detect_text = None
 
     if transcript_file.endswith('.json'):
         if not transcript_path.exists():
@@ -3014,6 +3034,7 @@ def query_streaming(transcript_file, question):
             if meeting_data.get('transcript'):
                 parts.append(f"TRANSCRIPT:\n{meeting_data['transcript']}")
             transcript_text = '\n\n'.join(parts)
+            detect_text = meeting_data.get('transcript', '')
             session_info = meeting_data.get("session_info", {})
         except Exception as e:
             print(f"STREAM_ERROR:Failed to read file: {e}", flush=True)
@@ -3030,10 +3051,11 @@ def query_streaming(transcript_file, question):
 
     from src.config import get_config
     # Provenance-aware: honour the note's saved language only when it was a real
-    # pin or a Whisper detection, else re-detect so a stale Parakeet "en" (#283)
-    # doesn't lock chat to English. CLI contract unchanged (<file> -q <question>).
+    # pin or a Whisper detection, else re-detect (over the RAW transcript) so a
+    # stale Parakeet "en" (#283) doesn't lock chat to English. CLI contract
+    # unchanged (<file> -q <question>).
     language = resolve_persisted_output_language(
-        session_info, transcript_text, get_config().get_language()
+        session_info, detect_text or transcript_text, get_config().get_language()
     )
 
     try:

--- a/skills/granola-to-steno/scripts/steno_gen.py
+++ b/skills/granola-to-steno/scripts/steno_gen.py
@@ -155,6 +155,12 @@ def build(meeting, language="en"):
         "date": date_iso,
         "duration_seconds": None,
         "language": language,
+        # The import language is a deliberate choice, so record it as a real pin
+        # (configured_language) with no engine detection. This gives the note
+        # provenance so Steno's recovery/chat paths keep the chosen output
+        # language instead of re-detecting it from the transcript (#283).
+        "configured_language": language,
+        "detected_language": None,
         "is_diarised": is_diar,
         "transcription_failed": False,
         # Unknown frontmatter keys are ignored by Steno's parser. This one

--- a/src/language_detect.py
+++ b/src/language_detect.py
@@ -1,0 +1,136 @@
+"""Dependency-free text language detection for the Parakeet-supported languages.
+
+Parakeet's transcription backends (``src/_parakeet_mlx.py`` /
+``src/_parakeet_onnx.py``) are language-agnostic at inference and never return a
+detected language — they only echo an explicit caller pin. With the default
+``language="auto"`` that means ``detected_language`` is ``None``, so the output
+language resolves to English and a German/French/… meeting gets an English
+summary (#283). Whisper is unaffected (whisper.cpp reports a real
+``detected_language``).
+
+This module fills that gap with a small stopword/function-word classifier over
+the transcript text. It covers exactly the European languages Parakeet
+transcribes well (``en, fr, de, es, nl, pt`` — the ``PARAKEET_LANGUAGES`` set
+minus ``auto``) and returns ``None`` when the evidence is inconclusive, so the
+existing "en" fallback still applies. No pip dependency (PyInstaller bundle size
++ licensing); the method is a plain aggregate word-match count.
+"""
+
+import re
+from collections import Counter
+from typing import Optional
+
+# High-frequency function words per language. Curated for distinctiveness:
+# cross-language collisions (e.g. "die" in de/nl/en, "de" in fr/es/pt/nl) are
+# fine because the aggregate count decides — every list carries enough words
+# that don't collide for the true language to lead. Codes match the Parakeet
+# set (transcription-languages.ts: PARAKEET_LANGUAGES minus "auto").
+_STOPWORDS: dict[str, frozenset[str]] = {
+    "en": frozenset({
+        "the", "and", "that", "have", "for", "not", "with", "you", "this",
+        "but", "from", "they", "his", "her", "she", "will", "would", "there",
+        "their", "what", "about", "which", "when", "can", "like", "just",
+        "know", "your", "some", "could", "them", "than", "then", "only",
+        "also", "been", "has", "had", "were", "are", "our", "how", "who",
+        "why", "where", "into", "over", "these", "those", "being", "does",
+        "did", "because", "should", "very", "here", "much", "more",
+    }),
+    "fr": frozenset({
+        "le", "la", "les", "un", "une", "des", "du", "de", "et", "est",
+        "que", "qui", "dans", "pour", "pas", "plus", "avec", "sur", "ce",
+        "cette", "ces", "mais", "ou", "donc", "il", "elle", "ils", "elles",
+        "nous", "vous", "je", "son", "sa", "ses", "leur", "leurs", "être",
+        "avoir", "fait", "faire", "très", "bien", "aussi", "comme", "tout",
+        "tous", "alors", "parce", "quand", "peut", "cela", "notre", "votre",
+        "sont", "était", "ont",
+    }),
+    "de": frozenset({
+        "der", "die", "das", "und", "ist", "nicht", "ein", "eine", "einen",
+        "einem", "einer", "den", "dem", "mit", "auf", "für", "auch", "aber",
+        "oder", "wir", "ich", "sie", "wenn", "dann", "weil", "dass", "doch",
+        "noch", "schon", "immer", "sehr", "mehr", "viel", "hier", "jetzt",
+        "was", "wie", "warum", "wer", "haben", "hat", "hatte", "sein", "sind",
+        "war", "waren", "wird", "werden", "würde", "kann", "können", "muss",
+        "über", "durch", "nach", "diese", "dieser", "dieses",
+    }),
+    "es": frozenset({
+        "el", "la", "los", "las", "un", "una", "unos", "unas", "del", "en",
+        "que", "por", "para", "con", "se", "su", "sus", "lo", "le", "como",
+        "más", "pero", "este", "esta", "esto", "estos", "ese", "esa", "muy",
+        "también", "porque", "cuando", "donde", "hay", "ser", "estar",
+        "tiene", "tienen", "tener", "son", "era", "eran", "fue", "fueron",
+        "está", "están", "puede", "pueden", "todo", "todos", "nosotros",
+        "ellos", "ellas", "usted", "ustedes", "ahora", "entonces",
+    }),
+    "nl": frozenset({
+        "de", "het", "een", "en", "van", "dat", "die", "in", "is", "ik",
+        "je", "niet", "met", "op", "te", "zijn", "voor", "maar", "ook",
+        "aan", "om", "dan", "wat", "wij", "jij", "hij", "zij", "deze", "dit",
+        "daar", "hier", "naar", "door", "over", "worden", "wordt", "heeft",
+        "hebben", "heb", "kan", "kunnen", "moet", "moeten", "zou", "zal",
+        "nog", "wel", "heel", "veel", "meer", "waarom", "wie", "waar", "hoe",
+        "omdat", "wanneer", "alle", "alles",
+    }),
+    "pt": frozenset({
+        "os", "as", "um", "uma", "do", "da", "dos", "das", "em", "no", "na",
+        "nos", "nas", "que", "por", "para", "com", "não", "se", "seu", "sua",
+        "como", "mais", "mas", "este", "esta", "isto", "esse", "essa", "isso",
+        "muito", "também", "porque", "quando", "onde", "ser", "estar", "tem",
+        "têm", "ter", "são", "era", "eram", "foi", "foram", "está", "estão",
+        "pode", "podem", "tudo", "nós", "eles", "elas", "você", "vocês",
+        "agora", "então",
+    }),
+}
+
+# Strip diarisation markers ([You] / [Others] / [Together]) and bracketed
+# timestamps like [00:12:34] so they don't dilute the word count.
+_BRACKET_RE = re.compile(r"\[[^\]]*\]")
+# Strip bare clock timestamps (12:34 or 00:12:34) that appear without brackets.
+_TIMESTAMP_RE = re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?\b")
+# Unicode letter runs (keeps accented characters: é, ü, ñ, ç, ã, …).
+_WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+# Only look at the start of a transcript — enough signal without scanning a
+# multi-megabyte file.
+_MAX_CHARS = 8000
+# Require a solid base of evidence and a clear lead over the runner-up before
+# committing to a language; otherwise return None and let "en" apply.
+_MIN_HITS = 15
+_LEAD_RATIO = 1.3
+
+
+def detect_transcript_language(text: str) -> Optional[str]:
+    """Best-effort language of ``text``, or ``None`` when inconclusive.
+
+    Returns one of ``{en, fr, de, es, nl, pt}`` — the Parakeet-supported set —
+    only when the winning language clears ``_MIN_HITS`` stopword matches and
+    leads the runner-up by at least ``_LEAD_RATIO``. Diarisation markers and
+    timestamps are ignored and only the first ``_MAX_CHARS`` are scanned.
+    """
+    if not text:
+        return None
+
+    sample = text[:_MAX_CHARS]
+    sample = _BRACKET_RE.sub(" ", sample)
+    sample = _TIMESTAMP_RE.sub(" ", sample)
+
+    tokens = _WORD_RE.findall(sample.lower())
+    if not tokens:
+        return None
+
+    counts = Counter(tokens)
+    scores = {
+        lang: sum(counts[word] for word in words)
+        for lang, words in _STOPWORDS.items()
+    }
+
+    ranked = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+    top_lang, top_score = ranked[0]
+    runner_score = ranked[1][1] if len(ranked) > 1 else 0
+
+    if top_score < _MIN_HITS:
+        return None
+    if runner_score and top_score < runner_score * _LEAD_RATIO:
+        return None
+
+    return top_lang

--- a/src/report_store.py
+++ b/src/report_store.py
@@ -107,6 +107,12 @@ def read_meeting(meeting_path) -> dict:
             "transcript": d.get("transcript", "") or d.get("diarised_text", "") or "",
             "notes": d.get("user_notes"),
             "language": si.get("output_language") or si.get("language"),
+            # Provenance of the persisted language, for the recovery paths to
+            # decide whether it was pin-/engine-backed (trustworthy) or a bare
+            # fallback (#283). Markdown front matter never stored these, so they
+            # are None there - which is the correct "unprovable" signal.
+            "configured_language": si.get("configured_language"),
+            "detected_language": si.get("detected_language"),
             "duration_minutes": si.get("duration_minutes") or (int(ds / 60) if ds else None),
             "summary_markdown": summary_md,
         }
@@ -117,6 +123,8 @@ def read_meeting(meeting_path) -> dict:
         "transcript": transcript,
         "notes": notes,
         "language": fm.get("language"),
+        "configured_language": fm.get("configured_language"),
+        "detected_language": fm.get("detected_language"),
         "duration_minutes": (int(ds) // 60) if (ds and str(ds).isdigit()) else None,
         "summary_markdown": summary_md,
     }

--- a/src/report_store.py
+++ b/src/report_store.py
@@ -57,7 +57,18 @@ def _split_frontmatter(text: str):
             for line in block.splitlines():
                 if ":" in line:
                     k, _, v = line.partition(":")
-                    fm[k.strip()] = v.strip().strip('"')
+                    v = v.strip()
+                    # Coerce the serialised-None forms to real None (in ONE
+                    # place, for every consumer): the writer emits missing values
+                    # as unquoted `null`, and an empty value reads back as "".
+                    # Leaving them as the truthy strings "null"/"" would make a
+                    # provenance key like detected_language look engine-backed and
+                    # wrongly pin an auto/Parakeet note's language (#283). Mirrors
+                    # _parse_meeting_markdown's null handling.
+                    if v == "null" or v == "":
+                        fm[k.strip()] = None
+                    else:
+                        fm[k.strip()] = v.strip('"')
     return fm, body
 
 

--- a/tests/test_granola_steno_gen.py
+++ b/tests/test_granola_steno_gen.py
@@ -35,6 +35,12 @@ class LanguageFlagTests(unittest.TestCase):
         _stem, summary_md, transcript_txt = steno_gen.build(meeting, language="de")
 
         self.assertIn('language: "de"', summary_md)
+        # The import language is a deliberate choice, so it's recorded as a real
+        # pin (configured_language) with no engine detection, giving the note
+        # provenance so Steno's recovery/chat paths keep it instead of
+        # re-detecting (#283).
+        self.assertIn('configured_language: "de"', summary_md)
+        self.assertIn('detected_language: null', summary_md)
         self.assertIn("Language setting: de", transcript_txt)
         self.assertIn("Detected language: de", transcript_txt)
         self.assertIn("Summary output language: de", transcript_txt)
@@ -141,7 +147,7 @@ class FrontmatterEscapingTests(unittest.TestCase):
         fm_lines = [line for line in fm_block.strip().splitlines() if line.strip()]
         # One line per frontmatter key -- an unescaped newline in a scalar
         # would inject a bogus extra "key" line here and corrupt the block.
-        self.assertEqual(len(fm_lines), 7)
+        self.assertEqual(len(fm_lines), 9)
         self.assertIn('title: "Line one Line two"', summary_md)
 
 

--- a/tests/test_language_detect.py
+++ b/tests/test_language_detect.py
@@ -10,13 +10,18 @@ stopword classifier over the Parakeet-supported languages, and
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
+from click.testing import CliRunner
+
+import simple_recorder
 from simple_recorder import (
     MeetingPipeline,
     _parse_meeting_markdown,
     resolve_output_language,
     resolve_persisted_output_language,
 )
+from src.config import Config
 from src.language_detect import detect_transcript_language
 
 # Realistic meeting-style paragraphs (>=80 words each). Function-word rich so
@@ -230,12 +235,41 @@ class ResolvePersistedOutputLanguageTests(unittest.TestCase):
             "en",
         )
 
-    def test_fallback_configured_pin_trusts_persisted(self):
-        # A markdown note stores no configured_language of its own; the caller's
-        # current pin supplies the provenance, so the persisted value is kept.
-        session_info = {"output_language": "de"}
+    def test_legacy_note_honors_current_pin_not_stale_persisted(self):
+        # HIGH fix: a legacy note persisted "en" with NO stored provenance must
+        # NOT be authenticated by the caller's CURRENT pin. With config pinned to
+        # "fr", the current "fr" pin wins over the stale "en" (and over the
+        # German transcript, because a pin beats detection).
+        session_info = {"output_language": "en"}
         self.assertEqual(
-            resolve_persisted_output_language(session_info, EN_TEXT, "de"),
+            resolve_persisted_output_language(session_info, DE_TEXT, "fr"),
+            "fr",
+        )
+
+    def test_legacy_note_current_auto_redetects_from_transcript(self):
+        # Same legacy note, but the caller is on auto now -> re-detect the German
+        # transcript instead of trusting the stale "en".
+        session_info = {"output_language": "en"}
+        self.assertEqual(
+            resolve_persisted_output_language(session_info, DE_TEXT, "auto"),
+            "de",
+        )
+
+    def test_stored_pin_honored_regardless_of_current_config(self):
+        # A note with a STORED pin keeps it even when current config differs.
+        session_info = {"output_language": "en", "configured_language": "en"}
+        self.assertEqual(
+            resolve_persisted_output_language(session_info, DE_TEXT, "fr"),
+            "en",
+        )
+
+    def test_stored_pin_without_persisted_output_language_is_honored(self):
+        # A real stored pin with no persisted output_language must still win over
+        # the caller's current config (it reaches the untrusted branch because
+        # output_language is empty, but the stored pin is preferred there).
+        session_info = {"configured_language": "de"}
+        self.assertEqual(
+            resolve_persisted_output_language(session_info, EN_TEXT, "fr"),
             "de",
         )
 
@@ -306,6 +340,41 @@ class MarkdownProvenanceTests(unittest.TestCase):
                 resolve_persisted_output_language(session_info, EN_TEXT, "auto"),
                 "de",
             )
+
+
+class QueryPathLanguageTests(unittest.TestCase):
+    """The chat/query paths must detect over the RAW transcript, not the combined
+    summary+topics+transcript context (#283).
+
+    Detection samples only the first ~8000 chars, so a legacy English summary at
+    the front of the combined text could otherwise flip a German meeting to "en".
+    """
+
+    def _run_query(self, tmp: str, md_body: str) -> str:
+        md = Path(tmp) / "meeting_summary.md"
+        md.write_text(md_body, encoding="utf-8")
+        cfg = Config(config_path=Path(tmp) / "config.json")  # defaults to "auto"
+        fake = mock.MagicMock()
+        fake.query_transcript.return_value = "antwort"
+        with mock.patch("src.config.get_config", return_value=cfg), \
+             mock.patch.object(simple_recorder, "OllamaSummarizer", return_value=fake):
+            res = CliRunner().invoke(
+                simple_recorder.query, [str(md), "-q", "Worum ging es?"]
+            )
+        self.assertEqual(res.exit_code, 0, res.output)
+        fake.query_transcript.assert_called_once()
+        return fake.query_transcript.call_args.kwargs["language"]
+
+    def test_english_summary_german_transcript_resolves_to_de(self):
+        # Legacy note labelled English (no provenance) with an English summary but
+        # a German transcript: chat must answer in German, driven by the RAW
+        # transcript. Under the old combined-context detection this flipped to en.
+        md_body = (
+            f"---\ntitle: Sync\nlanguage: en\n---\n\n"
+            f"## Summary\n\n{EN_TEXT}\n\n## Transcript\n\n{DE_TEXT}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(self._run_query(tmp, md_body), "de")
 
 
 if __name__ == "__main__":

--- a/tests/test_language_detect.py
+++ b/tests/test_language_detect.py
@@ -1,0 +1,176 @@
+"""Unit coverage for the transcript language detector (#283).
+
+Parakeet never reports a detected language, so auto-mode meetings used to fall
+back to English summaries. ``detect_transcript_language`` fills that gap with a
+stopword classifier over the Parakeet-supported languages, and
+``resolve_output_language`` slots it into the priority chain
+(pin > engine-detected > text-detected > "en").
+"""
+
+import unittest
+
+from simple_recorder import MeetingPipeline, resolve_output_language
+from src.language_detect import detect_transcript_language
+
+# Realistic meeting-style paragraphs (>=80 words each). Function-word rich so
+# the aggregate classifier has enough signal, as a real transcript would.
+EN_TEXT = (
+    "So the main thing that we need to decide today is whether we should ship "
+    "the new onboarding flow this week or wait until the next release. I think "
+    "the data we have from the last test is good, but there are still a couple "
+    "of things that could be better before we send it to all of our users. "
+    "What would you like to do about the pricing page? Can we also talk about "
+    "how the team will handle support when more people start using it, because "
+    "that is the part that worries me the most right now."
+)
+FR_TEXT = (
+    "Donc, la question que nous devons trancher aujourd'hui est de savoir si "
+    "nous allons lancer le nouveau parcours cette semaine ou attendre la "
+    "prochaine version. Je pense que les données que nous avons sont bonnes, "
+    "mais il y a encore des choses qui pourraient être meilleures avant de "
+    "les envoyer à tous nos utilisateurs. Que voulez-vous faire pour la page "
+    "des prix ? Nous devons aussi parler de la façon dont l'équipe va gérer le "
+    "support quand plus de personnes vont commencer à l'utiliser, parce que "
+    "c'est la partie qui m'inquiète le plus."
+)
+DE_TEXT = (
+    "Also, die Frage, die wir heute entscheiden müssen, ist, ob wir den neuen "
+    "Ablauf diese Woche ausliefern oder bis zur nächsten Version warten "
+    "sollen. Ich denke, dass die Daten, die wir aus dem letzten Test haben, "
+    "gut sind, aber es gibt noch ein paar Dinge, die besser sein könnten, "
+    "bevor wir es an alle unsere Nutzer schicken. Was möchtest du mit der "
+    "Preisseite machen? Wir müssen auch darüber reden, wie das Team den "
+    "Support macht, wenn mehr Leute anfangen, es zu benutzen, weil das der "
+    "Teil ist, der mir am meisten Sorgen macht."
+)
+ES_TEXT = (
+    "Entonces, la pregunta que tenemos que decidir hoy es si deberíamos lanzar "
+    "el nuevo flujo esta semana o esperar hasta la próxima versión. Creo que "
+    "los datos que tenemos de la última prueba son buenos, pero todavía hay un "
+    "par de cosas que podrían ser mejores antes de enviarlo a todos nuestros "
+    "usuarios. ¿Qué te gustaría hacer con la página de precios? También "
+    "tenemos que hablar de cómo el equipo va a gestionar el soporte cuando más "
+    "personas empiecen a usarlo, porque esa es la parte que más me preocupa "
+    "en este momento."
+)
+NL_TEXT = (
+    "Dus de vraag die we vandaag moeten beslissen is of we de nieuwe flow deze "
+    "week gaan uitbrengen of wachten tot de volgende versie. Ik denk dat de "
+    "gegevens die we van de laatste test hebben goed zijn, maar er zijn nog "
+    "een paar dingen die beter kunnen voordat we het naar al onze gebruikers "
+    "sturen. Wat wil je doen met de prijspagina? We moeten het er ook over "
+    "hebben hoe het team de ondersteuning gaat doen wanneer meer mensen het "
+    "gaan gebruiken, omdat dat het deel is waar ik me het meest zorgen over "
+    "maak."
+)
+PT_TEXT = (
+    "Então, a questão que precisamos decidir hoje é se devemos lançar o novo "
+    "fluxo esta semana ou esperar até a próxima versão. Eu acho que os dados "
+    "que temos do último teste são bons, mas ainda há algumas coisas que "
+    "poderiam ser melhores antes de enviá-lo para todos os nossos usuários. O "
+    "que você gostaria de fazer com a página de preços? Nós também precisamos "
+    "falar sobre como a equipe vai lidar com o suporte quando mais pessoas "
+    "começarem a usá-lo, porque essa é a parte que mais me preocupa agora."
+)
+
+# A diarised transcript with speaker markers and timestamps — the detector must
+# ignore the [You]/[Others] labels and clock stamps and still read German.
+DE_DIARISED_TEXT = (
+    "[00:00:02] [You] Also ich denke, dass wir die neue Version diese Woche "
+    "ausliefern sollten, weil die Daten wirklich gut sind.\n"
+    "[00:00:11] [Others] Ja, aber wir müssen noch über den Support reden, "
+    "wenn mehr Nutzer anfangen, es zu benutzen.\n"
+    "[00:00:20] [You] Das stimmt. Was möchtest du mit der Preisseite machen, "
+    "bevor wir es an alle unsere Kunden schicken?\n"
+    "[00:00:29] [Others] Ich glaube, wir sollten hier noch ein paar Dinge "
+    "besser machen, sonst gibt es zu viele Fragen."
+)
+
+
+class DetectTranscriptLanguageTests(unittest.TestCase):
+    def test_detects_each_supported_language(self):
+        cases = {
+            "en": EN_TEXT,
+            "fr": FR_TEXT,
+            "de": DE_TEXT,
+            "es": ES_TEXT,
+            "nl": NL_TEXT,
+            "pt": PT_TEXT,
+        }
+        for expected, text in cases.items():
+            with self.subTest(language=expected):
+                self.assertEqual(detect_transcript_language(text), expected)
+
+    def test_ignores_diarisation_markers_and_timestamps(self):
+        # Markers ([You]/[Others]) and [HH:MM:SS] stamps must not derail the
+        # aggregate — this German transcript still reads as German.
+        self.assertEqual(detect_transcript_language(DE_DIARISED_TEXT), "de")
+
+    def test_mixed_text_dominated_by_german_is_de(self):
+        mixed = (
+            "Quick note in English at the start. " + DE_TEXT +
+            " That is all for now, thanks everyone."
+        )
+        self.assertEqual(detect_transcript_language(mixed), "de")
+
+    def test_empty_input_is_none(self):
+        self.assertIsNone(detect_transcript_language(""))
+
+    def test_none_input_is_none(self):
+        self.assertIsNone(detect_transcript_language(None))
+
+    def test_whitespace_only_input_is_none(self):
+        self.assertIsNone(detect_transcript_language("   \n\t  "))
+
+    def test_short_ambiguous_input_is_none(self):
+        # Too few stopword hits to clear the evidence threshold.
+        self.assertIsNone(detect_transcript_language("Okay. Yes. Thanks."))
+
+    def test_numeric_and_symbol_only_input_is_none(self):
+        self.assertIsNone(detect_transcript_language("123 456 !!! @@@ 00:12:34 ### 99"))
+
+
+class ResolveOutputLanguagePriorityTests(unittest.TestCase):
+    def test_pinned_config_wins_over_everything(self):
+        # A concrete pin beats both an engine language and the transcript body.
+        self.assertEqual(
+            resolve_output_language("fr", detected_language="de", transcript_text=EN_TEXT),
+            "fr",
+        )
+
+    def test_engine_detected_wins_over_text_detection(self):
+        # In auto mode a real engine language (Whisper) takes precedence over
+        # the text classifier, even if the text looks like another language.
+        self.assertEqual(
+            resolve_output_language("auto", detected_language="es", transcript_text=DE_TEXT),
+            "es",
+        )
+
+    def test_text_detection_used_only_in_auto_plus_none(self):
+        self.assertEqual(
+            resolve_output_language("auto", detected_language=None, transcript_text=DE_TEXT),
+            "de",
+        )
+
+    def test_falls_back_to_en_when_detector_inconclusive(self):
+        self.assertEqual(
+            resolve_output_language("auto", detected_language=None, transcript_text="Yes. No."),
+            "en",
+        )
+
+    def test_falls_back_to_en_without_transcript(self):
+        self.assertEqual(resolve_output_language("auto"), "en")
+
+    def test_method_delegates_to_module_function(self):
+        # The MeetingPipeline method is a thin delegate — same priority result
+        # without constructing the (heavy) pipeline.
+        recorder = MeetingPipeline.__new__(MeetingPipeline)
+        self.assertEqual(
+            recorder._resolve_output_language("auto", None, transcript_text=FR_TEXT),
+            "fr",
+        )
+        self.assertEqual(recorder._resolve_output_language("de"), "de")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_language_detect.py
+++ b/tests/test_language_detect.py
@@ -7,10 +7,13 @@ stopword classifier over the Parakeet-supported languages, and
 (pin > engine-detected > text-detected > "en").
 """
 
+import tempfile
 import unittest
+from pathlib import Path
 
 from simple_recorder import (
     MeetingPipeline,
+    _parse_meeting_markdown,
     resolve_output_language,
     resolve_persisted_output_language,
 )
@@ -235,6 +238,74 @@ class ResolvePersistedOutputLanguageTests(unittest.TestCase):
             resolve_persisted_output_language(session_info, EN_TEXT, "de"),
             "de",
         )
+
+
+def _write_md(tmp: str, frontmatter: str) -> Path:
+    p = Path(tmp) / "meeting_summary.md"
+    p.write_text(
+        f"---\n{frontmatter}---\n\n## Summary\n\nEin kurzer Ueberblick.\n\n"
+        "## Transcript\n\n[You] Hallo zusammen. [Others] Guten Morgen.\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+class MarkdownProvenanceTests(unittest.TestCase):
+    """Markdown notes must persist + restore language provenance (#283).
+
+    Without it, reprocessing / chatting a Whisper .md note loses the engine
+    detection (re-detection could discard a valid 'de'), and a stale Parakeet
+    'en' can't be told apart from a real pin.
+    """
+
+    def test_provenance_keys_round_trip_through_parser(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            md = _write_md(
+                tmp,
+                "title: Standup\nlanguage: de\nconfigured_language: auto\n"
+                "detected_language: de\nduration_seconds: 120\n",
+            )
+            session_info = _parse_meeting_markdown(md)["session_info"]
+            self.assertEqual(session_info["output_language"], "de")
+            self.assertEqual(session_info["configured_language"], "auto")
+            self.assertEqual(session_info["detected_language"], "de")
+
+    def test_old_markdown_without_keys_parses_with_none_provenance(self):
+        # A .md written before these keys existed must still parse; missing keys
+        # read as None (no provenance -> re-detect, prior behaviour preserved).
+        with tempfile.TemporaryDirectory() as tmp:
+            md = _write_md(tmp, "title: Legacy\nlanguage: en\nduration_seconds: 60\n")
+            session_info = _parse_meeting_markdown(md)["session_info"]
+            self.assertEqual(session_info["output_language"], "en")
+            self.assertIsNone(session_info["configured_language"])
+            self.assertIsNone(session_info["detected_language"])
+
+    def test_query_decision_stale_en_note_redetects_from_transcript(self):
+        # The chat/query seam (Python-side): a legacy Parakeet auto-mode note
+        # persisted "en" with no provenance. Parsing it then running the
+        # resolver over a German transcript must recover German, not stay English.
+        with tempfile.TemporaryDirectory() as tmp:
+            md = _write_md(tmp, "title: Legacy\nlanguage: en\nduration_seconds: 60\n")
+            session_info = _parse_meeting_markdown(md)["session_info"]
+            self.assertEqual(
+                resolve_persisted_output_language(session_info, DE_TEXT, "auto"),
+                "de",
+            )
+
+    def test_query_decision_whisper_note_keeps_engine_language(self):
+        # A Whisper note carries detected_language provenance, so its persisted
+        # language is kept even when the (foreign) transcript text disagrees.
+        with tempfile.TemporaryDirectory() as tmp:
+            md = _write_md(
+                tmp,
+                "title: Whisper\nlanguage: de\ndetected_language: de\n"
+                "duration_seconds: 60\n",
+            )
+            session_info = _parse_meeting_markdown(md)["session_info"]
+            self.assertEqual(
+                resolve_persisted_output_language(session_info, EN_TEXT, "auto"),
+                "de",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_language_detect.py
+++ b/tests/test_language_detect.py
@@ -9,7 +9,11 @@ stopword classifier over the Parakeet-supported languages, and
 
 import unittest
 
-from simple_recorder import MeetingPipeline, resolve_output_language
+from simple_recorder import (
+    MeetingPipeline,
+    resolve_output_language,
+    resolve_persisted_output_language,
+)
 from src.language_detect import detect_transcript_language
 
 # Realistic meeting-style paragraphs (>=80 words each). Function-word rich so
@@ -170,6 +174,67 @@ class ResolveOutputLanguagePriorityTests(unittest.TestCase):
             "fr",
         )
         self.assertEqual(recorder._resolve_output_language("de"), "de")
+
+
+class ResolvePersistedOutputLanguageTests(unittest.TestCase):
+    """Provenance rule for the reprocess / generate-report / regen-title paths.
+
+    A persisted output_language is trusted only when pin- or engine-backed;
+    a bare fallback "en" from the old Parakeet auto-mode bug (#283) is
+    re-detected from the transcript instead of being re-pinned to English.
+    """
+
+    def test_stale_en_auto_mode_no_engine_is_redetected(self):
+        # The #283 case: a markdown note persisted "en" with no configured/
+        # detected provenance, user still on auto → re-detect from the German
+        # transcript rather than trusting the stale "en".
+        session_info = {"output_language": "en"}
+        self.assertEqual(
+            resolve_persisted_output_language(session_info, DE_TEXT, "auto"),
+            "de",
+        )
+
+    def test_persisted_pin_respected_even_with_foreign_transcript(self):
+        # A pin-backed note keeps its language even if the transcript text looks
+        # like another language.
+        session_info = {"output_language": "en", "configured_language": "en"}
+        self.assertEqual(
+            resolve_persisted_output_language(session_info, DE_TEXT, "auto"),
+            "en",
+        )
+
+    def test_persisted_with_engine_detection_respected(self):
+        # Engine (Whisper) detection is trustworthy provenance: keep the
+        # persisted value even though the current config is auto and the text
+        # reads as German.
+        session_info = {"output_language": "fr", "detected_language": "fr"}
+        self.assertEqual(
+            resolve_persisted_output_language(session_info, DE_TEXT, "auto"),
+            "fr",
+        )
+
+    def test_empty_session_info_auto_config_redetects(self):
+        # No persisted value at all → detection from the transcript.
+        self.assertEqual(
+            resolve_persisted_output_language({}, DE_TEXT, "auto"),
+            "de",
+        )
+
+    def test_empty_session_info_auto_config_inconclusive_is_en(self):
+        # No persisted value and nothing to detect → "en" fallback.
+        self.assertEqual(
+            resolve_persisted_output_language({}, "Yes. No.", "auto"),
+            "en",
+        )
+
+    def test_fallback_configured_pin_trusts_persisted(self):
+        # A markdown note stores no configured_language of its own; the caller's
+        # current pin supplies the provenance, so the persisted value is kept.
+        session_info = {"output_language": "de"}
+        self.assertEqual(
+            resolve_persisted_output_language(session_info, EN_TEXT, "de"),
+            "de",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_report_store.py
+++ b/tests/test_report_store.py
@@ -79,6 +79,25 @@ class ReadMeetingTests(unittest.TestCase):
             self.assertEqual(m["language"], "de")
             self.assertEqual(m["duration_minutes"], 2)
 
+    def test_md_null_provenance_reads_as_none_not_string(self):
+        # A markdown note written for an auto/Parakeet meeting serialises its
+        # provenance as unquoted `null`. read_meeting must surface real None, not
+        # the truthy string "null" - otherwise resolve_persisted_output_language
+        # would treat the note as engine-backed and wrongly pin its language in
+        # the report path (#283).
+        md = (
+            '---\ntitle: "Note"\nduration_seconds: 60\nlanguage: "en"\n'
+            'configured_language: null\ndetected_language: null\n---\n\n'
+            '## Summary\nAn overview.\n\n## Transcript\n\nSpeaker A: hello.\n'
+        )
+        with tempfile.TemporaryDirectory() as t:
+            mp = Path(t) / "m_summary.md"
+            mp.write_text(md, encoding="utf-8")
+            m = S.read_meeting(mp)
+            self.assertIsNone(m["configured_language"])
+            self.assertIsNone(m["detected_language"])
+            self.assertEqual(m["language"], "en")
+
     def test_reads_json_meeting(self):
         with tempfile.TemporaryDirectory() as t:
             mp = Path(t) / "m_summary.json"

--- a/tests/test_reprocess_frontmatter.py
+++ b/tests/test_reprocess_frontmatter.py
@@ -96,6 +96,40 @@ class ReprocessFrontmatterTests(unittest.TestCase):
             # is_live_transcript must NOT be injected when it was never set.
             self.assertNotIn("is_live_transcript", reparsed["session_info"])
 
+    def test_language_provenance_preserved_across_reprocess(self):
+        """reprocess must carry forward configured/detected language provenance.
+
+        Without it, a re-detection on the next reprocess/chat could discard a
+        valid Whisper engine detection (#283).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = _write_summary(
+                tmp,
+                extra_frontmatter="configured_language: de\ndetected_language: de\n",
+            )
+            res = _run_reprocess(tmp, summary)
+            self.assertEqual(res.exit_code, 0, res.output)
+
+            reparsed = simple_recorder._parse_meeting_markdown(summary)
+            self.assertEqual(reparsed["session_info"]["configured_language"], "de")
+            self.assertEqual(reparsed["session_info"]["detected_language"], "de")
+
+    def test_missing_provenance_reprocesses_to_null_provenance(self):
+        """A legacy note without provenance stays provenance-less (null), so the
+        recovery paths keep re-detecting rather than trusting a stale value."""
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = _write_summary(tmp)  # no configured/detected keys
+            res = _run_reprocess(tmp, summary)
+            self.assertEqual(res.exit_code, 0, res.output)
+
+            frontmatter = summary.read_text().split('---')[1]
+            self.assertIn('configured_language: null', frontmatter)
+            self.assertIn('detected_language: null', frontmatter)
+
+            reparsed = simple_recorder._parse_meeting_markdown(summary)
+            self.assertIsNone(reparsed["session_info"]["configured_language"])
+            self.assertIsNone(reparsed["session_info"]["detected_language"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #283.

## Problem

Parakeet's backends never report a detected language, they only echo an explicit pin. With the default `language="auto"`, `detected_language` is `None` and `_resolve_output_language("auto", None)` falls through to `"en"`, so anyone on the default engine who hasn't pinned a language gets English summaries, titles, reports and chat answers for a German/French/... meeting. Whisper is unaffected (whisper.cpp reports a real detected language).

## Fix

**New `src/language_detect.py`**: a dependency-free stopword/function-word classifier over exactly the Parakeet-supported languages (`en, fr, de, es, nl, pt`, the `PARAKEET_LANGUAGES` set minus `auto`). It strips diarisation markers and timestamps, samples the first 8000 chars, and only commits to a language when it clears a hit threshold (15) and leads the runner-up by 1.3x; otherwise it returns `None` and the existing `"en"` fallback applies. No new pip dependency (PyInstaller bundle size and licensing).

**New priority tier** in the output-language resolution, now module-level and unit-testable (`resolve_output_language`, the `MeetingPipeline` method delegates to it):

1. explicit user pin
2. engine-detected (Whisper, unchanged)
3. NEW: text detection over the transcript
4. `"en"` fallback

Wired at every call site that has transcript text: initial pipelines (streaming + non-streaming, incl. auto-summarize-off), reprocess, `generate_report`, `regen-title`, transcript write, and the `query`/`query_streaming` chat paths. Intentionally unchanged: `_handle_transcription_failure` (no transcript to detect from) and `chat_global_streaming` (multi-meeting corpus, single-language detection would be unreliable).

**Provenance rule for persisted values** (`resolve_persisted_output_language`): notes processed before this fix persisted `output_language: "en"` from the buggy fallback, which would otherwise act as a pin and keep the recovery paths English forever. A persisted `output_language` is now honoured only when it is pin-backed (`configured_language != "auto"`) or engine-backed (`detected_language` present); otherwise reprocess/report/regen-title re-detect from the transcript. A real user pin always wins, Whisper detections are respected, and re-detecting a previously text-detected note is idempotent. `report_store.read_meeting` additionally surfaces `configured_language`/`detected_language` to carry that provenance.

Privacy: the one new log line carries only the detected language code, never transcript content.

## Tests

20 unit tests in `tests/test_language_detect.py`: per-language meeting-style samples (with diarisation markers/timestamps), inconclusive/short/empty/symbol inputs return `None`, mixed-language dominance, full priority-order matrix, and the persisted-provenance matrix (stale fallback re-detects; pins and engine detections are never second-guessed).

`ruff check` clean on all touched files (`simple_recorder.py` keeps its 16 pre-existing findings, one old one removed). Full-suite `unittest discover` compared against an origin/main baseline in the same environment: identical pre-existing failures, delta is exactly the 20 new passing tests, zero regression.

No e2e spec in this PR: asserting the output language end-to-end requires a real summarization model, which belongs to the `@pipeline` lane; the resolution logic itself is deliberately module-level and fully unit-covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects meeting language from transcript and uses it in auto mode, so Parakeet recordings no longer default to English. Adds provenance-aware recovery and chat so old notes with a stale "en" recover to the correct language.

- **New Features**
  - Added `src/language_detect.py`: a dependency‑free detector for `en, fr, de, es, nl, pt` that scans early transcript text and ignores diarisation/timestamps.
  - Introduced module‑level `resolve_output_language`: priority is user pin > engine (Whisper) > transcript > "en"; all call sites now pass transcript text where available.
  - Persisted language provenance: markdown front matter now writes `configured_language`/`detected_language` on create and reprocess; `report_store.read_meeting` returns them (coercing `null`/`""` to `None`); `skills/granola-to-steno` sets `configured_language` and `detected_language: null` on import.

- **Bug Fixes**
  - Fixes #283: Parakeet auto meetings no longer fall back to English; recovery paths (reprocess, report, title) and chat resolve via `resolve_persisted_output_language`, trusting a persisted language only when pin‑ or engine‑backed.
  - Query and streaming query detect language over the raw transcript (not combined summary/context) to avoid legacy English summaries flipping detection.

<sup>Written for commit 7ab280782f63d021e2d86becdb141ecee958405e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

