### PR TITLE
fix: keep transcript continuity + hide notes CTA on resume

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -237,6 +237,26 @@ function install({ ipcMain }) {
       sessionName: rec.active || rec.processing ? rec.sessionName : null,
     }),
 
+    // Live transcript backfill. Real main.js populates liveTranscriptState from
+    // the ASR sidecar (a model) — unreachable in T1 — so we seed it here. With
+    // STENOAI_E2E_SEED_PRIOR_SEGMENTS=1 it returns carried-over priorSegments
+    // (the resume/continue case) so the generate-notes-bar T1 can assert the
+    // live bar shows earlier speech instead of starting blank.
+    'get-live-transcript-state': async () => ({
+      success: true,
+      sessionName: rec.active || rec.processing ? rec.sessionName : null,
+      segments: [],
+      priorSegments:
+        process.env.STENOAI_E2E_SEED_PRIOR_SEGMENTS === '1' && (rec.active || rec.processing)
+          ? [
+              { text: 'earlier bit one', start: 3, end: 5, isFinal: true, speaker: 'You' },
+              { text: 'earlier bit two', start: 6, end: 8, isFinal: true, speaker: 'Others' },
+            ]
+          : [],
+      ready: true,
+      error: null,
+    }),
+
     // Engine is static per launch; STENOAI_E2E_MOCK_ENGINE lets the pill-dock
     // T1 drive the Whisper variant (no live transcript, inline pause/resume).
     'get-transcription-engine': async () => ({

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -167,6 +167,10 @@ function install({ ipcMain }) {
     paused: false,
     processing: false,
     sessionName: null,
+    // The append/resume target (summary file) of the active recording, mirrored
+    // into get-queue-status.recordingSummaryFile so the detail view can match
+    // "recording this note" by identity (not display name).
+    appendTo: null,
     startedAt: 0,
     pausedAt: 0,
   };
@@ -185,17 +189,19 @@ function install({ ipcMain }) {
   // real ipcMain.handle callback. Mirror the real handlers' return shapes from
   // app/main.js (get-ai-provider ~5950, org-* ~7990).
   const MOCKS = {
-    'start-recording-ui': async (_event, name) => {
+    'start-recording-ui': async (_event, name, _trigger, appendTo) => {
       rec.active = true;
       rec.paused = false;
       rec.processing = false;
       rec.sessionName = name && String(name).trim() ? String(name).trim() : 'Note';
+      rec.appendTo = appendTo && String(appendTo).trim() ? String(appendTo).trim() : null;
       rec.startedAt = Date.now();
       return { success: true, sessionName: rec.sessionName };
     },
     'stop-recording-ui': async () => {
       rec.active = false;
       rec.paused = false;
+      rec.appendTo = null;
       // Park in "processing" — T1 has no backend to complete it; the spec only
       // asserts the renderer's optimistic transition to the processing dock.
       rec.processing = true;
@@ -235,6 +241,7 @@ function install({ ipcMain }) {
         ? Math.floor(((rec.paused ? rec.pausedAt : Date.now()) - rec.startedAt) / 1000)
         : 0,
       sessionName: rec.active || rec.processing ? rec.sessionName : null,
+      recordingSummaryFile: rec.active ? rec.appendTo : null,
     }),
 
     // Live transcript backfill. Real main.js populates liveTranscriptState from

--- a/app/main.js
+++ b/app/main.js
@@ -3533,7 +3533,15 @@ ipcMain.handle('get-queue-status', async () => {
       : (isProcessing && currentProcessingStartedAtMs
           ? Math.floor((Date.now() - currentProcessingStartedAtMs) / 1000)
           : 0),
-    sessionName: currentRecordingSessionName
+    sessionName: currentRecordingSessionName,
+    // The note (summary-file realpath) an active continue/resume is recording
+    // INTO, so the renderer can tell "recording this note" from "recording a
+    // different one" by identity rather than by the (collidable) display name.
+    // Null for a fresh new-note recording (no existing target) or when idle.
+    recordingSummaryFile:
+      (currentRecordingProcess !== null || systemAudioRecordingActive)
+        ? (currentRecordingAppendTarget || null)
+        : null,
   };
 });
 
@@ -3928,6 +3936,13 @@ let processingQueue = [];
 // to load, MLX missing, etc.) for the UI to surface.
 let liveTranscriptState = {
   sessionName: null,
+  // The note (summary-file realpath) this buffer belongs to, used to decide
+  // whether a resume/continue is continuing THIS note (carry its prior
+  // segments) or a different one (start fresh). Set at start for appends and
+  // stamped at stop for a fresh recording once its landing note is known — so
+  // matching on it is unambiguous even when two notes share the default "Note"
+  // name (session name alone would collide).
+  summaryFile: null,
   segments: [],
   // Display-only carry-over: the finalised segments from the PREVIOUS
   // recording into this same note, preserved across a resume/continue so the
@@ -4793,16 +4808,22 @@ ipcMain.handle('start-recording-ui', async (_, sessionName, trigger, appendTo) =
     // On a resume/continue into the SAME note, preserve the previous session's
     // finalised segments as display-only `priorSegments` so the live bar shows
     // the earlier speech instead of starting blank. Guarded on the append
-    // target + matching session name so an intervening recording of a
-    // different note can't leak its segments in; falls back to empty when the
-    // in-memory state is a fresh app launch or a different session.
+    // target matching the note the previous buffer belonged to (summary-file
+    // identity, not the display name — two "Note"-named notes would collide);
+    // falls back to empty on a fresh launch or a different note. Prepends any
+    // existing priorSegments so a SECOND continue keeps the first recording's
+    // carried-over text as well, not just the latest tail.
     const carryPrior =
       currentRecordingAppendTarget &&
-      liveTranscriptState.sessionName === actualSessionName
-        ? (liveTranscriptState.segments || []).filter((s) => s && s.isFinal && s.text)
+      liveTranscriptState.summaryFile === currentRecordingAppendTarget
+        ? [
+            ...(liveTranscriptState.priorSegments || []),
+            ...(liveTranscriptState.segments || []).filter((s) => s && s.isFinal && s.text),
+          ]
         : [];
     liveTranscriptState = {
       sessionName: actualSessionName,
+      summaryFile: currentRecordingAppendTarget || null,
       segments: [],
       priorSegments: carryPrior,
       ready: false,
@@ -5027,6 +5048,14 @@ ipcMain.handle('stop-recording-ui', async () => {
     // case a race (renderer torn down / recorder errored before reporting) left
     // it stuck true. Closing the live sidecar lets Python drain its final
     // utterance; a watchdog SIGTERM in stopLiveTranscribe covers stuck cases.
+    // Stamp the buffer with the note it landed on (fresh recordings only learn
+    // their summary file here). A later resume/continue matches on this to
+    // decide whether to carry the prior segments over — see the carry guard in
+    // start-recording-ui. Skipped when there's no landing note (Whisper/import
+    // → no live buffer to carry anyway).
+    if (instantSummaryFile) {
+      liveTranscriptState.summaryFile = instantSummaryFile;
+    }
     systemAudioRecordingActive = false;
     stopLiveTranscribe();
     currentRecordingSessionName = null;

--- a/app/main.js
+++ b/app/main.js
@@ -3584,6 +3584,7 @@ ipcMain.handle('get-live-transcript-state', async () => {
     success: true,
     sessionName: liveTranscriptState.sessionName,
     segments: liveTranscriptState.segments.slice(),
+    priorSegments: (liveTranscriptState.priorSegments || []).slice(),
     ready: liveTranscriptState.ready,
     error: liveTranscriptState.error,
   };
@@ -3928,6 +3929,15 @@ let processingQueue = [];
 let liveTranscriptState = {
   sessionName: null,
   segments: [],
+  // Display-only carry-over: the finalised segments from the PREVIOUS
+  // recording into this same note, preserved across a resume/continue so the
+  // live bar shows earlier speech instead of starting blank. Kept SEPARATE
+  // from `segments` on purpose — the resumed sidecar restarts its clock at 0,
+  // so folding these into the chronologically-sorted `segments` would misorder
+  // them, and including them in the stop-time snapshot/append would duplicate
+  // text the note already holds on disk. Rendered before the live tail; never
+  // fed to the snapshot/placeholder/append pipeline.
+  priorSegments: [],
   ready: false,
   error: null,
 };
@@ -4780,9 +4790,21 @@ ipcMain.handle('start-recording-ui', async (_, sessionName, trigger, appendTo) =
     // success / clears it on failure.
     systemAudioRecordingActive = true;
     // Reset the live transcript buffer before the sidecar starts emitting.
+    // On a resume/continue into the SAME note, preserve the previous session's
+    // finalised segments as display-only `priorSegments` so the live bar shows
+    // the earlier speech instead of starting blank. Guarded on the append
+    // target + matching session name so an intervening recording of a
+    // different note can't leak its segments in; falls back to empty when the
+    // in-memory state is a fresh app launch or a different session.
+    const carryPrior =
+      currentRecordingAppendTarget &&
+      liveTranscriptState.sessionName === actualSessionName
+        ? (liveTranscriptState.segments || []).filter((s) => s && s.isFinal && s.text)
+        : [];
     liveTranscriptState = {
       sessionName: actualSessionName,
       segments: [],
+      priorSegments: carryPrior,
       ready: false,
       error: null,
     };

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -1,19 +1,8 @@
 import * as React from 'react';
-import {
-  Check,
-  ChevronDown,
-  Copy,
-  Play,
-  Search as SearchIcon,
-  Square,
-} from 'lucide-react';
+import { Check, ChevronDown, Copy, Play, Search as SearchIcon, Square } from 'lucide-react';
 import { AudioWave } from '@/components/AudioWave';
 import { Input } from '@/components/ui/input';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { useLiveTranscript } from '@/hooks/useLiveTranscript';
 import { useRecording } from '@/hooks/useRecording';
@@ -56,7 +45,16 @@ export function LiveTranscriptBar() {
   const isRecording = recording.status === 'recording';
   const stopped = !paused && !isRecording;
 
-  const { status, segments, error, slow } = useLiveTranscript(sessionName);
+  const { status, segments, priorSegments, error, slow } = useLiveTranscript(sessionName);
+
+  // On a resume/continue, prior finalised segments render before the live
+  // tail so the bar shows earlier speech instead of starting blank. Merge for
+  // search/copy/scroll; a divider marks the boundary (only when unfiltered,
+  // where the first priorSegments.length rows are the carried-over ones).
+  const allSegments = React.useMemo(
+    () => (priorSegments.length ? [...priorSegments, ...segments] : segments),
+    [priorSegments, segments]
+  );
 
   const open = useLiveTranscriptOpen((s) => s.open);
   const setOpen = useLiveTranscriptOpen((s) => s.setOpen);
@@ -73,23 +71,23 @@ export function LiveTranscriptBar() {
   // were browsing past matches and a jump to the new tail would yank the
   // viewport away from what they were reading. They get the new segment
   // automatically once they clear the query.
-  const tailText = segments[segments.length - 1]?.text ?? '';
+  const tailText = allSegments[allSegments.length - 1]?.text ?? '';
   const filtering = query.trim().length > 0;
   React.useEffect(() => {
     if (filtering) return;
     const el = bodyRef.current;
     if (!el || !open) return;
     el.scrollTop = el.scrollHeight;
-  }, [segments.length, tailText, open, filtering]);
+  }, [allSegments.length, tailText, open, filtering]);
 
   const filtered = React.useMemo(() => {
-    if (!query.trim()) return segments;
+    if (!query.trim()) return allSegments;
     const needle = query.trim().toLowerCase();
-    return segments.filter((s) => s.text.toLowerCase().includes(needle));
-  }, [segments, query]);
+    return allSegments.filter((s) => s.text.toLowerCase().includes(needle));
+  }, [allSegments, query]);
 
   const copyAll = React.useCallback(async () => {
-    const text = segments
+    const text = allSegments
       .filter((s) => s.isFinal)
       .map((s) => s.text.trim())
       .filter(Boolean)
@@ -98,7 +96,7 @@ export function LiveTranscriptBar() {
     await navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
-  }, [segments]);
+  }, [allSegments]);
 
   const onPauseToggle = () => {
     if (paused) void recording.resumeRecording();
@@ -116,10 +114,7 @@ export function LiveTranscriptBar() {
 
   return (
     <div className="pointer-events-auto" data-testid="live-transcript-panel">
-      <div
-        className="mv-transcript open"
-        onMouseDown={(e) => e.stopPropagation()}
-      >
+      <div className="mv-transcript open" onMouseDown={(e) => e.stopPropagation()}>
         {/* Header — wave + "Transcript" + copy + minimize. The minimize
             (chevron) is the primary click target; copy is a sibling
             action button, not nested. (Nesting `<button>` inside `<button>`
@@ -129,7 +124,13 @@ export function LiveTranscriptBar() {
           {/* Static (non-animated) wave for the header — the "is anything
               happening?" cue lives in the footer's recording indicator. */}
           <span className="mv-transcript-wave mv-transcript-wave-static" aria-hidden="true">
-            <span /><span /><span /><span /><span /><span /><span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
           </span>
           <span className="mv-transcript-label">Transcript</span>
           <button
@@ -179,8 +180,9 @@ export function LiveTranscriptBar() {
             status={status}
             error={error}
             segments={filtered}
-            filtering={query.trim().length > 0}
+            filtering={filtering}
             slow={slow}
+            dividerAfter={filtering ? -1 : priorSegments.length}
           />
         </div>
 
@@ -239,16 +241,25 @@ interface BodyStateProps {
   segments: ReturnType<typeof useLiveTranscript>['segments'];
   filtering: boolean;
   slow: boolean;
+  /** Render an "Earlier" divider before this index (the boundary between
+   *  carried-over prior segments and the current session's live tail). -1
+   *  disables it (e.g. while filtering, where the boundary is meaningless). */
+  dividerAfter: number;
 }
 
-function LiveTranscriptBodyState({ status, error, segments, filtering, slow }: BodyStateProps) {
+function LiveTranscriptBodyState({
+  status,
+  error,
+  segments,
+  filtering,
+  slow,
+  dividerAfter,
+}: BodyStateProps) {
   if (status === 'error' && error) {
     return (
       <EmptyState
         title="Live transcription unavailable"
-        subtitle={
-          error.message ? `${error.stage}: ${error.message}` : `Stage: ${error.stage}`
-        }
+        subtitle={error.message ? `${error.stage}: ${error.message}` : `Stage: ${error.stage}`}
       />
     );
   }
@@ -287,32 +298,47 @@ function LiveTranscriptBodyState({ status, error, segments, filtering, slow }: B
     <ul className="flex flex-col gap-0">
       {segments.map((seg, i) => {
         const isYou = seg.speaker !== 'Others';
+        const showDivider = i === dividerAfter && dividerAfter > 0;
         return (
-          <li
-            key={i}
-            className={cn(
-              'flex flex-col gap-0.5 px-1 py-0.5',
-              isYou ? 'items-end' : 'items-start',
+          <React.Fragment key={i}>
+            {showDivider && (
+              <li
+                className="flex items-center gap-2 px-1 py-1.5"
+                aria-hidden="true"
+                data-testid="live-transcript-resume-divider"
+              >
+                <span className="h-px flex-1" style={{ background: 'var(--border-subtle)' }} />
+                <span
+                  className="text-[10px] font-medium uppercase tracking-wide"
+                  style={{ color: 'var(--fg-2)' }}
+                >
+                  Resumed
+                </span>
+                <span className="h-px flex-1" style={{ background: 'var(--border-subtle)' }} />
+              </li>
             )}
-            style={{ opacity: seg.isFinal ? 1 : 0.55 }}
-          >
-            <span
-              className="px-1.5 text-[10.5px] tabular-nums"
-              style={{ color: 'var(--fg-2)' }}
-            >
-              {fmtTimestamp(seg.start)}
-            </span>
-            <div
+            <li
               className={cn(
-                'max-w-[78%] rounded-2xl px-3 py-1.5 text-sm leading-[1.5]',
-                isYou
-                  ? 'bg-green-100 text-green-950 rounded-br-md dark:bg-green-900/40 dark:text-green-100'
-                  : 'bg-neutral-200/80 text-neutral-900 rounded-bl-md dark:bg-neutral-700/60 dark:text-neutral-100',
+                'flex flex-col gap-0.5 px-1 py-0.5',
+                isYou ? 'items-end' : 'items-start'
               )}
+              style={{ opacity: seg.isFinal ? 1 : 0.55 }}
             >
-              {seg.text}
-            </div>
-          </li>
+              <span className="px-1.5 text-[10.5px] tabular-nums" style={{ color: 'var(--fg-2)' }}>
+                {fmtTimestamp(seg.start)}
+              </span>
+              <div
+                className={cn(
+                  'max-w-[78%] rounded-2xl px-3 py-1.5 text-sm leading-[1.5]',
+                  isYou
+                    ? 'bg-green-100 text-green-950 rounded-br-md dark:bg-green-900/40 dark:text-green-100'
+                    : 'bg-neutral-200/80 text-neutral-900 rounded-bl-md dark:bg-neutral-700/60 dark:text-neutral-100'
+                )}
+              >
+                {seg.text}
+              </div>
+            </li>
+          </React.Fragment>
         );
       })}
     </ul>
@@ -373,7 +399,7 @@ function LanguageSelector() {
           type="button"
           className={cn(
             'inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium',
-            'cursor-pointer transition-colors hover:bg-[color:var(--surface-hover)]',
+            'cursor-pointer transition-colors hover:bg-[color:var(--surface-hover)]'
           )}
           style={{ color: 'var(--fg-2)' }}
           aria-label={`Language: ${display}`}
@@ -393,7 +419,7 @@ function LanguageSelector() {
               onClick={() => pick(opt.code)}
               className={cn(
                 'flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left',
-                'cursor-pointer transition-colors hover:bg-[color:var(--surface-hover)]',
+                'cursor-pointer transition-colors hover:bg-[color:var(--surface-hover)]'
               )}
             >
               <span
@@ -432,14 +458,7 @@ function RecordingStatusChip({
       style={{ color: 'var(--fg-1)' }}
     >
       <span style={{ color: 'var(--recording)' }}>
-        <AudioWave
-          active={!paused}
-          paused={paused}
-          bars={7}
-          height={14}
-          barWidth={2}
-          gap={2}
-        />
+        <AudioWave active={!paused} paused={paused} bars={7} height={14} barWidth={2} gap={2} />
       </span>
       <span style={{ color: 'var(--fg-2)' }}>{label}</span>
       <span
@@ -451,4 +470,3 @@ function RecordingStatusChip({
     </span>
   );
 }
-

--- a/app/renderer/src/hooks/useLiveTranscript.ts
+++ b/app/renderer/src/hooks/useLiveTranscript.ts
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import { ipc, type LiveSegment } from '@/lib/ipc';
 
-export type LiveTranscriptStatus =
-  | 'idle'
-  | 'loading'
-  | 'streaming'
-  | 'error';
+export type LiveTranscriptStatus = 'idle' | 'loading' | 'streaming' | 'error';
 
 export interface UseLiveTranscriptResult {
   status: LiveTranscriptStatus;
   segments: LiveSegment[];
+  /** Finalised segments from the previous recording into this same note,
+   *  carried across a resume/continue. Display-only — render these before
+   *  `segments` so the live bar shows the earlier speech instead of blank.
+   *  Empty on a fresh (non-continued) recording. */
+  priorSegments: LiveSegment[];
   /** Last error reported by the Python consumer (model load failure, MLX
    *  missing, etc.). Null on success. */
   error: { stage: string; message?: string } | null;
@@ -57,7 +58,7 @@ function insertLiveSegment(prev: LiveSegment[], segment: LiveSegment): LiveSegme
     // dropping every same-speaker partial indiscriminately would clobber
     // that unrelated one until its next partial tick.
     const remainingPartials = partials.filter(
-      (s) => speakerKey(s) !== key || s.start > segment.end,
+      (s) => speakerKey(s) !== key || s.start > segment.end
     );
     return [...nextFinals, ...remainingPartials];
   }
@@ -86,6 +87,10 @@ function insertLiveSegment(prev: LiveSegment[], segment: LiveSegment): LiveSegme
  */
 export function useLiveTranscript(sessionName: string | null): UseLiveTranscriptResult {
   const [segments, setSegments] = React.useState<LiveSegment[]>([]);
+  // Carried over from the previous recording into this same note. Static for
+  // the session — only the getState backfill populates it (there is no live
+  // event for it), so it's set once and never folded into `segments`.
+  const [priorSegments, setPriorSegments] = React.useState<LiveSegment[]>([]);
   const [ready, setReady] = React.useState(false);
   const [error, setError] = React.useState<{ stage: string; message?: string } | null>(null);
   // Per-session marker that flips true the moment any subscription event
@@ -100,6 +105,7 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
     // event can fire for the new session.
     receivedEventRef.current = false;
     setSegments([]);
+    setPriorSegments([]);
     setReady(false);
     setError(null);
 
@@ -137,6 +143,10 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
       .then((res) => {
         if (cancelled || !res.success) return;
         if (res.sessionName !== sessionName) return;
+        // priorSegments are independent of the live tail (no live event ever
+        // updates them), so apply them even if a chunk raced ahead — the
+        // receivedEventRef guard below only protects the live `segments`.
+        setPriorSegments(res.priorSegments ?? []);
         if (receivedEventRef.current) return;
         // Backfilled segments already carry their true speaker tag —
         // main.js stores it verbatim in liveTranscriptState.segments.
@@ -162,7 +172,7 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
     ? 'error'
     : !sessionName
       ? 'idle'
-      : segments.length > 0 || ready
+      : segments.length > 0 || priorSegments.length > 0 || ready
         ? 'streaming'
         : 'loading';
 
@@ -182,5 +192,5 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
     };
   }, [status, sessionName]);
 
-  return { status, segments, error, slow };
+  return { status, segments, priorSegments, error, slow };
 }

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -42,9 +42,7 @@ function subscribeVisibility(callback: () => void): () => void {
 }
 
 function getVisibilitySnapshot(): boolean {
-  return typeof document !== 'undefined'
-    ? document.visibilityState === 'visible'
-    : true;
+  return typeof document !== 'undefined' ? document.visibilityState === 'visible' : true;
 }
 
 // SSR fallback. Renderer-only today, but keeps useSyncExternalStore happy.
@@ -56,7 +54,7 @@ function useIsWindowVisible(): boolean {
   return React.useSyncExternalStore(
     subscribeVisibility,
     getVisibilitySnapshot,
-    getVisibilityServerSnapshot,
+    getVisibilityServerSnapshot
   );
 }
 
@@ -162,6 +160,10 @@ export function useRecording() {
         isPaused: false,
         elapsedSeconds: 0,
         sessionName: optimisticName,
+        // Reflect the resume/continue target immediately so a detail view's
+        // "recording this note" gate flips on click, not a poll later. The
+        // next queue poll reconciles it (null for a fresh new-note start).
+        recordingSummaryFile: appendTo ?? null,
       });
       // No navigation: recording coexists with the app. PrimaryDock keys off
       // the optimistic status flip above and docks the transcription pill on
@@ -185,12 +187,12 @@ export function useRecording() {
         // flashes out with no explanation. Route it through the same native
         // notification the renderer-capture failure path uses.
         ipc().recording.reportCaptureError(
-          err instanceof Error ? err.message : 'Recording could not start',
+          err instanceof Error ? err.message : 'Recording could not start'
         );
         throw err;
       }
     },
-    [qc],
+    [qc]
   );
 
   const stopRecording = React.useCallback(async () => {
@@ -251,6 +253,10 @@ export function useRecording() {
     // otherwise Home goes blank between "stopped" and "processed" and the
     // user can't see anything is happening in the background.
     sessionName: queue.data?.sessionName ?? queue.data?.currentJob ?? null,
+    /** The note (summary-file realpath) an active continue/resume is recording
+     *  INTO — lets a detail view match by identity rather than the collidable
+     *  display name. Null for a fresh new-note recording or when idle. */
+    recordingSummaryFile: queue.data?.recordingSummaryFile ?? null,
     /** Set of summary files whose `reprocess-meeting` IPC is currently
      *  in flight. Used by useMeetings to flip the matching existing
      *  meeting rows' `is_processing` flag so Home shows the badge even
@@ -352,9 +358,7 @@ export function useRecordingProcessingEffects() {
         const newSummaryFile = newMeeting.session_info.summary_file;
         qc.setQueryData<Meeting[]>(meetingsKeys.list(), (prev) => {
           if (!prev) return [newMeeting];
-          const filtered = prev.filter(
-            (m) => m.session_info.summary_file !== newSummaryFile,
-          );
+          const filtered = prev.filter((m) => m.session_info.summary_file !== newSummaryFile);
           return [newMeeting, ...filtered];
         });
 

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -104,13 +104,7 @@ export interface CalendarEvent {
   meeting_url?: string;
   description?: string;
   is_all_day?: boolean;
-  response_status?:
-    | 'accepted'
-    | 'declined'
-    | 'tentative'
-    | 'needsAction'
-    | 'organizer'
-    | 'unknown';
+  response_status?: 'accepted' | 'declined' | 'tentative' | 'needsAction' | 'organizer' | 'unknown';
   color?: string;
 }
 
@@ -667,6 +661,11 @@ export interface LiveSegment {
 export type LiveTranscriptStateResponse = Result<{
   sessionName: string | null;
   segments: LiveSegment[];
+  /** Finalised segments carried over from the previous recording into this
+   *  same note on a resume/continue. Display-only — rendered before the live
+   *  tail so the bar shows earlier speech instead of starting blank. Static
+   *  for the session's lifetime; empty on a fresh (non-continued) recording. */
+  priorSegments?: LiveSegment[];
   /** True once the Python side has loaded the Parakeet model. Before this
    *  flips, the UI should show a model-loading state instead of an empty
    *  "no speech yet" panel — the difference matters for first-launch UX. */
@@ -828,10 +827,19 @@ export interface StenoaiBridge {
       Result<{ message: string }>
     >;
     saveNotes: RequestFn<[name: string, notes: string], SaveMeetingNotesResponse>;
-    exportTranscript: RequestFn<[defaultFilename: string, content: string], Result<{ path: string }>>;
+    exportTranscript: RequestFn<
+      [defaultFilename: string, content: string],
+      Result<{ path: string }>
+    >;
     regenTitle: RequestFn<[summaryFile: string, name: string], Result<Record<string, never>>>;
-    generateReport: RequestFn<[summaryFile: string, templateId: string], Result<{ message: string }>>;
-    setActiveReport: RequestFn<[summaryFile: string, reportId: string], Result<Record<string, never>>>;
+    generateReport: RequestFn<
+      [summaryFile: string, templateId: string],
+      Result<{ message: string }>
+    >;
+    setActiveReport: RequestFn<
+      [summaryFile: string, reportId: string],
+      Result<Record<string, never>>
+    >;
     deleteReport: RequestFn<[summaryFile: string, reportId: string], Result<Record<string, never>>>;
   };
 
@@ -854,10 +862,7 @@ export interface StenoaiBridge {
     updateIcon: RequestFn<[id: string, icon: string], Result<Record<string, never>>>;
     delete: RequestFn<[id: string], Result<Record<string, never>>>;
     reorder: RequestFn<[ids: string[]], Result<Record<string, never>>>;
-    addMeeting: RequestFn<
-      [summaryFile: string, folderId: string],
-      Result<Record<string, never>>
-    >;
+    addMeeting: RequestFn<[summaryFile: string, folderId: string], Result<Record<string, never>>>;
     removeMeeting: RequestFn<
       [summaryFile: string, folderId: string],
       Result<Record<string, never>>
@@ -907,7 +912,10 @@ export interface StenoaiBridge {
     getNotifications: RequestFn<[], GetNotificationsResponse>;
     setNotifications: RequestFn<[v: boolean], Result<Record<string, never>>>;
     getTelemetry: RequestFn<[], GetTelemetryResponse>;
-    setTelemetry: RequestFn<[v: boolean, source: TelemetryToggleSource], Result<Record<string, never>>>;
+    setTelemetry: RequestFn<
+      [v: boolean, source: TelemetryToggleSource],
+      Result<Record<string, never>>
+    >;
     getDockIcon: RequestFn<[], GetDockIconResponse>;
     setDockIcon: RequestFn<[v: boolean], Result<Record<string, never>>>;
     getSystemAudio: RequestFn<[], GetSystemAudioResponse>;
@@ -960,7 +968,10 @@ export interface StenoaiBridge {
     setStoragePath: RequestFn<[p: string], Result<Record<string, never>>>;
     pickStorageFolder: RequestFn<[], PickStorageFolderResponse>;
     getAiPrompts: RequestFn<[], GetAiPromptsResponse>;
-    saveDiagnostics: RequestFn<[defaultFilename: string, content: string], Result<{ path: string }>>;
+    saveDiagnostics: RequestFn<
+      [defaultFilename: string, content: string],
+      Result<{ path: string }>
+    >;
   };
 
   ai: {
@@ -1039,7 +1050,12 @@ export interface StenoaiBridge {
     navigateToMeeting: Subscribe<{ summaryFile: string }>;
     trayOpenSettings: Subscribe<void>;
     showQuitDialog: Subscribe<{ type: 'recording' | 'processing'; jobCount?: number }>;
-    showNotification: Subscribe<{ title: string; time: string; meeting_url?: string; attendees?: string }>;
+    showNotification: Subscribe<{
+      title: string;
+      time: string;
+      meeting_url?: string;
+      attendees?: string;
+    }>;
   };
 
   org: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -365,6 +365,11 @@ export interface QueueStatus {
   isPaused: boolean;
   elapsedSeconds: number;
   sessionName: string | null;
+  /** The note (summary-file realpath) an active continue/resume is recording
+   *  INTO — lets a detail view tell "recording this note" from "recording a
+   *  different one" by identity rather than the collidable display name. Null
+   *  for a fresh new-note recording or when idle. */
+  recordingSummaryFile?: string | null;
 }
 
 export type PickAudioFileResponse = Result<{ filePath: string }>;

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -18,21 +18,11 @@ import {
   Trash2,
   Users,
 } from 'lucide-react';
-import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useQueryClient } from '@tanstack/react-query';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { MeetingsShell } from '@/components/MeetingsShell';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectSeparator,
-} from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectSeparator } from '@/components/ui/select';
 import {
   useMeeting,
   useReprocessMeeting,
@@ -61,11 +51,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from '@/components/ui/tooltip';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import {
   useFolders,
   useAddMeetingToFolder,
@@ -80,12 +66,9 @@ import { unwrap } from '@/lib/result';
 import { cn } from '@/lib/utils';
 import { navigate } from '@/lib/router';
 import { stripReasoning } from '@/lib/markdown';
-import {
-  pendingTitleRegens,
-  streamCache,
-  type StreamPhase,
-} from '@/lib/meetingDetailState';
+import { pendingTitleRegens, streamCache, type StreamPhase } from '@/lib/meetingDetailState';
 import { useReprocessBridge } from '@/hooks/reprocessBridgeStore';
+import { useRecording } from '@/hooks/useRecording';
 
 const LAST_OPENED_KEY = 'steno-last-opened-meeting';
 
@@ -123,11 +106,7 @@ export function MeetingDetail({ summaryFile }: MeetingDetailProps) {
           <p className="text-[17px] leading-[1.55]" style={{ color: 'var(--fg-2)' }}>
             {(meeting.error as Error)?.message ?? 'An error occurred loading this note.'}
           </p>
-          <button
-            type="button"
-            className="mv-chip"
-            onClick={() => navigate('/meetings')}
-          >
+          <button type="button" className="mv-chip" onClick={() => navigate('/meetings')}>
             Back to meetings
           </button>
         </div>
@@ -137,11 +116,7 @@ export function MeetingDetail({ summaryFile }: MeetingDetailProps) {
           <p className="text-[17px] leading-[1.55]" style={{ color: 'var(--fg-2)' }}>
             This recording may have been deleted. Pick another from the sidebar.
           </p>
-          <button
-            type="button"
-            className="mv-chip"
-            onClick={() => navigate('/meetings')}
-          >
+          <button type="button" className="mv-chip" onClick={() => navigate('/meetings')}>
             Back to meetings
           </button>
         </div>
@@ -223,7 +198,7 @@ function DetailContent({
     }
   };
   const [titleRegening, setTitleRegening] = React.useState(() =>
-    pendingTitleRegens.has(summaryFile),
+    pendingTitleRegens.has(summaryFile)
   );
   const [prevSummaryFile, setPrevSummaryFile] = React.useState(summaryFile);
   if (summaryFile !== prevSummaryFile) {
@@ -274,7 +249,9 @@ function DetailContent({
   const cached = streamCache.get(summaryFile);
   const [streamText, setStreamText] = React.useState(cached?.text ?? '');
   const [streamPhase, setStreamPhase] = React.useState<StreamPhase>(cached?.phase ?? 'idle');
-  const [chunkProgress, setChunkProgress] = React.useState<{ step: number; total: number } | null>(null);
+  const [chunkProgress, setChunkProgress] = React.useState<{ step: number; total: number } | null>(
+    null
+  );
   const [reprocessFailed, setReprocessFailed] = React.useState(false);
   const qc = useQueryClient();
 
@@ -283,15 +260,17 @@ function DetailContent({
   // active_report so reopening a note lands on whatever was last viewed.
   const reports = meeting.reports ?? [];
   const [activeReportId, setActiveReportId] = React.useState<string | null>(
-    meeting.active_report ?? null,
+    meeting.active_report ?? null
   );
-  const [prevMeetingReport, setPrevMeetingReport] = React.useState<string | null>(meeting.active_report ?? null);
+  const [prevMeetingReport, setPrevMeetingReport] = React.useState<string | null>(
+    meeting.active_report ?? null
+  );
   if ((meeting.active_report ?? null) !== prevMeetingReport) {
     setPrevMeetingReport(meeting.active_report ?? null);
     setActiveReportId(meeting.active_report ?? null);
   }
   const activeReport = activeReportId
-    ? reports.find((r) => r.id === activeReportId) ?? null
+    ? (reports.find((r) => r.id === activeReportId) ?? null)
     : null;
   // When a report generation finishes, summaryComplete fires for THIS meeting
   // and we want to land on the freshly-created report. The IPC stream doesn't
@@ -339,12 +318,10 @@ function DetailContent({
       // (the backend marks it active) once the fresh detail payload arrives.
       if (generatingReportRef.current) {
         generatingReportRef.current = false;
-        void qc
-          .invalidateQueries({ queryKey: meetingsKeys.detail(summaryFile) })
-          .then(() => {
-            const fresh = qc.getQueryData<Meeting>(meetingsKeys.detail(summaryFile));
-            if (fresh?.active_report) setActiveReportId(fresh.active_report);
-          });
+        void qc.invalidateQueries({ queryKey: meetingsKeys.detail(summaryFile) }).then(() => {
+          const fresh = qc.getQueryData<Meeting>(meetingsKeys.detail(summaryFile));
+          if (fresh?.active_report) setActiveReportId(fresh.active_report);
+        });
         setChunkProgress(null);
         setTimeout(() => {
           setStreamText('');
@@ -420,7 +397,7 @@ function DetailContent({
           setChunkProgress(null);
           streamCache.delete(summaryFile);
         },
-      },
+      }
     );
   };
 
@@ -461,7 +438,7 @@ function DetailContent({
           streamCache.delete(summaryFile);
           setReprocessFailed(true);
         },
-      },
+      }
     );
   };
 
@@ -508,7 +485,7 @@ function DetailContent({
     try {
       const res = await ipc().meetings.exportTranscript(
         defaultExportFilename(meeting),
-        transcriptBundle,
+        transcriptBundle
       );
       if (!res.success && res.error !== EXPORT_CANCELED_ERROR) {
         setExportError(`Couldn't save transcript: ${res.error || 'unknown error'}`);
@@ -536,7 +513,7 @@ function DetailContent({
         actionItems: asStringArray(meeting.action_items),
         participants: asStringArray(meeting.participants),
       },
-      activeReport ? { content: stripReasoning(activeReport.content) } : null,
+      activeReport ? { content: stripReasoning(activeReport.content) } : null
     );
     void navigator.clipboard.writeText(text);
     setCopied(true);
@@ -560,6 +537,18 @@ function DetailContent({
   // "finishing up" affordance and suppress the Generate-notes CTA until the
   // pipeline completes (or clears the flag on failure).
   const isProcessing = meeting.session_info.processing === true;
+  // While a recording is live on THIS note (resume/continue), the transcript
+  // is still growing — offering "Generate notes" mid-recording would summarise
+  // a moving target and strand the CTA once it finishes. Suppress it until the
+  // recording is stopped. Matched by session name (the same identity the
+  // live-transcript chunk filter uses); a recording on a *different* note
+  // leaves this note's CTA untouched.
+  const recording = useRecording();
+  const isRecordingThisNote =
+    recording.status !== 'idle' &&
+    recording.status !== 'processing' &&
+    recording.sessionName != null &&
+    recording.sessionName === info.name;
 
   // Publish this note's reprocess trigger + streaming state so the floating
   // GenerateNotesBar (mounted at App level, above the Ask bar) drives THIS
@@ -572,7 +561,11 @@ function DetailContent({
   // trigger must not offer "Generate notes" for it either (#313 review —
   // reprocess on a failed note exits non-zero and strands the UI).
   const summaryPending =
-    notesNotGenerated && !transcriptionFailed && !isProcessing && Boolean(meeting.transcript);
+    notesNotGenerated &&
+    !transcriptionFailed &&
+    !isProcessing &&
+    !isRecordingThisNote &&
+    Boolean(meeting.transcript);
   // A continued note (continue-recording appended a segment after notes were
   // generated): the summary no longer covers the transcript — offer the same
   // floating "Generate notes" CTA. reprocess clears the flag on rewrite.
@@ -580,6 +573,7 @@ function DetailContent({
     meeting.session_info.notes_stale === true &&
     !transcriptionFailed &&
     !isProcessing &&
+    !isRecordingThisNote &&
     Boolean(meeting.transcript);
   const reprocessStreaming = reprocess.isPending || streamPhase !== 'idle';
   const startReprocessRef = React.useRef(startReprocess);
@@ -666,7 +660,11 @@ function DetailContent({
                   onClick={() => void copyTranscriptForAi()}
                   disabled={!transcriptBundle}
                 >
-                  {copiedTranscript ? <Check className="size-[13px]" /> : <FileText className="size-[13px]" />}
+                  {copiedTranscript ? (
+                    <Check className="size-[13px]" />
+                  ) : (
+                    <FileText className="size-[13px]" />
+                  )}
                 </ActionIconButton>
               </TooltipTrigger>
               <TooltipContent side="bottom">
@@ -691,7 +689,7 @@ function DetailContent({
                         (reprocess.isPending ||
                           streamPhase === 'analyzing' ||
                           streamPhase === 'generating') &&
-                          'animate-spin',
+                          'animate-spin'
                       )}
                     />
                   </ActionIconButton>
@@ -734,8 +732,8 @@ function DetailContent({
                   <Download className="size-[13px] shrink-0" style={{ color: 'var(--fg-2)' }} />
                   Save transcript as .md…
                 </button>
-                {orgSession.data?.signedIn && (
-                  isShared ? (
+                {orgSession.data?.signedIn &&
+                  (isShared ? (
                     <button
                       type="button"
                       className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50"
@@ -767,8 +765,7 @@ function DetailContent({
                           ? `Share failed: ${shareError}`
                           : `Share with ${orgSession.data.orgId}`}
                     </button>
-                  )
-                )}
+                  ))}
                 <button
                   type="button"
                   className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-[color:var(--surface-hover)]"
@@ -818,16 +815,13 @@ function DetailContent({
               }
             }}
             disabled={
-              titleRegening ||
-              reprocess.isPending ||
-              streamPhase !== 'idle' ||
-              isEditingTitle
+              titleRegening || reprocess.isPending || streamPhase !== 'idle' || isEditingTitle
             }
             aria-label="Regenerate title"
             title="Regenerate title"
             className={cn(
               'inline-flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 disabled:pointer-events-none',
-              titleRegening && 'opacity-100',
+              titleRegening && 'opacity-100'
             )}
             style={{
               verticalAlign: 'middle',
@@ -875,12 +869,8 @@ function DetailContent({
         </h1>
 
         <div className="flex flex-wrap gap-1.5">
-          {date && (
-            <ChipV2 icon={<CalendarIcon className="size-[11px]" />}>{date}</ChipV2>
-          )}
-          {duration && (
-            <ChipV2 icon={<Clock className="size-[11px]" />}>{duration}</ChipV2>
-          )}
+          {date && <ChipV2 icon={<CalendarIcon className="size-[11px]" />}>{date}</ChipV2>}
+          {duration && <ChipV2 icon={<Clock className="size-[11px]" />}>{duration}</ChipV2>}
           <FolderPicker
             summaryFile={summaryFile}
             assignedFolderIds={meeting.folders ?? meeting.session_info.folders ?? []}
@@ -929,207 +919,198 @@ function DetailContent({
       />
 
       {tab === 'summary' && (
-      <>
-      {reprocessFailed && (
-        <section
-          className="flex flex-col items-start gap-2 rounded-lg p-4"
-          style={{
-            background: 'var(--surface-raised)',
-            border: '1px solid var(--border-subtle, var(--surface-raised))',
-          }}
-          data-testid="reprocess-retry"
-        >
-          <div className="text-[15px] font-medium" style={{ color: 'var(--fg-1)' }}>
-            Notes weren’t generated
-          </div>
-          <p
-            className="text-[14px] leading-[1.6]"
-            style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
-          >
-            That didn’t work this time — give it another go. If it keeps failing
-            on a long meeting, switch to a smaller model in Settings.
-          </p>
-          <Button
-            className="mt-1"
-            onClick={startReprocess}
-            disabled={reprocess.isPending || streamPhase !== 'idle'}
-          >
-            Generate notes
-          </Button>
-        </section>
-      )}
-      {streamPhase !== 'idle' ? (
-        <StreamingView text={streamText} phase={streamPhase} chunkProgress={chunkProgress} />
-      ) : activeReport ? (
-        <section
-          className="stream-markdown"
-          data-testid="report-content"
-          style={{ color: 'var(--fg-1)', maxWidth: '72ch' }}
-        >
-          <ReactMarkdown>{stripReasoning(activeReport.content)}</ReactMarkdown>
-        </section>
-      ) : (
-        <div className="flex flex-col gap-9">
-          {transcriptionFailed ? (
-            <section
-              className="flex flex-col gap-2 rounded-lg p-4"
-              style={{
-                background: 'var(--surface-raised)',
-                border: '1px solid var(--border-subtle, var(--surface-raised))',
-              }}
-              data-testid="transcription-failed-notice"
-            >
-              <div
-                className="text-[15px] font-medium"
-                style={{ color: 'var(--fg-1)' }}
-              >
-                Transcription failed
-              </div>
-              <p
-                className="text-[14px] leading-[1.6]"
-                style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
-              >
-                No notes could be generated for this recording. Your audio was
-                preserved (not deleted), so nothing was lost.
-              </p>
-              {transcriptionError && (
-                <p
-                  className="text-[12.5px] leading-[1.5]"
-                  style={{ color: 'var(--fg-2)', opacity: 0.8 }}
-                >
-                  Details: {transcriptionError}
-                </p>
-              )}
-            </section>
-          ) : isProcessing ? (
-            <section
-              className="flex flex-col gap-2 rounded-lg p-4"
-              style={{
-                background: 'var(--surface-raised)',
-                border: '1px solid var(--border-subtle, var(--surface-raised))',
-              }}
-              data-testid="note-processing"
-            >
-              <div
-                className="flex items-center gap-1.5 text-[15px] font-medium"
-                style={{ color: 'var(--fg-1)' }}
-              >
-                Finishing up
-                <span className="thinking-dot" />
-                <span className="thinking-dot" />
-                <span className="thinking-dot" />
-              </div>
-              <p
-                className="text-[14px] leading-[1.6]"
-                style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
-              >
-                Your transcript is captured — refining it and generating notes in
-                the background. You can read and edit <strong>My notes</strong> now.
-              </p>
-            </section>
-          ) : summary ? (
-            <section className="flex flex-col gap-3">
-              <SectionTitle>Summary</SectionTitle>
-              <div data-testid="tab-summary-content">
-                {stripReasoning(summary).split(/\n{2,}/).map((para, i) => (
-                  <p
-                    key={i}
-                    className="text-[15.5px] leading-[1.65]"
-                    style={{ color: 'var(--fg-1)', maxWidth: '64ch' }}
-                  >
-                    {para}
-                  </p>
-                ))}
-              </div>
-            </section>
-          ) : notesNotGenerated && meeting.transcript ? (
+        <>
+          {reprocessFailed && (
             <section
               className="flex flex-col items-start gap-2 rounded-lg p-4"
               style={{
                 background: 'var(--surface-raised)',
                 border: '1px solid var(--border-subtle, var(--surface-raised))',
               }}
-              data-testid="no-notes-yet"
+              data-testid="reprocess-retry"
             >
-              <div
-                className="text-[15px] font-medium"
-                style={{ color: 'var(--fg-1)' }}
-              >
-                No notes yet
+              <div className="text-[15px] font-medium" style={{ color: 'var(--fg-1)' }}>
+                Notes weren’t generated
               </div>
               <p
                 className="text-[14px] leading-[1.6]"
                 style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
               >
-                This recording was transcribed but notes were not generated
-                automatically. Use the <strong>Generate notes</strong> button
-                below to create them, or copy or save the transcript from the
-                actions above.
+                That didn’t work this time — give it another go. If it keeps failing on a long
+                meeting, switch to a smaller model in Settings.
               </p>
+              <Button
+                className="mt-1"
+                onClick={startReprocess}
+                disabled={reprocess.isPending || streamPhase !== 'idle'}
+              >
+                Generate notes
+              </Button>
+            </section>
+          )}
+          {streamPhase !== 'idle' ? (
+            <StreamingView text={streamText} phase={streamPhase} chunkProgress={chunkProgress} />
+          ) : activeReport ? (
+            <section
+              className="stream-markdown"
+              data-testid="report-content"
+              style={{ color: 'var(--fg-1)', maxWidth: '72ch' }}
+            >
+              <ReactMarkdown>{stripReasoning(activeReport.content)}</ReactMarkdown>
             </section>
           ) : (
-            <p className="py-2 text-sm" style={{ color: 'var(--fg-2)' }}>
-              No summary available for this meeting.
-            </p>
-          )}
-
-          {discussionAreas.length > 0 && (
-            <section className="flex flex-col gap-3">
-              <SectionTitle>Key topics</SectionTitle>
-              <div className="mv-topics">
-                {discussionAreas.map((area, i) => (
-                  <div key={i} className="flex flex-col gap-1">
-                    <div className="mv-topic-title">{area.title}</div>
-                    {area.analysis && <div className="mv-topic-body">{area.analysis}</div>}
+            <div className="flex flex-col gap-9">
+              {transcriptionFailed ? (
+                <section
+                  className="flex flex-col gap-2 rounded-lg p-4"
+                  style={{
+                    background: 'var(--surface-raised)',
+                    border: '1px solid var(--border-subtle, var(--surface-raised))',
+                  }}
+                  data-testid="transcription-failed-notice"
+                >
+                  <div className="text-[15px] font-medium" style={{ color: 'var(--fg-1)' }}>
+                    Transcription failed
                   </div>
-                ))}
-              </div>
-            </section>
-          )}
+                  <p
+                    className="text-[14px] leading-[1.6]"
+                    style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
+                  >
+                    No notes could be generated for this recording. Your audio was preserved (not
+                    deleted), so nothing was lost.
+                  </p>
+                  {transcriptionError && (
+                    <p
+                      className="text-[12.5px] leading-[1.5]"
+                      style={{ color: 'var(--fg-2)', opacity: 0.8 }}
+                    >
+                      Details: {transcriptionError}
+                    </p>
+                  )}
+                </section>
+              ) : isProcessing ? (
+                <section
+                  className="flex flex-col gap-2 rounded-lg p-4"
+                  style={{
+                    background: 'var(--surface-raised)',
+                    border: '1px solid var(--border-subtle, var(--surface-raised))',
+                  }}
+                  data-testid="note-processing"
+                >
+                  <div
+                    className="flex items-center gap-1.5 text-[15px] font-medium"
+                    style={{ color: 'var(--fg-1)' }}
+                  >
+                    Finishing up
+                    <span className="thinking-dot" />
+                    <span className="thinking-dot" />
+                    <span className="thinking-dot" />
+                  </div>
+                  <p
+                    className="text-[14px] leading-[1.6]"
+                    style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
+                  >
+                    Your transcript is captured — refining it and generating notes in the
+                    background. You can read and edit <strong>My notes</strong> now.
+                  </p>
+                </section>
+              ) : summary ? (
+                <section className="flex flex-col gap-3">
+                  <SectionTitle>Summary</SectionTitle>
+                  <div data-testid="tab-summary-content">
+                    {stripReasoning(summary)
+                      .split(/\n{2,}/)
+                      .map((para, i) => (
+                        <p
+                          key={i}
+                          className="text-[15.5px] leading-[1.65]"
+                          style={{ color: 'var(--fg-1)', maxWidth: '64ch' }}
+                        >
+                          {para}
+                        </p>
+                      ))}
+                  </div>
+                </section>
+              ) : notesNotGenerated && meeting.transcript ? (
+                <section
+                  className="flex flex-col items-start gap-2 rounded-lg p-4"
+                  style={{
+                    background: 'var(--surface-raised)',
+                    border: '1px solid var(--border-subtle, var(--surface-raised))',
+                  }}
+                  data-testid="no-notes-yet"
+                >
+                  <div className="text-[15px] font-medium" style={{ color: 'var(--fg-1)' }}>
+                    No notes yet
+                  </div>
+                  <p
+                    className="text-[14px] leading-[1.6]"
+                    style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
+                  >
+                    This recording was transcribed but notes were not generated automatically. Use
+                    the <strong>Generate notes</strong> button below to create them, or copy or save
+                    the transcript from the actions above.
+                  </p>
+                </section>
+              ) : (
+                <p className="py-2 text-sm" style={{ color: 'var(--fg-2)' }}>
+                  No summary available for this meeting.
+                </p>
+              )}
 
-          {keyPoints.length > 0 && (
-            <section className="flex flex-col gap-3">
-              <SectionTitle>Key points</SectionTitle>
-              <ul className="mv-bullets">
-                {keyPoints.map((p, i) => (
-                  <li key={i}>{p}</li>
-                ))}
-              </ul>
-            </section>
-          )}
+              {discussionAreas.length > 0 && (
+                <section className="flex flex-col gap-3">
+                  <SectionTitle>Key topics</SectionTitle>
+                  <div className="mv-topics">
+                    {discussionAreas.map((area, i) => (
+                      <div key={i} className="flex flex-col gap-1">
+                        <div className="mv-topic-title">{area.title}</div>
+                        {area.analysis && <div className="mv-topic-body">{area.analysis}</div>}
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
 
-          {actionItems.length > 0 && (
-            <section className="flex flex-col gap-3">
-              <SectionTitle>Action items</SectionTitle>
-              <ul className="mv-bullets">
-                {actionItems.map((a, i) => (
-                  <li key={i}>{a}</li>
-                ))}
-              </ul>
-            </section>
-          )}
+              {keyPoints.length > 0 && (
+                <section className="flex flex-col gap-3">
+                  <SectionTitle>Key points</SectionTitle>
+                  <ul className="mv-bullets">
+                    {keyPoints.map((p, i) => (
+                      <li key={i}>{p}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
 
-          {participants.length > 0 && (
-            <section className="flex flex-col gap-3">
-              <SectionTitle>Participants</SectionTitle>
-              <div className="flex flex-wrap gap-1.5">
-                {participants.map((p, i) => (
-                  <ChipV2 key={i}>{p}</ChipV2>
-                ))}
-              </div>
-            </section>
-          )}
+              {actionItems.length > 0 && (
+                <section className="flex flex-col gap-3">
+                  <SectionTitle>Action items</SectionTitle>
+                  <ul className="mv-bullets">
+                    {actionItems.map((a, i) => (
+                      <li key={i}>{a}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
 
-        </div>
-      )}
-      </>
+              {participants.length > 0 && (
+                <section className="flex flex-col gap-3">
+                  <SectionTitle>Participants</SectionTitle>
+                  <div className="flex flex-wrap gap-1.5">
+                    {participants.map((p, i) => (
+                      <ChipV2 key={i}>{p}</ChipV2>
+                    ))}
+                  </div>
+                </section>
+              )}
+            </div>
+          )}
+        </>
       )}
 
       {tab === 'notes' && (
-        <MyNotesEditor
-          summaryFile={routeSummaryFile}
-          initialNotes={meeting.user_notes ?? ''}
-        />
+        <MyNotesEditor summaryFile={routeSummaryFile} initialNotes={meeting.user_notes ?? ''} />
       )}
 
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
@@ -1137,7 +1118,8 @@ function DetailContent({
           <DialogHeader>
             <DialogTitle>Delete this note?</DialogTitle>
             <DialogDescription>
-              This will permanently delete the recording, transcript, and summary. This can't be undone.
+              This will permanently delete the recording, transcript, and summary. This can't be
+              undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -1165,8 +1147,8 @@ function DetailContent({
               Unshare from {orgSession.data?.signedIn ? orgSession.data.orgId : 'your org'}?
             </DialogTitle>
             <DialogDescription>
-              The shared copy will be removed from your organisation. Your
-              local note stays on this device. You can re-share at any time.
+              The shared copy will be removed from your organisation. Your local note stays on this
+              device. You can re-share at any time.
             </DialogDescription>
           </DialogHeader>
           {shareError && (
@@ -1238,7 +1220,7 @@ function NoteViewToggle({
   const activeLabel =
     activeReportId === null
       ? 'Summary'
-      : reports.find((r) => r.id === activeReportId)?.template_name ?? 'Summary';
+      : (reports.find((r) => r.id === activeReportId)?.template_name ?? 'Summary');
 
   const selectView = (id: string | null) => {
     setMenuOpen(false);
@@ -1589,7 +1571,15 @@ function parseMarkdownBlocks(text: string): MarkdownBlock[] {
 const CHAR_TRANSITION = 'top 0.12s ease-out';
 const ROW_TRANSITION = 'top 0.35s cubic-bezier(0.45, 0, 0.55, 1)';
 
-function StreamingView({ text, phase, chunkProgress }: { text: string; phase: StreamPhase; chunkProgress?: { step: number; total: number } | null }) {
+function StreamingView({
+  text,
+  phase,
+  chunkProgress,
+}: {
+  text: string;
+  phase: StreamPhase;
+  chunkProgress?: { step: number; total: number } | null;
+}) {
   const blocks = parseMarkdownBlocks(stripReasoning(text));
   const isStreaming = phase === 'analyzing' || phase === 'generating';
 
@@ -1629,9 +1619,12 @@ function StreamingView({ text, phase, chunkProgress }: { text: string; phase: St
         indicator.style.left = '-12px';
         indicator.style.right = '-12px';
         indicator.style.width = '';
-        requestAnimationFrame(() => requestAnimationFrame(() => {
-          if (indicatorRef.current) indicatorRef.current.style.transition = currentTransitionRef.current;
-        }));
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            if (indicatorRef.current)
+              indicatorRef.current.style.transition = currentTransitionRef.current;
+          })
+        );
         return;
       }
       indicator.style.position = 'absolute';
@@ -1685,9 +1678,12 @@ function StreamingView({ text, phase, chunkProgress }: { text: string; phase: St
     return () => window.removeEventListener('scroll', repositionIndicator);
   }, [isStreaming, repositionIndicator]);
 
-  React.useEffect(() => () => {
-    if (rowTransitionTimerRef.current) clearTimeout(rowTransitionTimerRef.current);
-  }, []);
+  React.useEffect(
+    () => () => {
+      if (rowTransitionTimerRef.current) clearTimeout(rowTransitionTimerRef.current);
+    },
+    []
+  );
 
   const indicatorLabel = chunkProgress
     ? `Summarising part ${chunkProgress.step}/${chunkProgress.total}`
@@ -1701,17 +1697,15 @@ function StreamingView({ text, phase, chunkProgress }: { text: string; phase: St
         {blocks.map((block, i) => {
           const animate = i >= firstNewIdx;
           if (block.type === 'heading') {
-            return (
-              <SectionTitle key={i}>
-                {block.text}
-              </SectionTitle>
-            );
+            return <SectionTitle key={i}>{block.text}</SectionTitle>;
           }
           if (block.type === 'bullet') {
             return (
               <div key={i} className={cn('flex gap-2', animate && 'animate-fade-in')}>
                 <span className="mt-[0.45em] size-1 flex-shrink-0 rounded-full bg-[color:var(--fg-2)]" />
-                <p className="text-sm leading-[1.65]" style={{ color: 'var(--fg-1)' }}>{block.text}</p>
+                <p className="text-sm leading-[1.65]" style={{ color: 'var(--fg-1)' }}>
+                  {block.text}
+                </p>
               </div>
             );
           }
@@ -1740,7 +1734,9 @@ function StreamingView({ text, phase, chunkProgress }: { text: string; phase: St
             className="inline-block size-3 animate-spin-fast rounded-full border-2 border-transparent"
             style={{ borderTopColor: 'var(--fg-2)' }}
           />
-          <span className="text-xs" style={{ color: 'var(--fg-1)' }}>{indicatorLabel}</span>
+          <span className="text-xs" style={{ color: 'var(--fg-1)' }}>
+            {indicatorLabel}
+          </span>
         </div>
       )}
     </div>
@@ -1754,7 +1750,13 @@ function StreamingView({ text, phase, chunkProgress }: { text: string; phase: St
 const FOLDER_NONE = '__none__';
 const FOLDER_NEW = '__new__';
 
-function FolderPicker({ summaryFile, assignedFolderIds }: { summaryFile: string; assignedFolderIds: string[] }) {
+function FolderPicker({
+  summaryFile,
+  assignedFolderIds,
+}: {
+  summaryFile: string;
+  assignedFolderIds: string[];
+}) {
   const folders = useFolders();
   const addMeeting = useAddMeetingToFolder();
   const removeMeeting = useRemoveMeetingFromFolder();
@@ -1846,7 +1848,10 @@ function FolderPicker({ summaryFile, assignedFolderIds }: { summaryFile: string;
             value={newFolderName}
             onChange={(e) => setNewFolderName(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); void submitNewFolder(); }
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                void submitNewFolder();
+              }
               if (e.key === 'Escape') {
                 setNewFolderName('');
                 setFolderError(null);
@@ -1867,10 +1872,7 @@ function FolderPicker({ summaryFile, assignedFolderIds }: { summaryFile: string;
 
   return (
     <div className="space-y-1">
-      <Select
-        value={localFolderId ?? FOLDER_NONE}
-        onValueChange={handleValueChange}
-      >
+      <Select value={localFolderId ?? FOLDER_NONE} onValueChange={handleValueChange}>
         <SelectPrimitive.Trigger asChild>
           <button type="button" className="mv-chip">
             {currentFolderLabel}
@@ -1880,7 +1882,9 @@ function FolderPicker({ summaryFile, assignedFolderIds }: { summaryFile: string;
           <SelectItem value={FOLDER_NONE}>No folder</SelectItem>
           <SelectSeparator />
           {allFolders.map((f) => (
-            <SelectItem key={f.id} value={f.id}>{f.name}</SelectItem>
+            <SelectItem key={f.id} value={f.id}>
+              {f.name}
+            </SelectItem>
           ))}
           <SelectSeparator />
           <SelectItem value={FOLDER_NEW}>New folder...</SelectItem>
@@ -1895,7 +1899,10 @@ function FolderPicker({ summaryFile, assignedFolderIds }: { summaryFile: string;
 // Pure formatting / parsing helpers
 // ---------------------------------------------------------------------------
 
-function formatDetailDate(info: { processed_at?: string; updated_at?: string }): string | undefined {
+function formatDetailDate(info: {
+  processed_at?: string;
+  updated_at?: string;
+}): string | undefined {
   const raw = info.processed_at ?? info.updated_at;
   if (!raw) return undefined;
   const d = new Date(raw);
@@ -2010,16 +2017,12 @@ export function composeShareBody(meeting: Meeting): string {
 
   const keyPoints = (meeting.key_points ?? []).filter(Boolean);
   if (keyPoints.length) {
-    sections.push(
-      `## Key points\n\n${keyPoints.map((kp) => `- ${kp}`).join('\n')}`,
-    );
+    sections.push(`## Key points\n\n${keyPoints.map((kp) => `- ${kp}`).join('\n')}`);
   }
 
   const actionItems = asStringArray(meeting.action_items);
   if (actionItems.length) {
-    sections.push(
-      `## Action items\n\n${actionItems.map((ai) => `- ${ai}`).join('\n')}`,
-    );
+    sections.push(`## Action items\n\n${actionItems.map((ai) => `- ${ai}`).join('\n')}`);
   }
 
   // Deliberately do NOT fall back to meeting.transcript here: the raw

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -540,15 +540,15 @@ function DetailContent({
   // While a recording is live on THIS note (resume/continue), the transcript
   // is still growing — offering "Generate notes" mid-recording would summarise
   // a moving target and strand the CTA once it finishes. Suppress it until the
-  // recording is stopped. Matched by session name (the same identity the
-  // live-transcript chunk filter uses); a recording on a *different* note
-  // leaves this note's CTA untouched.
+  // recording is stopped. Matched by summary-file IDENTITY (not display name,
+  // which collides for two default-"Note" notes); a recording on a *different*
+  // note leaves this note's CTA untouched.
   const recording = useRecording();
   const isRecordingThisNote =
     recording.status !== 'idle' &&
     recording.status !== 'processing' &&
-    recording.sessionName != null &&
-    recording.sessionName === info.name;
+    recording.recordingSummaryFile != null &&
+    recording.recordingSummaryFile === info.summary_file;
 
   // Publish this note's reprocess trigger + streaming state so the floating
   // GenerateNotesBar (mounted at App level, above the Ask bar) drives THIS
@@ -681,7 +681,10 @@ function DetailContent({
                   <ActionIconButton
                     label="Generate notes"
                     onClick={startReprocess}
-                    disabled={reprocess.isPending || streamPhase !== 'idle'}
+                    // Disable while a recording is live on THIS note — same
+                    // reason the floating CTA hides: don't summarise a
+                    // still-growing transcript out from under the recording.
+                    disabled={reprocess.isPending || streamPhase !== 'idle' || isRecordingThisNote}
                   >
                     <RefreshCw
                       className={cn(

--- a/e2e/specs/generate-notes-bar.t1.spec.ts
+++ b/e2e/specs/generate-notes-bar.t1.spec.ts
@@ -40,6 +40,36 @@ test('shows the floating Generate notes button for a transcript-only note', asyn
   await expect(cta).toBeDisabled();
 });
 
+test('hides the floating Generate notes button while a recording is live on THIS note', async ({
+  launchApp,
+}) => {
+  // Resume/continue-recording into a transcript-only note: the transcript is
+  // still growing, so the "Generate notes" CTA must disappear until the
+  // recording stops (summarising a moving target would strand the CTA once it
+  // finishes). Matched by session name — a recording on a DIFFERENT note leaves
+  // this one's CTA alone. Regression guard for the resume-leaves-CTA bug.
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_PENDING_NOTE: '1', STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' },
+  });
+  await openMeeting(page, 'pending_summary.md');
+
+  const cta = page.getByTestId('generate-notes-dock-button');
+  await expect(cta).toBeVisible();
+
+  // Start a recording whose session name matches this note (as resume does,
+  // appending to pending_summary.md). The queue poll flips useRecording to
+  // 'recording' and the CTA must clear.
+  await page.evaluate(() =>
+    window.stenoai.recording.start('New note', 'manual', 'pending_summary.md'),
+  );
+  await expect(cta).toHaveCount(0);
+
+  // Stop → no longer recording this note → the CTA returns.
+  await page.evaluate(() => window.stenoai.recording.stop());
+  await expect(cta).toBeVisible();
+});
+
 test('hides the floating Generate notes button for a normal (summarised) note', async ({
   launchApp,
 }) => {

--- a/e2e/specs/generate-notes-bar.t1.spec.ts
+++ b/e2e/specs/generate-notes-bar.t1.spec.ts
@@ -46,8 +46,9 @@ test('hides the floating Generate notes button while a recording is live on THIS
   // Resume/continue-recording into a transcript-only note: the transcript is
   // still growing, so the "Generate notes" CTA must disappear until the
   // recording stops (summarising a moving target would strand the CTA once it
-  // finishes). Matched by session name — a recording on a DIFFERENT note leaves
-  // this one's CTA alone. Regression guard for the resume-leaves-CTA bug.
+  // finishes). Matched by summary-file IDENTITY — a recording on a DIFFERENT
+  // note (even one sharing the default name) leaves this one's CTA alone.
+  // Regression guard for the resume-leaves-CTA bug.
   const { page } = await launchApp({
     mockIpc: true,
     env: { STENOAI_E2E_SEED_PENDING_NOTE: '1', STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' },
@@ -57,9 +58,20 @@ test('hides the floating Generate notes button while a recording is live on THIS
   const cta = page.getByTestId('generate-notes-dock-button');
   await expect(cta).toBeVisible();
 
-  // Start a recording whose session name matches this note (as resume does,
-  // appending to pending_summary.md). The queue poll flips useRecording to
-  // 'recording' and the CTA must clear.
+  // A recording on a DIFFERENT note (same display name, different summary file)
+  // must NOT hide this note's CTA — identity, not name. The pill appearing
+  // proves the queue poll has seen the recording, so the CTA-still-visible
+  // assertion isn't racing an un-propagated state.
+  await page.evaluate(() =>
+    window.stenoai.recording.start('New note', 'manual', 'other_summary.md'),
+  );
+  await expect(page.getByTestId('transcription-pill')).toBeVisible();
+  await expect(cta).toBeVisible();
+  await page.evaluate(() => window.stenoai.recording.stop());
+  await expect(page.getByTestId('transcription-pill')).toHaveCount(0);
+
+  // Now resume INTO this note (append target = pending_summary.md). The queue
+  // poll flips useRecording to 'recording' on THIS note and the CTA must clear.
   await page.evaluate(() =>
     window.stenoai.recording.start('New note', 'manual', 'pending_summary.md'),
   );

--- a/e2e/specs/pill-dock.t1.spec.ts
+++ b/e2e/specs/pill-dock.t1.spec.ts
@@ -144,6 +144,32 @@ test('auto-pause rescue: Resume appears only when the system paused the recordin
   await expect(pill.getByRole('button', { name: 'Stop recording' })).toBeVisible();
 });
 
+test('resume: the live transcript panel shows the earlier bits carried over from before the stop', async ({
+  launchApp,
+}) => {
+  // Regression guard: resuming/continuing a recording used to drop the earlier
+  // transcript from the live bar (it reset to blank). main.js now carries the
+  // previous session's finalised segments across as display-only priorSegments;
+  // the bar renders them before the live tail. STENOAI_E2E_SEED_PRIOR_SEGMENTS
+  // seeds them through the mock get-live-transcript-state (the real buffer is
+  // model-populated — see live-transcript-fallback.t2).
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { ...PILL_ENV, STENOAI_E2E_SEED_PRIOR_SEGMENTS: '1' },
+  });
+  const pill = await startInBackground(page);
+
+  // Expand into the live transcript panel.
+  await pill.getByRole('button', { name: 'Show transcript' }).click();
+  const panel = page.getByTestId('live-transcript-panel');
+  await expect(panel).toBeVisible();
+
+  // The earlier speech renders instead of a blank "Listening…" — the user sees
+  // continuity across the resume, not a transcript that starts over.
+  await expect(panel.getByText('earlier bit one')).toBeVisible();
+  await expect(panel.getByText('earlier bit two')).toBeVisible();
+});
+
 test('whisper variant: compact pill has no expand and no pause', async ({ launchApp }) => {
   const { page } = await launchApp({
     mockIpc: true,


### PR DESCRIPTION
## Summary

Two coupled bugs in the resume/continue-recording flow (both surfaced by the coexisting pill-dock model):

1. **"Generate notes" CTA stayed visible after resuming.** The floating CTA is published from `MeetingDetail`, which never consulted recording state. It now suppresses the CTA while a recording is live on **this** note (matched by session name, so recording a *different* note leaves this one's CTA alone) and restores it on stop.

2. **Resuming dropped the earlier live transcript.** The live bar reset to blank on resume. `start-recording-ui` now carries the previous session's finalised segments across a resume/continue into the same note as display-only `priorSegments`; the live bar renders them before the new tail with a subtle "Resumed" divider. Kept deliberately separate from `.segments` so it can't misorder (the sidecar restarts its clock at 0) or duplicate text in the stop-time snapshot/append pipeline.

## Files
- `app/renderer/src/routes/MeetingDetail.tsx` — gate the CTA on `isRecordingThisNote`
- `app/main.js` — carry `priorSegments` across resume; expose via `get-live-transcript-state`
- `app/renderer/src/hooks/useLiveTranscript.ts` + `LiveTranscriptBar.tsx` + `lib/ipc.ts` — render prior segments
- `app/e2e-mock-ipc.js` — `get-live-transcript-state` stub with `STENOAI_E2E_SEED_PRIOR_SEGMENTS`

## Tests
- `generate-notes-bar.t1` — new case: CTA hides while recording this note, returns on stop
- `pill-dock.t1` — new case: live panel shows carried-over earlier bits
- Typecheck, renderer build, and the 6 `ipc-contract` tests pass

## Notes / limitations
- The backend carry-over reads `liveTranscriptState`, which only the real ASR sidecar populates — the full end-to-end path (record → stop → resume → see old bits) is model-coupled and best verified in the `@pipeline` lane / manually. The T1 covers the renderer rendering half.
- Narrow, non-destructive edge: two notes both named the default "Note" resumed back-to-back (no recording in between) could show the wrong prior context in the bar. Never affects the saved transcript or summary (`priorSegments` never feed the pipeline). Can be tightened with a summary-file identity if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resume-flow bugs: the “Generate notes” prompts now hide/disable while recording into this note, and the live transcript keeps continuity on resume with a “Resumed” divider. Matching uses note identity (summary file), not the display name, to avoid collisions.

- **Bug Fixes**
  - Hide the floating CTA and disable the in-note “Generate notes” button while an active recording targets this note; restore on stop. Matched by `recordingSummaryFile === info.summary_file`.
  - Keep transcript continuity by carrying prior finalised segments across resume as display-only `priorSegments`, rendered before the live tail with a “Resumed” divider. Guarded by `summaryFile` identity and accumulates across multiple continues.
  - Tests: e2e cover CTA behavior (including recording on a different note doesn’t hide it) and transcript continuity; mocks expose `recordingSummaryFile` and seed `priorSegments` via `STENOAI_E2E_SEED_PRIOR_SEGMENTS`.

<sup>Written for commit 54b15dcbb7adddff2e52b7177c6e95ffd2ead82a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

