### PR TITLE
feat: privacy onboarding disclosure + one-time consent notice

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -587,7 +587,7 @@ async function initTelemetry() {
     anonymousId = config.anonymous_id;
 
     if (telemetryEnabled) {
-      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST, disableGeoip: true });
       // Identify user for DAU tracking
       posthogClient.identify({
         distinctId: anonymousId,
@@ -6783,12 +6783,38 @@ ipcMain.handle('get-telemetry', async () => {
   }
 });
 
+ipcMain.handle('get-privacy-notice-seen', async () => {
+  try {
+    const result = await runPythonScript('simple_recorder.py', ['get-privacy-notice-seen']);
+    const jsonData = JSON.parse(result);
+    return {
+      success: true,
+      privacy_notice_seen: jsonData.privacy_notice_seen
+    };
+  } catch (error) {
+    sendDebugLog(`Error getting privacy notice state: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('set-privacy-notice-seen', async () => {
+  try {
+    const result = await runPythonScript('simple_recorder.py', ['set-privacy-notice-seen']);
+    const jsonData = JSON.parse(result);
+    return jsonData;
+  } catch (error) {
+    sendDebugLog(`Error marking privacy notice seen: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+});
+
 // Where the telemetry toggle was flipped -- 'setup' names the Setup.tsx
-// SCREEN, not a lifecycle stage: it's also reachable later via "run setup
-// wizard" from Settings (see trigger-setup-wizard), so this deliberately
-// does NOT claim to mean "first run". Whitelisted so a stale/forged
-// renderer arg can't smuggle an arbitrary string into PostHog.
-const TELEMETRY_TOGGLE_SOURCES = new Set(['setup', 'settings']);
+// screen and 'consent' names the one-time privacy notice modal. 'setup' is
+// also reachable later via "run setup wizard" from Settings (see
+// trigger-setup-wizard), so this deliberately does NOT claim to mean "first
+// run". Whitelisted so a stale/forged renderer arg can't smuggle an arbitrary
+// string into PostHog.
+const TELEMETRY_TOGGLE_SOURCES = new Set(['setup', 'settings', 'consent']);
 
 ipcMain.handle('set-telemetry', async (event, enabled, source) => {
   try {
@@ -6804,7 +6830,7 @@ ipcMain.handle('set-telemetry', async (event, enabled, source) => {
     if (enabled && !posthogClient) {
       // Bring the client up and identify FIRST so both the super-properties
       // and this event land fresh, rather than waiting for next launch.
-      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+      posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST, disableGeoip: true });
       telemetryEnabled = true;
       refreshIdentitySuperProperties();
       trackEvent('telemetry_toggled', { enabled: true, source: toggleSource });

--- a/app/preload.js
+++ b/app/preload.js
@@ -91,6 +91,11 @@ const stenoai = {
     triggerWizard: () => invoke('trigger-setup-wizard'),
   },
 
+  privacy: {
+    getNoticeSeen: () => invoke('get-privacy-notice-seen'),
+    markNoticeSeen: () => invoke('set-privacy-notice-seen'),
+  },
+
   perm: {
     checkMicrophone: () => invoke('check-microphone-permission'),
     requestMicrophone: () => invoke('request-microphone-permission'),

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -20,6 +20,8 @@ import { BottomDockSlot } from '@/components/BottomDockSlot';
 import { PrimaryDock } from '@/components/PrimaryDock';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { QuitDialog } from '@/components/QuitDialog';
+import { PrivacyConsentModal } from '@/components/PrivacyConsentModal';
+import { usePrivacyNoticeSeen } from '@/hooks/useSettings';
 import { ImportDropZone } from '@/components/ImportDropZone';
 import { CommandPaletteProvider, useCommandPalette } from '@/components/CommandPalette';
 import { AskBarProvider } from '@/lib/askBarContext';
@@ -38,6 +40,17 @@ export function App() {
   useTheme();
   const route = useRoute();
 
+  // One-time privacy disclosure for upgraders. Show it only when the marker is
+  // explicitly false (existing install predating telemetry/launch-on-login) and
+  // we're NOT on /setup — an upgrader who also lacks a model lands on onboarding,
+  // which discloses the same toggles and marks the notice seen on exit
+  // (Setup.finishOnboarding), so we don't double up. A config-but-no-model
+  // upgrader can see the modal for a sub-second frame before the async /setup
+  // redirect lands; accepted as cosmetic for that rare state (the redirect and
+  // onboarding's mark-seen still make it correct).
+  const privacyNotice = usePrivacyNoticeSeen();
+  const showPrivacyModal = privacyNotice.data === false && route !== '/setup';
+
   React.useLayoutEffect(() => {
     if (typeof window !== 'undefined' && window.stenoai) {
       ipc().window.readyToShow();
@@ -47,6 +60,16 @@ export function App() {
       document.documentElement.dataset.appReady = '1';
     }
   }, []);
+
+  // Reflect the resolved privacy-gate value onto the root element so e2e can
+  // deterministically wait for the query to settle (data-privacy-gate="true"
+  // means the notice was already seen) before asserting the modal's absence,
+  // instead of racing a not-yet-resolved query. Mirrors the data-app-ready
+  // readiness signal; no effect on production behaviour.
+  React.useEffect(() => {
+    if (privacyNotice.data === undefined) return;
+    document.documentElement.dataset.privacyGate = String(privacyNotice.data);
+  }, [privacyNotice.data]);
 
 
 
@@ -190,6 +213,7 @@ export function App() {
       <AskBarProvider>
         <RouteView route={route} />
         <QuitDialog />
+        <PrivacyConsentModal open={showPrivacyModal} />
         <ImportDropZone />
 
         {/* Bottom dock — shared anchor across recording → processing → meeting.

--- a/app/renderer/src/components/PrivacyConsentModal.tsx
+++ b/app/renderer/src/components/PrivacyConsentModal.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { SettingRow } from '@/routes/settings/primitives';
+import {
+  settingsKeys,
+  useLaunchOnLoginSetting,
+  useSetLaunchOnLogin,
+  useSetTelemetry,
+  useTelemetrySetting,
+} from '@/hooks/useSettings';
+import { ipc } from '@/lib/ipc';
+
+/**
+ * One-time, soft privacy disclosure for existing installs upgrading into the
+ * version that added telemetry + launch-on-login (both default ON). Nothing is
+ * gated or held back — the modal only discloses what's on and offers immediate
+ * off-toggles. Acknowledging (the "Got it" button, the X, or Escape) marks the
+ * notice seen forever via `privacy.markNoticeSeen()` and invalidates the gate
+ * query so it can never reappear.
+ *
+ * Mounted by App.tsx, which owns the `open` decision (notice not seen AND not
+ * on the /setup route, so an upgrader who also lacks a model and lands on
+ * onboarding isn't disclosed to twice).
+ */
+export function PrivacyConsentModal({ open }: { open: boolean }) {
+  const qc = useQueryClient();
+
+  const telemetry = useTelemetrySetting();
+  const setTelemetry = useSetTelemetry();
+  const telemetryEnabled = telemetry.data?.telemetry_enabled ?? true;
+
+  const launchOnLogin = useLaunchOnLoginSetting();
+  const setLaunchOnLogin = useSetLaunchOnLogin();
+  const launchOnLoginEnabled = launchOnLogin.data ?? true;
+
+  // Guard so the mark-seen write fires exactly once even if the button click
+  // and the Dialog's onOpenChange(false) both resolve to acknowledge.
+  const acknowledgedRef = React.useRef(false);
+
+  const acknowledge = React.useCallback(async () => {
+    if (acknowledgedRef.current) return;
+    acknowledgedRef.current = true;
+    try {
+      const res = await ipc().privacy.markNoticeSeen();
+      if (!res?.success) throw new Error(res?.error || 'markNoticeSeen failed');
+      // Flip the gate synchronously so App stops rendering the modal
+      // immediately — don't depend on the refetch, which could fail and leave
+      // the modal stuck open with the latch already set. The invalidate then
+      // reconciles against disk in the background.
+      qc.setQueryData(settingsKeys.privacyNoticeSeen(), true);
+      qc.invalidateQueries({ queryKey: settingsKeys.privacyNoticeSeen() });
+    } catch {
+      // Persisting the marker failed (e.g. a config-write error). Unlatch so
+      // the user can dismiss again instead of being trapped behind a modal
+      // that no longer responds to the button, X, or Escape.
+      acknowledgedRef.current = false;
+    }
+  }, [qc]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) void acknowledge();
+      }}
+    >
+      <DialogContent className="max-w-md" data-privacy-consent>
+        <DialogHeader>
+          <DialogTitle>A quick note on privacy</DialogTitle>
+          <DialogDescription>
+            To help find and fix failures, Steno sends anonymous usage data —
+            never your recordings, transcripts, or notes. Steno also starts
+            automatically when you log in. Both are on by default and you can
+            change either one anytime in Settings.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-1">
+          <SettingRow
+            label="Anonymous usage data"
+            description="Crash and usage signals only. Meeting content is never sent."
+          >
+            <Switch
+              checked={telemetryEnabled}
+              onCheckedChange={(v) => setTelemetry.mutate({ enabled: v, source: 'consent' })}
+              disabled={telemetry.data === undefined}
+              aria-label="Anonymous usage data"
+              data-privacy-telemetry
+            />
+          </SettingRow>
+          <SettingRow
+            label="Launch on login"
+            description="Start Steno automatically when you log in (hidden in the menu bar)."
+            noBorder
+          >
+            <Switch
+              checked={launchOnLoginEnabled}
+              onCheckedChange={(v) => setLaunchOnLogin.mutate(v)}
+              disabled={launchOnLogin.data === undefined}
+              aria-label="Launch on login"
+              data-privacy-launch
+            />
+          </SettingRow>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => void acknowledge()} data-privacy-ack>
+            Got it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/renderer/src/components/PrivacyConsentModal.tsx
+++ b/app/renderer/src/components/PrivacyConsentModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 
 import {
   Dialog,
@@ -13,13 +12,12 @@ import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { SettingRow } from '@/routes/settings/primitives';
 import {
-  settingsKeys,
   useLaunchOnLoginSetting,
+  useMarkPrivacyNoticeSeen,
   useSetLaunchOnLogin,
   useSetTelemetry,
   useTelemetrySetting,
 } from '@/hooks/useSettings';
-import { ipc } from '@/lib/ipc';
 
 /**
  * One-time, soft privacy disclosure for existing installs upgrading into the
@@ -34,7 +32,7 @@ import { ipc } from '@/lib/ipc';
  * onboarding isn't disclosed to twice).
  */
 export function PrivacyConsentModal({ open }: { open: boolean }) {
-  const qc = useQueryClient();
+  const { mutateAsync: markNoticeSeen } = useMarkPrivacyNoticeSeen();
 
   const telemetry = useTelemetrySetting();
   const setTelemetry = useSetTelemetry();
@@ -52,21 +50,15 @@ export function PrivacyConsentModal({ open }: { open: boolean }) {
     if (acknowledgedRef.current) return;
     acknowledgedRef.current = true;
     try {
-      const res = await ipc().privacy.markNoticeSeen();
-      if (!res?.success) throw new Error(res?.error || 'markNoticeSeen failed');
-      // Flip the gate synchronously so App stops rendering the modal
-      // immediately — don't depend on the refetch, which could fail and leave
-      // the modal stuck open with the latch already set. The invalidate then
-      // reconciles against disk in the background.
-      qc.setQueryData(settingsKeys.privacyNoticeSeen(), true);
-      qc.invalidateQueries({ queryKey: settingsKeys.privacyNoticeSeen() });
+      // Persists the marker and flips the gate query (see the shared hook).
+      await markNoticeSeen();
     } catch {
       // Persisting the marker failed (e.g. a config-write error). Unlatch so
       // the user can dismiss again instead of being trapped behind a modal
       // that no longer responds to the button, X, or Escape.
       acknowledgedRef.current = false;
     }
-  }, [qc]);
+  }, [markNoticeSeen]);
 
   return (
     <Dialog

--- a/app/renderer/src/hooks/useSettings.ts
+++ b/app/renderer/src/hooks/useSettings.ts
@@ -64,6 +64,28 @@ export function usePrivacyNoticeSeen() {
   });
 }
 
+/** Persist the one-time privacy notice as seen and flip the gate query so the
+ *  disclosure can't reappear. Shared by the consent modal and onboarding so the
+ *  cache key + invalidation never drift as the gate evolves. The gate is set
+ *  synchronously on success (don't depend on the refetch, which could fail and
+ *  leave the modal stuck open); the invalidate reconciles against disk in the
+ *  background. Rejects if the backend write failed — callers own their own
+ *  control flow (re-arm, navigate) around it. */
+export function useMarkPrivacyNoticeSeen() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const res = await ipc().privacy.markNoticeSeen();
+      if (!res?.success) throw new Error(res?.error || 'markNoticeSeen failed');
+      return res;
+    },
+    onSuccess: () => {
+      qc.setQueryData(settingsKeys.privacyNoticeSeen(), true);
+      qc.invalidateQueries({ queryKey: settingsKeys.privacyNoticeSeen() });
+    },
+  });
+}
+
 export function useDockIconSetting() {
   return useQuery({
     queryKey: settingsKeys.dockIcon(),

--- a/app/renderer/src/hooks/useSettings.ts
+++ b/app/renderer/src/hooks/useSettings.ts
@@ -6,6 +6,7 @@ export const settingsKeys = {
   all: ['settings'] as const,
   notifications: () => [...settingsKeys.all, 'notifications'] as const,
   telemetry: () => [...settingsKeys.all, 'telemetry'] as const,
+  privacyNoticeSeen: () => [...settingsKeys.all, 'privacyNoticeSeen'] as const,
   dockIcon: () => [...settingsKeys.all, 'dockIcon'] as const,
   systemAudio: () => [...settingsKeys.all, 'systemAudio'] as const,
   systemAudioSupport: () => [...settingsKeys.all, 'systemAudioSupport'] as const,
@@ -47,6 +48,19 @@ export function useSetTelemetry() {
     mutationFn: async ({ enabled, source }: { enabled: boolean; source: TelemetryToggleSource }) =>
       unwrap(await ipc().settings.setTelemetry(enabled, source)),
     onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.telemetry() }),
+  });
+}
+
+/** One-time privacy disclosure gate. `privacy_notice_seen` is false only for
+ *  existing installs whose config predates the marker (see
+ *  Config._migrate_privacy_notice_seen); fresh installs are disclosed during
+ *  onboarding and start true. The consent modal reads this and, on
+ *  acknowledgement, marks it seen forever and invalidates this query so it
+ *  won't re-open. */
+export function usePrivacyNoticeSeen() {
+  return useQuery({
+    queryKey: settingsKeys.privacyNoticeSeen(),
+    queryFn: async () => unwrap(await ipc().privacy.getNoticeSeen()).privacy_notice_seen,
   });
 }
 

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -748,7 +748,7 @@ export interface StenoaiBridge {
 
   privacy: {
     getNoticeSeen: RequestFn<[], GetPrivacyNoticeSeenResponse>;
-    markNoticeSeen: RequestFn<[], Result<Record<string, never>>>;
+    markNoticeSeen: RequestFn<[], Result<{ privacy_notice_seen: boolean }>>;
   };
 
   perm: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -335,11 +335,11 @@ export type ScreenRecordingPermissionResponse = Result<{ screenPermission: strin
  *  actually moves the needle. */
 export type RecordingTrigger = 'manual' | 'notification_click' | 'hotkey' | 'tray' | 'url_scheme';
 
-/** Mirrors TELEMETRY_TOGGLE_SOURCES in main.js -- which SCREEN the telemetry
- *  toggle was flipped from. 'setup' names the Setup.tsx screen, not a
- *  lifecycle stage: it's also reachable later via "run setup wizard" from
- *  Settings, so this does not mean "first run". */
-export type TelemetryToggleSource = 'setup' | 'settings';
+/** Mirrors TELEMETRY_TOGGLE_SOURCES in main.js -- which UI surface the
+ *  telemetry toggle was flipped from. 'setup' names the Setup.tsx screen,
+ *  not a lifecycle stage: it's also reachable later via "run setup wizard"
+ *  from Settings, so this does not mean "first run". */
+export type TelemetryToggleSource = 'setup' | 'settings' | 'consent';
 
 export type StartRecordingResponse = Result<{ message: string; sessionName?: string }>;
 export type StopRecordingResponse = Result<{
@@ -491,6 +491,7 @@ export type GetTelemetryResponse = Result<{
   telemetry_enabled: boolean;
   anonymous_id?: string;
 }>;
+export type GetPrivacyNoticeSeenResponse = Result<{ privacy_notice_seen: boolean }>;
 export type GetDockIconResponse = Result<{ hide_dock_icon: boolean }>;
 export type GetSystemAudioResponse = Result<{ system_audio_enabled: boolean }>;
 export type GetAutoDetectMeetingsResponse = Result<{ auto_detect_meetings_enabled: boolean }>;
@@ -743,6 +744,11 @@ export interface StenoaiBridge {
     parakeet: RequestFn<[], Result<Record<string, unknown>>>;
     test: RequestFn<[], Result<Record<string, unknown>>>;
     triggerWizard: RequestFn<[], Result<Record<string, unknown>>>;
+  };
+
+  privacy: {
+    getNoticeSeen: RequestFn<[], GetPrivacyNoticeSeenResponse>;
+    markNoticeSeen: RequestFn<[], Result<Record<string, never>>>;
   };
 
   perm: {

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -14,15 +14,14 @@ import { Display, Lead, Muted } from '@/components/ui/typography';
 import { useNavigate } from '@/lib/router';
 import { useCheckMicPermission, useRequestMicPermission, useSetupStep } from '@/hooks/useSetup';
 import {
-  settingsKeys,
   useLaunchOnLoginSetting,
+  useMarkPrivacyNoticeSeen,
   useSetLaunchOnLogin,
   useSetTelemetry,
   useSetUserName,
   useTelemetrySetting,
   useUserName,
 } from '@/hooks/useSettings';
-import { useQueryClient } from '@tanstack/react-query';
 import {
   useSetAiProvider,
   useSetCloudApiKey,
@@ -143,28 +142,23 @@ export function Setup() {
   const setLaunchOnLogin = useSetLaunchOnLogin();
   const launchOnLoginEnabled = launchOnLogin.data ?? true;
 
-  const qc = useQueryClient();
   // Onboarding discloses telemetry + launch-on-login, so mark the one-time
   // privacy notice seen on the way out. Without this, an upgrader who had a
   // config but no model (so they were routed here) would land on Home and get
   // the consent modal a second time for the same toggles. Idempotent — a fresh
   // install is already seen. Navigate regardless so a persist hiccup never
-  // traps the user in Setup.
+  // traps the user in Setup. The shared hook flips the gate query synchronously
+  // on success so the consent modal can't flash on the way home.
+  const { mutateAsync: markPrivacyNoticeSeen } = useMarkPrivacyNoticeSeen();
   const finishOnboarding = React.useCallback(async () => {
     try {
-      const res = await ipc().privacy.markNoticeSeen();
-      if (res?.success) {
-        // Flip the gate synchronously before navigating home so the consent
-        // modal can't flash on the way out; invalidate reconciles with disk.
-        qc.setQueryData(settingsKeys.privacyNoticeSeen(), true);
-        qc.invalidateQueries({ queryKey: settingsKeys.privacyNoticeSeen() });
-      }
+      await markPrivacyNoticeSeen();
     } catch {
       // best-effort; the consent modal is a soft disclosure, not a gate
     } finally {
       navigate('/');
     }
-  }, [qc, navigate]);
+  }, [markPrivacyNoticeSeen, navigate]);
 
   // First name powers the in-app greeting ("Hi <name>, ask anything"). Stored
   // locally only — never sent anywhere. Persisted on blur to avoid a write

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -14,11 +14,15 @@ import { Display, Lead, Muted } from '@/components/ui/typography';
 import { useNavigate } from '@/lib/router';
 import { useCheckMicPermission, useRequestMicPermission, useSetupStep } from '@/hooks/useSetup';
 import {
+  settingsKeys,
+  useLaunchOnLoginSetting,
+  useSetLaunchOnLogin,
   useSetTelemetry,
   useSetUserName,
   useTelemetrySetting,
   useUserName,
 } from '@/hooks/useSettings';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   useSetAiProvider,
   useSetCloudApiKey,
@@ -131,6 +135,36 @@ export function Setup() {
   const telemetry = useTelemetrySetting();
   const setTelemetry = useSetTelemetry();
   const telemetryEnabled = telemetry.data?.telemetry_enabled ?? true;
+
+  // Launch-on-login disclosed here too (defaults ON) so onboarding fully
+  // discloses the two default-on behaviours; both persist immediately via the
+  // same backend the Settings page uses.
+  const launchOnLogin = useLaunchOnLoginSetting();
+  const setLaunchOnLogin = useSetLaunchOnLogin();
+  const launchOnLoginEnabled = launchOnLogin.data ?? true;
+
+  const qc = useQueryClient();
+  // Onboarding discloses telemetry + launch-on-login, so mark the one-time
+  // privacy notice seen on the way out. Without this, an upgrader who had a
+  // config but no model (so they were routed here) would land on Home and get
+  // the consent modal a second time for the same toggles. Idempotent — a fresh
+  // install is already seen. Navigate regardless so a persist hiccup never
+  // traps the user in Setup.
+  const finishOnboarding = React.useCallback(async () => {
+    try {
+      const res = await ipc().privacy.markNoticeSeen();
+      if (res?.success) {
+        // Flip the gate synchronously before navigating home so the consent
+        // modal can't flash on the way out; invalidate reconciles with disk.
+        qc.setQueryData(settingsKeys.privacyNoticeSeen(), true);
+        qc.invalidateQueries({ queryKey: settingsKeys.privacyNoticeSeen() });
+      }
+    } catch {
+      // best-effort; the consent modal is a soft disclosure, not a gate
+    } finally {
+      navigate('/');
+    }
+  }, [qc, navigate]);
 
   // First name powers the in-app greeting ("Hi <name>, ask anything"). Stored
   // locally only — never sent anywhere. Persisted on blur to avoid a write
@@ -574,9 +608,30 @@ export function Setup() {
           />
         </div>
 
+        <div
+          className="mt-3 flex items-start gap-4 rounded-md border border-border p-4"
+          data-setup-launch
+        >
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium text-foreground">
+              Launch on login
+            </div>
+            <Muted className="mt-0.5">
+              Start Steno automatically when you log in (hidden in the menu
+              bar). You can change this any time in Settings.
+            </Muted>
+          </div>
+          <Switch
+            checked={launchOnLoginEnabled}
+            onCheckedChange={(v) => setLaunchOnLogin.mutate(v)}
+            disabled={launchOnLogin.data === undefined}
+            aria-label="Launch on login"
+          />
+        </div>
+
         <div className="mt-8 flex flex-col items-center gap-2">
           {done ? (
-            <Button size="lg" onClick={() => navigate('/')}>
+            <Button size="lg" onClick={() => void finishOnboarding()}>
               Continue to app
             </Button>
           ) : (

--- a/e2e/specs/privacy-consent.t2.spec.ts
+++ b/e2e/specs/privacy-consent.t2.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readUserConfig, writeUserConfig } from '../fixtures/user-config';
+
+/**
+ * T2 — one-time privacy consent modal for upgraders. Model-free + deterministic:
+ * seed a config.json that EXISTS but has no `privacy_notice_seen` key (an
+ * existing install predating the marker). The backend migration
+ * (Config._migrate_privacy_notice_seen) then resolves the marker to false, so
+ * `privacy.getNoticeSeen()` returns false and App.tsx renders the modal.
+ *
+ * The app auto-redirects to /setup once when no ASR model is installed (the
+ * model-free T2 bundle has none). The consent modal deliberately hides on
+ * /setup (onboarding discloses the same toggles), so the tests force a neutral
+ * route and wait for it — the setup gate only redirects once, so '#/' sticks.
+ */
+
+const MODAL = '[data-privacy-consent]';
+const ACK = '[data-privacy-ack]';
+const TELEMETRY_SWITCH = '[data-privacy-telemetry]';
+const LAUNCH_SWITCH = '[data-privacy-launch]';
+
+/** Simulate an upgrader: a pre-existing config.json with no privacy marker. */
+function seedUpgraderConfig(userDataDir: string): void {
+  writeUserConfig(userDataDir, { user_name: 'Upgrader' });
+}
+
+/**
+ * Drive the app to a neutral route and wait for the consent modal. Re-forces
+ * '#/' each poll iteration to out-race the one-shot setup-gate redirect to
+ * /setup (which would otherwise hide the modal on a model-free bundle).
+ */
+async function waitForConsentModal(page: import('@playwright/test').Page) {
+  await expect
+    .poll(
+      async () => {
+        await page.evaluate(() => {
+          window.location.hash = '#/';
+        });
+        return page.locator(MODAL).isVisible();
+      },
+      { message: 'privacy consent modal should appear for an upgrader on a neutral route' },
+    )
+    .toBe(true);
+}
+
+test('upgrader sees the consent modal; acknowledging marks it seen and it does not return', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  seedUpgraderConfig(userDataDir);
+
+  const { page } = await launchApp();
+  await waitForConsentModal(page);
+
+  // The backend migration flipped the absent marker to false on first load.
+  expect(readUserConfig(userDataDir).privacy_notice_seen).toBe(false);
+
+  // Both disclosed toggles reflect the persisted default (ON).
+  await expect(page.locator(TELEMETRY_SWITCH)).toHaveAttribute('data-state', 'checked');
+  await expect(page.locator(LAUNCH_SWITCH)).toHaveAttribute('data-state', 'checked');
+
+  // Acknowledge via the primary button.
+  await page.locator(ACK).click();
+
+  // Backend truth: the marker is now true, forever.
+  await expect
+    .poll(() => readUserConfig(userDataDir).privacy_notice_seen, {
+      message: 'acknowledging flips privacy_notice_seen to true on disk',
+    })
+    .toBe(true);
+
+  // UI truth: the modal is gone and stays gone even after re-forcing the
+  // neutral route (the gate query refetched true, so it can never reopen).
+  await expect(page.locator(MODAL)).toBeHidden();
+  await page.evaluate(() => {
+    window.location.hash = '#/meetings';
+  });
+  await page.evaluate(() => {
+    window.location.hash = '#/';
+  });
+  await expect(page.locator(MODAL)).toBeHidden();
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+// Show-once across a restart is proven compositionally, without an in-test
+// relaunch (the single-launch fixture doesn't support one): the test above
+// proves acknowledging persists privacy_notice_seen: true on disk, and the test
+// below proves a config that already carries the marker never renders the modal.
+// The pair is non-vacuous by construction — the test above fails if the gate
+// ever fails to SHOW on a false marker, and the test below fails if it ever
+// SHOWS on a true marker — so neither a stuck-hidden nor a stuck-shown gate can
+// slip through.
+test('a config that already has the marker never shows the modal', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // Fresh installs are seeded privacy_notice_seen: true by the backend
+  // migration; simulate that (and any already-acknowledged install) directly.
+  writeUserConfig(userDataDir, { user_name: 'Seen', privacy_notice_seen: true });
+
+  const { page } = await launchApp();
+  // A model-free bundle auto-redirects to /setup once; the gate is one-shot so
+  // forcing #/ then sticks on the neutral route the modal would appear on.
+  await page.evaluate(() => {
+    window.location.hash = '#/';
+  });
+
+  // Deterministic sync: wait until the privacy query has actually RESOLVED to
+  // true (App mirrors the settled gate value onto data-privacy-gate). This is
+  // what makes the "hidden" assertion below non-vacuous — it can no longer pass
+  // simply because the query is still pending and the modal hasn't mounted yet.
+  await expect(page.locator('html')).toHaveAttribute('data-privacy-gate', 'true');
+  // Sanity: the gate read exactly the marker we seeded.
+  expect(readUserConfig(userDataDir).privacy_notice_seen).toBe(true);
+
+  // Prove the modal stays hidden ON the neutral route across several ticks —
+  // re-forcing #/ each time so a late one-shot /setup redirect can't make the
+  // assertion pass for the wrong reason (hidden because of the route, not the
+  // marker). If the gate ever wrongly showed on a true marker, this catches it.
+  for (let i = 0; i < 3; i++) {
+    await page.evaluate(() => {
+      window.location.hash = '#/';
+    });
+    await expect(page).toHaveURL(/#\/$/);
+    await expect(page.locator(MODAL)).toBeHidden();
+    await page.waitForTimeout(150);
+  }
+});
+
+test('consent modal toggles persist telemetry_enabled and launch_on_login', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  seedUpgraderConfig(userDataDir);
+
+  const { page } = await launchApp();
+  await waitForConsentModal(page);
+
+  // Both default ON; a single click flips each off — flipping the default gives
+  // the assertions teeth (a no-op toggle would leave them unset/true).
+  await page.locator(TELEMETRY_SWITCH).click();
+  await expect
+    .poll(() => readUserConfig(userDataDir).telemetry_enabled, {
+      message: 'telemetry toggle -> config.telemetry_enabled',
+    })
+    .toBe(false);
+
+  await page.locator(LAUNCH_SWITCH).click();
+  await expect
+    .poll(() => readUserConfig(userDataDir).launch_on_login, {
+      message: 'launch-on-login toggle -> config.launch_on_login',
+    })
+    .toBe(false);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/e2e/specs/privacy-consent.t2.spec.ts
+++ b/e2e/specs/privacy-consent.t2.spec.ts
@@ -39,7 +39,14 @@ async function waitForConsentModal(page: import('@playwright/test').Page) {
         });
         return page.locator(MODAL).isVisible();
       },
-      { message: 'privacy consent modal should appear for an upgrader on a neutral route' },
+      {
+        message: 'privacy consent modal should appear for an upgrader on a neutral route',
+        // App launch + the config migration + the privacy gate query can race
+        // the one-shot /setup redirect on a loaded CI runner; the default 5s
+        // poll was occasionally too tight (flaky, green on retry). Give it more
+        // wall-clock — the assertion (modal must appear) is unchanged.
+        timeout: 20_000,
+      },
     )
     .toBe(true);
 }

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4064,6 +4064,28 @@ def set_telemetry(enabled):
 
 
 @cli.command()
+def get_privacy_notice_seen():
+    """Get whether the one-time privacy notice has been acknowledged."""
+    from src.config import get_config
+
+    config = get_config()
+    print(json.dumps({"privacy_notice_seen": config.get_privacy_notice_seen()}))
+
+
+@cli.command()
+def set_privacy_notice_seen():
+    """Mark the one-time privacy notice as acknowledged."""
+    from src.config import get_config
+
+    config = get_config()
+    success = config.set_privacy_notice_seen(True)
+    if success:
+        print(json.dumps({"success": True, "privacy_notice_seen": True}))
+    else:
+        print(json.dumps({"success": False, "error": "Failed to save config"}))
+
+
+@cli.command()
 def get_system_audio():
     """Get the current system audio capture preference"""
     from src.config import get_config

--- a/src/config.py
+++ b/src/config.py
@@ -297,6 +297,7 @@ class Config:
         self._migrate_whisper_model()
         self._migrate_summary_model()
         self._migrate_transcription_engine()
+        self._migrate_privacy_notice_seen()
         self._normalize_templates()
         self._seed_sample_template()
 
@@ -317,6 +318,64 @@ class Config:
             "whisper" if self._existed_at_load else "parakeet"
         )
         self._save()
+
+    def _migrate_privacy_notice_seen(self) -> None:
+        """Seed the one-time privacy notice marker for fresh and existing installs.
+
+        Fresh installs are disclosed during onboarding, so their default marker
+        is True. Existing installs whose on-disk config predates the marker get
+        False so the upgrade notice appears once. Inspecting the disk directly
+        keeps a default-filled in-memory config from masking key absence.
+        """
+        if self._load_failed:
+            return  # never persist defaults over a corrupt-but-recoverable file
+        if not self._existed_at_load:
+            self._config["privacy_notice_seen"] = True
+            return
+
+        on_disk = self._read_disk_for_merge()
+        if on_disk is not None and "privacy_notice_seen" in on_disk:
+            adopted = on_disk.get("privacy_notice_seen") is True
+            self._config["privacy_notice_seen"] = adopted
+            self._snapshot["privacy_notice_seen"] = adopted
+            return
+
+        self._config["privacy_notice_seen"] = False
+        self._persist_privacy_notice_migration()
+        # Keep an ordinary later _save() from bypassing the locked CAS. If the
+        # persist lost a race, the helper has already adopted the disk value.
+        self._snapshot["privacy_notice_seen"] = self._config[
+            "privacy_notice_seen"
+        ]
+
+    def _persist_privacy_notice_migration(self) -> None:
+        """Locked compare-and-set write for the privacy notice marker.
+
+        Re-read config.json while holding the lock. If another process wrote
+        the marker first, adopt its value rather than clobbering it. Failures
+        leave the existing install's in-memory value False and retry next load.
+        """
+        lock_path = str(self.config_path) + ".lock"
+        try:
+            with filelock.FileLock(lock_path, timeout=self._SAVE_LOCK_TIMEOUT):
+                base = self._read_disk_for_merge()
+                if base is None:
+                    return
+                if "privacy_notice_seen" in base:
+                    adopted = base.get("privacy_notice_seen") is True
+                    self._config["privacy_notice_seen"] = adopted
+                    self._snapshot["privacy_notice_seen"] = adopted
+                    return
+                base["privacy_notice_seen"] = False
+                _atomic_write_json(self.config_path, base)
+                self._snapshot["privacy_notice_seen"] = False
+        except filelock.Timeout:
+            logger.warning(
+                "Timed out acquiring config lock for privacy notice migration; "
+                "will retry on next load"
+            )
+        except Exception as e:
+            logger.error(f"Error persisting privacy notice migration: {e}")
 
     def _migrate_whisper_model(self) -> None:
         """Map any out-of-current-list whisper model to the supported one.
@@ -585,6 +644,10 @@ class Config:
             "model": self.DEFAULT_MODEL,
             "notifications_enabled": True,
             "telemetry_enabled": True,
+            # Fresh installs see the disclosure during onboarding. Existing
+            # configs missing this key are migrated to False so the one-time
+            # upgrade notice is shown.
+            "privacy_notice_seen": True,
             # Default ON on macOS — CoreAudio Process Tap captures system
             # audio alongside the mic on macOS 14.4+. Older macOS auto-falls
             # back to mic-only via main.js's loadSystemAudioEnabled() OS gate.
@@ -848,6 +911,15 @@ class Config:
             True if saved successfully, False otherwise
         """
         self._config["telemetry_enabled"] = enabled
+        return self._save()
+
+    def get_privacy_notice_seen(self) -> bool:
+        """Get whether the one-time privacy notice has been acknowledged."""
+        return self._config.get("privacy_notice_seen", True) is True
+
+    def set_privacy_notice_seen(self, seen: bool) -> bool:
+        """Set the privacy notice marker and end the migration window."""
+        self._config["privacy_notice_seen"] = seen
         return self._save()
 
     def get_hide_dock_icon(self) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -302,6 +302,86 @@ class ConfigLaunchOnLoginTests(unittest.TestCase):
             self.assertTrue(reloaded.get_launch_on_login())
 
 
+class ConfigPrivacyNoticeTests(unittest.TestCase):
+    def test_fresh_install_seeds_notice_seen_true(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+
+            self.assertTrue(config.get_privacy_notice_seen())
+            self.assertIs(json.loads(path.read_text())["privacy_notice_seen"], True)
+
+    def test_existing_config_without_marker_seeds_false_and_persists(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"model": Config.DEFAULT_MODEL}))
+
+            config = Config(config_path=path)
+
+            self.assertFalse(config.get_privacy_notice_seen())
+            self.assertIs(json.loads(path.read_text())["privacy_notice_seen"], False)
+
+    def test_set_notice_seen_true_round_trips_and_persists(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(json.dumps({"model": Config.DEFAULT_MODEL}))
+            config = Config(config_path=path)
+
+            self.assertTrue(config.set_privacy_notice_seen(True))
+            self.assertTrue(config.get_privacy_notice_seen())
+            self.assertIs(json.loads(path.read_text())["privacy_notice_seen"], True)
+            self.assertTrue(Config(config_path=path).get_privacy_notice_seen())
+
+    def test_present_marker_prevents_retrigger(self):
+        for seen in (False, True):
+            with self.subTest(seen=seen):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    path = Path(tmp_dir) / "config.json"
+                    payload = {
+                        "model": Config.DEFAULT_MODEL,
+                        "privacy_notice_seen": seen,
+                    }
+                    path.write_text(json.dumps(payload))
+
+                    config = Config(config_path=path)
+
+                    self.assertIs(config.get_privacy_notice_seen(), seen)
+                    self.assertIs(
+                        json.loads(path.read_text())["privacy_notice_seen"], seen
+                    )
+
+    def test_corrupt_config_never_persisted(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text("{not json")
+
+            config = Config(config_path=path)
+
+            self.assertTrue(config.get_privacy_notice_seen())
+            self.assertEqual(path.read_text(), "{not json")
+
+    def test_migration_cas_adopts_marker_that_lands_first(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "model": Config.DEFAULT_MODEL,
+                        "privacy_notice_seen": True,
+                    }
+                )
+            )
+            config = Config(config_path=path)
+            config._config["privacy_notice_seen"] = False
+            config._snapshot.pop("privacy_notice_seen", None)
+
+            config._persist_privacy_notice_migration()
+
+            self.assertIs(json.loads(path.read_text())["privacy_notice_seen"], True)
+            self.assertTrue(config.get_privacy_notice_seen())
+            self.assertIs(config._snapshot["privacy_notice_seen"], True)
+
+
 class ConfigOrgAutoBackupTests(unittest.TestCase):
     def test_default_auto_backup_is_true(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Adds an in-product privacy disclosure for telemetry and launch-on-login. Both **stay enabled by default** (no change to the shipped defaults); this PR is about *disclosing* them and giving users an easy, up-front off switch.

- **New installs** see both settings in onboarding and can turn either off there.
- **Existing installs** (upgraders who already have telemetry / launch-on-login on from v0.5.8 / v0.6.0) get a **single, soft, one-time consent modal** on first launch after updating: two inline toggles (both pre-set on), a short disclosure, and a "Got it" button. Nothing is gated or held back — the modal only discloses what is on and offers an immediate off switch.

This supersedes the earlier strict-opt-in attempts (#335, closed; #336, to be closed): rather than flip the defaults off, we keep telemetry coverage high but make the behaviour transparent and one-click reversible.

## Behaviour

| Config state | Telemetry / launch-on-login | Consent surface |
| --- | --- | --- |
| Fresh install | on (default) | Onboarding discloses both; no modal |
| Existing install, upgrading | on (unchanged) | One-time modal, once, then never again |
| Marker already set (seen) | unchanged | Nothing |
| Corrupt config | fails closed (no write) | Nothing |

## How it works

- New config key `privacy_notice_seen`, seeded by a one-time migration keyed on `Config._existed_at_load`: a config that did **not** exist at first load is a fresh install (onboarding is its disclosure) and seeds `true`; a config that existed but lacks the key is an upgrader and seeds `false`, so the modal shows exactly once. The migration reuses the locked compare-and-set / read-from-disk pattern from the telemetry work so a concurrent write is never clobbered and it fails closed on a corrupt config.
- The modal reads the marker via a new `window.stenoai.privacy` bridge (`get-/set-privacy-notice-seen`), and acknowledging (button, X, or Escape) marks it seen forever. Onboarding completion also marks it seen, so an upgrader who happens to lack a model (and is routed to onboarding) is not disclosed to twice.
- Telemetry / launch-on-login defaults are **unchanged** (both still `true`). The modal's telemetry toggle uses a new `'consent'` source, and `disableGeoip: true` is now explicit on both PostHog constructors (already the SDK default; drift protection).

## Testing

- `python -m pytest tests/test_config.py` — full config suite incl. `ConfigPrivacyNoticeTests` (fresh seeds true, existing-without-key seeds false + persists, round-trip, present-marker no-op, corrupt never persisted, CAS race adoption).
- `npm run typecheck:renderer` / `npm run lint:renderer` — clean.
- `npm run test:e2e -- --project=t2` — full model-free T2 suite green, including a new `privacy-consent.t2` (upgrader sees the modal → acknowledging persists `privacy_notice_seen: true` and it does not return; a config that already carries the marker never shows it; both toggles persist `telemetry_enabled` / `launch_on_login`). No regression in the other T2 specs from mounting the modal.

## Notes / out of scope

- Website/docs copy stays "enabled by default" — still accurate, so no copy change is needed.
- No changes to event payloads, sanitization, or `anonymous_id`.
- The full onboarding-completion path is covered by the config/logic layer but not by a model-bearing e2e (T2 is model-free by design). A no-model upgrader can see the modal flash for a sub-second before the onboarding redirect resolves — a minor, accepted cosmetic edge for a rare state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time privacy disclosure for upgraders and surfaces telemetry and launch-on-login during onboarding. Defaults stay on; users get a simple, upfront off switch.

- New Features
  - One-time consent modal for existing installs with inline toggles (telemetry, launch on login). Dismissal marks it seen and it never returns.
  - Onboarding now includes a launch-on-login toggle alongside telemetry.
  - New renderer bridge `window.stenoai.privacy` for getting/setting the notice state.
  - Telemetry toggle accepts source `'consent'`; PostHog is initialized with `disableGeoip: true`.
  - Shared `useMarkPrivacyNoticeSeen` hook used by the consent modal and onboarding; aligns IPC return type and flips the gate query immediately to avoid flicker. E2E stability improved with a longer wait for the modal.

- Migration
  - New config key `privacy_notice_seen`.
  - Fresh installs seed `true`; existing configs missing the key seed `false` to show the modal once.
  - Uses a locked compare-and-set write, adopts concurrent writes, and fails closed on corrupt configs.

<sup>Written for commit 0ef2c0d14c2196f424b96b9b53a0439c62d95b4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

