### PR TITLE
ci(release): auto-announce releases to Discord

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -273,3 +273,25 @@ jobs:
           release/*.yaml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Announce the release in Discord. Lives here (not a separate
+    # `on: release: published` workflow) because the release above is created
+    # with GITHUB_TOKEN, and GitHub does NOT fire downstream workflow triggers
+    # for GITHUB_TOKEN-authored events — so a standalone announce workflow would
+    # never run. continue-on-error + the script's no-webhook no-op guarantee a
+    # Discord problem can never fail the actual release. No-ops until the
+    # DISCORD_WEBHOOK_URL repo secret is set (so forks stay quiet).
+    - name: Setup Node.js (Discord announce)
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Announce release on Discord
+      if: startsWith(github.ref, 'refs/tags/v')
+      continue-on-error: true
+      env:
+        DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        VERSION: ${{ github.event.inputs.version || steps.package_version.outputs.version }}
+        RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version || steps.package_version.outputs.version }}
+        RELEASE_NOTES: ${{ steps.tag_body.outputs.text }}
+      run: node scripts/discord-release-announce.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,8 @@ Releases are automated via `.github/workflows/build-release.yml`. Never create r
    - Builds signed + notarized DMGs for both arm64 and x64
    - Creates a GitHub Release with the tag message as the body
    - Uploads both DMGs as release assets
-10. Do NOT build DMGs locally for releases, do NOT use `gh release create` manually.
+   - Posts a release announcement to Discord (summary + a few headline features + the contributor thank-you), via the `Announce release on Discord` step (`scripts/discord-release-announce.mjs`). This is automatic and requires no manual Discord post. It no-ops unless the `DISCORD_WEBHOOK_URL` repo secret is set (an incoming webhook for the announcements channel), and is `continue-on-error` so a Discord hiccup never fails the release.
+10. Do NOT build DMGs locally for releases, do NOT use `gh release create` manually. Do NOT post the Discord release announcement by hand — the workflow does it.
 
 ## Session Logging
 When the user says "log session" or similar (e.g., "update session log", "document this session"):

--- a/scripts/discord-release-announce.mjs
+++ b/scripts/discord-release-announce.mjs
@@ -102,11 +102,21 @@ if (process.env.DISCORD_DRY_RUN === '1') {
   process.exit(0);
 }
 
-const res = await fetch(webhook, {
-  method: 'POST',
-  headers: { 'content-type': 'application/json' },
-  body: JSON.stringify(payload),
-});
+let res;
+try {
+  res = await fetch(webhook, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+} catch (err) {
+  // Transport-level failure (DNS, timeout, connection refused) rejects the
+  // fetch promise — handle it the same as an HTTP error so a network hiccup
+  // logs cleanly and exits 0 rather than surfacing as an unhandled rejection
+  // (the design intent is to NEVER fail the release).
+  console.error(`Discord webhook request failed: ${err?.message || err}`);
+  process.exit(0);
+}
 
 if (!res.ok) {
   const body = await res.text().catch(() => '');

--- a/scripts/discord-release-announce.mjs
+++ b/scripts/discord-release-announce.mjs
@@ -78,17 +78,25 @@ function truncate(s, n) {
   return s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s;
 }
 
-// Assemble the embed description (Discord markdown; 4096-char cap — we're well under).
+// Casual @here greeting lives in `content` — embeds can't ping, so a mention
+// only fires from the message body. allowed_mentions lets the @here actually
+// notify the channel (webhooks otherwise won't ping @here/@everyone).
+const greeting = `🚀 Hey @here — **Steno v${version}** is out!`;
+
+// The embed carries the substance: summary, headline features, contributor
+// thanks, and a link to the full notes.
 const parts = [truncate(summary, 300)];
-if (features.length) parts.push(`**What's new**\n${features.join('\n')}`);
-if (contributors) parts.push(`**${contributors}**`);
-parts.push(`[Download & full release notes →](${releaseUrl})`);
+if (features.length) parts.push(`**A bunch of great features:**\n${features.join('\n')}`);
+if (contributors) parts.push(contributors);
+parts.push(`[Full release notes →](${releaseUrl})`);
 
 const payload = {
   username: 'Steno Releases',
+  content: greeting,
+  allowed_mentions: { parse: ['everyone'] }, // enables the @here ping
   embeds: [
     {
-      title: `📢 Steno v${version} is out`,
+      title: `Steno v${version}`,
       url: releaseUrl,
       description: parts.join('\n\n'),
       color: 0x1b1b19, // brand ink

--- a/scripts/discord-release-announce.mjs
+++ b/scripts/discord-release-announce.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Posts a release announcement to a Discord channel via an incoming webhook.
+// Invoked from the `release` job in .github/workflows/build-release.yml right
+// after the GitHub Release is created, so every tagged release announces itself
+// — the same brief note + a few headline features + a contributor thank-you the
+// maintainer used to post by hand.
+//
+// It NEVER fails the release: if the webhook secret is absent (forks, or before
+// the secret is configured) it logs and exits 0, and the workflow step also runs
+// with continue-on-error as a second belt.
+//
+// Inputs (env):
+//   DISCORD_WEBHOOK_URL  the channel's incoming-webhook URL (a repo secret)
+//   VERSION              e.g. "0.6.0" (no leading v)
+//   RELEASE_URL          canonical release page URL
+//   RELEASE_NOTES        the annotated-tag body (the notes we authored)
+//
+// Notes format it parses (see the release notes we write on the tag):
+//   <one-line summary>
+//   ### <Section>
+//   - **<Feature>** — <description>
+//   ...
+//   ### Thanks to our contributors
+//   <paragraph crediting @handles>
+
+const webhook = process.env.DISCORD_WEBHOOK_URL?.trim();
+const version = process.env.VERSION?.trim() || '';
+const releaseUrl = process.env.RELEASE_URL?.trim() || '';
+const notes = process.env.RELEASE_NOTES ?? '';
+
+if (!webhook) {
+  console.log('DISCORD_WEBHOOK_URL not set — skipping Discord announcement.');
+  process.exit(0);
+}
+
+const lines = notes.split('\n').map((l) => l.replace(/\r$/, ''));
+
+// 1. Summary = the first non-empty line that isn't a heading or a bullet.
+const summary =
+  lines.find((l) => {
+    const t = l.trim();
+    return t && !t.startsWith('#') && !t.startsWith('-') && !t.startsWith('>');
+  })?.trim() || `Steno v${version} is out.`;
+
+// 2. Headline features = the first few "- **Name** — desc" bullets, skipping the
+//    "Upgrade notes" and "Thanks to our contributors" sections (not features).
+const featureBullets = [];
+let section = '';
+for (const line of lines) {
+  const h = line.match(/^###\s+(.*)$/);
+  if (h) {
+    section = h[1].trim().toLowerCase();
+    continue;
+  }
+  if (section.includes('upgrade') || section.includes('contributor')) continue;
+  const m = line.match(/^-\s+\*\*(.+?)\*\*\s*(?:[—-]\s*(.*))?$/);
+  if (m) {
+    const name = m[1].trim();
+    const desc = (m[2] || '').trim().replace(/\s+/g, ' ');
+    featureBullets.push(desc ? `• **${name}** — ${truncate(desc, 140)}` : `• **${name}**`);
+  }
+}
+const features = featureBullets.slice(0, 4);
+
+// 3. Contributors = the paragraph under the "Thanks to our contributors" heading.
+let contributors = '';
+const thanksIdx = lines.findIndex((l) => /^###\s+.*contributor/i.test(l));
+if (thanksIdx !== -1) {
+  const rest = [];
+  for (let i = thanksIdx + 1; i < lines.length; i++) {
+    if (/^###\s+/.test(lines[i])) break;
+    if (lines[i].trim()) rest.push(lines[i].trim());
+  }
+  contributors = rest.join(' ').trim();
+}
+
+function truncate(s, n) {
+  return s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s;
+}
+
+// Assemble the embed description (Discord markdown; 4096-char cap — we're well under).
+const parts = [truncate(summary, 300)];
+if (features.length) parts.push(`**What's new**\n${features.join('\n')}`);
+if (contributors) parts.push(`**${contributors}**`);
+parts.push(`[Download & full release notes →](${releaseUrl})`);
+
+const payload = {
+  username: 'Steno Releases',
+  embeds: [
+    {
+      title: `📢 Steno v${version} is out`,
+      url: releaseUrl,
+      description: parts.join('\n\n'),
+      color: 0x1b1b19, // brand ink
+    },
+  ],
+};
+
+// DISCORD_DRY_RUN=1 prints the payload without posting — for local testing.
+if (process.env.DISCORD_DRY_RUN === '1') {
+  console.log(JSON.stringify(payload, null, 2));
+  process.exit(0);
+}
+
+const res = await fetch(webhook, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(payload),
+});
+
+if (!res.ok) {
+  const body = await res.text().catch(() => '');
+  // Don't hard-fail the release over a Discord hiccup — log and exit 0.
+  console.error(`Discord webhook returned ${res.status}: ${body}`);
+  process.exit(0);
+}
+console.log(`Announced Steno v${version} to Discord.`);


### PR DESCRIPTION
## Summary

Automates the Discord release announcement you currently post by hand. On every tagged release, the `release` job now posts an embed to a Discord channel webhook with the one-line summary, up to 4 headline features, and the contributor thank-you — all parsed from the annotated-tag release notes.

## How it works
- New `scripts/discord-release-announce.mjs` parses the tag notes (summary line, `- **Feature** — …` bullets, and the `### Thanks to our contributors` paragraph) and POSTs a Discord webhook embed.
- New **Announce release on Discord** step in `.github/workflows/build-release.yml`'s `release` job, right after the GitHub Release is created.

## Why a step, not a separate `on: release: published` workflow
The release is created with `GITHUB_TOKEN`, and GitHub **does not fire downstream workflow triggers for `GITHUB_TOKEN`-authored events** — a standalone announce workflow would never run. Putting the step in the same job sidesteps that.

## Safety
- `continue-on-error: true` on the step **and** a no-webhook no-op in the script → a Discord problem can **never** fail the actual DMG release.
- **Inert until configured**: no `DISCORD_WEBHOOK_URL` secret ⇒ it logs "skipping" and exits 0 (forks stay quiet).

## One-time setup (required for it to actually post)
1. In Discord: **announcements channel → Edit Channel → Integrations → Webhooks → New Webhook**, copy the URL.
2. Add it as a repo secret named **`DISCORD_WEBHOOK_URL`** (`gh secret set DISCORD_WEBHOOK_URL`, or Settings → Secrets and variables → Actions).

## Preview (dry-run against the real v0.6.0 notes)
`DISCORD_DRY_RUN=1 node scripts/discord-release-announce.mjs` renders:
> 📢 **Steno v0.6.0 is out**
> Recording that gets out of your way — a docked transcription pill, instant stop, continue-recording, and a My notes tab…
> **What's new** • Transcription pill dock • Instant stop • Continue recording • My notes tab
> **This release includes work from @Optic00, @WilliamDrewett, @Vassista, @luchfilip, and @valentinweyer. 🙏**
> [Download & full release notes →]

## Notes / follow-ups
- Contributor `@handles` are **GitHub** handles, so on Discord they render as plain text (not real pings) — same as the manual post. Real Discord pings would need a GitHub→Discord user map + bot (happy to add if you want).
- This posts into the channel; auto-**crossposting** an Announcement (News) channel to following servers needs a bot token + the crosspost API — can add as a follow-up if you use a News channel.

Documented in CLAUDE.md release process (step 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically announces each tagged release to Discord via a webhook. Sends a friendly @here ping with a branded embed: summary, up to 4 headline features, and the contributor thank‑you — replacing the manual post.

- **New Features**
  - Added `scripts/discord-release-announce.mjs` and an “Announce release on Discord” step in `.github/workflows/build-release.yml`; posts “🚀 Hey @here — Steno vX is out!” in message content (with `allowed_mentions`) and an embed with the summary, features, thanks, and a full notes link. Lives in the `release` job to avoid `GITHUB_TOKEN` trigger limits.
  - Safe by default: `continue-on-error`, no‑op if the webhook is missing, and network/webhook failures are caught and logged (exit 0); use `DISCORD_DRY_RUN=1` to print the payload for local testing.

- **Migration**
  - Create a Discord channel webhook and copy its URL.
  - Add it as the `DISCORD_WEBHOOK_URL` repo secret.

<sup>Written for commit 22caf12d76a7221f1112fe9cb3068e70ac4c41d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

