### PR TITLE
fix: make telemetry strict opt-in

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -580,7 +580,10 @@ async function initTelemetry() {
     anonymousId = config.anonymous_id;
 
     if (telemetryEnabled) {
-      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+      // disableGeoip is already the posthog-node default; explicit here as
+      // drift protection so an SDK upgrade can't silently re-enable IP
+      // geolocation for opted-in users.
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST, disableGeoip: true });
       // Identify user for DAU tracking
       posthogClient.identify({
         distinctId: anonymousId,
@@ -6398,7 +6401,7 @@ ipcMain.handle('set-telemetry', async (event, enabled, source) => {
     if (enabled && !posthogClient) {
       // Bring the client up and identify FIRST so both the super-properties
       // and this event land fresh, rather than waiting for next launch.
-      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST, disableGeoip: true });
       telemetryEnabled = true;
       refreshIdentitySuperProperties();
       trackEvent('telemetry_toggled', { enabled: true, source: toggleSource });

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -130,7 +130,7 @@ export function Setup() {
   // immediately via the same backend used by the Settings page.
   const telemetry = useTelemetrySetting();
   const setTelemetry = useSetTelemetry();
-  const telemetryEnabled = telemetry.data?.telemetry_enabled ?? true;
+  const telemetryEnabled = telemetry.data?.telemetry_enabled ?? false;
 
   // First name powers the in-app greeting ("Hi <name>, ask anything"). Stored
   // locally only — never sent anywhere. Persisted on blur to avoid a write

--- a/docs/superpowers/plans/2026-07-12-telemetry-opt-in.md
+++ b/docs/superpowers/plans/2026-07-12-telemetry-opt-in.md
@@ -1,0 +1,481 @@
+# Telemetry Opt-In Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Telemetry runs only for users who affirmatively enabled it — strict opt-in with a one-time consent reset for the installed base.
+
+**Architecture:** Python configuration stays the source of truth. The default and getter become strictly false unless the persisted value is exactly JSON boolean `true`; a one-time migration (guarded by a marker key, written through a locked compare-and-set) resets every non-consented legacy config to `false`. The Electron main process needs no gating changes because it already initializes PostHog only when the Python `get-telemetry` result is enabled.
+
+**Tech Stack:** Python `unittest`, Electron main process JavaScript, React/TypeScript, Playwright E2E.
+
+## Global Constraints
+
+- Strict consent means the persisted value is exactly JSON boolean `true` (`is True` in Python); malformed values (`"true"`, `1`, `null`) must never enable telemetry.
+- The migration marker key is `telemetry_opt_in_migrated`; fresh installs get it seeded in the defaults so they never migrate.
+- The migration persists `telemetry_enabled: false` unconditionally when the marker is absent — also when the key is merely missing (rollback protection: v0.5.8 treats a missing key as enabled).
+- Never persist over a corrupt config (`_load_failed` semantics, same as existing migrations); all migration failure modes fail closed.
+- `_save()` is not modified; the migration writes through its own locked compare-and-set.
+- No changes to event payloads, sanitization (`app/analytics-helpers.js`), IPC shape, CLI commands, or `anonymous_id`.
+- No website/docs copy changes in this PR (release-coordinated follow-up; named as a release-blocking checklist item in the PR description).
+- The onboarding toggle stays visible with unchanged notice text; no compensating UI to boost opt-in rates.
+
+---
+
+### Task 1: Python strict opt-in with one-time consent migration
+
+**Files:**
+- Modify: `tests/test_config.py` (add class after `ConfigLaunchOnLoginTests`, near line 255)
+- Modify: `src/config.py:585-587` (defaults), `src/config.py:835-850` (getter/setter), new methods near the other `_migrate_*` helpers
+
+**Interfaces:**
+- Consumes: existing `Config.__init__` migration chain, `self._load_failed`, `self._snapshot`, `filelock.FileLock`, `self._SAVE_LOCK_TIMEOUT`, `self._read_disk_for_merge()`, `_atomic_write_json(path, payload)`.
+- Produces: `Config.get_telemetry_enabled() -> bool` (strict `is True`), `Config.set_telemetry_enabled(enabled: bool) -> bool` (also writes the marker), `Config._migrate_telemetry_opt_in() -> None`, `Config._persist_telemetry_migration() -> None`. The CLI (`get-telemetry`/`set-telemetry` in `simple_recorder.py`) goes through these getters/setters and needs no change.
+
+- [ ] **Step 1: Write the failing contract tests**
+
+Add to `tests/test_config.py` directly after `ConfigLaunchOnLoginTests`:
+
+```python
+class ConfigTelemetryOptInTests(unittest.TestCase):
+    def test_fresh_config_defaults_off_with_marker(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertFalse(config.get_telemetry_enabled())
+            self.assertIs(config._config.get("telemetry_opt_in_migrated"), True)
+
+    def test_legacy_persisted_true_is_reset_and_persisted(self):
+        # v0.5.8 auto-persisted telemetry_enabled: true without consent; the
+        # one-time migration must reset it on disk, not only in memory.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"telemetry_enabled": True}))
+            config = Config(config_path=path)
+            self.assertFalse(config.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], False)
+            self.assertIs(on_disk["telemetry_opt_in_migrated"], True)
+
+    def test_legacy_missing_key_is_persisted_false(self):
+        # Rollback protection: v0.5.8 treats a missing key as enabled, so the
+        # migration must write an explicit false even when the key is absent.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"model": "gemma3:4b"}))
+            config = Config(config_path=path)
+            self.assertFalse(config.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], False)
+            self.assertIs(on_disk["telemetry_opt_in_migrated"], True)
+
+    def test_malformed_values_never_enable(self):
+        for malformed in ("true", "false", 1, 0, None, []):
+            with self.subTest(value=malformed):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    path = Path(tmp_dir) / "config.json"
+                    path.write_text(json.dumps({
+                        "telemetry_enabled": malformed,
+                        "telemetry_opt_in_migrated": True,
+                    }))
+                    config = Config(config_path=path)
+                    self.assertFalse(config.get_telemetry_enabled())
+
+    def test_marker_prevents_re_migration(self):
+        # An affirmative post-migration true must survive later loads.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({
+                "telemetry_enabled": True,
+                "telemetry_opt_in_migrated": True,
+            }))
+            config = Config(config_path=path)
+            self.assertTrue(config.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], True)
+
+    def test_round_trip_writes_marker(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertTrue(config.set_telemetry_enabled(True))
+            self.assertTrue(config.get_telemetry_enabled())
+            reloaded = Config(config_path=path)
+            self.assertTrue(reloaded.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_opt_in_migrated"], True)
+            self.assertTrue(reloaded.set_telemetry_enabled(False))
+            self.assertFalse(reloaded.get_telemetry_enabled())
+
+    def test_corrupt_config_never_persisted(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text("{not json")
+            config = Config(config_path=path)
+            self.assertFalse(config.get_telemetry_enabled())
+            # The corrupt original must stay recoverable on disk.
+            self.assertEqual(path.read_text(), "{not json")
+
+    def test_migration_cas_aborts_when_marker_lands_first(self):
+        # Deterministic race simulation: another process migrated AND the
+        # user affirmatively opted in before this (stale) instance persisted
+        # its migration. The locked compare-and-set must adopt the disk state
+        # instead of clobbering the opt-in.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({
+                "telemetry_enabled": True,
+                "telemetry_opt_in_migrated": True,
+            }))
+            config = Config(config_path=path)
+            # Rewind this instance to a pre-migration view of the world.
+            config._config["telemetry_enabled"] = False
+            config._config["telemetry_opt_in_migrated"] = False
+            config._persist_telemetry_migration()
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], True)
+            self.assertTrue(config.get_telemetry_enabled())
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+source venv/bin/activate && python -m pytest tests/test_config.py::ConfigTelemetryOptInTests -q
+```
+
+Expected: failures — fresh config still defaults true, legacy configs are not migrated, `_persist_telemetry_migration` does not exist. `test_corrupt_config_never_persisted` may already pass.
+
+- [ ] **Step 3: Implement the strict default, getter, setter, and migration**
+
+In `_get_default_config()` (`src/config.py:585-587`), replace:
+
+```python
+            "telemetry_enabled": True,
+```
+
+with:
+
+```python
+            # Strict opt-in — telemetry runs only after the user explicitly
+            # enables it (Setup or Settings → Advanced). Fresh installs carry
+            # the migration marker so the one-time consent reset never runs.
+            "telemetry_enabled": False,
+            "telemetry_opt_in_migrated": True,
+```
+
+Replace `get_telemetry_enabled` / extend `set_telemetry_enabled` (`src/config.py:835-850`):
+
+```python
+    def get_telemetry_enabled(self) -> bool:
+        """Get whether anonymous usage analytics are enabled."""
+        # Strict consent: only JSON boolean true counts. Malformed persisted
+        # values ("true", 1, null) must never enable telemetry.
+        return self._config.get("telemetry_enabled") is True
+
+    def set_telemetry_enabled(self, enabled: bool) -> bool:
+        """
+        Set whether anonymous usage analytics are enabled.
+
+        Args:
+            enabled: True to enable telemetry, False to disable
+
+        Returns:
+            True if saved successfully, False otherwise
+        """
+        self._config["telemetry_enabled"] = enabled
+        # Any real toggle is affirmative — it also ends the one-time
+        # consent-reset migration window.
+        self._config["telemetry_opt_in_migrated"] = True
+        return self._save()
+```
+
+Add the migration next to the other `_migrate_*` helpers:
+
+```python
+    def _migrate_telemetry_opt_in(self) -> None:
+        """One-time consent reset for telemetry (strict opt-in).
+
+        v0.5.8 shipped telemetry default-ON and _merge_for_save() lays down
+        the full default dict on first write, so existing installs carry
+        telemetry_enabled: true that was never an affirmative choice. Until
+        the marker is set, force the persisted value to False — also when the
+        key is merely missing, so a rollback to a build that treats
+        missing-as-true stays off. set_telemetry_enabled() also writes the
+        marker, so any real toggle ends the migration window.
+        """
+        if self._load_failed:
+            return  # never persist defaults over a corrupt-but-recoverable file
+        if self._config.get("telemetry_opt_in_migrated") is True:
+            return
+        self._config["telemetry_enabled"] = False
+        self._config["telemetry_opt_in_migrated"] = True
+        self._persist_telemetry_migration()
+
+    def _persist_telemetry_migration(self) -> None:
+        """Locked compare-and-set write for the telemetry consent reset.
+
+        Re-reads config.json after acquiring the lock and aborts if the
+        marker already landed on disk (another process migrated, or the user
+        affirmatively toggled), so a racing opt-in is never clobbered.
+        All failure modes fail closed: this process already sees False in
+        memory, and the next process retries the persist.
+        """
+        lock_path = str(self.config_path) + ".lock"
+        try:
+            with filelock.FileLock(lock_path, timeout=self._SAVE_LOCK_TIMEOUT):
+                base = self._read_disk_for_merge()
+                if base is None:
+                    # Missing or unreadable on disk: nothing trustworthy to
+                    # reset. A later _save() lays down the defaults, which
+                    # are already off.
+                    return
+                if base.get("telemetry_opt_in_migrated") is True:
+                    # Lost the race — adopt the disk state (bool by
+                    # construction: only the migration or the setter write
+                    # it) instead of overwriting an affirmative opt-in.
+                    adopted = base.get("telemetry_enabled") is True
+                    self._config["telemetry_enabled"] = adopted
+                    self._config["telemetry_opt_in_migrated"] = True
+                    self._snapshot["telemetry_enabled"] = adopted
+                    self._snapshot["telemetry_opt_in_migrated"] = True
+                    return
+                base["telemetry_enabled"] = False
+                base["telemetry_opt_in_migrated"] = True
+                _atomic_write_json(self.config_path, base)
+                # Sync the snapshot so a later _save() from this instance
+                # doesn't re-diff these keys against the pre-migration load.
+                self._snapshot["telemetry_enabled"] = False
+                self._snapshot["telemetry_opt_in_migrated"] = True
+        except filelock.Timeout:
+            logger.warning(
+                "Timed out acquiring config lock for telemetry consent "
+                "migration; will retry on next load"
+            )
+        except Exception as e:
+            logger.error(f"Error persisting telemetry consent migration: {e}")
+```
+
+Call it from `__init__` at the end of the migration chain (`src/config.py:296-301`):
+
+```python
+        self._migrate_cloud_model_map()
+        self._migrate_whisper_model()
+        self._migrate_summary_model()
+        self._migrate_transcription_engine()
+        self._migrate_telemetry_opt_in()
+        self._normalize_templates()
+        self._seed_sample_template()
+```
+
+- [ ] **Step 4: Run the new tests and verify they pass**
+
+Run:
+
+```bash
+source venv/bin/activate && python -m pytest tests/test_config.py::ConfigTelemetryOptInTests -q
+```
+
+Expected: `9 passed` (with 6 subtests inside the malformed-values test).
+
+- [ ] **Step 5: Run the full config suite and lint**
+
+Run:
+
+```bash
+source venv/bin/activate && python -m pytest tests/test_config.py -q && ruff check src/config.py tests/test_config.py
+```
+
+Expected: all passed (54 pre-existing + the new class), ruff clean. If an existing test asserted the old default-true behavior, update it to the opt-in contract — but a scan showed no existing telemetry tests in `tests/test_config.py`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.py tests/test_config.py
+git commit -m "fix: make telemetry strict opt-in with one-time consent reset"
+```
+
+---
+
+### Task 2: Align renderer fallback, PostHog options, and the E2E case
+
+**Files:**
+- Modify: `app/renderer/src/routes/Setup.tsx:133`
+- Modify: `app/main.js:583` and `app/main.js:6401` (PostHog constructor call sites)
+- Modify: `e2e/specs/settings-roundtrip.t2.spec.ts:64`
+
+**Interfaces:**
+- Consumes: Task 1's persisted contract (default off; setter writes value + marker).
+- Produces: no new interfaces; renderer fallback and E2E assertions match the opt-in default. `AdvancedTab.tsx` already uses `?? false` and needs no change.
+
+- [ ] **Step 1: Change the Setup onboarding fallback to off**
+
+In `app/renderer/src/routes/Setup.tsx:133`, replace:
+
+```tsx
+  const telemetryEnabled = telemetry.data?.telemetry_enabled ?? true;
+```
+
+with:
+
+```tsx
+  const telemetryEnabled = telemetry.data?.telemetry_enabled ?? false;
+```
+
+- [ ] **Step 2: Add explicit disableGeoip to both PostHog constructors**
+
+In `app/main.js` (init path, ~line 583), replace:
+
+```javascript
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+```
+
+with:
+
+```javascript
+      // disableGeoip is already the posthog-node default; explicit here as
+      // drift protection so an SDK upgrade can't silently re-enable IP
+      // geolocation for opted-in users.
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST, disableGeoip: true });
+```
+
+In the `set-telemetry` re-enable path (~line 6401), replace:
+
+```javascript
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+```
+
+with:
+
+```javascript
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST, disableGeoip: true });
+```
+
+- [ ] **Step 3: Flip the E2E setter case to the opposite of the new default**
+
+In `e2e/specs/settings-roundtrip.t2.spec.ts:64`, replace:
+
+```typescript
+  { kind: 'telemetry', value: false, configKey: 'telemetry_enabled' },
+```
+
+with:
+
+```typescript
+  // true flips the default (false) so the assertion has teeth — a no-op
+  // setter would leave the key unset/false and fail this case.
+  { kind: 'telemetry', value: true, configKey: 'telemetry_enabled' },
+```
+
+- [ ] **Step 4: Typecheck and lint the renderer**
+
+Run:
+
+```bash
+cd app && npm run typecheck:renderer && npm run lint:renderer
+```
+
+Expected: both clean.
+
+- [ ] **Step 5: Rebuild the backend bundle and run the focused T2 test**
+
+The T2 spec drives the bundled backend, so it must contain Task 1's migration:
+
+```bash
+source venv/bin/activate && python -m PyInstaller stenoai.spec --noconfirm
+cd app && npm run test:e2e -- --project=t2 --grep "settings setters persist"
+```
+
+Expected: `1 passed`. If the local environment cannot run Electron, record the constraint and rely on the required T2 CI job.
+
+- [ ] **Step 6: Scan for stale default-on semantics**
+
+Run:
+
+```bash
+rg -n -C 2 "telemetry_enabled|telemetryEnabled|telemetry_opt_in_migrated" src/config.py app/main.js app/renderer/src/routes/Setup.tsx app/renderer/src/routes/settings/AdvancedTab.tsx e2e/specs/settings-roundtrip.t2.spec.ts tests/test_config.py
+```
+
+Expected: no fallback resolves to enabled; no comment describes default-on behavior; the marker key appears only in `src/config.py` and its tests (it must not leak into `identify()` properties or the settings UI).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/renderer/src/routes/Setup.tsx app/main.js e2e/specs/settings-roundtrip.t2.spec.ts
+git commit -m "fix: opt-in telemetry fallbacks and explicit disableGeoip"
+```
+
+---
+
+### Task 3: Prepare the follow-up pull request
+
+**Files:**
+- No product files change in this task.
+
+**Interfaces:**
+- Consumes: the verified commits from Tasks 1 and 2.
+- Produces: a focused GitHub pull request against `ruzin/stenoai:main`.
+
+- [ ] **Step 1: Verify branch state and commit range**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean worktree; the range contains the design, plan, and two implementation commits only.
+
+- [ ] **Step 2: Push the branch to the fork (requires explicit user authorization)**
+
+```bash
+git push -u fork fix/telemetry-opt-in
+```
+
+- [ ] **Step 3: Create the pull request (requires explicit user authorization)**
+
+Title:
+
+```text
+fix: make telemetry strict opt-in
+```
+
+Body (`telemetry-opt-in-pr-body.md` in the session scratchpad):
+
+```markdown
+## Summary
+
+Telemetry becomes strict opt-in. The PostHog integration, event payloads, and sanitization layer are unchanged; only the consent model changes.
+
+- New installs default to `telemetry_enabled: false`.
+- Strict consent semantics: only JSON boolean `true` enables telemetry (`is True` in Python); malformed persisted values can never turn it on.
+- One-time consent reset for the installed base: v0.5.8 shipped default-on, and the config layer auto-persists the full default dict on first write, so existing installs carry `telemetry_enabled: true` that was never an affirmative choice. A marker-guarded migration (`telemetry_opt_in_migrated`) resets those configs to `false` once — written through a locked compare-and-set so a concurrent affirmative opt-in is never clobbered. The reset also writes an explicit `false` when the key was merely missing, so a rollback to v0.5.8 (missing key = on) stays off.
+- The onboarding and Settings toggles are unchanged and remain the only paths that persist `true`, so post-migration consent is affirmative by definition.
+- `disableGeoip: true` is now explicit on both PostHog constructors (already the SDK default; drift protection).
+
+## Rationale
+
+Anonymous, content-free analytics are legitimately useful, but default-on conflicts with Steno's local-first, privacy-respecting posture — the same reasoning as the launch-on-login opt-in correction (#335). Because default-on already shipped in v0.5.8, a default flip alone would not deliver opt-in for existing users; the one-time reset is the price of the previous `true` never having been affirmative.
+
+Known consequence: analytics volume will collapse after this ships, and users who genuinely opted in on v0.5.8 are reset once (locally indistinguishable) and must re-enable. Worth marking the release boundary in the PostHog dashboards so pre/post metrics are not compared as if collection were stable.
+
+## Testing
+
+- `python -m pytest tests/test_config.py -q` — full config suite including the new `ConfigTelemetryOptInTests` (fresh install off, legacy true reset on disk, missing key persisted false, malformed values never enable, marker prevents re-migration, round trip, corrupt config untouched, CAS race adoption).
+- `cd app && npm run typecheck:renderer && npm run lint:renderer`.
+- Focused T2 settings round-trip against a freshly built backend bundle; the telemetry case now writes `true` (the opposite of the new default).
+
+## Release checklist (blocking)
+
+- [ ] Website/docs copy must ship with the release that contains this change: `website/public/privacy.html` ("enabled by default"), `docs/privacy/how-on-device-works.mdx` ("no analytics"), and FAQ claims need release-coordinated corrections in a separate PR — the website deploys on merge while the latest published release still defaults on, so bundling the copy here would create a disclosure/version skew.
+
+## Follow-ups
+
+- A future onboarding step could present the telemetry choice more prominently; intentionally out of scope here.
+```
+
+```bash
+gh pr create --repo ruzin/stenoai --base main --head Optic00:fix/telemetry-opt-in --title "fix: make telemetry strict opt-in" --body-file <scratchpad>/telemetry-opt-in-pr-body.md
+```
+
+Do not push or create the PR until the user has authorized the external writes.

--- a/docs/superpowers/specs/2026-07-12-telemetry-opt-in-design.md
+++ b/docs/superpowers/specs/2026-07-12-telemetry-opt-in-design.md
@@ -1,0 +1,90 @@
+# Telemetry Opt-In Design
+
+## Context
+
+Steno sends anonymous product analytics to PostHog (`https://us.i.posthog.com`) from the Electron main process.
+The base implementation shipped in v0.5.8 with `telemetry_enabled` defaulting to `True`; PR #323 expanded the event set after that release.
+All payloads are metadata-only (enums, buckets, a random UUID `anonymous_id`); the sanitization layer in `app/analytics-helpers.js` prevents content, paths, and PII from being sent.
+
+Two consent problems exist:
+
+1. The default is opt-out, with an onboarding toggle that defaults to on.
+2. `Config._merge_for_save()` writes the full default dict wholesale when `config.json` is missing, so existing installations very likely have `telemetry_enabled: true` persisted without any affirmative user action.
+A persisted `true` therefore cannot be trusted as consent.
+
+Unlike the launch-on-login correction (#335), this cannot be fixed by a default flip alone: the installed base must be migrated.
+
+## Goal
+
+Telemetry runs only for users who have affirmatively enabled it after this change ships.
+Strict consent means the persisted value is exactly JSON boolean `true`, written by the user-facing toggle.
+
+## Behavior
+
+| Configuration state | Effective | Action |
+| --- | --- | --- |
+| New installation | off | Marker seeded in defaults; no migration ever runs |
+| Existing config, marker absent (any prior value: `true`, missing, malformed) | off | One-time migration persists `telemetry_enabled: false` + marker |
+| Explicit `true` written after migration (only reachable via the toggle) | on | Unchanged |
+| Explicit `false` | off | Unchanged |
+| Corrupt config (`_load_failed`) | off (in memory) | Never persisted over |
+
+Accepted consequence: v0.5.8 users who did affirmatively enable the toggle are also reset once (locally indistinguishable from auto-persisted `true`) and must re-enable.
+
+## Changes
+
+### Python (`src/config.py`) — core
+
+- Default `"telemetry_enabled": False` in `_get_default_config()`; seed the migration marker (`"telemetry_opt_in_migrated": True`) in the defaults so fresh installs never migrate.
+- `get_telemetry_enabled()` returns `self._config.get("telemetry_enabled") is True` — malformed persisted values (`"false"`, `1`, `null`) must not enable telemetry.
+- New one-time migration `_migrate_telemetry_opt_in()`, called from `__init__` after the existing migrations:
+  - Skips when `_load_failed` (corrupt-file recovery semantics, same as the other migrations).
+  - Skips when the marker is already `True` in the loaded config.
+  - Otherwise persists `telemetry_enabled: false` and the marker **unconditionally** — also when the key was merely missing, so a rollback to v0.5.8 (which treats a missing key as `true`) stays off.
+  - Persists through a dedicated locked compare-and-set write: acquire the existing config file lock, re-read the file from disk, abort without writing if the marker is already present on disk, else atomically write the updated file. `_save()` is not modified. Residual races fail closed (a lost affirmative opt-in at worst requires toggling again).
+- `set_telemetry_enabled()` additionally writes the marker, so any toggle action also ends the migration window.
+
+### Renderer
+
+- `Setup.tsx`: `telemetryEnabled` fallback `?? true` → `?? false`. The onboarding toggle stays visible with the existing notice text; no dark patterns, no new UI.
+- Same fallback change in `AdvancedTab.tsx` if a `?? true` fallback exists there.
+
+### Electron main (`app/main.js`)
+
+- No gating logic changes: `initTelemetry` already reads the Python `get-telemetry` result and only constructs PostHog when enabled.
+- Add explicit `disableGeoip: true` to both PostHog constructor call sites (init and re-enable). posthog-node 4.18.0 already defaults this to true; the explicit option is drift protection only.
+
+### Tests
+
+- Python contract tests (`ConfigTelemetryOptInTests`):
+  - Fresh config: off, marker present, no migration write needed.
+  - Legacy config with persisted `true` and no marker: getter returns `False`, file afterwards contains `telemetry_enabled: false` + marker.
+  - Legacy config **without** the key and no marker: same result (rollback protection).
+  - Malformed persisted values (`"false"`, `1`, `None`): getter `False`; migration normalizes to `false`.
+  - Marker present: migration never rewrites; an explicit post-migration `true` survives reload.
+  - Round trip: `set_telemetry_enabled(True/False)` persists value + marker.
+  - Corrupt config: nothing persisted.
+  - Concurrency: migration racing `set_telemetry_enabled(True)` — the locked compare-and-set aborts when the marker landed first.
+- E2E: `settings-roundtrip.t2.spec.ts` telemetry case flips to `value: true` (the opposite of the new default, so a no-op setter fails).
+- Renderer vitest for Setup/Advanced if their tests assert the fallback.
+
+## Data Flow
+
+Every CLI invocation constructs a fresh `Config`, so the migration takes effect in memory immediately even before its persist lands; `initTelemetry` in the Electron main process reads the migrated value via `get-telemetry` and simply never constructs the PostHog client for non-consented users.
+When the user enables the toggle, the existing IPC path persists `true` (+ marker) and main.js constructs the client immediately, as today.
+
+## Error Handling
+
+Unchanged outside the migration.
+The migration never writes over a corrupt config, degrades to no-op on lock timeout (the in-memory value is still `False` for this process; the next process retries), and all failure modes are fail-closed for privacy.
+
+## Out of Scope
+
+- Website and docs copy (`website/public/privacy.html` "enabled by default", `docs/privacy/how-on-device-works.mdx` "no analytics", FAQ claims): prepared as a **separate, release-coordinated PR** and named in this PR as an explicit release-blocking checklist item with an owner — the website auto-deploys on merge while released v0.5.8 still defaults on, so bundling would create a disclosure/version skew.
+- No changes to event payloads, sanitization, IPC shape, CLI commands, or the `anonymous_id` mechanism.
+- No compensating onboarding changes to boost opt-in rates.
+
+## PR Positioning
+
+Framed as a consent-model correction and an explicit product decision for the maintainer: analytics volume will collapse because the installed base is reset, and pre/post release metrics must not be compared as if collection were stable (mark the boundary in PostHog dashboards).
+The reset is the price of the previous `true` never having been affirmative.

--- a/e2e/specs/settings-roundtrip.t2.spec.ts
+++ b/e2e/specs/settings-roundtrip.t2.spec.ts
@@ -60,7 +60,9 @@ const CASES: Case[] = [
   // false flips the macOS default (true) so this has teeth on the primary signed
   // platform — asserting `true` there would pass even if the setter no-oped.
   { kind: 'systemAudio', value: false, configKey: 'system_audio_enabled' },
-  { kind: 'telemetry', value: false, configKey: 'telemetry_enabled' },
+  // true flips the default (false) so the assertion has teeth - a no-op
+  // setter would leave the key unset/false and fail this case.
+  { kind: 'telemetry', value: true, configKey: 'telemetry_enabled' },
   { kind: 'transcriptionEngine', value: 'whisper', configKey: 'transcription_engine' },
   { kind: 'dockIcon', value: true, configKey: 'hide_dock_icon' },
   // false flips the default (true) so the assertion has teeth — a no-op setter

--- a/src/config.py
+++ b/src/config.py
@@ -297,6 +297,7 @@ class Config:
         self._migrate_whisper_model()
         self._migrate_summary_model()
         self._migrate_transcription_engine()
+        self._migrate_telemetry_opt_in()
         self._normalize_templates()
         self._seed_sample_template()
 
@@ -317,6 +318,68 @@ class Config:
             "whisper" if self._existed_at_load else "parakeet"
         )
         self._save()
+
+    def _migrate_telemetry_opt_in(self) -> None:
+        """One-time consent reset for telemetry (strict opt-in).
+
+        v0.5.8 shipped telemetry default-ON and _merge_for_save() lays down
+        the full default dict on first write, so existing installs carry
+        telemetry_enabled: true that was never an affirmative choice. Until
+        the marker is set, force the persisted value to False — also when the
+        key is merely missing, so a rollback to a build that treats
+        missing-as-true stays off. set_telemetry_enabled() also writes the
+        marker, so any real toggle ends the migration window.
+        """
+        if self._load_failed:
+            return  # never persist defaults over a corrupt-but-recoverable file
+        if self._config.get("telemetry_opt_in_migrated") is True:
+            return
+        self._config["telemetry_enabled"] = False
+        self._config["telemetry_opt_in_migrated"] = True
+        self._persist_telemetry_migration()
+
+    def _persist_telemetry_migration(self) -> None:
+        """Locked compare-and-set write for the telemetry consent reset.
+
+        Re-reads config.json after acquiring the lock and aborts if the
+        marker already landed on disk (another process migrated, or the user
+        affirmatively toggled), so a racing opt-in is never clobbered.
+        All failure modes fail closed: this process already sees False in
+        memory, and the next process retries the persist.
+        """
+        lock_path = str(self.config_path) + ".lock"
+        try:
+            with filelock.FileLock(lock_path, timeout=self._SAVE_LOCK_TIMEOUT):
+                base = self._read_disk_for_merge()
+                if base is None:
+                    # Missing or unreadable on disk: nothing trustworthy to
+                    # reset. A later _save() lays down the defaults, which
+                    # are already off.
+                    return
+                if base.get("telemetry_opt_in_migrated") is True:
+                    # Lost the race — adopt the disk state (bool by
+                    # construction: only the migration or the setter write
+                    # it) instead of overwriting an affirmative opt-in.
+                    adopted = base.get("telemetry_enabled") is True
+                    self._config["telemetry_enabled"] = adopted
+                    self._config["telemetry_opt_in_migrated"] = True
+                    self._snapshot["telemetry_enabled"] = adopted
+                    self._snapshot["telemetry_opt_in_migrated"] = True
+                    return
+                base["telemetry_enabled"] = False
+                base["telemetry_opt_in_migrated"] = True
+                _atomic_write_json(self.config_path, base)
+                # Sync the snapshot so a later _save() from this instance
+                # doesn't re-diff these keys against the pre-migration load.
+                self._snapshot["telemetry_enabled"] = False
+                self._snapshot["telemetry_opt_in_migrated"] = True
+        except filelock.Timeout:
+            logger.warning(
+                "Timed out acquiring config lock for telemetry consent "
+                "migration; will retry on next load"
+            )
+        except Exception as e:
+            logger.error(f"Error persisting telemetry consent migration: {e}")
 
     def _migrate_whisper_model(self) -> None:
         """Map any out-of-current-list whisper model to the supported one.
@@ -584,7 +647,11 @@ class Config:
         return {
             "model": self.DEFAULT_MODEL,
             "notifications_enabled": True,
-            "telemetry_enabled": True,
+            # Strict opt-in — telemetry runs only after the user explicitly
+            # enables it (Setup or Settings → Advanced). Fresh installs carry
+            # the migration marker so the one-time consent reset never runs.
+            "telemetry_enabled": False,
+            "telemetry_opt_in_migrated": True,
             # Default ON on macOS — CoreAudio Process Tap captures system
             # audio alongside the mic on macOS 14.4+. Older macOS auto-falls
             # back to mic-only via main.js's loadSystemAudioEnabled() OS gate.
@@ -835,7 +902,9 @@ class Config:
 
     def get_telemetry_enabled(self) -> bool:
         """Get whether anonymous usage analytics are enabled."""
-        return self._config.get("telemetry_enabled", True)
+        # Strict consent: only JSON boolean true counts. Malformed persisted
+        # values ("true", 1, null) must never enable telemetry.
+        return self._config.get("telemetry_enabled") is True
 
     def set_telemetry_enabled(self, enabled: bool) -> bool:
         """
@@ -848,6 +917,9 @@ class Config:
             True if saved successfully, False otherwise
         """
         self._config["telemetry_enabled"] = enabled
+        # Any real toggle is affirmative — it also ends the one-time
+        # consent-reset migration window.
+        self._config["telemetry_opt_in_migrated"] = True
         return self._save()
 
     def get_hide_dock_icon(self) -> bool:

--- a/src/config.py
+++ b/src/config.py
@@ -337,6 +337,13 @@ class Config:
         self._config["telemetry_enabled"] = False
         self._config["telemetry_opt_in_migrated"] = True
         self._persist_telemetry_migration()
+        # Whatever the persist outcome, keep the snapshot in sync with the
+        # in-memory state of these two keys so a later ordinary _save() can
+        # never push them through the merge path and bypass the CAS above
+        # (which would clobber a concurrent affirmative opt-in). On persist
+        # failure the migration simply retries on the next load.
+        self._snapshot["telemetry_enabled"] = self._config["telemetry_enabled"]
+        self._snapshot["telemetry_opt_in_migrated"] = self._config["telemetry_opt_in_migrated"]
 
     def _persist_telemetry_migration(self) -> None:
         """Locked compare-and-set write for the telemetry consent reset.
@@ -363,16 +370,10 @@ class Config:
                     adopted = base.get("telemetry_enabled") is True
                     self._config["telemetry_enabled"] = adopted
                     self._config["telemetry_opt_in_migrated"] = True
-                    self._snapshot["telemetry_enabled"] = adopted
-                    self._snapshot["telemetry_opt_in_migrated"] = True
                     return
                 base["telemetry_enabled"] = False
                 base["telemetry_opt_in_migrated"] = True
                 _atomic_write_json(self.config_path, base)
-                # Sync the snapshot so a later _save() from this instance
-                # doesn't re-diff these keys against the pre-migration load.
-                self._snapshot["telemetry_enabled"] = False
-                self._snapshot["telemetry_opt_in_migrated"] = True
         except filelock.Timeout:
             logger.warning(
                 "Timed out acquiring config lock for telemetry consent "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -352,6 +352,38 @@ class ConfigTelemetryOptInTests(unittest.TestCase):
             self.assertIs(on_disk["telemetry_enabled"], True)
             self.assertTrue(config.get_telemetry_enabled())
 
+    def test_failed_migration_persist_does_not_leak_through_save(self):
+        # If the migration's CAS write fails (lock timeout, I/O error), a
+        # later ordinary _save() must not push the in-memory reset through
+        # the merge path - that would bypass the CAS and clobber a
+        # concurrent affirmative opt-in.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            # templates_seeded present so no construction-time seed _save
+            # runs before the concurrent opt-in below; the stale instance's
+            # own set_*() below is the "later ordinary _save" under test.
+            path.write_text(
+                json.dumps({"telemetry_enabled": True, "templates_seeded": True})
+            )
+            with patch.object(
+                Config, "_persist_telemetry_migration", lambda self: None
+            ):
+                config = Config(config_path=path)
+            # Fail closed in memory for this process.
+            self.assertFalse(config.get_telemetry_enabled())
+            # Concurrent process migrated AND the user opted in meanwhile.
+            path.write_text(json.dumps({
+                "telemetry_enabled": True,
+                "telemetry_opt_in_migrated": True,
+                "templates_seeded": True,
+            }))
+            # Any ordinary save from the stale instance...
+            config.set_notifications_enabled(True)
+            # ...must not clobber the affirmative opt-in on disk.
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], True)
+            self.assertIs(on_disk["telemetry_opt_in_migrated"], True)
+
 
 class ConfigOrgAutoBackupTests(unittest.TestCase):
     def test_default_auto_backup_is_true(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -254,6 +254,105 @@ class ConfigLaunchOnLoginTests(unittest.TestCase):
             self.assertTrue(reloaded.get_launch_on_login())
 
 
+class ConfigTelemetryOptInTests(unittest.TestCase):
+    def test_fresh_config_defaults_off_with_marker(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertFalse(config.get_telemetry_enabled())
+            self.assertIs(config._config.get("telemetry_opt_in_migrated"), True)
+
+    def test_legacy_persisted_true_is_reset_and_persisted(self):
+        # v0.5.8 auto-persisted telemetry_enabled: true without consent; the
+        # one-time migration must reset it on disk, not only in memory.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"telemetry_enabled": True}))
+            config = Config(config_path=path)
+            self.assertFalse(config.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], False)
+            self.assertIs(on_disk["telemetry_opt_in_migrated"], True)
+
+    def test_legacy_missing_key_is_persisted_false(self):
+        # Rollback protection: v0.5.8 treats a missing key as enabled, so the
+        # migration must write an explicit false even when the key is absent.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"model": "gemma3:4b"}))
+            config = Config(config_path=path)
+            self.assertFalse(config.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], False)
+            self.assertIs(on_disk["telemetry_opt_in_migrated"], True)
+
+    def test_malformed_values_never_enable(self):
+        for malformed in ("true", "false", 1, 0, None, []):
+            with self.subTest(value=malformed):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    path = Path(tmp_dir) / "config.json"
+                    path.write_text(json.dumps({
+                        "telemetry_enabled": malformed,
+                        "telemetry_opt_in_migrated": True,
+                    }))
+                    config = Config(config_path=path)
+                    self.assertFalse(config.get_telemetry_enabled())
+
+    def test_marker_prevents_re_migration(self):
+        # An affirmative post-migration true must survive later loads.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({
+                "telemetry_enabled": True,
+                "telemetry_opt_in_migrated": True,
+            }))
+            config = Config(config_path=path)
+            self.assertTrue(config.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], True)
+
+    def test_round_trip_writes_marker(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            self.assertTrue(config.set_telemetry_enabled(True))
+            self.assertTrue(config.get_telemetry_enabled())
+            reloaded = Config(config_path=path)
+            self.assertTrue(reloaded.get_telemetry_enabled())
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_opt_in_migrated"], True)
+            self.assertTrue(reloaded.set_telemetry_enabled(False))
+            self.assertFalse(reloaded.get_telemetry_enabled())
+
+    def test_corrupt_config_never_persisted(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text("{not json")
+            config = Config(config_path=path)
+            self.assertFalse(config.get_telemetry_enabled())
+            # The corrupt original must stay recoverable on disk.
+            self.assertEqual(path.read_text(), "{not json")
+
+    def test_migration_cas_aborts_when_marker_lands_first(self):
+        # Deterministic race simulation: another process migrated AND the
+        # user affirmatively opted in before this (stale) instance persisted
+        # its migration. The locked compare-and-set must adopt the disk state
+        # instead of clobbering the opt-in.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({
+                "telemetry_enabled": True,
+                "telemetry_opt_in_migrated": True,
+            }))
+            config = Config(config_path=path)
+            # Rewind this instance to a pre-migration view of the world.
+            config._config["telemetry_enabled"] = False
+            config._config["telemetry_opt_in_migrated"] = False
+            config._persist_telemetry_migration()
+            on_disk = json.loads(path.read_text())
+            self.assertIs(on_disk["telemetry_enabled"], True)
+            self.assertTrue(config.get_telemetry_enabled())
+
+
 class ConfigOrgAutoBackupTests(unittest.TestCase):
     def test_default_auto_backup_is_true(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Telemetry becomes strict opt-in. The PostHog integration, event payloads, and sanitization layer are unchanged; only the consent model changes.

- New installs default to `telemetry_enabled: false`.
- Strict consent semantics: only JSON boolean `true` enables telemetry (`is True` in Python); malformed persisted values can never turn it on.
- One-time consent reset for the installed base: v0.5.8 shipped default-on, and the config layer auto-persists the full default dict on first write, so existing installs carry `telemetry_enabled: true` that was never an affirmative choice. A marker-guarded migration (`telemetry_opt_in_migrated`) resets those configs to `false` once — written through a locked compare-and-set so a concurrent affirmative opt-in is never clobbered, with the snapshot kept in sync on every persist outcome so a later ordinary save cannot bypass that protection. The reset also writes an explicit `false` when the key was merely missing, so a rollback to v0.5.8 (missing key = on) stays off.
- The onboarding and Settings toggles are unchanged and remain the only paths that persist `true`, so post-migration consent is affirmative by definition.
- `disableGeoip: true` is now explicit on both PostHog constructors (already the SDK default; drift protection).

## Rationale

Anonymous, content-free analytics are legitimately useful, but default-on conflicts with Steno's local-first, privacy-respecting posture — the same reasoning as the launch-on-login opt-in correction (#335). Because default-on already shipped in v0.5.8, a default flip alone would not deliver opt-in for existing users; the one-time reset is the price of the previous `true` never having been affirmative.

Known consequence: analytics volume will collapse after this ships, and users who genuinely opted in on v0.5.8 are reset once (locally indistinguishable) and must re-enable. Worth marking the release boundary in the PostHog dashboards so pre/post metrics are not compared as if collection were stable.

## Testing

- `python -m pytest tests/test_config.py -q` — 63 passed + 8 subtests, including the new `ConfigTelemetryOptInTests` (fresh install off, legacy true reset on disk, missing key persisted false, malformed values never enable, marker prevents re-migration, round trip, corrupt config untouched, CAS race adoption, failed-persist no-clobber regression).
- `cd app && npm run typecheck:renderer && npm run lint:renderer` — clean.
- Focused T2 settings round-trip against a freshly built backend bundle — passed; the telemetry case now writes `true` (the opposite of the new default) so a no-op setter cannot pass.

## Release checklist (blocking)

- [ ] Website/docs copy must ship with the release that contains this change: `website/public/privacy.html` ("enabled by default"), `docs/privacy/how-on-device-works.mdx` ("no analytics"), and FAQ claims need release-coordinated corrections in a separate PR — the website deploys on merge while the latest published release still defaults on, so bundling the copy here would create a disclosure/version skew.

## Follow-ups

- A future onboarding step could present the telemetry choice more prominently; intentionally out of scope here.
- Pre-existing, unrelated residual: `_save()`'s lock-timeout fallback does an unlocked wholesale write for every config key by design ("a stuck lock must never block saves"); under two consecutive lock timeouts in one process it could overwrite concurrent writes. Not changed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make telemetry strict opt-in. New installs default to off, existing configs are reset once to off, telemetry only runs when `telemetry_enabled` is exactly JSON true, the Setup toggle defaults to off, and the PostHog client now sets `disableGeoip: true`.

- **Migration**
  - Resets `telemetry_enabled` to `false` once for configs missing `telemetry_opt_in_migrated`, and persists the marker; also writes `false` when the key was missing (rollback-safe).
  - Uses a locked compare-and-set; if a user opts in during migration, the on-disk opt-in is kept. Keeps the in-memory snapshot in sync even if the persist fails so later saves can’t clobber an affirmative opt-in.
  - No action needed; users who want telemetry must re-enable it in Settings or during Setup.

<sup>Written for commit b7185dfe8eb74b2f19d10867942ff05c69036b89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

