### PR TITLE
docs: add Mintlify changelog page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,24 +194,32 @@ Releases are automated via `.github/workflows/build-release.yml`. Never create r
    - Keep only the **most recent 4 entries** in the section — trim older ones as you add new ones, regardless of date. The section is a rolling marquee, not a changelog.
    - Update the "Features" list if any new user-facing capability is being added (or an existing one materially changed).
    - Update "Models & Performance" if the bundled Whisper or Ollama model lineup changed.
-3. **Bump version** in `app/package.json`.
-4. **Commit and merge** the README + version bump to `main` (or push directly if explicitly authorised).
-5. **Draft release notes** as markdown — they become the GitHub Release body verbatim:
+3. **Update `docs/changelog.mdx`** (the public docs changelog page) with a new `<Update label="v<version>" description="<Month DD, YYYY>">` block, grouped under `**New**` / `**Improved**` / `**Fixed**` / `**Known Issues**` as applicable — same source list as the README bullets, but every entry gets its own line here (not trimmed to 4).
+   - **Copy-review pass before merging:** re-read every bullet for readability, not just accuracy. Rewrite any sentence that:
+     - buries the actual instruction after multiple clauses (put the action first: "Turn off X to do Y" beats "Do Y, whenever ..., turn off X");
+     - has a trailing modifier or restatement that makes you re-read it (drop "with X hidden"-style tails; don't restate the same point twice, e.g. "...so it can be reprocessed -- it's never lost");
+     - uses a pronoun with no clear antecedent ("turn it on" referring to something not named in the sentence);
+     - is vague about what actually broke ("Fixed an issue choosing X" → "Fixed an issue that could prevent choosing X").
+   - Each bullet should read as one clear clause on first pass. If in doubt, read it aloud.
+4. **Bump version** in `app/package.json`.
+5. **Commit and merge** the README + changelog + version bump to `main` (or push directly if explicitly authorised).
+6. **Draft release notes** as markdown — they become the GitHub Release body verbatim:
    - One-line summary at the top.
    - Headline features grouped under `### Section` headers (e.g., "System audio", "UX polish", "Under the hood", "Fixes").
    - Migration/upgrade notes if anything changed paths, identifiers, defaults, or requires user action.
-6. **Run the release gate (blocks the tag).** Push a `release/v<version>` branch — `git push origin main:refs/heads/release/v0.3.0` — to trigger `.github/workflows/e2e-release-gate.yml`, which runs the full e2e matrix (T1 + macOS/Windows T2 + `@pipeline` + the `@long-meeting` T3 smoke). **Do not create the tag until this run is green.** The gate runs on the branch, before the immutable tag exists, so a failure is fixed-and-re-pushed rather than leaving a half-released tag. (You can also dry-run it via `workflow_dispatch`.) `build-release.yml` additionally runs a fast T1 backstop smoke (`gate-smoke`) before signing, but that is defense-in-depth — the branch gate is the real signal.
-7. **Create an annotated tag** on `main` with the release notes as the tag message. **Always pass `--cleanup=whitespace`** — without it, `git tag -F` strips every line starting with `#`, which silently deletes Markdown `### Section` headers from the release body:
+   - Apply the same copy-review pass as step 3 — these notes are public-facing too.
+7. **Run the release gate (blocks the tag).** Push a `release/v<version>` branch — `git push origin main:refs/heads/release/v0.3.0` — to trigger `.github/workflows/e2e-release-gate.yml`, which runs the full e2e matrix (T1 + macOS/Windows T2 + `@pipeline` + the `@long-meeting` T3 smoke). **Do not create the tag until this run is green.** The gate runs on the branch, before the immutable tag exists, so a failure is fixed-and-re-pushed rather than leaving a half-released tag. (You can also dry-run it via `workflow_dispatch`.) `build-release.yml` additionally runs a fast T1 backstop smoke (`gate-smoke`) before signing, but that is defense-in-depth — the branch gate is the real signal.
+8. **Create an annotated tag** on `main` with the release notes as the tag message. **Always pass `--cleanup=whitespace`** — without it, `git tag -F` strips every line starting with `#`, which silently deletes Markdown `### Section` headers from the release body:
    ```
    git tag -a v0.3.0 --cleanup=whitespace -F /path/to/notes.md
    git push origin v0.3.0
    ```
    (If using `-m` instead of `-F`, pass `--cleanup=whitespace` anyway — the comment-stripping default applies to both.)
-8. The tag push triggers the workflow which:
+9. The tag push triggers the workflow which:
    - Builds signed + notarized DMGs for both arm64 and x64
    - Creates a GitHub Release with the tag message as the body
    - Uploads both DMGs as release assets
-9. Do NOT build DMGs locally for releases, do NOT use `gh release create` manually.
+10. Do NOT build DMGs locally for releases, do NOT use `gh release create` manually.
 
 ## Session Logging
 When the user says "log session" or similar (e.g., "update session log", "document this session"):

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,0 +1,108 @@
+---
+title: "Changelog"
+description: "What's new in Steno -- recent releases and notable changes."
+---
+
+<Update label="v0.5.8" description="July 5, 2026">
+**New**
+- Added a "Generate notes automatically" toggle in Settings -- turn it off to skip AI summaries while recording, then generate them later whenever you're ready.
+- A new gallery of ready-made note templates to choose from in Settings.
+- Export a diagnostics file for support that hides your file paths and meeting titles.
+
+**Improved**
+- Steno is better at telling your voice apart from other speakers in the transcript.
+- Summaries are now written in the meeting's own language, instead of always defaulting to English.
+- Diagnostic logs no longer contain any of your meeting content, so they're safe to share for troubleshooting.
+
+**Fixed**
+- Improved transcription stability on Apple Silicon Macs.
+- The "note ready" notification now opens that note directly, instead of just the app.
+- Fixed a rare bug that could lose a settings change.
+- Fixed an issue that could prevent choosing your AWS region for cloud AI summaries.
+</Update>
+
+<Update label="v0.5.7" description="July 2, 2026">
+**New**
+- Every line of the transcript now shows a timestamp, so you know exactly when something was said.
+- You can pin a summary language (French, German, Spanish, Dutch, or Portuguese) instead of Steno defaulting to English.
+- Added a guide for importing your existing Granola notes into Steno.
+
+**Improved**
+- Local summaries can now run faster on Apple Silicon Macs -- turn on "Switch to faster build" in Settings.
+- Cleaner summaries -- the AI's internal reasoning no longer shows up in your notes.
+
+**Fixed**
+- Fewer false "meeting detected" prompts on newer versions of macOS.
+</Update>
+
+<Update label="v0.5.6" description="July 1, 2026">
+**New**
+- Create your own report templates, and generate more than one report per meeting.
+- Copy or save the full transcript as a text file.
+
+**Improved**
+- Long meetings now summarize reliably instead of sometimes failing.
+- The home screen now shows your current recording and upcoming meetings.
+
+**Fixed**
+- If transcription fails, Steno now uses the live transcript instead of saving a blank note.
+</Update>
+
+<Update label="v0.5.5" description="June 22, 2026">
+**New**
+- Search (⌘K) lets you jump straight to any note from anywhere in the app.
+- Import an existing audio file to transcribe and summarize it, not just live recordings.
+- Steno now reminds you a couple of minutes before a calendar meeting starts.
+
+**Improved**
+- Steno now works on corporate/work networks that route traffic through a proxy.
+- If a note fails to back up, you'll now see a warning you can click to retry.
+- Speaker separation stays accurate on long recordings, not just short ones.
+</Update>
+
+<Update label="v0.5.4" description="June 15, 2026">
+Bug fixes for reliability, on both Mac and Windows.
+
+**Fixed**
+- Fixed a bug where meeting notes could occasionally fail to save.
+- Windows: recordings, calendar sign-in, and your cloud API key were being saved in the wrong place. Nothing to do -- your existing settings move automatically.
+</Update>
+
+<Update label="v0.5.3" description="June 14, 2026">
+**New**
+- Two new AI models for summaries: one better for long meetings, one lighter for machines with less memory. Choose in Settings → AI.
+</Update>
+
+<Update label="v0.5.2" description="June 12, 2026">
+**Improved**
+- Closing your laptop lid now pauses your recording instead of letting it run with no audio. When you wake your Mac, you can resume it.
+- Audio is cleaned up before transcription, so noisy or quiet recordings come out more accurate.
+- Recordings start faster, especially on a slow or offline network.
+
+**Fixed**
+- Fixed a crash on recordings longer than 30 minutes.
+- If transcription fails, your audio is now always saved so the meeting can be reprocessed later.
+- Fixed transcription being stopped by mistake on slower Macs.
+- If transcription crashes, Steno now automatically tries again using a backup method.
+</Update>
+
+<Update label="v0.5.1" description="June 9, 2026">
+**Fixed**
+- Windows: the app now shows the correct Steno icon instead of a generic one.
+- Fixed an issue where the Windows installer could occasionally fail to download.
+</Update>
+
+<Update label="v0.5.0" description="June 9, 2026">
+**New**
+- Steno is now available on Windows (early access) -- record, transcribe, and summarize meetings fully on-device.
+- Windows can now capture both sides of a call (experimental).
+
+**Known Issues**
+- Windows may show a security warning on first launch, since the app isn't verified yet -- choose "More info" → "Run anyway" to continue.
+- Transcription and summaries are slower on Windows for now, since they don't yet use your graphics card.
+</Update>
+
+<Update label="v0.4.2" description="June 9, 2026">
+**Fixed**
+- Fixed a bug where the live transcript wouldn't appear on screen during recording. Recordings and final transcripts were not affected.
+</Update>

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -167,6 +167,47 @@ nav, aside, [class*="sidebar"] {
   color: #1A1A18;
 }
 
+/* ── Changelog version badge ────────────────────────────────────────────────── */
+
+/* The <Update> component's built-in badge uses bg-primary/10 + dark:text-primary-light,
+   which we never define a dark-mode tint for — a 10%-opacity near-black background
+   is nearly invisible on a dark page. Use the same ink/paper chip inversion as the
+   topbar CTA button so the version badge stands out in both themes. */
+[data-component-part="update-label"] {
+  background-color: var(--ink-900) !important;
+  color: var(--paper-0) !important;
+}
+
+/* The label/date column reserves a fixed 160px, far wider than the badge or date
+   text needs, then adds another 24px gap before the content column -- reads as a
+   large empty gutter. Narrow the column and tighten the gap so content sits closer
+   to the version/date. */
+@media (min-width: 1024px) {
+  .update-container {
+    gap: 1rem !important;
+  }
+
+  .update-container > div:first-child {
+    width: 120px !important;
+  }
+}
+
+/* Below the xl breakpoint the "On this page" TOC column disappears and #content-area
+   (box-border, so padding shrinks its content rather than growing the box) stretches
+   edge-to-edge with no right-hand breathing room. Add padding so the reading column
+   stays narrower even without the TOC reserving space. */
+@media (min-width: 1024px) {
+  #content-area {
+    padding-right: 3rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  #content-area {
+    padding-right: 4rem;
+  }
+}
+
 /* ── Dark mode adjustments ──────────────────────────────────────────────────── */
 
 .dark body, .dark .mintlify-root {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,6 +87,11 @@
     "global": {
       "anchors": [
         {
+          "anchor": "Changelog",
+          "href": "/changelog",
+          "icon": "clock-rotate-left"
+        },
+        {
           "anchor": "GitHub",
           "href": "https://github.com/ruzin/stenoai",
           "icon": "github"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -16,6 +16,9 @@ description: "Steno records, transcribes, and summarizes your meetings entirely 
   <Card title="Compare" icon="scale-balanced" href="/compare/local-vs-cloud">
     Local vs cloud meeting AI -- trade-offs and when to use each.
   </Card>
+  <Card title="Changelog" icon="clock-rotate-left" href="/changelog">
+    See what's new in the latest Steno releases.
+  </Card>
 </CardGroup>
 
 ## What is Steno?


### PR DESCRIPTION
## Summary
- Adds a public `/changelog` page to the Mintlify docs, covering the last 10 releases (v0.4.2 - v0.5.8), rewritten from the GitHub release notes in plain, user-facing language and grouped under **New** / **Improved** / **Fixed** / **Known Issues**.
- Moves "Changelog" into the global anchor rail (next to GitHub/Discord) instead of the main sidebar, for higher visibility without cluttering the doc-group nav.
- Fixes the `<Update>` version badge being nearly invisible in dark mode (`bg-primary/10` on an already-dark background), tightens the label/date column so it doesn't leave a large gap before the content, and adds right padding to the content area for viewports where the "On this page" TOC rail is hidden.
- Updates the release checklist in `CLAUDE.md` so `docs/changelog.mdx` is kept in sync with every future release, including a copy-review pass for readability.

## Test plan
- [x] Verified locally with `mintlify dev` — checked both light and dark mode, confirmed the badge, spacing, and nav placement render correctly
- [x] Validated `docs/docs.json` is well-formed JSON
- [x] Confirmed Mintlify's hosted preview build succeeds — https://stenoai-fade6014-williamdrewett-mintlify-changelog.mintlify.site

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public `/changelog` page to the Mintlify docs (last 10 releases) and surfaces it in the global anchor rail and on the homepage. Also fixes dark‑mode visibility and spacing for the `<Update>` component, and updates `CLAUDE.md` so the page stays in sync each release.

- **New Features**
  - New `/changelog` page covering v0.4.2–v0.5.8, grouped under New / Improved / Fixed / Known Issues.
  - "Changelog" added to global anchors and a homepage card for quick access.

- **Bug Fixes**
  - `<Update>` version badge now readable in dark mode.
  - Tightened label/date column and gap; added right padding when the TOC is hidden.

<sup>Written for commit 4fdd0d85f02bb3e433113237f5a671117aca69ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->