### PR TITLE
fix(onboarding): show model-download progress in the setup wizard

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -445,6 +445,48 @@ function install({ ipcMain }) {
       state.provider = 'local';
       return { success: true };
     },
+
+    // Onboarding permission gate. The real handlers ask macOS; under mock IPC we
+    // grant so the setup-progress spec can run past the first step. Harmless for
+    // other specs, none of which invoke these channels.
+    'check-microphone-permission': async () => ({ success: true, status: 'granted' }),
+    'request-microphone-permission': async () => ({ success: true, granted: true }),
+
+    // Onboarding model downloads. With STENOAI_E2E_SETUP_PROGRESS=1 the handler
+    // emits the same renderer progress events the real handlers do, then holds
+    // the step in its 'running' state (the promise never resolves) so the
+    // download-progress spec can observe the bar. The app is torn down at test
+    // end. Without the flag they resolve success, matching the permissive
+    // default so nothing else changes.
+    'setup-parakeet': async (event) => {
+      if (process.env.STENOAI_E2E_SETUP_PROGRESS === '1') {
+        const wc = event && event.sender;
+        if (wc && !wc.isDestroyed()) {
+          // Parakeet exposes only coarse stages (no byte counts).
+          wc.send('parakeet-pull-progress', { stage: 'downloading' });
+        }
+        return new Promise(() => {});
+      }
+      return { success: true, message: 'Parakeet model ready' };
+    },
+    'setup-ollama-and-model': async (event) => {
+      if (process.env.STENOAI_E2E_SETUP_PROGRESS === '1') {
+        const wc = event && event.sender;
+        if (wc && !wc.isDestroyed()) {
+          // Two records: the phase change (manifest -> blob) and a byte-progress
+          // line, mirroring the real { status, pct, completed, total } payload.
+          wc.send('setup-ollama-progress', { status: 'pulling manifest', pct: 0, completed: 0, total: 0 });
+          wc.send('setup-ollama-progress', {
+            status: 'pulling sha256:abcd',
+            pct: 42,
+            completed: 42,
+            total: 100,
+          });
+        }
+        return new Promise(() => {});
+      }
+      return { success: true, message: 'Ollama and AI model ready' };
+    },
   };
 
   // Static shapes for the channels that fire on first paint and would throw in

--- a/app/main.js
+++ b/app/main.js
@@ -5879,7 +5879,6 @@ ipcMain.handle('setup-ollama-and-model', async () => {
         // mid-record, so buffer across chunks and only parse complete lines -
         // splitting each chunk in isolation would corrupt a split record.
         let buffer = '';
-        let streamError = null;
         // Ollama reports byte progress PER LAYER/blob, so completed/total reset
         // for each new layer. Track every layer's { completed, total } keyed by
         // digest, then report progress from the SINGLE largest layer (the model
@@ -5903,7 +5902,6 @@ ipcMain.handle('setup-ollama-and-model', async () => {
         const handleRecord = (json) => {
           if (json.error) {
             sendDebugLog(`Pull error: ${json.error}`);
-            streamError = json.error;
             trackEvent('setup_failed', { step: 'ollama_and_model' });
             req.destroy();
             settle({ success: false, error: 'Failed to download AI model', details: json.error });
@@ -5972,11 +5970,10 @@ ipcMain.handle('setup-ollama-and-model', async () => {
         });
 
         res.on('end', async () => {
+          // The in-stream { error } path calls settle() synchronously (via
+          // handleRecord) before 'end' fires, so `settled` already covers it —
+          // no separate streamError check is needed here.
           if (settled) return;
-          if (streamError) {
-            settle({ success: false, error: 'Failed to download AI model', details: streamError });
-            return;
-          }
           // A final NDJSON record without a trailing newline stays in the buffer.
           // If that trailing line is an { error } record, an HTTP-200 end would
           // otherwise resolve success even though the pull failed - so parse it

--- a/app/main.js
+++ b/app/main.js
@@ -5849,6 +5849,23 @@ ipcMain.handle('setup-ollama-and-model', async () => {
     const http = require('http');
     return new Promise((resolve) => {
       const postData = JSON.stringify({ name: pullTarget });
+      // Resolve exactly once. A streamed error must be terminal, so guard the
+      // 'end' handler from resolving success after we've already reported a
+      // failure line.
+      let settled = false;
+      const settle = (result) => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
+      // Emit progress to the renderer's setup wizard. Dedicated channel (not
+      // the Settings 'model-pull-progress') because that one's listeners expect
+      // a { model, progress: string } shape and would throw on this payload.
+      const sendOllamaProgress = (payload) => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('setup-ollama-progress', payload);
+        }
+      };
       const req = http.request({
         hostname: '127.0.0.1',
         port: 11434,
@@ -5858,37 +5875,123 @@ ipcMain.handle('setup-ollama-and-model', async () => {
         timeout: 600000
       }, (res) => {
         let lastStatus = '';
+        // Ollama streams newline-delimited JSON. A single socket chunk can end
+        // mid-record, so buffer across chunks and only parse complete lines -
+        // splitting each chunk in isolation would corrupt a split record.
+        let buffer = '';
+        let streamError = null;
+        // Ollama reports byte progress PER LAYER/blob, so completed/total reset
+        // for each new layer. Track every layer's { completed, total } keyed by
+        // digest, then report progress from the SINGLE largest layer (the model
+        // blob dominates the pull at ~2GB of ~2.05GB total). That approximates
+        // overall progress and stays near-monotonic, without the aggregate's
+        // premature-100%-then-drop when a small layer finishes before the blob
+        // even appears.
+        const layers = new Map();
+        // Last emitted pct, so status-only lines (e.g. "verifying sha256",
+        // "success") keep the bar where it was instead of dropping it back to 0.
+        let lastPct = 0;
+        // Dedupe the IPC emit the same way the debug log dedupes via lastStatus:
+        // Ollama emits many records/sec and the renderer flickers if every one
+        // is forwarded. Skip the emit when both status and pct are unchanged.
+        let lastEmittedStatus = null;
+        let lastEmittedPct = -1;
+
+        // Fold one parsed NDJSON record into the largest-layer tracker and emit
+        // progress. Returns true when the record is a terminal error so callers
+        // stop.
+        const handleRecord = (json) => {
+          if (json.error) {
+            sendDebugLog(`Pull error: ${json.error}`);
+            streamError = json.error;
+            trackEvent('setup_failed', { step: 'ollama_and_model' });
+            req.destroy();
+            settle({ success: false, error: 'Failed to download AI model', details: json.error });
+            return true;
+          }
+          const status = json.status || '';
+          if (json.total) {
+            // Key by digest so each blob is tracked independently; fall back to
+            // the status label when a record carries no digest.
+            const key = json.digest || status || 'unkeyed';
+            layers.set(key, { completed: json.completed || 0, total: json.total });
+          }
+          // Drive the bar from the single layer with the largest total seen so
+          // far - the model blob. Computed from the map so status-only records
+          // (no total) still report that layer's bytes instead of dropping to 0.
+          let largest = null;
+          for (const layer of layers.values()) {
+            if (!largest || layer.total > largest.total) {
+              largest = layer;
+            }
+          }
+          const largestCompleted = largest ? largest.completed : 0;
+          const largestTotal = largest ? largest.total : 0;
+          if (json.total) {
+            // Guard divide-by-zero: leave the bar at its last position.
+            if (largestTotal > 0) {
+              lastPct = Math.round((100 * largestCompleted) / largestTotal);
+            }
+            const msg = `${status} ${lastPct}%`;
+            if (msg !== lastStatus) {
+              sendDebugLog(msg);
+              lastStatus = msg;
+            }
+          } else if (status !== lastStatus) {
+            // No byte counts on this line - retain the last bar position so
+            // phase changes update the label without a misleading reset.
+            sendDebugLog(status);
+            lastStatus = status;
+          }
+          // Emit only when status or pct actually changed, to avoid flicker.
+          if (status !== lastEmittedStatus || lastPct !== lastEmittedPct) {
+            lastEmittedStatus = status;
+            lastEmittedPct = lastPct;
+            sendOllamaProgress({ status, pct: lastPct, completed: largestCompleted, total: largestTotal });
+          }
+          return false;
+        };
+
         res.on('data', (chunk) => {
-          // Ollama streams newline-delimited JSON
-          const lines = chunk.toString().split('\n').filter(Boolean);
-          for (const line of lines) {
+          buffer += chunk.toString();
+          let nl;
+          while ((nl = buffer.indexOf('\n')) !== -1) {
+            const line = buffer.slice(0, nl).trim();
+            buffer = buffer.slice(nl + 1);
+            if (!line) continue;
+            let json;
             try {
-              const json = JSON.parse(line);
-              if (json.error) {
-                sendDebugLog(`Pull error: ${json.error}`);
-                return;
-              }
-              // Log progress without spamming duplicate status
-              const status = json.status || '';
-              if (json.total && json.completed) {
-                const pct = Math.round((json.completed / json.total) * 100);
-                const msg = `${status} ${pct}%`;
-                if (msg !== lastStatus) {
-                  sendDebugLog(msg);
-                  lastStatus = msg;
-                }
-              } else if (status !== lastStatus) {
-                sendDebugLog(status);
-                lastStatus = status;
-              }
+              json = JSON.parse(line);
             } catch (e) {
               // Non-JSON line, log as-is
-              sendDebugLog(chunk.toString().trim());
+              sendDebugLog(line);
+              continue;
             }
+            if (handleRecord(json)) return;
           }
         });
 
         res.on('end', async () => {
+          if (settled) return;
+          if (streamError) {
+            settle({ success: false, error: 'Failed to download AI model', details: streamError });
+            return;
+          }
+          // A final NDJSON record without a trailing newline stays in the buffer.
+          // If that trailing line is an { error } record, an HTTP-200 end would
+          // otherwise resolve success even though the pull failed - so parse it
+          // and treat a trailing error exactly like the in-stream error path.
+          const trailing = buffer.trim();
+          if (trailing) {
+            let json = null;
+            try { json = JSON.parse(trailing); } catch (_) { /* not JSON */ }
+            if (json && json.error) {
+              sendDebugLog(`Pull error: ${json.error}`);
+              trackEvent('setup_failed', { step: 'ollama_and_model' });
+              settle({ success: false, error: 'Failed to download AI model', details: json.error });
+              return;
+            }
+          }
           if (res.statusCode === 200) {
             sendDebugLog('AI model download completed successfully');
             try {
@@ -5897,24 +6000,24 @@ ipcMain.handle('setup-ollama-and-model', async () => {
               // Non-fatal -- config reset is best-effort
             }
             trackEvent('setup_completed', { step: 'ollama_and_model' });
-            resolve({ success: true, message: 'Ollama and AI model ready' });
+            settle({ success: true, message: 'Ollama and AI model ready' });
           } else {
             sendDebugLog(`AI model download failed with status: ${res.statusCode}`);
             trackEvent('setup_failed', { step: 'ollama_and_model' });
-            resolve({ success: false, error: 'Failed to download AI model', details: `HTTP ${res.statusCode}` });
+            settle({ success: false, error: 'Failed to download AI model', details: `HTTP ${res.statusCode}` });
           }
         });
       });
 
       req.on('error', (error) => {
         sendDebugLog(`Pull request error: ${error.message}`);
-        resolve({ success: false, error: 'Failed to download AI model', details: error.message });
+        settle({ success: false, error: 'Failed to download AI model', details: error.message });
       });
 
       req.on('timeout', () => {
         req.destroy();
         sendDebugLog('Model pull timed out after 10 minutes');
-        resolve({ success: false, error: 'Model download timed out' });
+        settle({ success: false, error: 'Model download timed out' });
       });
 
       req.write(postData);

--- a/app/preload.js
+++ b/app/preload.js
@@ -356,6 +356,7 @@ const stenoai = {
     whisperPullComplete: (cb) => subscribe('whisper-pull-complete', cb),
     parakeetPullProgress: (cb) => subscribe('parakeet-pull-progress', cb),
     parakeetPullComplete: (cb) => subscribe('parakeet-pull-complete', cb),
+    setupOllamaProgress: (cb) => subscribe('setup-ollama-progress', cb),
     liveTranscriptReady: (cb) => subscribe('live-transcript-ready', cb),
     liveTranscriptChunk: (cb) => subscribe('live-transcript-chunk', cb),
     liveTranscriptError: (cb) => subscribe('live-transcript-error', cb),

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -259,6 +259,13 @@
   from { opacity: 0; transform: translateY(-5px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+/* Onboarding transcription-model download: Parakeet exposes only coarse stages
+   (no byte counts), so its progress bar is indeterminate - a segment sweeps the
+   track to signal "working" without fabricating a percentage. */
+@keyframes steno-indeterminate {
+  0%   { left: -40%; }
+  100% { left: 100%; }
+}
 
 /* =============================================================================
    Component layer
@@ -268,6 +275,20 @@
 @layer components {
   .animate-title-in {
     animation: titleFadeIn 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  /* Indeterminate download bar (see @keyframes steno-indeterminate). The track
+     supplies position:relative + overflow-hidden; the sweeping segment is this
+     pseudo-element. */
+  .setup-indeterminate-bar::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 40%;
+    border-radius: inherit;
+    background: var(--fg-1);
+    animation: steno-indeterminate 1.1s ease-in-out infinite;
   }
 
   .thinking-dot {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -665,6 +665,18 @@ export interface ParakeetPullCompleteEvent {
   success: boolean;
   error?: string;
 }
+/** Byte-level progress from the onboarding wizard's local summarization-model
+ *  download (main.js 'setup-ollama-and-model'). Dedicated to the Setup flow -
+ *  distinct from the Settings model-pull events, whose payload is a
+ *  { model, progress: string } string. Ollama streams per-blob progress, so
+ *  `pct` can step back toward 0 as each new layer starts; the label carries the
+ *  current phase alongside the bar. */
+export interface SetupOllamaProgressEvent {
+  status: string;
+  pct: number;
+  completed: number;
+  total: number;
+}
 
 // ---------- live transcript ----------
 export interface LiveSegment {
@@ -1063,6 +1075,7 @@ export interface StenoaiBridge {
     whisperPullComplete: Subscribe<WhisperPullCompleteEvent>;
     parakeetPullProgress: Subscribe<ParakeetPullProgressEvent>;
     parakeetPullComplete: Subscribe<ParakeetPullCompleteEvent>;
+    setupOllamaProgress: Subscribe<SetupOllamaProgressEvent>;
     liveTranscriptReady: Subscribe<LiveTranscriptReadyEvent>;
     liveTranscriptChunk: Subscribe<LiveTranscriptChunkEvent>;
     liveTranscriptError: Subscribe<LiveTranscriptErrorEvent>;

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -178,7 +178,13 @@ export function Setup() {
   // events) emitted by main.js 'setup-parakeet' / 'setup-ollama-and-model'.
   React.useEffect(() => {
     if (typeof window === 'undefined' || !window.stenoai) return;
-    const offParakeet = ipc().on.parakeetPullProgress(({ stage }) => {
+    const offParakeet = ipc().on.parakeetPullProgress(({ model, stage }) => {
+      // Both the setup-parakeet flow and the Settings model-management pull
+      // emit on the shared 'parakeet-pull-progress' channel. Settings pulls
+      // carry a `model` id; the setup handler emits only { stage }. Ignore
+      // model-bearing events so the wizard bar can't reflect an unrelated
+      // Settings pull.
+      if (model != null) return;
       setParakeetStage(stage);
     });
     const offOllama = ipc().on.setupOllamaProgress(({ status, pct }) => {

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -40,6 +40,56 @@ interface Step {
   icon: React.ComponentType<{ className?: string }>;
   status: StepStatus;
   detail?: string;
+  /** Optional download-progress affordance rendered under the detail line
+   *  while the step is running (see the transcription/summarization steps). */
+  progressNode?: React.ReactNode;
+}
+
+/** Real byte-progress bar for the local summarization-model download. Ollama
+ *  streams per-blob progress, so `pct` can step back toward 0 as each new layer
+ *  begins - the status label carries the current phase so the bar never reads
+ *  as a single misleading aggregate. */
+function OllamaProgressBar({ status, pct }: { status: string; pct: number }) {
+  const clamped = Math.max(0, Math.min(100, Math.round(pct)));
+  return (
+    <div className="mt-2" data-setup-ollama-progress>
+      <div className="mb-1 flex items-center justify-between text-[11px] text-muted-foreground">
+        <span className="truncate">{status || 'Downloading model...'}</span>
+        <span className="tabular-nums">{clamped}%</span>
+      </div>
+      <div
+        className="h-1.5 overflow-hidden rounded-full"
+        style={{ background: 'var(--surface-sunken)' }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={clamped}
+        aria-label="Summarization model download progress"
+      >
+        <div
+          className="h-full rounded-full transition-[width] duration-300"
+          style={{ width: `${clamped}%`, background: 'var(--fg-1)' }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Indeterminate bar for the transcription-model download. Parakeet only
+ *  exposes coarse stages (no byte counts), so we signal activity without
+ *  fabricating a percentage. */
+function IndeterminateBar({ label }: { label: string }) {
+  return (
+    <div className="mt-2" data-setup-transcription-progress>
+      <div className="mb-1 text-[11px] text-muted-foreground">{label}</div>
+      <div
+        className="setup-indeterminate-bar relative h-1.5 overflow-hidden rounded-full"
+        style={{ background: 'var(--surface-sunken)' }}
+        role="progressbar"
+        aria-label={label}
+      />
+    </div>
+  );
 }
 
 function Badge({ status }: { status: StepStatus }) {
@@ -83,6 +133,7 @@ function StepCard({ step }: { step: Step }) {
           <Badge status={step.status} />
         </div>
         <Muted className="mt-0.5">{step.detail ?? step.description}</Muted>
+        {step.progressNode}
       </div>
     </div>
   );
@@ -104,6 +155,13 @@ export function Setup() {
   const [done, setDone] = React.useState(false);
   const [debugOpen, setDebugOpen] = React.useState(false);
   const [logs, setLogs] = React.useState<string[]>([]);
+  // Live download progress surfaced on the step cards. Parakeet only exposes a
+  // coarse stage (indeterminate bar); Ollama streams byte-level percent.
+  const [parakeetStage, setParakeetStage] = React.useState<string | null>(null);
+  const [ollamaProgress, setOllamaProgress] = React.useState<{
+    status: string;
+    pct: number;
+  } | null>(null);
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !window.stenoai) return;
@@ -113,6 +171,23 @@ export function Setup() {
         return next.length > 500 ? next.slice(-500) : next;
       });
     });
+  }, []);
+
+  // Subscribe once to the onboarding download-progress events. These are the
+  // setup-specific channels (distinct from the Settings model-management pull
+  // events) emitted by main.js 'setup-parakeet' / 'setup-ollama-and-model'.
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.stenoai) return;
+    const offParakeet = ipc().on.parakeetPullProgress(({ stage }) => {
+      setParakeetStage(stage);
+    });
+    const offOllama = ipc().on.setupOllamaProgress(({ status, pct }) => {
+      setOllamaProgress({ status, pct });
+    });
+    return () => {
+      offParakeet();
+      offOllama();
+    };
   }, []);
 
   const checkMic = useCheckMicPermission();
@@ -194,6 +269,10 @@ export function Setup() {
   const runSetup = async () => {
     setRunning(true);
     setDone(false);
+    // Reset any progress left over from a previous (failed) run so a retry
+    // starts from a clean bar rather than resuming a stale one.
+    setParakeetStage(null);
+    setOllamaProgress(null);
     // Capture the snapshot so we can branch on what's already done. Skipping
     // completed steps keeps retries fast (no re-prompting for mic permission,
     // no re-initialising Whisper) when the user is just fixing a bad API key.
@@ -243,6 +322,7 @@ export function Setup() {
         } else {
           setStatus('transcription', 'running', `Downloading Parakeet TDT v3 (${isMac ? '~572 MB' : '~670 MB'})...`);
           await parakeetStep.mutateAsync();
+          setParakeetStage(null);
           setStatus('transcription', 'done', 'Transcription model ready');
         }
       }
@@ -278,6 +358,7 @@ export function Setup() {
         ipc().analytics.track('ai_provider_selected', { provider: 'local' });
         setStatus('ollama', 'running', 'Downloading model (~2 GB)...');
         await ollamaStep.mutateAsync();
+        setOllamaProgress(null);
         setStatus('ollama', 'done', 'Model installed');
       }
 
@@ -302,6 +383,10 @@ export function Setup() {
       setDone(true);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Setup step failed';
+      // Clear the bars on failure - a failed step keeps its Failed badge +
+      // error detail, not a frozen progress bar.
+      setParakeetStage(null);
+      setOllamaProgress(null);
       setStatuses((prev) => {
         const failId = (Object.keys(prev) as Step['id'][]).find((k) => prev[k] === 'running');
         if (!failId) return prev;
@@ -329,6 +414,10 @@ export function Setup() {
       icon: MessageSquare,
       status: statuses.transcription,
       detail: details.transcription,
+      progressNode:
+        statuses.transcription === 'running' && parakeetStage !== null ? (
+          <IndeterminateBar label="Downloading and preparing model..." />
+        ) : undefined,
     },
     {
       id: 'ollama',
@@ -340,6 +429,10 @@ export function Setup() {
       icon: summaryMode === 'cloud' ? Cloud : Zap,
       status: statuses.ollama,
       detail: details.ollama,
+      progressNode:
+        statuses.ollama === 'running' && ollamaProgress !== null ? (
+          <OllamaProgressBar status={ollamaProgress.status} pct={ollamaProgress.pct} />
+        ) : undefined,
     },
   ];
 

--- a/e2e/specs/onboarding-download-progress.t1.spec.ts
+++ b/e2e/specs/onboarding-download-progress.t1.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 - renderer-only, mock IPC, no backend. Regression guard for #354: the
+ * onboarding wizard used to send model-download progress only to the collapsed
+ * debug console, so a fresh install showed a static "Downloading… (~2 GB)"
+ * string with no visible bar. Setup.tsx now subscribes to the setup-specific
+ * progress channels and renders progress on the step cards:
+ *   - transcription (Parakeet): an INDETERMINATE bar (stages only, no byte %).
+ *   - summarization (Ollama): a REAL bar + percent from setup-ollama-progress.
+ *
+ * The mock (app/e2e-mock-ipc.js, gated on STENOAI_E2E_SETUP_PROGRESS) emits the
+ * same renderer events the real main.js handlers do, then holds the step in its
+ * running state so the bar can be observed.
+ */
+
+test('summarization step renders a real progress bar + percent from setup-ollama-progress', async ({
+  launchApp,
+}) => {
+  // Parakeet pre-installed so the transcription step is skipped and the wizard
+  // goes straight to the Ollama download we want to observe.
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: {
+      STENOAI_E2E_SETUP_PROGRESS: '1',
+      STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1',
+    },
+  });
+
+  await page.evaluate(() => {
+    window.location.hash = '#/setup';
+  });
+
+  await page.getByRole('button', { name: 'Begin setup' }).click();
+
+  const ollamaStep = page.locator('[data-setup-step="ollama"]');
+  await expect(ollamaStep).toHaveAttribute('data-setup-status', 'running');
+
+  // A real bar with the streamed percent + the current status label.
+  const bar = ollamaStep.locator('[data-setup-ollama-progress]');
+  await expect(bar).toBeVisible();
+  await expect(bar.getByText('42%')).toBeVisible();
+  await expect(bar.getByText('pulling sha256:abcd')).toBeVisible();
+
+  const progressbar = ollamaStep.getByRole('progressbar');
+  await expect(progressbar).toHaveAttribute('aria-valuenow', '42');
+});
+
+test('transcription step renders an indeterminate "preparing" bar (no fabricated percent)', async ({
+  launchApp,
+}) => {
+  // Parakeet NOT installed → the transcription download runs. It only reports
+  // coarse stages, so the UI shows an indeterminate bar, never a percentage.
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SETUP_PROGRESS: '1' },
+  });
+
+  await page.evaluate(() => {
+    window.location.hash = '#/setup';
+  });
+
+  await page.getByRole('button', { name: 'Begin setup' }).click();
+
+  const transcriptionStep = page.locator('[data-setup-step="transcription"]');
+  await expect(transcriptionStep).toHaveAttribute('data-setup-status', 'running');
+
+  const bar = transcriptionStep.locator('[data-setup-transcription-progress]');
+  await expect(bar).toBeVisible();
+  await expect(bar.getByText('Downloading and preparing model...')).toBeVisible();
+  await expect(transcriptionStep.getByRole('progressbar')).toBeVisible();
+
+  // No fabricated percentage on the indeterminate bar.
+  await expect(bar.getByText('%')).toHaveCount(0);
+});


### PR DESCRIPTION
Closes #354.

## Problem
On a fresh install the onboarding wizard downloads ~2.6 GB of models (Parakeet ~572 MB + the ~2 GB local summarization model) but showed only a static "Downloading... (~2 GB)" string for the whole multi-minute wait. The Ollama percentage was actually computed but only sent to the collapsed **Debug console**, not the UI.

## Change
- **`main.js` `setup-ollama-and-model`:** emit a dedicated `setup-ollama-progress` event (distinct from the Settings `model-pull-progress` channel, whose payload shape differs). Drive the bar from the **largest layer** (the model blob dominates the pull), and dedupe emits to avoid renderer flicker.
- **`Setup.tsx`:** render a real bar + percent + status for the summarization download, and an **indeterminate** bar for the transcription model (Parakeet exposes coarse stages only, no byte %). Subscribe once with cleanup; reset before a run; clear on done/failed.
- **preload / ipc.ts:** dedicated channel + typing.
- **Two latent bugs fixed in the same handler:** buffer the NDJSON stream across socket chunks (a record could be split across chunks), and treat a streamed **or trailing** `json.error` as a terminal failure so an HTTP 200 can't resolve success after an error line.
- **Tests:** T1 renderer spec (mock IPC) asserting the real bar + % and the indeterminate state.

## Known limitation
A streaming multi-layer pull has no known total up front, so the overall % can briefly jump then self-correct at a layer boundary (a small layer completing before the big blob appears). This is inherent; the alternative (forcing monotonicity) is worse - it would falsely sit at 100% while still downloading. The current behaviour self-corrects to reality and is sub-second in practice.

## Verification
Confirmed live on a fresh isolated M1 install (real Ollama download): the bar + % render during the pull instead of the previous blackbox. `typecheck:renderer`, `lint:renderer` (0 errors), `node --check`, and the T1 suite all green. Reviewed cross-family (Codex) across three rounds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show real model-download progress in the setup wizard. Adds a percent bar for the local summarization model and an indeterminate bar for the Parakeet transcription model so users see real-time status during the multi‑GB pull.

- **New Features**
  - Emit `setup-ollama-progress` from `main.js` and dedupe emits; drive percent from the largest layer.
  - Render a real bar + percent for summarization and an indeterminate bar for Parakeet in `Setup.tsx`; reset and clean up subscriptions.
  - Add typed IPC in `preload`/`renderer` and CSS for the indeterminate animation. Note: percent can briefly step at layer boundaries; it self-corrects.

- **Bug Fixes**
  - Ignore non-setup `parakeet-pull-progress` events (those with `model`) so a Settings pull can’t drive the wizard bar.
  - Harden stream handling: buffer NDJSON across chunks, parse any trailing line, treat streamed/trailing `error` as terminal, and settle exactly once; remove the unreachable end-handler error branch.
  - Add a T1 spec verifying both bars and extend mock IPC to emit setup progress.

<sup>Written for commit d6d5982ff708b3016da5f1e7ba7de1c27fba6c8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

