### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
+- **2026-07-19** ⚙️ Redesigned Settings — a left nav rail with grouped sections replaces the old tab bar, plus a new About tab (version and update check) and finer control over notifications and the menu-bar icon.
 - **2026-07-19** 🏷️ Note titles restored — a note you summarise on demand (with automatic summaries off) now gets an AI-generated title instead of staying "Note"; a title you set yourself is never overwritten.
 - **2026-07-18** 🎙️ Recording that stays out of your way — a compact transcription pill docks beside the app instead of taking over, Stop lands you on the note instantly, and you can resume recording into any note (it appends). Plus a dedicated **My notes** tab that stays editable alongside the AI summary.
 - **2026-07-18** 🎚️ Microphone selection — choose which input device Steno records from in Settings.
-- **2026-07-18** 🚀 Launch on login — Steno can start hidden when you log in so capture is always ready; opt out in Settings.
 
 
 ## Features

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,17 @@ title: "Changelog"
 description: "What's new in Steno -- recent releases and notable changes."
 ---
 
+<Update label="v0.6.2" description="July 19, 2026">
+**Improved**
+- Redesigned Settings with a persistent left navigation rail and grouped sections (Preferences, AI, Templates, Workspace, System), replacing the old row of tabs.
+- Added an About tab that shows your app version with a built-in check-for-updates flow.
+- Added finer control over which notifications you see and how the menu-bar (tray) icon behaves.
+
+**Fixed**
+- The "Generate notes" button no longer stays visible after you resume recording into a note.
+- Resuming a recording now keeps the transcript continuous instead of breaking it.
+</Update>
+
 <Update label="v0.6.1" description="July 19, 2026">
 **Fixed**
 - Notes you summarise on demand ("Generate notes") now get an AI-generated title, instead of staying "Note". A title you set yourself is never overwritten.


### PR DESCRIPTION
Release prep for v0.6.2. Scope = what is already merged in main since v0.6.1: the Settings nav-rail redesign (#344) and the resume-flow fixes (#351).

- README "What's New": add the Settings redesign entry, trim to the most recent 4.
- `docs/changelog.mdx`: new v0.6.2 block (Improved + Fixed).
- `app/package.json`: 0.6.1 → 0.6.2.

Cloud transcription / notification migration (#349) is intentionally **not** in this release — it stays open for a reconcile + security review and ships in a fast follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v0.6.2: ships the Settings redesign and resume-recording fixes, updates What’s New and changelog, and bumps the app to 0.6.2. Cloud transcription/notification migration is excluded and will follow.

- **New Features**
  - Redesigned Settings with a left nav rail and grouped sections; new About tab with version and update check; finer controls for notifications and the tray icon.

- **Bug Fixes**
  - “Generate notes” button no longer stays visible after resuming.
  - Resuming recording keeps the transcript continuous.

<sup>Written for commit 2fdf7a5ee1e229ab0406e89b99829844a24d1c74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

