### PR TITLE
fix: make launch on login opt-in

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -518,9 +518,8 @@ function applyLoginItemSetting(enabled) {
  * Initialize PostHog telemetry by reading config from Python backend.
  */
 // One config.json read (no extra subprocess) + a token-file existence check
-// for the identify() super-properties below. `launch_on_login` defaults ON
-// (feature ships enabled-for-everyone; users opt out in Settings), so a legacy
-// config missing the key reports true.
+// for the identify() super-properties below. `launch_on_login` is opt-in, so a
+// legacy config missing the key reports false.
 function loadIdentitySuperProperties() {
   let cfg = {};
   try {
@@ -535,7 +534,7 @@ function loadIdentitySuperProperties() {
     ai_provider: cfg.ai_provider || 'local',
     notifications_enabled: cfg.notifications_enabled !== false,
     calendar_connected: calendarConnected,
-    launch_on_login: cfg.launch_on_login !== false,
+    launch_on_login: cfg.launch_on_login === true,
   };
 }
 
@@ -1306,15 +1305,15 @@ if (!gotSingleInstanceLock) {
     // app_opened event and the first window show below. macOS reports it via
     // wasOpenedAtLogin (the deprecated openAsHidden no longer works on 13+);
     // Windows carries the `--hidden` arg we registered the login item with.
-    // Only treat it as hidden if the setting isn't explicitly off, so a stale
-    // OS login item (setting since disabled) doesn't wrongly hide the window.
+    // Only treat it as hidden when the user explicitly enabled the setting, so
+    // a stale OS login item doesn't wrongly hide the window.
     try {
-      let launchOnLoginEnabled = true;
+      let launchOnLoginEnabled = false;
       try {
         const cfgPath = path.join(getUserDataDir(), 'config.json');
         if (fs.existsSync(cfgPath)) {
           const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
-          launchOnLoginEnabled = cfg.launch_on_login !== false;
+          launchOnLoginEnabled = cfg.launch_on_login === true;
         }
       } catch (_) {}
       const openedAtLogin =
@@ -1501,17 +1500,16 @@ if (!gotSingleInstanceLock) {
     }
 
     // Re-apply the OS "launch on login" item on every startup from the
-    // persisted preference (config.json read directly — no subprocess). This is
-    // what makes the feature default-ON for everyone: new installs default true
-    // and existing configs missing the key fall back to true (registering the
-    // login item on this launch), while a user who turned it off persists false
-    // and stays unregistered. Idempotent; no-op under E2E / dev (see helper).
+    // persisted preference (config.json read directly — no subprocess). New
+    // installs and existing configs without the key remain off; only an
+    // explicit true registers the login item. Idempotent; no-op under E2E / dev
+    // (see helper).
     try {
-      let launchOnLoginEnabled = true;
+      let launchOnLoginEnabled = false;
       const cfgPath = path.join(getUserDataDir(), 'config.json');
       if (fs.existsSync(cfgPath)) {
         const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
-        launchOnLoginEnabled = cfg.launch_on_login !== false;
+        launchOnLoginEnabled = cfg.launch_on_login === true;
       }
       applyLoginItemSetting(launchOnLoginEnabled);
     } catch (e) {

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -324,7 +324,7 @@ export function GeneralTab() {
         description="Start Steno automatically when you log in, hidden in the menu bar. Turn off to launch it manually."
       >
         <Switch
-          checked={launchOnLogin.data ?? true}
+          checked={launchOnLogin.data ?? false}
           onCheckedChange={(v) => setLaunchOnLogin.mutate(v)}
           disabled={launchOnLogin.data === undefined}
         />

--- a/docs/superpowers/plans/2026-07-12-launch-on-login-opt-in.md
+++ b/docs/superpowers/plans/2026-07-12-launch-on-login-opt-in.md
@@ -1,0 +1,292 @@
+# Launch on Login Opt-In Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve the launch-on-login feature while requiring an explicitly persisted `true` before Steno registers itself as an OS login item.
+
+**Architecture:** Keep the existing config, IPC, renderer, and Electron login-item flow intact. Change every missing-value fallback from permissive/default-on semantics to strict opt-in semantics, with Python configuration as the persisted source of truth and matching fallbacks in the Electron main process, telemetry, and renderer.
+
+**Tech Stack:** Python `unittest`/pytest, Electron main process JavaScript, React/TypeScript, Vitest, Playwright E2E.
+
+## Global Constraints
+
+- Do not add onboarding UI; mention it only as a possible future improvement in the PR description.
+- Do not change `applyLoginItemSetting()`, IPC contracts, CLI commands, hidden-launch behavior, or startup reconciliation.
+- Do not add migration or cleanup state because PR #328 has not shipped in a published release.
+- An explicit persisted `launch_on_login: true` must remain enabled across launches.
+- A new config, a legacy config without the key, and a missing config file must all resolve to disabled.
+
+---
+
+### Task 1: Make launch on login strict opt-in across all layers
+
+**Files:**
+- Modify: `tests/test_config.py:231-254`
+- Modify: `src/config.py:600-604,1010-1015`
+- Modify: `app/main.js:520-539,1305-1324,1503-1518`
+- Modify: `app/renderer/src/routes/settings/GeneralTab.tsx:322-330`
+- Modify: `e2e/specs/settings-roundtrip.t2.spec.ts:65-68`
+
+**Interfaces:**
+- Consumes: Existing `Config.get_launch_on_login() -> bool`, `Config.set_launch_on_login(enabled: bool) -> bool`, Electron `applyLoginItemSetting(enabled)`, and renderer `launchOnLogin.data: boolean | undefined`.
+- Produces: A consistent effective preference where only boolean `true` enables launch on login; no signatures or IPC payloads change.
+
+- [ ] **Step 1: Change the Python contract tests to specify opt-in behavior**
+
+Replace `ConfigLaunchOnLoginTests` with:
+
+```python
+class ConfigLaunchOnLoginTests(unittest.TestCase):
+    def test_default_launch_on_login_is_false(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertFalse(config.get_launch_on_login())
+
+    def test_legacy_config_without_key_defaults_false(self):
+        # Existing installs whose config predates this key must remain opt-in.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"model": "gemma3:4b"}))
+            config = Config(config_path=path)
+            self.assertFalse(config.get_launch_on_login())
+
+    def test_launch_on_login_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertTrue(config.set_launch_on_login(True))
+            self.assertTrue(config.get_launch_on_login())
+            reloaded = Config(config_path=path)
+            self.assertTrue(reloaded.get_launch_on_login())
+            self.assertTrue(reloaded.set_launch_on_login(False))
+            self.assertFalse(reloaded.get_launch_on_login())
+```
+
+- [ ] **Step 2: Run the focused tests and verify the new contract fails**
+
+Run:
+
+```bash
+python -m pytest tests/test_config.py::ConfigLaunchOnLoginTests -q
+```
+
+Expected: two failures because a new config and a config without `launch_on_login` still resolve to `True`; the round-trip test passes.
+
+- [ ] **Step 3: Change the Python default and legacy fallback to opt-in**
+
+In `_get_default_config()`, replace the launch-on-login entry and comment with:
+
+```python
+            # Default OFF — Steno only registers itself as an OS login item
+            # after the user explicitly enables the setting. When enabled, it
+            # starts hidden in the tray/menu bar.
+            "launch_on_login": False,
+```
+
+Implement the getter as:
+
+```python
+    def get_launch_on_login(self) -> bool:
+        """Get whether Steno launches automatically on login."""
+        # Missing keys belong to installs that never opted in. Keep them off;
+        # main.js re-applies only the resulting persisted preference.
+        return self._config.get("launch_on_login", False)
+```
+
+- [ ] **Step 4: Run the focused Python tests and verify they pass**
+
+Run:
+
+```bash
+python -m pytest tests/test_config.py::ConfigLaunchOnLoginTests -q
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 5: Align Electron startup and telemetry with explicit consent**
+
+Update the identity comment and property in `loadIdentitySuperProperties()`:
+
+```javascript
+// One config.json read (no extra subprocess) + a token-file existence check
+// for the identify() super-properties below. `launch_on_login` is opt-in, so a
+// legacy config missing the key reports false.
+```
+
+```javascript
+    launch_on_login: cfg.launch_on_login === true,
+```
+
+In hidden-launch resolution, use a disabled fallback and strict boolean check:
+
+```javascript
+      let launchOnLoginEnabled = false;
+      try {
+        const cfgPath = path.join(getUserDataDir(), 'config.json');
+        if (fs.existsSync(cfgPath)) {
+          const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+          launchOnLoginEnabled = cfg.launch_on_login === true;
+        }
+      } catch (_) {}
+```
+
+Update the startup reconciliation comment and implementation:
+
+```javascript
+    // Re-apply the OS "launch on login" item on every startup from the
+    // persisted preference (config.json read directly — no subprocess). New
+    // installs and existing configs without the key remain off; only an
+    // explicit true registers the login item. Idempotent; no-op under E2E / dev
+    // (see helper).
+    try {
+      let launchOnLoginEnabled = false;
+      const cfgPath = path.join(getUserDataDir(), 'config.json');
+      if (fs.existsSync(cfgPath)) {
+        const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+        launchOnLoginEnabled = cfg.launch_on_login === true;
+      }
+      applyLoginItemSetting(launchOnLoginEnabled);
+    } catch (e) {
+      console.warn('Failed to apply launch-on-login setting at startup:', e?.message);
+    }
+```
+
+- [ ] **Step 6: Align the renderer fallback and E2E setter case**
+
+Change the settings switch fallback in `GeneralTab.tsx`:
+
+```tsx
+        <Switch
+          checked={launchOnLogin.data ?? false}
+          onCheckedChange={(v) => setLaunchOnLogin.mutate(v)}
+          disabled={launchOnLogin.data === undefined}
+        />
+```
+
+Change the E2E case so it writes the opposite of the new default:
+
+```typescript
+  // true flips the default (false) so the assertion has teeth — a no-op setter
+  // would leave the key unset/false and fail this case.
+  { kind: 'launchOnLogin', value: true, configKey: 'launch_on_login' },
+```
+
+- [ ] **Step 7: Scan for stale default-on semantics**
+
+Run:
+
+```bash
+rg -n -C 2 "launch_on_login|launchOnLogin" src/config.py app/main.js app/renderer/src/routes/settings/GeneralTab.tsx tests/test_config.py e2e/specs/settings-roundtrip.t2.spec.ts
+```
+
+Expected: all defaults and missing-key fallbacks are `false`/`=== true`; no launch-on-login comment describes default-on or opt-out behavior.
+
+- [ ] **Step 8: Run focused and layer-level verification**
+
+Run:
+
+```bash
+python -m pytest tests/test_config.py::ConfigLaunchOnLoginTests -q
+python -m pytest tests/test_config.py -q
+cd app && npx vitest run renderer/src/routes/settings/GeneralTab.test.tsx
+npm run test:e2e -- --project=t2 --grep "settings setters persist"
+```
+
+Expected: all Python and Vitest tests pass. The focused T2 test passes when the bundled backend in `dist/stenoai/` is available; if the bundle is unavailable locally, record that constraint and rely on the required T2 CI job rather than claiming a local pass.
+
+- [ ] **Step 9: Review the final diff for scope and formatting**
+
+Run:
+
+```bash
+git diff --check
+git diff -- src/config.py tests/test_config.py app/main.js app/renderer/src/routes/settings/GeneralTab.tsx e2e/specs/settings-roundtrip.t2.spec.ts
+```
+
+Expected: no whitespace errors; only default/fallback values, associated comments, and tests change. No IPC, CLI, onboarding, or login-item API code changes.
+
+- [ ] **Step 10: Commit the implementation**
+
+```bash
+git add src/config.py tests/test_config.py app/main.js app/renderer/src/routes/settings/GeneralTab.tsx e2e/specs/settings-roundtrip.t2.spec.ts
+git commit -m "fix: make launch on login opt-in"
+```
+
+Expected: one focused implementation commit after the existing design and plan commits.
+
+---
+
+### Task 2: Prepare the follow-up pull request
+
+**Files:**
+- No product files change in this task.
+
+**Interfaces:**
+- Consumes: The verified implementation commit from Task 1.
+- Produces: A focused GitHub pull request against `ruzin/stenoai:main`.
+
+- [ ] **Step 1: Verify branch state and commit range**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean worktree; the range contains the design, plan, and implementation commits only.
+
+- [ ] **Step 2: Push the branch to the fork**
+
+Run:
+
+```bash
+git push -u fork fix/launch-on-login-opt-in
+```
+
+Expected: the branch is available as `Optic00:fix/launch-on-login-opt-in`.
+
+- [ ] **Step 3: Create the pull request**
+
+Use title:
+
+```text
+fix: make launch on login opt-in
+```
+
+Create `/tmp/launch-on-login-opt-in-pr-body.md` with exactly this body:
+
+```markdown
+## Summary
+
+- default launch on login to off for new installations
+- treat legacy configs without an explicit preference as off
+- align Electron startup, telemetry, the Settings toggle, and tests with opt-in semantics
+- preserve explicit opt-ins and the existing login-item implementation
+
+## Rationale
+
+PR #328 added the launch-on-login plumbing, but enabling it automatically for existing installations would register Steno as an OS login item without prior user consent. This follow-up keeps the feature intact while requiring an explicit opt-in, which better matches Steno's local-first and user-respecting product posture.
+
+PR #328 has not shipped in a published release, so no migration or cleanup marker is required.
+
+## Testing
+
+- `python -m pytest tests/test_config.py::ConfigLaunchOnLoginTests -q`
+- `python -m pytest tests/test_config.py -q`
+- `cd app && npx vitest run renderer/src/routes/settings/GeneralTab.test.tsx`
+- T2 settings round-trip test locally if the bundled backend is available; otherwise required CI coverage
+
+## Follow-ups
+
+- A future onboarding step could offer launch on login as an explicit choice.
+- OS-level disabling in macOS System Settings or Windows Task Manager could be handled more precisely after platform-specific testing; this PR intentionally leaves startup reconciliation unchanged.
+```
+
+Run:
+
+```bash
+gh pr create --repo ruzin/stenoai --base main --head Optic00:fix/launch-on-login-opt-in --title "fix: make launch on login opt-in" --body-file /tmp/launch-on-login-opt-in-pr-body.md
+```
+
+Expected: GitHub creates a PR targeting `ruzin/stenoai:main`. Do not create the PR until the user has authorized the external write.

--- a/docs/superpowers/specs/2026-07-12-launch-on-login-opt-in-design.md
+++ b/docs/superpowers/specs/2026-07-12-launch-on-login-opt-in-design.md
@@ -1,0 +1,69 @@
+# Launch on Login Opt-In Design
+
+## Context
+
+PR #328 added launch-on-login support and made it enabled by default for new and existing users. The implementation is complete across configuration, IPC, the settings UI, OS login-item registration, and telemetry, but silently registering existing installations as login items conflicts with Steno's privacy-conscious, local-first product posture.
+
+The feature has been merged into `main` but is not included in a published release. This allows the default to be corrected without a migration or one-time cleanup path.
+
+## Goal
+
+Keep the existing launch-on-login feature while requiring an explicit user choice before Steno registers itself as an OS login item.
+
+## Behavior
+
+| Configuration state | Effective preference | Startup behavior |
+| --- | --- | --- |
+| New configuration | `false` | Ensure the login item is not registered |
+| Existing configuration without `launch_on_login` | `false` | Ensure the login item is not registered |
+| Explicit `launch_on_login: false` | `false` | Ensure the login item is not registered |
+| Explicit `launch_on_login: true` | `true` | Register or retain the login item |
+
+The settings toggle remains available and applies changes immediately. An explicit `true` remains stable across later launches.
+
+## Changes
+
+### Configuration
+
+- Change the default `launch_on_login` value in `src/config.py` from `true` to `false`.
+- Change the legacy-config fallback in `get_launch_on_login()` from `true` to `false`.
+- Update comments to describe opt-in behavior.
+
+### Main process
+
+- Treat a missing `launch_on_login` key as `false` when loading telemetry identity properties.
+- Treat the key as `false` in both direct startup reads: hidden-launch resolution and login-item application.
+- Retain the existing startup reconciliation, IPC handlers, and `applyLoginItemSetting()` implementation.
+- Update comments from default-on/opt-out language to opt-in language.
+
+### Settings UI
+
+- Change the temporary render fallback for the switch from `true` to `false`.
+- Keep the switch disabled until the persisted setting has loaded, as it is today.
+
+### Tests
+
+- Update the new-config test to expect `false`.
+- Update the legacy-config-without-key test to expect `false`.
+- Preserve round-trip coverage for explicit `false` and `true` values.
+- Change the settings E2E round-trip case to write `true`, the opposite of the new default. This ensures a no-op setter cannot pass accidentally.
+- Update test names and comments to describe opt-in behavior.
+
+## Data Flow
+
+At startup, a missing key resolves to `false` consistently in Python configuration, the Electron main process, telemetry, and the renderer. The main process applies `false` to Electron's login-item API. When the user explicitly enables the setting, the existing IPC path persists `true` and immediately registers the login item. Future launches read the explicit value and retain registration.
+
+## Error Handling
+
+No error-handling behavior changes. Login-item API failures remain non-fatal, configuration persistence errors continue through the existing IPC result, and the switch remains disabled while its initial value is unavailable.
+
+## Non-Goals
+
+- No onboarding prompt or callout is added in this PR. A future onboarding step may offer launch-on-login as an explicit choice.
+- No change is made to startup reconciliation or handling of users who disable the item directly in macOS System Settings or Windows Task Manager. Respecting OS-level overrides more precisely can be addressed separately after platform-specific testing.
+- No migration or cleanup marker is added because the default-on implementation has not shipped in a release.
+- No changes are made to hidden-launch behavior, analytics event structure, IPC shape, or CLI commands.
+
+## PR Positioning
+
+The follow-up PR should be framed as a focused product-default correction rather than a rollback of the feature. It preserves all launch-on-login functionality and changes only the consent model from opt-out to opt-in. The description should mention onboarding and OS-level state handling as possible future improvements, without making either a merge requirement for this correction.

--- a/e2e/specs/settings-roundtrip.t2.spec.ts
+++ b/e2e/specs/settings-roundtrip.t2.spec.ts
@@ -63,9 +63,9 @@ const CASES: Case[] = [
   { kind: 'telemetry', value: false, configKey: 'telemetry_enabled' },
   { kind: 'transcriptionEngine', value: 'whisper', configKey: 'transcription_engine' },
   { kind: 'dockIcon', value: true, configKey: 'hide_dock_icon' },
-  // false flips the default (true) so the assertion has teeth — a no-op setter
-  // would leave the key unset/true and fail this case.
-  { kind: 'launchOnLogin', value: false, configKey: 'launch_on_login' },
+  // true flips the default (false) so the assertion has teeth — a no-op setter
+  // would leave the key unset/false and fail this case.
+  { kind: 'launchOnLogin', value: true, configKey: 'launch_on_login' },
 ];
 
 function applySetting(

--- a/src/config.py
+++ b/src/config.py
@@ -597,11 +597,10 @@ class Config:
             # any non-Steno app starts capturing the mic. Helper is gated
             # to macOS 14+ in main.js; users can flip off in Settings.
             "auto_detect_meetings_enabled": True,
-            # Default ON — Steno auto-starts (hidden, in the tray/menu bar)
-            # when the user logs in. main.js registers/removes the OS login
-            # item and suppresses the first window show on a login launch.
-            # Users opt out in Settings.
-            "launch_on_login": True,
+            # Default OFF — Steno only registers itself as an OS login item
+            # after the user explicitly enables the setting. When enabled, it
+            # starts hidden in the tray/menu bar.
+            "launch_on_login": False,
             # "auto" so _resolve_output_language() picks the transcript's
             # detected language instead of silently defaulting every
             # unconfigured install to English summaries (#281).
@@ -1009,10 +1008,9 @@ class Config:
 
     def get_launch_on_login(self) -> bool:
         """Get whether Steno launches automatically on login."""
-        # Fall back to True so existing installs whose config predates this
-        # key default ON (the feature ships enabled-for-everyone; users opt out
-        # in Settings). main.js re-applies the OS login item on every startup.
-        return self._config.get("launch_on_login", True)
+        # Missing keys belong to installs that never opted in. Keep them off;
+        # main.js re-applies only the resulting persisted preference.
+        return self._config.get("launch_on_login", False)
 
     def set_launch_on_login(self, enabled: bool) -> bool:
         """Set whether Steno launches automatically on login."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,29 +229,29 @@ class ConfigAutoDetectMeetingsTests(unittest.TestCase):
 
 
 class ConfigLaunchOnLoginTests(unittest.TestCase):
-    def test_default_launch_on_login_is_true(self):
+    def test_default_launch_on_login_is_false(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            self.assertTrue(config.get_launch_on_login())
+            self.assertFalse(config.get_launch_on_login())
 
-    def test_legacy_config_without_key_defaults_true(self):
-        # Existing installs whose config predates this key must default ON.
+    def test_legacy_config_without_key_defaults_false(self):
+        # Existing installs whose config predates this key must remain opt-in.
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / "config.json"
             path.write_text(json.dumps({"model": "gemma3:4b"}))
             config = Config(config_path=path)
-            self.assertTrue(config.get_launch_on_login())
+            self.assertFalse(config.get_launch_on_login())
 
     def test_launch_on_login_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / "config.json"
             config = Config(config_path=path)
-            self.assertTrue(config.set_launch_on_login(False))
-            self.assertFalse(config.get_launch_on_login())
+            self.assertTrue(config.set_launch_on_login(True))
+            self.assertTrue(config.get_launch_on_login())
             reloaded = Config(config_path=path)
-            self.assertFalse(reloaded.get_launch_on_login())
-            self.assertTrue(reloaded.set_launch_on_login(True))
             self.assertTrue(reloaded.get_launch_on_login())
+            self.assertTrue(reloaded.set_launch_on_login(False))
+            self.assertFalse(reloaded.get_launch_on_login())
 
 
 class ConfigOrgAutoBackupTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Follow-up to #328: launch on login becomes strict opt-in. The feature and its implementation stay as they are; only the consent model changes. Steno registers itself as an OS login item only after the user explicitly enables the setting.

- New installs default to `launch_on_login: false` (`src/config.py`).
- Legacy configs without the key resolve to off instead of on, in the Python getter and in both direct `config.json` reads in `main.js` (hidden-launch detection and startup reconciliation), which now require an explicit `launch_on_login === true`.
- Telemetry identity and the Settings toggle fallback report/render off unless explicitly enabled.
- An explicit persisted `true` keeps working exactly as before: the login item is registered and survives restarts.

## Rationale

#328 enabled the feature for everyone, including existing installations, which would silently register Steno as a login item without prior consent. That sits badly with Steno's local-first, user-respecting posture. Since #328 has not shipped in a published release yet, the default can still be corrected cleanly: no migration, no cleanup marker, nobody to un-register.

## Testing

- `python -m pytest tests/test_config.py -q`: 54 passed + 2 subtests, including the rewritten `ConfigLaunchOnLoginTests` (new config off, legacy config without key off, explicit true/false round-trip).
- `cd app && npx vitest run renderer/src/routes/settings/GeneralTab.test.tsx`: 8 passed.
- Focused T2 (`settings setters persist each value to the right config.json key`) passed locally against a freshly built backend bundle. The E2E case now writes `true` (the opposite of the new default) so a no-op setter cannot pass.
- Renderer typecheck clean.

## Out of scope / follow-ups

- No onboarding prompt; a future onboarding step could offer launch on login as an explicit choice.
- Startup reconciliation is intentionally unchanged, including its error handling: if `config.json` exists but cannot be parsed, the reconciliation is skipped and a previously registered login item stays registered (pre-existing behavior from #328). Auto-unregistering on a read error could just as well drop a genuine opt-in, so this is left for a separate decision if it matters in practice.
- OS-level disabling via macOS System Settings or Windows Task Manager is not handled more precisely here; that needs platform-specific testing first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Launch on Login opt-in. New and legacy installs default to off; Steno only registers as an OS login item after the user explicitly enables it. Explicit true persists and keeps the login item.

- **Bug Fixes**
  - Default `launch_on_login` to false in config; missing key/file resolves to off.
  - Electron main requires `launch_on_login === true` for telemetry, hidden-launch detection, and startup reconciliation; otherwise remains off.
  - Settings toggle fallback renders off; unit tests and E2E round-trip updated to reflect opt-in behavior.

<sup>Written for commit ed0e89a2e218dc2c6ace946f2793f63b5caec440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

