### PR TITLE
refactor(main): split main.js — Phase 0 seams + Folders pilot (RFC #327)

### DIFF
--- a/app/backend-cli.js
+++ b/app/backend-cli.js
@@ -1,0 +1,169 @@
+'use strict';
+
+/**
+ * Backend CLI seam — the spawn wrapper, process-tree kill, bundled-backend
+ * path resolution, and the `runPythonScript` invoker that ~90 call sites in
+ * main.js depend on. Carved out of app/main.js (RFC #327, Phase 0) with ZERO
+ * behavior change: the code is a verbatim move; only the cross-cutting seams
+ * (logging + diagnostics forwarding, and electron's `app`) are injected via
+ * `createBackendCli(deps)` so main.js stays the one place that wires them.
+ *
+ * `spawn` and `killProcessTree` are pure (child_process + process only) and
+ * exported directly for unit coverage. `getBackendPath`/`getBackendCwd`/
+ * `runPythonScript` need electron's `app` and the logging seams, so they come
+ * out of the factory. Importing this module does NOT require electron — `app`
+ * is only touched when getBackendPath/getBackendCwd are actually called — so
+ * the pure exports stay testable under `node --test`.
+ */
+
+const path = require('path');
+const { spawn: _spawnRaw } = require('child_process');
+
+// Wrap spawn so every backend / ollama launch defaults to windowsHide:true.
+// The PyInstaller backend (stenoai.exe) and bundled ollama.exe are console
+// subsystem binaries; without this Electron pops a visible console window on
+// Windows for every recording, live-transcribe, query, and the long-lived
+// `ollama serve` keeps one open for the whole session. No-op on macOS/Linux.
+// Callers can still override by passing an explicit windowsHide.
+function spawn(command, args, options) {
+  if (Array.isArray(args) || args === undefined || args === null) {
+    return _spawnRaw(command, args, { windowsHide: true, ...(options || {}) });
+  }
+  // 2-arg form: spawn(command, options)
+  return _spawnRaw(command, { windowsHide: true, ...args });
+}
+
+// Terminate a process AND its child processes. On Windows `process.kill(pid)`
+// only kills the named process, orphaning its children — `ollama serve` spawns
+// per-model "runner" subprocesses that would leak after quit. `taskkill /T`
+// walks the whole tree. On POSIX we keep the existing SIGTERM -> SIGKILL
+// escalation (ollama tears its runners down on SIGTERM there). Synchronous on
+// Windows (execFileSync) so it completes during the app's will-quit handler.
+function killProcessTree(pid) {
+  if (!pid) return;
+  if (process.platform === 'win32') {
+    try {
+      require('child_process').execFileSync(
+        'taskkill',
+        ['/PID', String(pid), '/T', '/F'],
+        { windowsHide: true, stdio: 'ignore' },
+      );
+    } catch (_) {}
+    return;
+  }
+  try { process.kill(pid, 'SIGTERM'); } catch (_) {}
+  setTimeout(() => {
+    try { process.kill(pid, 'SIGKILL'); } catch (_) {}
+  }, 1000);
+}
+
+/**
+ * @param {object} deps
+ * @param {import('electron').App} deps.app            electron app (isPackaged / resourcesPath)
+ * @param {(msg: string) => void} deps.sendDebugLog    renderer debug-panel logger
+ * @param {(args: string[]) => string} deps.sanitizeArgsForLog  PII-scrub for the echoed argv
+ * @param {(proc, label) => void} deps.attachProcessingStderr   persistent stderr capture (opt-in)
+ * @param {(line: string, source: string) => void} deps.forwardDiagnosticStdout  structural stdout markers
+ */
+function createBackendCli({
+  app,
+  sendDebugLog,
+  sanitizeArgsForLog,
+  attachProcessingStderr,
+  forwardDiagnosticStdout,
+}) {
+  // Backend executable path - always use bundled stenoai
+  function getBackendPath() {
+    const exe = process.platform === 'win32' ? 'stenoai.exe' : 'stenoai';
+    if (app.isPackaged) {
+      // Production: bundled in app resources
+      return path.join(process.resourcesPath, 'stenoai', exe);
+    } else {
+      // Development: use local build
+      return path.join(__dirname, '..', 'dist', 'stenoai', exe);
+    }
+  }
+
+  function getBackendCwd() {
+    if (app.isPackaged) {
+      return path.join(process.resourcesPath, 'stenoai');
+    } else {
+      return path.join(__dirname, '..', 'dist', 'stenoai');
+    }
+  }
+
+  function runPythonScript(script, args = [], silent = false, extraEnv = {}, logLabel = null) {
+    return new Promise((resolve, reject) => {
+      const backendPath = getBackendPath();
+
+      // Log the command being executed (unless silent)
+      console.log('Running:', `${backendPath} ${args.join(' ')}`);
+      if (!silent) {
+        // Sanitize the echoed argv: denylisted commands (query, save-template,
+        // set-user-name/storage-path, folder + URL setters) carry content/PII in
+        // their args. This rewrites the LOGGED string only; the spawned `args`
+        // below are untouched.
+        sendDebugLog(`$ stenoai ${sanitizeArgsForLog(args)}`);
+      }
+
+      const process = spawn(backendPath, args, {
+        cwd: getBackendCwd(),
+        env: Object.keys(extraEnv).length > 0 ? { ...require('process').env, ...extraEnv } : undefined
+      });
+
+      // Opt-in persistent capture for the legacy process-recording path only.
+      // Default null → generic backend calls (config reads, chat query, …) are
+      // NOT persisted, preserving the no-global-tee privacy boundary.
+      if (logLabel) attachProcessingStderr(process, logLabel);
+
+      let stdout = '';
+      let stderr = '';
+
+      process.stdout.on('data', (data) => {
+        const output = data.toString();
+        stdout += output;
+        console.log('Python stdout:', output);
+        // Stream stdout to debug panel in real-time (unless silent), but only the
+        // structural diagnostic markers — query answers and other content are
+        // dropped so they never reach the shareable buffer.
+        if (!silent) {
+          output.split('\n').forEach(line => {
+            forwardDiagnosticStdout(line, 'backend');
+          });
+        }
+      });
+
+      process.stderr.on('data', (data) => {
+        const output = data.toString();
+        stderr += output;
+        console.log('Python stderr:', output);
+        // Stream stderr to debug panel in real-time (unless silent)
+        if (!silent) {
+          output.split('\n').forEach(line => {
+            if (line.trim()) sendDebugLog('STDERR: ' + line.trim());
+          });
+        }
+      });
+
+      process.on('close', (code) => {
+        if (!silent) {
+          sendDebugLog(`Command completed with exit code: ${code}`);
+        }
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          reject(new Error(`Python script failed with code ${code}: ${stderr}`));
+        }
+      });
+
+      process.on('error', (error) => {
+        sendDebugLog(`Command error: ${error.message}`);
+        reject(error);
+      });
+    });
+  }
+
+  return { getBackendPath, getBackendCwd, runPythonScript };
+}
+
+module.exports = { spawn, killProcessTree, createBackendCli };

--- a/app/backend-cli.test.js
+++ b/app/backend-cli.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const { test, mock, afterEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+// backend-cli.js destructures child_process.spawn at load time, so stub it
+// BEFORE the first require. killProcessTree reads child_process.execFileSync at
+// call time, so that can be stubbed per-test.
+const cp = require('child_process');
+const realSpawn = cp.spawn;
+let spawnCalls = [];
+cp.spawn = (...args) => { spawnCalls.push(args); return { fake: true }; };
+
+const { spawn, killProcessTree, createBackendCli } = require('./backend-cli');
+
+afterEach(() => {
+  spawnCalls = [];
+  mock.restoreAll();
+});
+
+// ---- spawn wrapper -------------------------------------------------------
+
+test('spawn defaults windowsHide:true for the (command, args[]) form', () => {
+  spawn('backend', ['a', 'b']);
+  assert.deepStrictEqual(spawnCalls[0][0], 'backend');
+  assert.deepStrictEqual(spawnCalls[0][1], ['a', 'b']);
+  assert.deepStrictEqual(spawnCalls[0][2], { windowsHide: true });
+});
+
+test('spawn lets a caller override windowsHide', () => {
+  spawn('backend', ['a'], { windowsHide: false, cwd: '/x' });
+  assert.deepStrictEqual(spawnCalls[0][2], { windowsHide: false, cwd: '/x' });
+});
+
+test('spawn handles the 2-arg (command, options) form', () => {
+  spawn('backend', { cwd: '/y' });
+  // Collapsed to the options-object overload; windowsHide defaulted in.
+  assert.deepStrictEqual(spawnCalls[0][1], { windowsHide: true, cwd: '/y' });
+});
+
+test('spawn defaults options when args is null/undefined', () => {
+  spawn('backend');
+  assert.deepStrictEqual(spawnCalls[0][1], undefined);
+  assert.deepStrictEqual(spawnCalls[0][2], { windowsHide: true });
+});
+
+// ---- killProcessTree -----------------------------------------------------
+
+test('killProcessTree is a no-op for a falsy pid', () => {
+  const killMock = mock.method(process, 'kill', () => {});
+  killProcessTree(0);
+  killProcessTree(null);
+  killProcessTree(undefined);
+  assert.strictEqual(killMock.mock.callCount(), 0);
+});
+
+test('killProcessTree escalates SIGTERM -> SIGKILL on POSIX', () => {
+  if (process.platform === 'win32') return; // POSIX-only branch
+  const killMock = mock.method(process, 'kill', () => {});
+  mock.timers.enable({ apis: ['setTimeout'] });
+  killProcessTree(4242);
+  // Immediate SIGTERM.
+  assert.strictEqual(killMock.mock.callCount(), 1);
+  assert.deepStrictEqual(killMock.mock.calls[0].arguments, [4242, 'SIGTERM']);
+  // SIGKILL only after the 1s escalation timer.
+  mock.timers.tick(1000);
+  assert.strictEqual(killMock.mock.callCount(), 2);
+  assert.deepStrictEqual(killMock.mock.calls[1].arguments, [4242, 'SIGKILL']);
+});
+
+test('killProcessTree tree-kills via taskkill on win32', () => {
+  const origPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  const execMock = mock.method(cp, 'execFileSync', () => {});
+  try {
+    killProcessTree(777);
+    assert.strictEqual(execMock.mock.callCount(), 1);
+    const [bin, argv, opts] = execMock.mock.calls[0].arguments;
+    assert.strictEqual(bin, 'taskkill');
+    assert.deepStrictEqual(argv, ['/PID', '777', '/T', '/F']);
+    assert.strictEqual(opts.windowsHide, true);
+  } finally {
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  }
+});
+
+// ---- createBackendCli: packaging-aware paths -----------------------------
+
+test('getBackendPath/getBackendCwd resolve the dev build via injected app', () => {
+  const { getBackendPath, getBackendCwd } = createBackendCli({ app: { isPackaged: false } });
+  const exe = process.platform === 'win32' ? 'stenoai.exe' : 'stenoai';
+  // __dirname is app/, so dev paths point at <repo>/dist/stenoai/*.
+  assert.strictEqual(getBackendPath(), path.join(__dirname, '..', 'dist', 'stenoai', exe));
+  assert.strictEqual(getBackendCwd(), path.join(__dirname, '..', 'dist', 'stenoai'));
+});
+
+test('getBackendPath/getBackendCwd resolve the packaged resources dir', () => {
+  const origRes = process.resourcesPath;
+  Object.defineProperty(process, 'resourcesPath', { value: '/Apps/Steno.app/Contents/Resources', configurable: true });
+  const exe = process.platform === 'win32' ? 'stenoai.exe' : 'stenoai';
+  try {
+    const { getBackendPath, getBackendCwd } = createBackendCli({ app: { isPackaged: true } });
+    assert.strictEqual(getBackendPath(), path.join('/Apps/Steno.app/Contents/Resources', 'stenoai', exe));
+    assert.strictEqual(getBackendCwd(), path.join('/Apps/Steno.app/Contents/Resources', 'stenoai'));
+  } finally {
+    Object.defineProperty(process, 'resourcesPath', { value: origRes, configurable: true });
+  }
+});
+
+// Restore the real child_process.spawn once this file's tests are done.
+test('teardown: restore child_process.spawn', () => {
+  cp.spawn = realSpawn;
+});

--- a/app/backend-cli.test.js
+++ b/app/backend-cli.test.js
@@ -99,9 +99,10 @@ test('killProcessTree escalates SIGTERM -> SIGKILL on POSIX', () => {
 
 test('killProcessTree tree-kills via taskkill on win32', () => {
   const origPlatform = process.platform;
-  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-  const execMock = mock.method(cp, 'execFileSync', () => {});
   try {
+    // Inside the try so any throw during setup still hits the finally restore.
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const execMock = mock.method(cp, 'execFileSync', () => {});
     killProcessTree(777);
     assert.strictEqual(execMock.mock.callCount(), 1);
     const [bin, argv, opts] = execMock.mock.calls[0].arguments;
@@ -125,9 +126,10 @@ test('getBackendPath/getBackendCwd resolve the dev build via injected app', () =
 
 test('getBackendPath/getBackendCwd resolve the packaged resources dir', () => {
   const origRes = process.resourcesPath;
-  Object.defineProperty(process, 'resourcesPath', { value: '/Apps/Steno.app/Contents/Resources', configurable: true });
-  const exe = process.platform === 'win32' ? 'stenoai.exe' : 'stenoai';
   try {
+    // Inside the try so any throw during setup still hits the finally restore.
+    Object.defineProperty(process, 'resourcesPath', { value: '/Apps/Steno.app/Contents/Resources', configurable: true });
+    const exe = process.platform === 'win32' ? 'stenoai.exe' : 'stenoai';
     const { getBackendPath, getBackendCwd } = createBackendCli({ app: { isPackaged: true } });
     assert.strictEqual(getBackendPath(), path.join('/Apps/Steno.app/Contents/Resources', 'stenoai', exe));
     assert.strictEqual(getBackendCwd(), path.join('/Apps/Steno.app/Contents/Resources', 'stenoai'));

--- a/app/backend-cli.test.js
+++ b/app/backend-cli.test.js
@@ -10,14 +10,42 @@ const path = require('path');
 const cp = require('child_process');
 const realSpawn = cp.spawn;
 let spawnCalls = [];
-cp.spawn = (...args) => { spawnCalls.push(args); return { fake: true }; };
+let stubChild = { fake: true };
+cp.spawn = (...args) => { spawnCalls.push(args); return stubChild; };
 
 const { spawn, killProcessTree, createBackendCli } = require('./backend-cli');
 
 afterEach(() => {
   spawnCalls = [];
+  stubChild = { fake: true };
   mock.restoreAll();
 });
+
+// A controllable child-process double: runPythonScript registers stdout/stderr/
+// process handlers synchronously, so a test can drive them after the call.
+function fakeChild() {
+  const bags = { stdout: {}, stderr: {}, proc: {} };
+  const sink = (bag) => ({ on: (evt, cb) => { bag[evt] = cb; } });
+  return {
+    stdout: sink(bags.stdout),
+    stderr: sink(bags.stderr),
+    on: (evt, cb) => { bags.proc[evt] = cb; },
+    emit: (which, evt, arg) => { const h = bags[which][evt]; if (h) h(arg); },
+  };
+}
+
+function recordingDeps(extra = {}) {
+  const rec = { debug: [], forwarded: [], attached: [] };
+  const deps = {
+    app: { isPackaged: false },
+    sendDebugLog: (m) => rec.debug.push(m),
+    sanitizeArgsForLog: () => 'SANITIZED',
+    attachProcessingStderr: (proc, label) => rec.attached.push({ proc, label }),
+    forwardDiagnosticStdout: (line, source) => rec.forwarded.push({ line, source }),
+    ...extra,
+  };
+  return { rec, run: createBackendCli(deps).runPythonScript };
+}
 
 // ---- spawn wrapper -------------------------------------------------------
 
@@ -106,6 +134,89 @@ test('getBackendPath/getBackendCwd resolve the packaged resources dir', () => {
   } finally {
     Object.defineProperty(process, 'resourcesPath', { value: origRes, configurable: true });
   }
+});
+
+// ---- createBackendCli: runPythonScript behavior -------------------------
+
+test('runPythonScript (non-silent) sanitizes the echoed argv and streams output', async () => {
+  stubChild = fakeChild();
+  const { rec, run } = recordingDeps();
+  const p = run('simple_recorder.py', ['create-folder', 'secret'], false);
+  // The spawned argv is untouched; only the LOGGED echo is sanitized.
+  assert.deepStrictEqual(spawnCalls[0][1], ['create-folder', 'secret']);
+  assert.ok(rec.debug.includes('$ stenoai SANITIZED'));
+  // No extraEnv -> env is left undefined (inherit parent).
+  assert.strictEqual(spawnCalls[0][2].env, undefined);
+
+  stubChild.emit('stdout', 'data', Buffer.from('one\ntwo'));
+  assert.deepStrictEqual(rec.forwarded, [
+    { line: 'one', source: 'backend' },
+    { line: 'two', source: 'backend' },
+  ]);
+  stubChild.emit('stderr', 'data', Buffer.from('bad\n'));
+  assert.ok(rec.debug.includes('STDERR: bad'));
+
+  stubChild.emit('proc', 'close', 0);
+  assert.ok(rec.debug.includes('Command completed with exit code: 0'));
+  assert.strictEqual(await p, 'one\ntwo');
+});
+
+test('runPythonScript (silent) suppresses all debug-panel logging', async () => {
+  stubChild = fakeChild();
+  const { rec, run } = recordingDeps();
+  const p = run('simple_recorder.py', ['status'], true);
+  stubChild.emit('stdout', 'data', Buffer.from('quiet'));
+  stubChild.emit('stderr', 'data', Buffer.from('noise\n'));
+  stubChild.emit('proc', 'close', 0);
+  assert.deepStrictEqual(rec.debug, []);
+  assert.deepStrictEqual(rec.forwarded, []);
+  assert.strictEqual(await p, 'quiet');
+});
+
+test('runPythonScript merges extraEnv over the parent environment', async () => {
+  stubChild = fakeChild();
+  const { run } = recordingDeps();
+  const p = run('simple_recorder.py', ['x'], true, { STENO_TEST_FLAG: 'on' });
+  const env = spawnCalls[0][2].env;
+  assert.strictEqual(env.STENO_TEST_FLAG, 'on');
+  assert.strictEqual(env.PATH, process.env.PATH); // parent env preserved
+  stubChild.emit('proc', 'close', 0);
+  await p;
+});
+
+test('runPythonScript attaches persistent stderr capture only when a logLabel is given', async () => {
+  stubChild = fakeChild();
+  const withLabel = recordingDeps();
+  const p1 = withLabel.run('simple_recorder.py', ['x'], true, {}, 'process-streaming');
+  assert.strictEqual(withLabel.rec.attached.length, 1);
+  assert.strictEqual(withLabel.rec.attached[0].label, 'process-streaming');
+  stubChild.emit('proc', 'close', 0);
+  await p1;
+
+  stubChild = fakeChild();
+  const noLabel = recordingDeps();
+  const p2 = noLabel.run('simple_recorder.py', ['x'], true);
+  assert.strictEqual(noLabel.rec.attached.length, 0);
+  stubChild.emit('proc', 'close', 0);
+  await p2;
+});
+
+test('runPythonScript rejects with the stderr text on a non-zero exit', async () => {
+  stubChild = fakeChild();
+  const { run } = recordingDeps();
+  const p = run('simple_recorder.py', ['x'], true);
+  stubChild.emit('stderr', 'data', Buffer.from('boom happened'));
+  stubChild.emit('proc', 'close', 3);
+  await assert.rejects(p, /code 3: boom happened/);
+});
+
+test('runPythonScript rejects and logs on a spawn error event', async () => {
+  stubChild = fakeChild();
+  const { rec, run } = recordingDeps();
+  const p = run('simple_recorder.py', ['x'], false);
+  stubChild.emit('proc', 'error', new Error('ENOENT'));
+  await assert.rejects(p, /ENOENT/);
+  assert.ok(rec.debug.includes('Command error: ENOENT'));
 });
 
 // Restore the real child_process.spawn once this file's tests are done.

--- a/app/debug-log.js
+++ b/app/debug-log.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Debug-log seam — the `sendDebugLog` sink that streams backend command echoes,
+ * stderr, and pipeline progress to the renderer's setup console + debug panel.
+ * Carved out of app/main.js (RFC #327, Phase 0) with ZERO behavior change: the
+ * body is verbatim; the only cross-cutting dependency (the main BrowserWindow)
+ * is injected via a `getMainWindow` accessor so this module never closes over
+ * main.js's mutable `mainWindow` binding directly. main.js stays the one place
+ * that owns the window and wires it in.
+ *
+ * The accessor is read on every call (not captured once) so a window created,
+ * destroyed, or recreated after wiring is always reflected — matching the old
+ * behavior where `sendDebugLog` read the live module-scope `mainWindow`.
+ */
+
+/**
+ * @param {object} deps
+ * @param {() => (import('electron').BrowserWindow | null | undefined)} deps.getMainWindow
+ * @returns {(message: string) => void}
+ */
+function createDebugLog({ getMainWindow }) {
+  return function sendDebugLog(message) {
+    // Send to main window (both setup console and debug panel)
+    const mainWindow = getMainWindow();
+    if (mainWindow) {
+      mainWindow.webContents.send('debug-log', message);
+    }
+  };
+}
+
+module.exports = { createDebugLog };

--- a/app/debug-log.test.js
+++ b/app/debug-log.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { createDebugLog } = require('./debug-log');
+
+function fakeWindow() {
+  const sent = [];
+  return { sent, webContents: { send: (...a) => sent.push(a) } };
+}
+
+test('sends the message to the main window on the debug-log channel', () => {
+  const win = fakeWindow();
+  const sendDebugLog = createDebugLog({ getMainWindow: () => win });
+  sendDebugLog('hello');
+  assert.deepStrictEqual(win.sent, [['debug-log', 'hello']]);
+});
+
+test('is a silent no-op when there is no window', () => {
+  const sendDebugLog = createDebugLog({ getMainWindow: () => null });
+  assert.doesNotThrow(() => sendDebugLog('dropped'));
+});
+
+test('reads the accessor on every call (window created/destroyed after wiring)', () => {
+  let win = null;
+  const sendDebugLog = createDebugLog({ getMainWindow: () => win });
+  sendDebugLog('before'); // no window yet — dropped
+  const real = fakeWindow();
+  win = real;
+  sendDebugLog('after'); // window now present
+  win = null;
+  sendDebugLog('gone'); // destroyed again — dropped
+  assert.deepStrictEqual(real.sent, [['debug-log', 'after']]);
+});

--- a/app/folders-ipc.js
+++ b/app/folders-ipc.js
@@ -1,0 +1,191 @@
+'use strict';
+
+/**
+ * Folders + storage-layout IPC handlers — the folder CRUD/ordering surface plus
+ * the three storage-path handlers that own where user data lives (RFC #327
+ * groups them as one "storage layout" module). The pilot extraction that
+ * establishes the handler-group pattern: a single `registerFoldersIpc(deps)`
+ * entry point that main.js calls once, in place, so registration timing and
+ * behavior are identical to the inline handlers it replaces (ZERO behavior
+ * change).
+ *
+ * Cross-cutting seams are injected — main.js stays the only place that wires
+ * them:
+ *   - runPythonScript          the bundled-backend invoker (backend-cli seam)
+ *   - dialog                   electron dialog (native folder picker)
+ *   - getMainWindow            accessor for the modal parent window
+ *   - getUserDataDir           per-OS default data dir (storage-path display)
+ *   - validateMeetingFilePath  symlink-safe containment check for meeting paths
+ *   - setCachedCustomStoragePath  updates main.js's storage-path cache that the
+ *                              file-validation readers consult
+ */
+
+function registerFoldersIpc({
+  ipcMain,
+  runPythonScript,
+  dialog,
+  getMainWindow,
+  getUserDataDir,
+  validateMeetingFilePath,
+  setCachedCustomStoragePath,
+}) {
+  // Storage path handlers
+  ipcMain.handle('get-storage-path', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-storage-path'], true);
+      const jsonData = JSON.parse(result.trim());
+      // Python only returns the user's custom path (empty string when not set).
+      // Augment with the platform default so the renderer can show "where your
+      // data actually lives" without hardcoding the path. custom_path mirrors
+      // storage_path but is null when empty for cleaner conditionals.
+      const customPath = jsonData.storage_path && jsonData.storage_path.trim()
+        ? jsonData.storage_path
+        : null;
+      // getUserDataDir() so the "where your data lives" path shown in Settings is
+      // correct on Windows (%APPDATA%/stenoai), not a macOS literal. It already
+      // resolves to the per-OS .../stenoai dir.
+      const defaultPath = getUserDataDir();
+      return {
+        success: true,
+        storage_path: customPath || defaultPath,
+        custom_path: customPath,
+        default_path: defaultPath,
+      };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('set-storage-path', async (event, storagePath) => {
+    try {
+      const args = ['set-storage-path'];
+      if (storagePath) {
+        args.push(storagePath);
+      }
+      const result = await runPythonScript('simple_recorder.py', args);
+      // Update cached custom path for file validation
+      setCachedCustomStoragePath(storagePath || null);
+      const jsonMatch = result.match(/\{.*\}/s);
+      if (jsonMatch) {
+        return JSON.parse(jsonMatch[0]);
+      }
+      return { success: true, storage_path: storagePath };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('select-storage-folder', async () => {
+    try {
+      const result = await dialog.showOpenDialog(getMainWindow(), {
+        properties: ['openDirectory', 'createDirectory'],
+        title: 'Choose storage location for Steno data',
+        buttonLabel: 'Select Folder'
+      });
+
+      if (!result.canceled && result.filePaths.length > 0) {
+        return { success: true, folderPath: result.filePaths[0] };
+      }
+      return { success: false, error: 'No folder selected' };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  // Folder management handlers
+  ipcMain.handle('list-folders', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['list-folders'], true);
+      return { success: true, ...JSON.parse(result.trim()) };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('create-folder', async (event, name, color) => {
+    try {
+      const args = ['create-folder', name];
+      if (color) args.push('--color', color);
+      const result = await runPythonScript('simple_recorder.py', args);
+      const jsonMatch = result.match(/\{.*\}/s);
+      return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('rename-folder', async (event, folderId, name) => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['rename-folder', folderId, name]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('update-folder-icon', async (event, folderId, icon) => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['update-folder-icon', folderId, icon]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('delete-folder', async (event, folderId) => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['delete-folder', folderId]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('reorder-folders', async (event, folderIds) => {
+    try {
+      const args = ['reorder-folders', ...folderIds];
+      const result = await runPythonScript('simple_recorder.py', args);
+      const jsonMatch = result.match(/\{.*\}/s);
+      return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('add-meeting-to-folder', async (event, summaryFile, folderId) => {
+    try {
+      // Security: the renderer is untrusted, so containment-check the summary path
+      // (symlink-safe, output/ only) and pass the canonical realPath to the backend.
+      const validated = await validateMeetingFilePath(summaryFile);
+      if (validated.error) {
+        return { success: false, error: validated.error };
+      }
+      const result = await runPythonScript('simple_recorder.py', ['add-meeting-to-folder', validated.realPath, folderId]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('remove-meeting-from-folder', async (event, summaryFile, folderId) => {
+    try {
+      // Security: the renderer is untrusted, so containment-check the summary path
+      // (symlink-safe, output/ only) and pass the canonical realPath to the backend.
+      const validated = await validateMeetingFilePath(summaryFile);
+      if (validated.error) {
+        return { success: false, error: validated.error };
+      }
+      const result = await runPythonScript('simple_recorder.py', ['remove-meeting-from-folder', validated.realPath, folderId]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+}
+
+module.exports = { registerFoldersIpc };

--- a/app/folders-ipc.test.js
+++ b/app/folders-ipc.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { registerFoldersIpc } = require('./folders-ipc');
+
+// Minimal fakes: capture handlers by channel, record backend calls, and let
+// each test drive one handler and assert its argv/seam usage. No electron.
+function harness(overrides = {}) {
+  const handlers = {};
+  const calls = { py: [], setCache: [], dialog: [], validate: [] };
+  const deps = {
+    ipcMain: { handle: (ch, fn) => { handlers[ch] = fn; } },
+    runPythonScript: async (script, args) => {
+      calls.py.push({ script, args });
+      return overrides.pyResult ?? '{"success": true}';
+    },
+    dialog: {
+      showOpenDialog: async (win, opts) => {
+        calls.dialog.push({ win, opts });
+        return overrides.dialogResult ?? { canceled: false, filePaths: ['/picked/dir'] };
+      },
+    },
+    getMainWindow: () => overrides.mainWindow ?? { id: 'win' },
+    getUserDataDir: () => overrides.userDataDir ?? '/default/data',
+    validateMeetingFilePath: async (p) => {
+      calls.validate.push(p);
+      return overrides.validate ?? { realPath: `/real/${p}` };
+    },
+    setCachedCustomStoragePath: (v) => { calls.setCache.push(v); },
+  };
+  registerFoldersIpc(deps);
+  return { handlers, calls };
+}
+
+const CHANNELS = [
+  'get-storage-path', 'set-storage-path', 'select-storage-folder',
+  'list-folders', 'create-folder', 'rename-folder', 'update-folder-icon',
+  'delete-folder', 'reorder-folders', 'add-meeting-to-folder',
+  'remove-meeting-from-folder',
+];
+
+test('registers exactly the 11 folder + storage handlers', () => {
+  const { handlers } = harness();
+  assert.deepStrictEqual(Object.keys(handlers).sort(), [...CHANNELS].sort());
+});
+
+test('list-folders calls the backend silently and spreads the parsed result', async () => {
+  const { handlers, calls } = harness({ pyResult: '{"folders": [{"id": "a"}]}' });
+  const res = await handlers['list-folders']();
+  assert.deepStrictEqual(calls.py[0], { script: 'simple_recorder.py', args: ['list-folders'] });
+  assert.deepStrictEqual(res, { success: true, folders: [{ id: 'a' }] });
+});
+
+test('create-folder appends --color only when a color is given', async () => {
+  const withColor = harness();
+  await withColor.handlers['create-folder']({}, 'Work', '#fff');
+  assert.deepStrictEqual(withColor.calls.py[0].args, ['create-folder', 'Work', '--color', '#fff']);
+
+  const noColor = harness();
+  await noColor.handlers['create-folder']({}, 'Work', undefined);
+  assert.deepStrictEqual(noColor.calls.py[0].args, ['create-folder', 'Work']);
+});
+
+test('rename / update-icon / delete pass their ids through verbatim', async () => {
+  const h = harness();
+  await h.handlers['rename-folder']({}, 'id1', 'New');
+  await h.handlers['update-folder-icon']({}, 'id1', '📁');
+  await h.handlers['delete-folder']({}, 'id1');
+  assert.deepStrictEqual(h.calls.py[0].args, ['rename-folder', 'id1', 'New']);
+  assert.deepStrictEqual(h.calls.py[1].args, ['update-folder-icon', 'id1', '📁']);
+  assert.deepStrictEqual(h.calls.py[2].args, ['delete-folder', 'id1']);
+});
+
+test('reorder-folders spreads the id list into the argv', async () => {
+  const h = harness();
+  await h.handlers['reorder-folders']({}, ['a', 'b', 'c']);
+  assert.deepStrictEqual(h.calls.py[0].args, ['reorder-folders', 'a', 'b', 'c']);
+});
+
+test('add-meeting-to-folder validates the path and forwards the canonical realPath', async () => {
+  const h = harness({ validate: { realPath: '/real/output/m.json' } });
+  const res = await h.handlers['add-meeting-to-folder']({}, 'output/m.json', 'fid');
+  assert.deepStrictEqual(h.calls.validate, ['output/m.json']);
+  assert.deepStrictEqual(h.calls.py[0].args, ['add-meeting-to-folder', '/real/output/m.json', 'fid']);
+  assert.strictEqual(res.success, true);
+});
+
+test('add-meeting-to-folder rejects a failed path validation without calling the backend', async () => {
+  const h = harness({ validate: { error: 'outside allowed dirs' } });
+  const res = await h.handlers['add-meeting-to-folder']({}, '../evil', 'fid');
+  assert.deepStrictEqual(res, { success: false, error: 'outside allowed dirs' });
+  assert.strictEqual(h.calls.py.length, 0);
+});
+
+test('remove-meeting-from-folder mirrors the validate-then-forward contract', async () => {
+  const ok = harness({ validate: { realPath: '/real/output/m.json' } });
+  await ok.handlers['remove-meeting-from-folder']({}, 'output/m.json', 'fid');
+  assert.deepStrictEqual(ok.calls.py[0].args, ['remove-meeting-from-folder', '/real/output/m.json', 'fid']);
+
+  const bad = harness({ validate: { error: 'nope' } });
+  const res = await bad.handlers['remove-meeting-from-folder']({}, 'x', 'fid');
+  assert.deepStrictEqual(res, { success: false, error: 'nope' });
+  assert.strictEqual(bad.calls.py.length, 0);
+});
+
+test('get-storage-path augments the custom path with the injected default', async () => {
+  const custom = harness({ pyResult: '{"storage_path": "/my/vault"}', userDataDir: '/default/data' });
+  const res = await custom.handlers['get-storage-path']();
+  assert.deepStrictEqual(custom.calls.py[0], { script: 'simple_recorder.py', args: ['get-storage-path'] });
+  assert.deepStrictEqual(res, {
+    success: true, storage_path: '/my/vault', custom_path: '/my/vault', default_path: '/default/data',
+  });
+
+  const none = harness({ pyResult: '{"storage_path": ""}', userDataDir: '/default/data' });
+  const res2 = await none.handlers['get-storage-path']();
+  assert.deepStrictEqual(res2, {
+    success: true, storage_path: '/default/data', custom_path: null, default_path: '/default/data',
+  });
+});
+
+test('set-storage-path updates the injected cache setter (set-path -> reader regression)', async () => {
+  const h = harness({ pyResult: '{"success": true, "storage_path": "/vault"}' });
+  await h.handlers['set-storage-path']({}, '/vault');
+  assert.deepStrictEqual(h.calls.py[0].args, ['set-storage-path', '/vault']);
+  assert.deepStrictEqual(h.calls.setCache, ['/vault']);
+
+  // Clearing to default: empty path -> null cache, and the setter still fires.
+  const cleared = harness({ pyResult: '{"success": true}' });
+  await cleared.handlers['set-storage-path']({}, '');
+  assert.deepStrictEqual(cleared.calls.py[0].args, ['set-storage-path']); // no path arg appended
+  assert.deepStrictEqual(cleared.calls.setCache, [null]);
+});
+
+test('select-storage-folder opens the dialog parented to the injected window', async () => {
+  const picked = harness({ mainWindow: { id: 'main' }, dialogResult: { canceled: false, filePaths: ['/chosen'] } });
+  const res = await picked.handlers['select-storage-folder']();
+  assert.deepStrictEqual(picked.calls.dialog[0].win, { id: 'main' });
+  assert.deepStrictEqual(res, { success: true, folderPath: '/chosen' });
+
+  const canceled = harness({ dialogResult: { canceled: true, filePaths: [] } });
+  const res2 = await canceled.handlers['select-storage-folder']();
+  assert.deepStrictEqual(res2, { success: false, error: 'No folder selected' });
+});
+
+test('backend failures surface as { success:false, error } (not a throw)', async () => {
+  const h = harness();
+  h.calls; // noop
+  const throwing = {
+    ipcMain: { handle: (ch, fn) => { throwing._h = throwing._h || {}; throwing._h[ch] = fn; } },
+    runPythonScript: async () => { throw new Error('backend exploded'); },
+    dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+    getMainWindow: () => ({}),
+    getUserDataDir: () => '/d',
+    validateMeetingFilePath: async (p) => ({ realPath: p }),
+    setCachedCustomStoragePath: () => {},
+  };
+  registerFoldersIpc(throwing);
+  const res = await throwing._h['list-folders']();
+  assert.deepStrictEqual(res, { success: false, error: 'backend exploded' });
+});

--- a/app/folders-ipc.test.js
+++ b/app/folders-ipc.test.js
@@ -11,8 +11,12 @@ function harness(overrides = {}) {
   const calls = { py: [], setCache: [], dialog: [], validate: [] };
   const deps = {
     ipcMain: { handle: (ch, fn) => { handlers[ch] = fn; } },
-    runPythonScript: async (script, args) => {
-      calls.py.push({ script, args });
+    runPythonScript: async (script, args, silent) => {
+      calls.py.push({ script, args, silent });
+      if (overrides.pyThrows) throw new Error(overrides.pyThrows);
+      // Record that the setter had NOT yet fired at backend-return time, so the
+      // set-storage-path test can pin "setter runs after the backend call".
+      calls.setCacheAtPyReturn = calls.setCache.length;
       return overrides.pyResult ?? '{"success": true}';
     },
     dialog: {
@@ -48,7 +52,7 @@ test('registers exactly the 11 folder + storage handlers', () => {
 test('list-folders calls the backend silently and spreads the parsed result', async () => {
   const { handlers, calls } = harness({ pyResult: '{"folders": [{"id": "a"}]}' });
   const res = await handlers['list-folders']();
-  assert.deepStrictEqual(calls.py[0], { script: 'simple_recorder.py', args: ['list-folders'] });
+  assert.deepStrictEqual(calls.py[0], { script: 'simple_recorder.py', args: ['list-folders'], silent: true });
   assert.deepStrictEqual(res, { success: true, folders: [{ id: 'a' }] });
 });
 
@@ -70,6 +74,8 @@ test('rename / update-icon / delete pass their ids through verbatim', async () =
   assert.deepStrictEqual(h.calls.py[0].args, ['rename-folder', 'id1', 'New']);
   assert.deepStrictEqual(h.calls.py[1].args, ['update-folder-icon', 'id1', '📁']);
   assert.deepStrictEqual(h.calls.py[2].args, ['delete-folder', 'id1']);
+  // Mutations stream to the debug panel — they must NOT pass silent:true.
+  assert.ok(h.calls.py.every((c) => !c.silent));
 });
 
 test('reorder-folders spreads the id list into the argv', async () => {
@@ -107,7 +113,7 @@ test('remove-meeting-from-folder mirrors the validate-then-forward contract', as
 test('get-storage-path augments the custom path with the injected default', async () => {
   const custom = harness({ pyResult: '{"storage_path": "/my/vault"}', userDataDir: '/default/data' });
   const res = await custom.handlers['get-storage-path']();
-  assert.deepStrictEqual(custom.calls.py[0], { script: 'simple_recorder.py', args: ['get-storage-path'] });
+  assert.deepStrictEqual(custom.calls.py[0], { script: 'simple_recorder.py', args: ['get-storage-path'], silent: true });
   assert.deepStrictEqual(res, {
     success: true, storage_path: '/my/vault', custom_path: '/my/vault', default_path: '/default/data',
   });
@@ -124,6 +130,8 @@ test('set-storage-path updates the injected cache setter (set-path -> reader reg
   await h.handlers['set-storage-path']({}, '/vault');
   assert.deepStrictEqual(h.calls.py[0].args, ['set-storage-path', '/vault']);
   assert.deepStrictEqual(h.calls.setCache, ['/vault']);
+  // The setter fires AFTER the backend call (0 setter calls at backend return).
+  assert.strictEqual(h.calls.setCacheAtPyReturn, 0);
 
   // Clearing to default: empty path -> null cache, and the setter still fires.
   const cleared = harness({ pyResult: '{"success": true}' });
@@ -132,10 +140,20 @@ test('set-storage-path updates the injected cache setter (set-path -> reader reg
   assert.deepStrictEqual(cleared.calls.setCache, [null]);
 });
 
+test('set-storage-path does NOT touch the cache when the backend fails', async () => {
+  const h = harness({ pyThrows: 'disk full' });
+  const res = await h.handlers['set-storage-path']({}, '/vault');
+  assert.deepStrictEqual(res, { success: false, error: 'disk full' });
+  assert.deepStrictEqual(h.calls.setCache, []); // cache untouched on failure
+});
+
 test('select-storage-folder opens the dialog parented to the injected window', async () => {
   const picked = harness({ mainWindow: { id: 'main' }, dialogResult: { canceled: false, filePaths: ['/chosen'] } });
   const res = await picked.handlers['select-storage-folder']();
   assert.deepStrictEqual(picked.calls.dialog[0].win, { id: 'main' });
+  // Pin the dialog options — a directory picker with create-folder affordance.
+  assert.deepStrictEqual(picked.calls.dialog[0].opts.properties, ['openDirectory', 'createDirectory']);
+  assert.strictEqual(picked.calls.dialog[0].opts.buttonLabel, 'Select Folder');
   assert.deepStrictEqual(res, { success: true, folderPath: '/chosen' });
 
   const canceled = harness({ dialogResult: { canceled: true, filePaths: [] } });

--- a/app/folders-ipc.test.js
+++ b/app/folders-ipc.test.js
@@ -162,18 +162,7 @@ test('select-storage-folder opens the dialog parented to the injected window', a
 });
 
 test('backend failures surface as { success:false, error } (not a throw)', async () => {
-  const h = harness();
-  h.calls; // noop
-  const throwing = {
-    ipcMain: { handle: (ch, fn) => { throwing._h = throwing._h || {}; throwing._h[ch] = fn; } },
-    runPythonScript: async () => { throw new Error('backend exploded'); },
-    dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
-    getMainWindow: () => ({}),
-    getUserDataDir: () => '/d',
-    validateMeetingFilePath: async (p) => ({ realPath: p }),
-    setCachedCustomStoragePath: () => {},
-  };
-  registerFoldersIpc(throwing);
-  const res = await throwing._h['list-folders']();
+  const { handlers } = harness({ pyThrows: 'backend exploded' });
+  const res = await handlers['list-folders']();
   assert.deepStrictEqual(res, { success: false, error: 'backend exploded' });
 });

--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -246,14 +246,21 @@ test('every extracted seam module is required AND invoked in main.js (reachabili
     // emit-only module: entry point is the createDebugLog factory
     { file: 'debug-log.js', entryPoints: ['createDebugLog'] },
   ];
+  // Scan main.js with comments stripped, so a stale pointer comment that
+  // mentions a require()/factory call (e.g. "// sendDebugLog now comes from
+  // ./debug-log via createDebugLog(...)") can't satisfy the check — a de-wired
+  // module must actually fail. Line-comment strip guards against `://` in URLs.
+  const code = MAIN
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
   const unwired = [];
   for (const { file, entryPoints } of modules) {
     const base = file.replace(/\.js$/, '');
     const required =
-      MAIN.includes(`require('./${base}')`) || MAIN.includes(`require("./${base}")`);
+      code.includes(`require('./${base}')`) || code.includes(`require("./${base}")`);
     const invoked =
       entryPoints.length > 0 &&
-      entryPoints.every((fn) => new RegExp(`\\b${fn}\\s*\\(`).test(MAIN));
+      entryPoints.every((fn) => new RegExp(`\\b${fn}\\s*\\(`).test(code));
     if (!required || !invoked) unwired.push(`${file} (required:${required} invoked:${invoked})`);
   }
   assert.deepStrictEqual(

--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -230,3 +230,35 @@ test('ipc.ts bridge namespaces match the preload bridge (type mirror in sync)', 
     `preload bridge and StenoaiBridge namespaces drifted — only in preload: [${onlyPreload}], only in ipc.ts: [${onlyTs}]`,
   );
 });
+
+// The registration + emission scans read the sibling modules straight off disk,
+// so a module whose require()/register call was deleted from main.js would still
+// look "wired" to the union (its channels register/emit to the scanner even though
+// nothing invokes it at runtime). Assert the wiring explicitly: main.js must both
+// require each extracted module AND call its entry point.
+test('every extracted seam module is required AND invoked in main.js (reachability)', () => {
+  const modules = [
+    // handler modules: entry points are their register* exports
+    ...fs
+      .readdirSync(__dirname)
+      .filter((f) => /-ipc\.js$/.test(f) && f !== 'e2e-mock-ipc.js' && !/\.test\.js$/.test(f))
+      .map((f) => ({ file: f, entryPoints: matchAll(read(f), /function\s+(register\w+)\s*\(/g) })),
+    // emit-only module: entry point is the createDebugLog factory
+    { file: 'debug-log.js', entryPoints: ['createDebugLog'] },
+  ];
+  const unwired = [];
+  for (const { file, entryPoints } of modules) {
+    const base = file.replace(/\.js$/, '');
+    const required =
+      MAIN.includes(`require('./${base}')`) || MAIN.includes(`require("./${base}")`);
+    const invoked =
+      entryPoints.length > 0 &&
+      entryPoints.every((fn) => new RegExp(`\\b${fn}\\s*\\(`).test(MAIN));
+    if (!required || !invoked) unwired.push(`${file} (required:${required} invoked:${invoked})`);
+  }
+  assert.deepStrictEqual(
+    unwired,
+    [],
+    `extracted module(s) not wired into main.js (dead registration?): ${unwired.join('; ')}`,
+  );
+});

--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -54,6 +54,24 @@ const PRELOAD = read('preload.js');
 const MOCK = read('e2e-mock-ipc.js');
 const IPC_TS = read('renderer/src/lib/ipc.ts');
 
+// Extracted sibling IPC modules (RFC #327): main.js delegates whole handler
+// groups to `*-ipc.js` modules, so the registration + M->R emission scans union
+// them with main.js — a handler or send() that MOVED out of main.js must still
+// count as present. e2e-mock-ipc.js also matches `*-ipc.js` but is the T1 test
+// double, not a real registrar, so it is excluded. debug-log.js is not a handler
+// module but owns `.send('debug-log')` after the Phase 0 extraction, so it joins
+// the EMISSION sources only.
+const SIBLING_IPC_MODULES = fs
+  .readdirSync(__dirname)
+  .filter((f) => /-ipc\.js$/.test(f) && f !== 'e2e-mock-ipc.js' && !/\.test\.js$/.test(f))
+  .map((f) => read(f));
+const EMIT_ONLY_SOURCES = ['debug-log.js'].map((f) => read(f));
+
+// Where ipcMain.handle/on/once registrations may live: main.js + handler modules.
+const REGISTRATION_SOURCES = [MAIN, ...SIBLING_IPC_MODULES];
+// Where main->renderer `.send()` emissions may live: the above + emit-only modules.
+const EMISSION_SOURCES = [MAIN, ...SIBLING_IPC_MODULES, ...EMIT_ONLY_SOURCES];
+
 // Channels registered outside our own source: electron-audio-loopback's
 // initMain() (app/main.js) installs these ipcMain handlers itself, so they are
 // renderer-callable without a literal ipcMain.handle in main.js.
@@ -67,7 +85,9 @@ function matchAll(src, re) {
 
 // --- main.js: every ipcMain.handle / .on / .once registration ---
 function mainRegistrations() {
-  return matchAll(MAIN, /ipcMain\.(?:handle|on|once)\(\s*["']([^"']+)["']/g);
+  return REGISTRATION_SOURCES.flatMap((src) =>
+    matchAll(src, /ipcMain\.(?:handle|on|once)\(\s*["']([^"']+)["']/g),
+  );
 }
 
 // --- preload.js: renderer->main channels (invoke = request, send = fire) ---
@@ -171,11 +191,13 @@ function firstSendArg(src, i) {
 
 function channelsEmittedViaSend() {
   const emitted = new Set();
-  const re = /\.send\(/g;
-  let m;
-  while ((m = re.exec(MAIN))) {
-    const arg = firstSendArg(MAIN, re.lastIndex);
-    for (const lit of arg.matchAll(/["']([^"']+)["']/g)) emitted.add(lit[1]);
+  for (const src of EMISSION_SOURCES) {
+    const re = /\.send\(/g;
+    let m;
+    while ((m = re.exec(src))) {
+      const arg = firstSendArg(src, re.lastIndex);
+      for (const lit of arg.matchAll(/["']([^"']+)["']/g)) emitted.add(lit[1]);
+    }
   }
   return emitted;
 }

--- a/app/main.js
+++ b/app/main.js
@@ -34,7 +34,12 @@ if (process.platform !== 'darwin') {
 }
 
 const path = require('path');
-const { spawn: _spawnRaw } = require('child_process');
+// Backend CLI seam (spawn wrapper, process-tree kill, bundled-backend paths,
+// runPythonScript), the debug-log sink, and the quit teardown registry are
+// carved out of this file (RFC #327, Phase 0); wired once below via factories.
+const { spawn, killProcessTree, createBackendCli } = require('./backend-cli');
+const { createDebugLog } = require('./debug-log');
+const { createTeardownRegistry } = require('./teardown');
 const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
 const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
@@ -67,43 +72,8 @@ const {
   withTimeout,
 } = require('./analytics-helpers');
 
-// Wrap spawn so every backend / ollama launch defaults to windowsHide:true.
-// The PyInstaller backend (stenoai.exe) and bundled ollama.exe are console
-// subsystem binaries; without this Electron pops a visible console window on
-// Windows for every recording, live-transcribe, query, and the long-lived
-// `ollama serve` keeps one open for the whole session. No-op on macOS/Linux.
-// Callers can still override by passing an explicit windowsHide.
-function spawn(command, args, options) {
-  if (Array.isArray(args) || args === undefined || args === null) {
-    return _spawnRaw(command, args, { windowsHide: true, ...(options || {}) });
-  }
-  // 2-arg form: spawn(command, options)
-  return _spawnRaw(command, { windowsHide: true, ...args });
-}
-
-// Terminate a process AND its child processes. On Windows `process.kill(pid)`
-// only kills the named process, orphaning its children — `ollama serve` spawns
-// per-model "runner" subprocesses that would leak after quit. `taskkill /T`
-// walks the whole tree. On POSIX we keep the existing SIGTERM -> SIGKILL
-// escalation (ollama tears its runners down on SIGTERM there). Synchronous on
-// Windows (execFileSync) so it completes during the app's will-quit handler.
-function killProcessTree(pid) {
-  if (!pid) return;
-  if (process.platform === 'win32') {
-    try {
-      require('child_process').execFileSync(
-        'taskkill',
-        ['/PID', String(pid), '/T', '/F'],
-        { windowsHide: true, stdio: 'ignore' },
-      );
-    } catch (_) {}
-    return;
-  }
-  try { process.kill(pid, 'SIGTERM'); } catch (_) {}
-  setTimeout(() => {
-    try { process.kill(pid, 'SIGKILL'); } catch (_) {}
-  }, 1000);
-}
+// `spawn` (windowsHide wrapper) and `killProcessTree` now live in ./backend-cli
+// (imported above), with unit coverage in backend-cli.test.js.
 const fs = require('fs');
 const https = require('https');
 const http = require('http');
@@ -241,6 +211,27 @@ let launchedHidden = false;
 // (extractShortcutUrlFromArgv, sanitizeShortcutUrlForLogs, parseShortcutUrl,
 // and the parse-internal sanitizeShortcutSessionName) live in ./shortcut-url,
 // imported at the top of this file.
+// --- Phase 0 infra seams (RFC #327), wired once here ---
+// Placed after the module state declarations above and before every call site
+// (sendDebugLog, getBackendPath, runPythonScript are all used far below). The
+// debug-log sink reads the live `mainWindow` through an accessor; backend-cli's
+// runPythonScript gets the logging + diagnostics seams injected. These are
+// `const`s (not hoisted like the old function declarations), so they must be
+// defined before first use — hence their position here.
+const sendDebugLog = createDebugLog({ getMainWindow: () => mainWindow });
+const { getBackendPath, getBackendCwd, runPythonScript } = createBackendCli({
+  app,
+  sendDebugLog,
+  sanitizeArgsForLog,
+  attachProcessingStderr,
+  forwardDiagnosticStdout,
+});
+// Quit teardown registry (RFC #327 ground rule 4). No consumers yet — domains
+// that own a child process/timer (Ollama, mic monitor, recording runtime, …)
+// register an idempotent dispose() as they move out of main.js. Drained in
+// will-quit below.
+const teardown = createTeardownRegistry();
+
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
 
 function registerShortcutProtocolClient() {
@@ -260,25 +251,8 @@ function registerShortcutProtocolClient() {
   return app.setAsDefaultProtocolClient(SHORTCUT_PROTOCOL);
 }
 
-// Backend executable path - always use bundled stenoai
-function getBackendPath() {
-  const exe = process.platform === 'win32' ? 'stenoai.exe' : 'stenoai';
-  if (app.isPackaged) {
-    // Production: bundled in app resources
-    return path.join(process.resourcesPath, 'stenoai', exe);
-  } else {
-    // Development: use local build
-    return path.join(__dirname, '..', 'dist', 'stenoai', exe);
-  }
-}
-
-function getBackendCwd() {
-  if (app.isPackaged) {
-    return path.join(process.resourcesPath, 'stenoai');
-  } else {
-    return path.join(__dirname, '..', 'dist', 'stenoai');
-  }
-}
+// getBackendPath / getBackendCwd / runPythonScript now come from ./backend-cli
+// via createBackendCli(...) wired near the top of this file.
 
 // Path to the mic-in-use helper. Keeps the .exe suffix branch ready for a
 // future Windows port — the JSON-line stdout contract is platform-agnostic,
@@ -1670,6 +1644,11 @@ if (!gotSingleInstanceLock) {
       killProcessTree(ollamaPid);
       ollamaPid = null;
     }
+    // Drain the teardown registry (RFC #327 ground rule 4) BEFORE the async
+    // telemetry shutdown — Electron does not await quit handlers, so work after
+    // the first await is not a reliable barrier. Synchronous + idempotent;
+    // no-op until domains register disposers.
+    teardown.drain();
     await shutdownTelemetry();
   });
 
@@ -1869,76 +1848,8 @@ ipcMain.handle('relaunch-app', async () => {
 // Debug functionality handled by side panel now
 
 // Backend communication - always uses bundled stenoai executable
-function runPythonScript(script, args = [], silent = false, extraEnv = {}, logLabel = null) {
-  return new Promise((resolve, reject) => {
-    const backendPath = getBackendPath();
-
-    // Log the command being executed (unless silent)
-    console.log('Running:', `${backendPath} ${args.join(' ')}`);
-    if (!silent) {
-      // Sanitize the echoed argv: denylisted commands (query, save-template,
-      // set-user-name/storage-path, folder + URL setters) carry content/PII in
-      // their args. This rewrites the LOGGED string only; the spawned `args`
-      // below are untouched.
-      sendDebugLog(`$ stenoai ${sanitizeArgsForLog(args)}`);
-    }
-
-    const process = spawn(backendPath, args, {
-      cwd: getBackendCwd(),
-      env: Object.keys(extraEnv).length > 0 ? { ...require('process').env, ...extraEnv } : undefined
-    });
-
-    // Opt-in persistent capture for the legacy process-recording path only.
-    // Default null → generic backend calls (config reads, chat query, …) are
-    // NOT persisted, preserving the no-global-tee privacy boundary.
-    if (logLabel) attachProcessingStderr(process, logLabel);
-
-    let stdout = '';
-    let stderr = '';
-
-    process.stdout.on('data', (data) => {
-      const output = data.toString();
-      stdout += output;
-      console.log('Python stdout:', output);
-      // Stream stdout to debug panel in real-time (unless silent), but only the
-      // structural diagnostic markers — query answers and other content are
-      // dropped so they never reach the shareable buffer.
-      if (!silent) {
-        output.split('\n').forEach(line => {
-          forwardDiagnosticStdout(line, 'backend');
-        });
-      }
-    });
-
-    process.stderr.on('data', (data) => {
-      const output = data.toString();
-      stderr += output;
-      console.log('Python stderr:', output);
-      // Stream stderr to debug panel in real-time (unless silent)
-      if (!silent) {
-        output.split('\n').forEach(line => {
-          if (line.trim()) sendDebugLog('STDERR: ' + line.trim());
-        });
-      }
-    });
-
-    process.on('close', (code) => {
-      if (!silent) {
-        sendDebugLog(`Command completed with exit code: ${code}`);
-      }
-      if (code === 0) {
-        resolve(stdout);
-      } else {
-        reject(new Error(`Python script failed with code ${code}: ${stderr}`));
-      }
-    });
-
-    process.on('error', (error) => {
-      sendDebugLog(`Command error: ${error.message}`);
-      reject(error);
-    });
-  });
-}
+// runPythonScript is provided by createBackendCli(...) wired near the top of
+// this file (verbatim body moved to ./backend-cli).
 
 async function getBackendStatusInternal(silent = true) {
   const result = await runPythonScript('simple_recorder.py', ['status'], silent);
@@ -5610,13 +5521,8 @@ app.on('before-quit', () => {
   clearPreMeetingTimers();
 });
 
-// Add IPC handler for sending debug logs to frontend
-function sendDebugLog(message) {
-  // Send to main window (both setup console and debug panel)
-  if (mainWindow) {
-    mainWindow.webContents.send('debug-log', message);
-  }
-}
+// sendDebugLog now comes from ./debug-log via createDebugLog(...) wired near the
+// top of this file (the main-window sink is injected as an accessor).
 
 // Feed a child process's stderr into the persistent processing log, one record
 // per complete line. Node 'data' events deliver arbitrary chunks (not lines),

--- a/app/main.js
+++ b/app/main.js
@@ -40,6 +40,7 @@ const path = require('path');
 const { spawn, killProcessTree, createBackendCli } = require('./backend-cli');
 const { createDebugLog } = require('./debug-log');
 const { createTeardownRegistry } = require('./teardown');
+const { registerFoldersIpc } = require('./folders-ipc');
 const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
 const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
@@ -5953,162 +5954,20 @@ ipcMain.handle('get-app-version', async () => {
   }
 });
 
-// Storage path handlers
-ipcMain.handle('get-storage-path', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-storage-path'], true);
-    const jsonData = JSON.parse(result.trim());
-    // Python only returns the user's custom path (empty string when not set).
-    // Augment with the platform default so the renderer can show "where your
-    // data actually lives" without hardcoding the path. custom_path mirrors
-    // storage_path but is null when empty for cleaner conditionals.
-    const customPath = jsonData.storage_path && jsonData.storage_path.trim()
-      ? jsonData.storage_path
-      : null;
-    // getUserDataDir() so the "where your data lives" path shown in Settings is
-    // correct on Windows (%APPDATA%/stenoai), not a macOS literal. It already
-    // resolves to the per-OS .../stenoai dir.
-    const defaultPath = getUserDataDir();
-    return {
-      success: true,
-      storage_path: customPath || defaultPath,
-      custom_path: customPath,
-      default_path: defaultPath,
-    };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('set-storage-path', async (event, storagePath) => {
-  try {
-    const args = ['set-storage-path'];
-    if (storagePath) {
-      args.push(storagePath);
-    }
-    const result = await runPythonScript('simple_recorder.py', args);
-    // Update cached custom path for file validation
-    _cachedCustomStoragePath = storagePath || null;
-    const jsonMatch = result.match(/\{.*\}/s);
-    if (jsonMatch) {
-      return JSON.parse(jsonMatch[0]);
-    }
-    return { success: true, storage_path: storagePath };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('select-storage-folder', async () => {
-  try {
-    const result = await dialog.showOpenDialog(mainWindow, {
-      properties: ['openDirectory', 'createDirectory'],
-      title: 'Choose storage location for Steno data',
-      buttonLabel: 'Select Folder'
-    });
-
-    if (!result.canceled && result.filePaths.length > 0) {
-      return { success: true, folderPath: result.filePaths[0] };
-    }
-    return { success: false, error: 'No folder selected' };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-// Folder management handlers
-ipcMain.handle('list-folders', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['list-folders'], true);
-    return { success: true, ...JSON.parse(result.trim()) };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('create-folder', async (event, name, color) => {
-  try {
-    const args = ['create-folder', name];
-    if (color) args.push('--color', color);
-    const result = await runPythonScript('simple_recorder.py', args);
-    const jsonMatch = result.match(/\{.*\}/s);
-    return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('rename-folder', async (event, folderId, name) => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['rename-folder', folderId, name]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('update-folder-icon', async (event, folderId, icon) => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['update-folder-icon', folderId, icon]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('delete-folder', async (event, folderId) => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['delete-folder', folderId]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('reorder-folders', async (event, folderIds) => {
-  try {
-    const args = ['reorder-folders', ...folderIds];
-    const result = await runPythonScript('simple_recorder.py', args);
-    const jsonMatch = result.match(/\{.*\}/s);
-    return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('add-meeting-to-folder', async (event, summaryFile, folderId) => {
-  try {
-    // Security: the renderer is untrusted, so containment-check the summary path
-    // (symlink-safe, output/ only) and pass the canonical realPath to the backend.
-    const validated = await validateMeetingFilePath(summaryFile);
-    if (validated.error) {
-      return { success: false, error: validated.error };
-    }
-    const result = await runPythonScript('simple_recorder.py', ['add-meeting-to-folder', validated.realPath, folderId]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('remove-meeting-from-folder', async (event, summaryFile, folderId) => {
-  try {
-    // Security: the renderer is untrusted, so containment-check the summary path
-    // (symlink-safe, output/ only) and pass the canonical realPath to the backend.
-    const validated = await validateMeetingFilePath(summaryFile);
-    if (validated.error) {
-      return { success: false, error: validated.error };
-    }
-    const result = await runPythonScript('simple_recorder.py', ['remove-meeting-from-folder', validated.realPath, folderId]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    return jsonMatch ? JSON.parse(jsonMatch[0]) : { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
+// Folders + storage-layout IPC handlers (RFC #327 Folders pilot) — extracted to
+// ./folders-ipc and registered here in place, so registration timing + behavior
+// are identical to the inline handlers this replaces. The storage-path cache
+// stays a main.js `let`; the module updates it through the injected setter, and
+// the readers (getOutputDir / getAllowedBaseDirs / resolveRecordingsDir /
+// validateMeetingFilePath) keep reading the live binding.
+registerFoldersIpc({
+  ipcMain,
+  runPythonScript,
+  dialog,
+  getMainWindow: () => mainWindow,
+  getUserDataDir,
+  validateMeetingFilePath,
+  setCachedCustomStoragePath: (v) => { _cachedCustomStoragePath = v; },
 });
 
 ipcMain.handle('get-ai-prompts', async () => {

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/teardown.js
+++ b/app/teardown.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Teardown registry — the single drain point the app's quit handlers call so
+ * modules that own a child process or timer (Ollama, the mic monitor, the
+ * recording runtime, the pre-meeting scheduler, …) can register an idempotent
+ * `dispose()` instead of each installing its own `before-quit`/`will-quit`
+ * handler. Introduced by RFC #327 Phase 0; consumers arrive as those domains
+ * move out of main.js (Ollama lifecycle is the first, Phase 2).
+ *
+ * Disposal contract (RFC ground rule 4), pinned here:
+ *   - SYNCHRONOUS. Electron's quit hooks do not await promises, so a dispose()
+ *     may only do synchronous work or fire-and-forget kill signals. drain()
+ *     never returns a promise and never awaits.
+ *   - Drained in REVERSE registration order (last registered tears down first),
+ *     mirroring how nested resources unwind.
+ *   - REENTRANT-SAFE + IDEMPOTENT. drain() run twice (both before-quit and
+ *     will-quit fire, or a dispose triggers another drain) does nothing the
+ *     second time. Individual dispose()s should also be idempotent.
+ *   - ISOLATED. A throwing dispose() is swallowed so it can't abort the drain
+ *     and strand later resources (a leaked process is worse than a lost error).
+ */
+
+function createTeardownRegistry() {
+  /** @type {Array<() => void>} */
+  const disposers = [];
+  let draining = false;
+
+  return {
+    /** Register an idempotent, synchronous dispose(). Non-functions are ignored. */
+    register(dispose) {
+      if (typeof dispose === 'function') disposers.push(dispose);
+    },
+
+    /** Run every registered dispose() once, in reverse order. Safe to call
+     *  multiple times and reentrantly; later calls are no-ops. */
+    drain() {
+      if (draining) return;
+      draining = true;
+      // Reverse order; splice each out as we go so a reentrant drain (a dispose
+      // that ends up calling drain again) can't double-run a disposer even if
+      // the guard were bypassed.
+      while (disposers.length > 0) {
+        const dispose = disposers.pop();
+        try {
+          dispose();
+        } catch (_) {
+          // Swallow: a failing teardown must not strand the resources after it.
+        }
+      }
+      draining = false;
+    },
+  };
+}
+
+module.exports = { createTeardownRegistry };

--- a/app/teardown.js
+++ b/app/teardown.js
@@ -16,10 +16,11 @@
  *     mirroring how nested resources unwind.
  *   - REENTRANT-SAFE + IDEMPOTENT per disposer. A disposer runs at most once per
  *     drain, and a drain re-entered from within a dispose is a no-op (the guard).
- *     Each registered disposer is removed as it runs, so a redundant drain with
- *     nothing newly registered does nothing. The registry DOES re-arm, though: a
- *     disposer registered AFTER a drain will run on the next drain (used when a
- *     resource is (re)created post-teardown). Individual dispose()s should also
+ *     The live list is snapshotted and cleared at the start of a drain, so a
+ *     disposer registered DURING or AFTER a drain is deferred to the NEXT drain,
+ *     never pulled into the running pass — that is what keeps a self-registering
+ *     disposer from spinning the quit path forever. A redundant drain with
+ *     nothing newly registered does nothing. Individual dispose()s should also
  *     be idempotent so a resource torn down twice is harmless.
  *   - ISOLATED. A throwing dispose() is swallowed so it can't abort the drain
  *     and strand later resources (a leaked process is worse than a lost error).
@@ -37,22 +38,28 @@ function createTeardownRegistry() {
     },
 
     /** Run every registered dispose() once, in reverse order. Safe to call
-     *  multiple times and reentrantly; later calls are no-ops. */
+     *  multiple times and reentrantly; later calls with nothing newly registered
+     *  are no-ops. */
     drain() {
       if (draining) return;
       draining = true;
-      // Reverse order; splice each out as we go so a reentrant drain (a dispose
-      // that ends up calling drain again) can't double-run a disposer even if
-      // the guard were bypassed.
-      while (disposers.length > 0) {
-        const dispose = disposers.pop();
-        try {
-          dispose();
-        } catch (_) {
-          // Swallow: a failing teardown must not strand the resources after it.
+      try {
+        // Snapshot + clear the live list up front. A dispose() that registers a
+        // NEW disposer during teardown (e.g. re-creating a resource) lands in the
+        // now-empty live list and is left for the NEXT drain — it is NOT pulled
+        // into this pass. Draining the live array directly would otherwise spin
+        // forever if a disposer re-registered itself. Reverse registration order.
+        const pending = disposers.splice(0).reverse();
+        for (const dispose of pending) {
+          try {
+            dispose();
+          } catch (_) {
+            // Swallow: a failing teardown must not strand the resources after it.
+          }
         }
+      } finally {
+        draining = false;
       }
-      draining = false;
     },
   };
 }

--- a/app/teardown.js
+++ b/app/teardown.js
@@ -22,6 +22,11 @@
  *     disposer from spinning the quit path forever. A redundant drain with
  *     nothing newly registered does nothing. Individual dispose()s should also
  *     be idempotent so a resource torn down twice is harmless.
+ *     NOTE for when consumers arrive (Phase 2): at QUIT there is no "next drain",
+ *     so a dispose() that re-arms a resource mid-teardown would leak it. If a
+ *     consumer ever needs that, switch to a BOUNDED re-drain loop (N passes until
+ *     the list is empty) — bounded so a pathological self-re-register still can't
+ *     hang quit. Left simple here because there are no consumers yet.
  *   - ISOLATED. A throwing dispose() is swallowed so it can't abort the drain
  *     and strand later resources (a leaked process is worse than a lost error).
  */

--- a/app/teardown.js
+++ b/app/teardown.js
@@ -14,9 +14,13 @@
  *     never returns a promise and never awaits.
  *   - Drained in REVERSE registration order (last registered tears down first),
  *     mirroring how nested resources unwind.
- *   - REENTRANT-SAFE + IDEMPOTENT. drain() run twice (both before-quit and
- *     will-quit fire, or a dispose triggers another drain) does nothing the
- *     second time. Individual dispose()s should also be idempotent.
+ *   - REENTRANT-SAFE + IDEMPOTENT per disposer. A disposer runs at most once per
+ *     drain, and a drain re-entered from within a dispose is a no-op (the guard).
+ *     Each registered disposer is removed as it runs, so a redundant drain with
+ *     nothing newly registered does nothing. The registry DOES re-arm, though: a
+ *     disposer registered AFTER a drain will run on the next drain (used when a
+ *     resource is (re)created post-teardown). Individual dispose()s should also
+ *     be idempotent so a resource torn down twice is harmless.
  *   - ISOLATED. A throwing dispose() is swallowed so it can't abort the drain
  *     and strand later resources (a leaked process is worse than a lost error).
  */

--- a/app/teardown.test.js
+++ b/app/teardown.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { createTeardownRegistry } = require('./teardown');
+
+test('drains disposers in reverse registration order', () => {
+  const order = [];
+  const t = createTeardownRegistry();
+  t.register(() => order.push('a'));
+  t.register(() => order.push('b'));
+  t.register(() => order.push('c'));
+  t.drain();
+  assert.deepStrictEqual(order, ['c', 'b', 'a']);
+});
+
+test('drain is idempotent — a second drain runs nothing again', () => {
+  let count = 0;
+  const t = createTeardownRegistry();
+  t.register(() => { count += 1; });
+  t.drain();
+  t.drain();
+  assert.strictEqual(count, 1);
+});
+
+test('a throwing disposer does not strand the ones after it', () => {
+  const ran = [];
+  const t = createTeardownRegistry();
+  t.register(() => ran.push('first-registered')); // runs LAST (reverse)
+  t.register(() => { throw new Error('boom'); });
+  t.register(() => ran.push('last-registered')); // runs FIRST (reverse)
+  assert.doesNotThrow(() => t.drain());
+  assert.deepStrictEqual(ran, ['last-registered', 'first-registered']);
+});
+
+test('a dispose that reentrantly calls drain does not double-run disposers', () => {
+  const ran = [];
+  const t = createTeardownRegistry();
+  t.register(() => ran.push('a'));
+  t.register(() => { ran.push('b'); t.drain(); }); // reentrant drain
+  t.drain();
+  assert.deepStrictEqual(ran, ['b', 'a']); // each exactly once
+});
+
+test('ignores non-function registrations', () => {
+  const t = createTeardownRegistry();
+  assert.doesNotThrow(() => {
+    t.register(null);
+    t.register(undefined);
+    t.register(42);
+    t.drain();
+  });
+});
+
+test('register after a drain participates in the next drain', () => {
+  const ran = [];
+  const t = createTeardownRegistry();
+  t.register(() => ran.push('first'));
+  t.drain();
+  t.register(() => ran.push('second'));
+  t.drain();
+  assert.deepStrictEqual(ran, ['first', 'second']);
+});

--- a/app/teardown.test.js
+++ b/app/teardown.test.js
@@ -52,6 +52,37 @@ test('ignores non-function registrations', () => {
   });
 });
 
+test('a disposer that registers during drain defers the new one (no infinite loop)', () => {
+  const ran = [];
+  const t = createTeardownRegistry();
+  let armed = false;
+  t.register(() => {
+    ran.push('first');
+    // Re-register during teardown — the buggy version would run this in the same
+    // pass and, if it kept re-registering, spin forever.
+    if (!armed) {
+      armed = true;
+      t.register(() => ran.push('late'));
+    }
+  });
+  t.drain(); // must terminate; the mid-drain registration is deferred.
+  assert.deepStrictEqual(ran, ['first']);
+  t.drain(); // next drain runs the deferred disposer.
+  assert.deepStrictEqual(ran, ['first', 'late']);
+});
+
+test('a self-re-registering disposer cannot spin the drain forever', () => {
+  let count = 0;
+  const t = createTeardownRegistry();
+  const selfReregister = () => {
+    count += 1;
+    t.register(selfReregister); // pathological: re-registers itself every run
+  };
+  t.register(selfReregister);
+  t.drain(); // terminates: only the snapshot (1 entry) runs this pass.
+  assert.strictEqual(count, 1);
+});
+
 test('register after a drain participates in the next drain', () => {
   const ran = [];
   const t = createTeardownRegistry();


### PR DESCRIPTION
Implements the first slice of #327 — **Phase 0 (infra seams) + the Folders pilot** — the exact starting slice the RFC recommends to validate the approach before the harder domains. **Zero behavior change**: moved code is verbatim; only the cross-cutting seams that plumbing requires are injected via `create*`/`register*` factories, wired once in `main.js`.

### What moves out of `main.js`

**Phase 0 — infra seams** (`df916f1`)
- `app/backend-cli.js` — `spawn` (windowsHide wrapper) + `killProcessTree` as pure direct exports, and `createBackendCli({ app, sendDebugLog, sanitizeArgsForLog, attachProcessingStderr, forwardDiagnosticStdout })` returning `getBackendPath` / `getBackendCwd` / `runPythonScript` (~90 call sites unchanged).
- `app/debug-log.js` — `createDebugLog({ getMainWindow })` → `sendDebugLog`, reading the live window through an accessor.
- `app/teardown.js` — `createTeardownRegistry()`, the single quit-drain point (reverse order, idempotent, reentrant-safe, synchronous). No consumers yet; drained in `will-quit` before the async telemetry shutdown.

**Folders pilot** (`ef375bf`)
- `app/folders-ipc.js` — `registerFoldersIpc(deps)` with the 8 folder handlers + the 3 storage-path handlers (the RFC's "storage layout" group). Establishes the `registerXxxIpc` handler-group pattern. The `_cachedCustomStoragePath` cache stays a `main.js` `let`; the module writes it through an injected setter, and every reader keeps reading the live binding.

**Test infra** (`6b85b30`)
- `ipc-contract.test.js` now unions `main.js` with sibling `*-ipc.js` modules for registrations (excluding the e2e-mock double) and adds `debug-log.js` to the M→R emission sources, plus a **reachability** assertion so a module that's on disk but no longer required/invoked in `main.js` fails the gate.
- New unit suites for `backend-cli` (incl. `runPythonScript` behavior), `debug-log`, `teardown`, and `folders-ipc` (all 11 registrations + injected seams).

### Wiring note
The factory outputs become `const`s (not the old hoisted function declarations), so they're defined right after the module state declarations, before the first call site (`sendDebugLog`, `getBackendPath`, `runPythonScript` are all used far below).

### Verification
- Unit: **172 `node:test` + 104 vitest** green.
- **Full model-free T2 e2e matrix (69 passed)** against a freshly built backend bundle — `folders-crud.t2` exercises the extracted handlers end-to-end.
- Independent cross-family review (GPT-5.x) of the full diff: no production behavior regression; its four test/doc findings are folded into `6b85b30`.

### Notes for review
- **Sequencing:** Phase 0 touches the `runPythonScript`/`sendDebugLog` seams, so it conflicts with essentially every open `main.js`-touching PR — merge timing is yours to pick (the RFC's "serial, small PRs after in-flight work merges" is exactly why).
- **Open RFC questions** decided here (both reversible): flat `app/*.js` layout to match the existing extracted-module precedent, and the module name `folders-ipc.js`.
- Happy to split this into two PRs (Phase 0 / Folders) if you'd rather review them separately — they're already separate commits.

Refs #327.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split main.js into small modules (Phase 0 seams + Folders pilot) per RFC #327 with zero behavior change. Moves backend CLI, debug-log, teardown, and folders/storage IPC into dedicated files and wires them through factories in main.js; also fixes the teardown drain to avoid infinite loops and hardens the IPC reachability test.

- **Refactors**
  - Extracted backend CLI seam to `app/backend-cli.js` with `spawn`, `killProcessTree`, and `createBackendCli(...)` → `getBackendPath`/`getBackendCwd`/`runPythonScript`; wired in `main.js`.
  - Moved debug-log sink to `app/debug-log.js` via `createDebugLog({ getMainWindow })`, and added `app/teardown.js` with `createTeardownRegistry()` drained on quit.
  - Moved folders + storage-layout IPC to `app/folders-ipc.js` via `registerFoldersIpc(deps)`; updates the storage-path cache through an injected setter; registration timing and behavior unchanged.
  - Updated `app/main.js` to use the factories and call `registerFoldersIpc(...)`; no logic changes.
  - Tests: added unit suites for the new modules and strengthened `app/ipc-contract.test.js` (union scan of sibling `*-ipc.js` and reachability check); updated `test:unit` in `app/package.json`.

- **Bug Fixes**
  - Teardown registry: drain a snapshot of disposers so mid-drain registrations (or self-re-register) can’t spin quit; added regression tests.
  - IPC contract reachability: strip comments before scanning `main.js` so a token in a pointer comment can’t mask a de-wired module.

Refs #327.

<sup>Written for commit f0c67866a1a337d68e3c4d146eb222671f0f4567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

