### PR TITLE
fix(live): keep Parakeet partials in pace on slow Apple Silicon (#357)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -3581,6 +3581,39 @@ ipcMain.handle('get-queue-status', async () => {
 // either a Node Buffer or a TypedArray; both stringify safely to bytes via
 // the same write() call. No-op if the sidecar isn't running (e.g. spawn
 // failed, or recording ended).
+// Back-pressure-aware write to the live-transcribe sidecar's stdin (#357).
+// stdin.write() returns false when the OS pipe buffer is full; ignoring that
+// signal lets a stalled sidecar force main to buffer live audio unboundedly on
+// the JS heap. We honor it: once back-pressured, queue chunks and flush them on
+// the stream's 'drain' event (listener installed in spawnLiveTranscribe). The
+// queue is bounded — under a genuine stall (which Fix #1's Python keep-pace
+// guard makes very unlikely) we drop the OLDEST (stalest) audio rather than grow
+// the heap without limit. Reaching the cap needs ~64 s of *continuous*
+// back-pressure, i.e. a sidecar that has effectively hung: at that point the
+// live transcript is already compromised and dropping (which can splice a gap
+// into the live FINAL) is the least-bad option — the post-stop batch
+// transcription reads the on-disk recording and is unaffected. All state is
+// per-process (bound on `proc` in spawnLiveTranscribe) so a quick stop→start
+// can't bleed a stale queue into the new sidecar.
+const LIVE_STDIN_MAX_QUEUE_BYTES = 8 * 1024 * 1024; // ≈ 64 s of 16 kHz stereo float32
+
+function writeLiveChunk(proc, buf) {
+  if (proc._stdinBackpressured) {
+    proc._stdinQueue.push(buf);
+    proc._stdinQueueBytes += buf.length;
+    // Bound the queue: drop the oldest chunk(s) once we exceed the cap. Keep at
+    // least the chunk we just pushed so a single oversized buffer still flows.
+    while (proc._stdinQueueBytes > LIVE_STDIN_MAX_QUEUE_BYTES
+           && proc._stdinQueue.length > 1) {
+      const dropped = proc._stdinQueue.shift();
+      proc._stdinQueueBytes -= dropped.length;
+      proc._stdinDroppedBytes += dropped.length;
+    }
+    return;
+  }
+  if (!proc.stdin.write(buf)) proc._stdinBackpressured = true;
+}
+
 ipcMain.on('live-transcribe-chunk', (event, payload) => {
   const proc = liveTranscribeProcess;
   if (!proc || proc.killed) return;
@@ -3595,7 +3628,7 @@ ipcMain.on('live-transcribe-chunk', (event, payload) => {
   // Buffer here. If a TypedArray slipped through, normalise.
   const buf = Buffer.isBuffer(payload) ? payload : Buffer.from(payload);
   try {
-    stdin.write(buf);
+    writeLiveChunk(proc, buf);
   } catch (e) {
     // EPIPE means Python exited (e.g. crashed). Drop silently; the exit
     // handler will null out the process ref.
@@ -3666,6 +3699,29 @@ function spawnLiveTranscribe(sessionName) {
   proc._drainResolve = null;
   proc._drainPromise = new Promise((resolve) => {
     proc._drainResolve = resolve;
+  });
+
+  // stdin back-pressure state (#357): honored by writeLiveChunk(). Flushed on
+  // 'drain' below. Per-process so a quick stop→start starts with an empty queue.
+  proc._stdinBackpressured = false;
+  proc._stdinQueue = [];
+  proc._stdinQueueBytes = 0;
+  proc._stdinDroppedBytes = 0;
+  proc.stdin.on('drain', () => {
+    proc._stdinBackpressured = false;
+    while (proc._stdinQueue.length > 0
+           && proc.stdin.writable && !proc.stdin.writableEnded) {
+      const chunk = proc._stdinQueue.shift();
+      proc._stdinQueueBytes -= chunk.length;
+      if (!proc.stdin.write(chunk)) { proc._stdinBackpressured = true; break; }
+    }
+    if (proc._stdinDroppedBytes > 0) {
+      sendDebugLog(
+        `live-transcribe stdin back-pressure: dropped ${proc._stdinDroppedBytes} `
+        + 'bytes of stale audio while the sidecar was behind',
+      );
+      proc._stdinDroppedBytes = 0;
+    }
   });
 
   proc.stdout.on('data', (data) => {
@@ -3858,6 +3914,17 @@ function stopLiveTranscribe() {
   // quick restart can't cross resolvers between processes (review-2, Finding 2).
   const exited = proc._drainPromise || Promise.resolve();
   try {
+    // Flush any back-pressure queue (#357) into stdin before ending it.
+    // Chunks held in proc._stdinQueue haven't reached Node's write buffer yet,
+    // so a stop while back-pressured would otherwise discard the tail of the
+    // last utterance and truncate Python's live FINAL. Handing them to write()
+    // now lets end() flush them to the sidecar; Node buffers past the OS pipe
+    // limit here, which is fine for a one-shot drain at teardown.
+    if (proc._stdinQueue && proc._stdinQueue.length > 0
+        && proc.stdin.writable && !proc.stdin.writableEnded) {
+      for (const chunk of proc._stdinQueue) proc.stdin.write(chunk);
+    }
+    if (proc._stdinQueue) { proc._stdinQueue = []; proc._stdinQueueBytes = 0; }
     proc.stdin.end();
   } catch (_) { /* already closed */ }
   // Watchdog: if THIS Python process hasn't exited in SIDECAR_KILL_WATCHDOG_MS,

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -1930,6 +1930,37 @@ class _LiveVadPipeline:
     MAX_UTTERANCE_S = 30.0
     PREROLL_CHUNKS = 2  # ≈ 512 ms at 256 ms per callback
 
+    # Keep-pace guard (issue #357). Read + VAD + partial/final decode run
+    # synchronously on the single stdin-consumer thread, so a partial decode
+    # that takes longer than the audio it represents back-pressures the stdin
+    # pipe and the sidecar drifts behind real time (measured ~670 ms partial
+    # decode on a fanless M1 Air vs the 400 ms interval → ~94 % of partials
+    # over budget, audio backing up across the recording). Partials are
+    # best-effort display only — finals accumulate every sample regardless —
+    # so when decode is slow we stretch the *effective* partial cadence to an
+    # EWMA of measured decode time, dropping the partials that would otherwise
+    # queue up while always draining stdin. On fast machines (decode ≪ the
+    # interval) the effective cadence is the base interval, unchanged.
+    #
+    # Scope + known limits (kept deliberately per-channel; the shared decode
+    # coordinator belongs with the strategic ANE/threading rework):
+    #   * Cadence is tracked per channel, so two channels in *sustained*
+    #     simultaneous speech each keep their own pace but their decodes still
+    #     run serially on the one consumer thread — combined load can exceed
+    #     real time. The dominant single-speaker case (and the issue's own
+    #     measurements) is fully covered; continuous cross-talk on a fanless
+    #     Air is the residual gap, bounded by the stdin queue on the JS side.
+    #   * The EWMA only samples when a partial actually decodes, and its ALPHA
+    #     smoothing means a one-off spike inflates the interval only partly and
+    #     decays back over the next few partials of sustained speech.
+    KEEP_PACE_SAFETY = 1.15         # headroom over measured decode time
+    KEEP_PACE_ALPHA = 0.3           # EWMA weight for the newest decode sample
+    # Ceiling on the stretched cadence. High enough that a genuinely slow
+    # decoder (e.g. onnx-asr on a Windows CPU, several seconds per 15 s window)
+    # can still stretch far enough to keep pace, while ALPHA smoothing keeps a
+    # spurious spike from pinning partials at the ceiling.
+    KEEP_PACE_MAX_INTERVAL_S = 8.0
+
     @classmethod
     def _load_shared(cls, source_rate, source_label):
         """Load Parakeet config shared by both channel pipelines. Returns
@@ -2115,6 +2146,12 @@ class _LiveVadPipeline:
         self.last_partial_text = ""
         self.preroll: list = []
         self.cursor = 0
+        # Keep-pace guard state (issue #357): EWMA of measured partial-decode
+        # wall-time, used to stretch the effective partial cadence so a slow
+        # decode can't back-pressure stdin. 0.0 until the first partial has
+        # been timed (until then the fast path uses the base interval).
+        self._partial_decode_ewma_s = 0.0
+        self._keep_pace_max_interval_samples = int(sr * self.KEEP_PACE_MAX_INTERVAL_S)
 
     def parse_float32_bytes(self, raw_bytes):
         """Parse raw little-endian float32 bytes into a 1-D float32 array.
@@ -2226,23 +2263,62 @@ class _LiveVadPipeline:
         self.last_partial_count = 0
         self.last_partial_text = ""
 
+    def _effective_partial_interval_samples(self):
+        """Adaptive partial cadence in samples (issue #357 keep-pace guard).
+
+        Base cadence is ``partial_interval_samples`` (0.4 s of audio). Once a
+        partial decode has been timed and its EWMA exceeds that budget, the
+        sidecar would fall behind real time, so we require at least as much
+        *audio* between partials as the decode takes wall-clock (× a safety
+        margin), capped at ``KEEP_PACE_MAX_INTERVAL_S`` so a one-off spike
+        can't starve partials entirely. On fast machines (decode ≪ budget)
+        this returns the base cadence unchanged.
+        """
+        if self._partial_decode_ewma_s <= 0.0:
+            return self.partial_interval_samples
+        pace_samples = int(self._partial_decode_ewma_s * self.KEEP_PACE_SAFETY * self.sr)
+        effective = max(self.partial_interval_samples, pace_samples)
+        return min(effective, self._keep_pace_max_interval_samples)
+
+    def _record_partial_decode_time(self, dt_s):
+        """Fold a measured partial-decode wall-time into the keep-pace EWMA."""
+        if dt_s < 0:
+            return
+        if self._partial_decode_ewma_s <= 0.0:
+            self._partial_decode_ewma_s = dt_s
+        else:
+            self._partial_decode_ewma_s = (
+                (1.0 - self.KEEP_PACE_ALPHA) * self._partial_decode_ewma_s
+                + self.KEEP_PACE_ALPHA * dt_s
+            )
+
     def _maybe_emit_partial(self):
         delta = len(self.speech_samples) - self.last_partial_count
-        if delta < self.partial_interval_samples:
+        if delta < self._effective_partial_interval_samples():
             return
         if len(self.speech_samples) < self.min_utterance_samples:
             return
         # Only the trailing window — re-transcribing the full utterance
-        # every PARTIAL_INTERVAL_S would scale O(n²) with utterance length.
+        # every partial would scale O(n²) with utterance length.
         tail = self.speech_samples[-self.partial_window_samples:]
+        decode_started = time.monotonic()
         try:
             result = self.transcribe_samples(tail, language=self.language)
         except Exception as e:
             # Partials are best-effort. Don't tear down the consumer over
             # a transient decode hiccup; the next partial/final retries.
+            # Still fold the wall-time spent into the keep-pace EWMA — a
+            # decode that burns 700 ms before throwing is exactly the kind of
+            # cost that must widen the cadence, or a failing decoder would
+            # rebuild the backlog at the tight interval it was meant to relieve.
+            self._record_partial_decode_time(time.monotonic() - decode_started)
             logger.debug("partial transcribe failed: %s", e)
             self.last_partial_count = len(self.speech_samples)
             return
+        # Fold real decode wall-time into the keep-pace EWMA before anything
+        # can early-return, so a slow machine widens the next interval even
+        # when the text is empty or unchanged.
+        self._record_partial_decode_time(time.monotonic() - decode_started)
         text = (result.get("text") or "").strip() if result else ""
         self.last_partial_count = len(self.speech_samples)
         if text and text != self.last_partial_text:

--- a/tests/test_live_keep_pace.py
+++ b/tests/test_live_keep_pace.py
@@ -1,0 +1,219 @@
+"""Regression tests for the live-transcript keep-pace guard (issue #357).
+
+On fanless Apple Silicon (e.g. an M1 MacBook Air) a Parakeet partial decode can
+take ~670 ms, well over the 400 ms partial interval. Because read + VAD +
+partial/final decode run synchronously on the single stdin-consumer thread, a
+partial that runs longer than the audio it represents back-pressures the stdin
+pipe and the sidecar drifts behind real time.
+
+The fix (``_LiveVadPipeline``): partials are best-effort display only — finals
+accumulate every sample regardless — so when the measured partial-decode
+wall-time exceeds the interval budget we stretch the *effective* partial cadence
+to an EWMA of that decode time, dropping the partials that would otherwise queue
+up while always draining stdin. On fast machines the cadence is unchanged.
+
+These tests pin that contract without loading any real model: a fake VAD keeps
+the pipeline permanently "in speech", a stub ``transcribe_samples`` stands in for
+the decoder, and a fake monotonic clock makes each decode "take" a controlled
+amount of wall-time so the assertions are deterministic (no real sleeps).
+"""
+
+import unittest
+from unittest import mock
+
+try:
+    import numpy as np
+    _HAVE_NUMPY = True
+except ImportError:  # pragma: no cover - numpy is a hard backend dep
+    _HAVE_NUMPY = False
+
+from simple_recorder import _LiveVadPipeline
+
+
+class _FakeVAD:
+    """Minimal VAD stub: permanently in speech, emits no boundary events, so
+    ``process()`` accumulates every chunk and drives ``_maybe_emit_partial``
+    without ever finalising."""
+
+    def __init__(self):
+        self.in_speech = True
+
+    def process(self, chunk):
+        return []
+
+    def flush(self):
+        return []
+
+
+class _FakeCoordinator:
+    """Stand-in for the shared pending-finals coordinator (unused here since the
+    fake VAD never finalises)."""
+
+    def add(self, **kwargs):
+        pass
+
+    def flush_ready(self, other_idle):
+        return []
+
+
+class _SpeechStart:  # sentinel types; the fake VAD never emits them
+    pass
+
+
+class _SpeechEnd:
+    pass
+
+
+class _FakeClock:
+    """Deterministic ``time.monotonic`` replacement. ``_maybe_emit_partial``
+    reads the clock exactly twice per decode (start, then end); this advances by
+    ``decode_s`` on every second read so each decode measures ``decode_s`` of
+    wall-time regardless of real time."""
+
+    def __init__(self, decode_s):
+        self.t = 0.0
+        self.decode_s = decode_s
+        self._reads = 0
+
+    def monotonic(self):
+        self._reads += 1
+        if self._reads % 2 == 0:
+            self.t += self.decode_s
+        return self.t
+
+
+def _make_pipeline(transcribe_samples, sr=16000):
+    pipe = _LiveVadPipeline(
+        np=np,
+        vad=_FakeVAD(),
+        sr=sr,
+        SpeechStart=_SpeechStart,
+        SpeechEnd=_SpeechEnd,
+        transcribe_samples=transcribe_samples,
+        speaker="You",
+        pending_finals=_FakeCoordinator(),
+        language="auto",
+    )
+    # Silence the stdout LIVE_SEG emission; we only care about decode cadence.
+    pipe._emit = lambda *a, **k: None
+    return pipe
+
+
+@unittest.skipUnless(_HAVE_NUMPY, "numpy required for _LiveVadPipeline")
+class EffectiveIntervalTests(unittest.TestCase):
+    """Unit coverage of the pure cadence math."""
+
+    def setUp(self):
+        self.pipe = _make_pipeline(lambda samples, language="auto": {"text": "x"})
+
+    def test_base_interval_before_any_decode_timed(self):
+        # EWMA starts at 0 → fast path returns the unmodified base interval.
+        self.assertEqual(
+            self.pipe._effective_partial_interval_samples(),
+            self.pipe.partial_interval_samples,
+        )
+
+    def test_fast_decode_keeps_base_interval(self):
+        # 150 ms decode is well under the 400 ms budget → cadence unchanged.
+        self.pipe._record_partial_decode_time(0.15)
+        self.assertEqual(
+            self.pipe._effective_partial_interval_samples(),
+            self.pipe.partial_interval_samples,
+        )
+
+    def test_slow_decode_widens_interval(self):
+        # 800 ms decode → require ~800 ms × safety of audio between partials.
+        self.pipe._record_partial_decode_time(0.8)
+        expected = int(0.8 * _LiveVadPipeline.KEEP_PACE_SAFETY * self.pipe.sr)
+        self.assertEqual(
+            self.pipe._effective_partial_interval_samples(), expected,
+        )
+        self.assertGreater(
+            self.pipe._effective_partial_interval_samples(),
+            self.pipe.partial_interval_samples,
+        )
+
+    def test_interval_is_capped(self):
+        # A pathological decode can't stretch the cadence without bound.
+        self.pipe._record_partial_decode_time(10.0)
+        self.assertEqual(
+            self.pipe._effective_partial_interval_samples(),
+            int(_LiveVadPipeline.KEEP_PACE_MAX_INTERVAL_S * self.pipe.sr),
+        )
+
+    def test_ewma_smooths_successive_samples(self):
+        # First sample seeds the EWMA directly; the second blends by ALPHA.
+        self.pipe._record_partial_decode_time(0.4)
+        self.pipe._record_partial_decode_time(0.8)
+        alpha = _LiveVadPipeline.KEEP_PACE_ALPHA
+        self.assertAlmostEqual(
+            self.pipe._partial_decode_ewma_s,
+            (1.0 - alpha) * 0.4 + alpha * 0.8,
+            places=6,
+        )
+
+    def test_negative_decode_time_ignored(self):
+        self.pipe._record_partial_decode_time(-1.0)
+        self.assertEqual(self.pipe._partial_decode_ewma_s, 0.0)
+
+
+@unittest.skipUnless(_HAVE_NUMPY, "numpy required for _LiveVadPipeline")
+class KeepPaceThrottlingTests(unittest.TestCase):
+    """End-to-end: driving the same audio through a slow decoder produces fewer
+    partial decodes than a fast one, proving the guard drops partials instead of
+    queuing them up."""
+
+    def _drive(self, decode_s, audio_seconds=6.0, chunk_seconds=0.1):
+        calls = {"n": 0}
+
+        def transcribe(samples, language="auto"):
+            calls["n"] += 1
+            return {"text": f"partial-{calls['n']}"}
+
+        pipe = _make_pipeline(transcribe)
+        chunk = np.zeros(int(pipe.sr * chunk_seconds), dtype=np.float32)
+        n_chunks = int(audio_seconds / chunk_seconds)
+        clock = _FakeClock(decode_s)
+        with mock.patch("simple_recorder.time.monotonic", clock.monotonic):
+            for _ in range(n_chunks):
+                pipe.process(chunk.copy())
+        return calls["n"]
+
+    def test_slow_decode_throttles_partials(self):
+        fast = self._drive(decode_s=0.15)  # under budget → base cadence
+        slow = self._drive(decode_s=0.6)   # over budget → stretched cadence
+        self.assertGreater(
+            fast, slow,
+            msg=f"expected the slow decoder to run fewer partials (fast={fast}, slow={slow})",
+        )
+
+    def test_failed_partial_still_records_decode_time(self):
+        # A decoder that burns wall-time and then throws must still widen the
+        # cadence — otherwise a failing decoder rebuilds the very backlog the
+        # guard exists to relieve (cross-family review, #357).
+        def transcribe(samples, language="auto"):
+            raise RuntimeError("decode blew up")
+
+        pipe = _make_pipeline(transcribe)
+        chunk = np.zeros(int(pipe.sr * 0.1), dtype=np.float32)
+        clock = _FakeClock(0.7)  # each (failed) decode measures 0.7 s
+        with mock.patch("simple_recorder.time.monotonic", clock.monotonic):
+            for _ in range(12):  # ~1.2 s of audio → at least one partial attempt
+                pipe.process(chunk.copy())
+        self.assertGreater(pipe._partial_decode_ewma_s, 0.0)
+        self.assertGreater(
+            pipe._effective_partial_interval_samples(),
+            pipe.partial_interval_samples,
+        )
+
+    def test_fast_decode_matches_base_cadence(self):
+        # Over 6 s of audio at the 0.4 s base interval, a fast decoder should run
+        # roughly audio/interval partials (minus the MIN_UTTERANCE warm-up).
+        fast = self._drive(decode_s=0.05, audio_seconds=6.0)
+        naive = int(6.0 / _LiveVadPipeline.PARTIAL_INTERVAL_S)
+        self.assertGreaterEqual(fast, naive - 3)
+        self.assertLessEqual(fast, naive)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #357 (the immediate, self-contained fixes 1 + 2; the strategic ANE/FluidAudio direction stays a separate track).

## Problem
On fanless MacBook Airs a Parakeet **partial** decode (~670 ms measured on an M1 Air, vs the 400 ms partial interval) runs longer than the audio it represents. Read + VAD + partial/final decode are synchronous on the single stdin-consumer thread, so an over-budget partial back-pressures the stdin pipe and the sidecar drifts behind real time: the live transcript lags and the instant-stop note is delayed. The post-stop **summary is unaffected** (independent batch transcription) — this is a live-path UX + battery issue.

## Fix 1 — drop-behind, not queue-up (`simple_recorder.py`, `_LiveVadPipeline`)
Partials are best-effort display only; **finals accumulate every sample regardless**. So we stretch the *effective* partial cadence to an EWMA of measured partial-decode wall-time (× a 1.15 safety margin, capped), dropping the partials that would otherwise queue up while **always draining stdin**. On fast machines (decode ≪ interval) the cadence is the base 400 ms, unchanged.

- Decode time is recorded **even when the decode throws**, so a failing decoder can't rebuild the backlog at the tight interval.
- The cap (8 s) is high enough that a slow Windows-CPU onnx-asr decode can still stretch far enough to keep pace, while the EWMA smoothing keeps a one-off spike from pinning partials at the ceiling.

## Fix 2 — respect stdin back-pressure (`app/main.js`, `live-transcribe-chunk`)
Honor `stdin.write()`'s return value. Once back-pressured, queue chunks and flush them on the stream's `drain`; the queue is **bounded** so a genuine (multi-minute) stall drops the oldest audio rather than growing the JS heap. On stop, the queued tail is flushed into stdin **before** `end()`, so a stop mid-back-pressure doesn't truncate Python's live FINAL. All state is per-process, so a quick stop→start starts clean.

With Fix 1 keeping the pipe drained, Fix 2 is belt-and-suspenders in normal operation.

## Tests
`tests/test_live_keep_pace.py` (9 tests, model-free, deterministic via a fake monotonic clock): the cadence math, the failed-decode path, and end-to-end throttling (14 → 8 → 5 partials as the decoder slows).

- `python -m unittest discover tests` → 464 passed
- `ruff check` clean on the changed code; `node --check app/main.js` OK

## Known limits (deliberately deferred to the strategic rework)
- **Per-channel cadence:** two channels in *sustained* simultaneous speech each keep their own pace but still decode serially on the one thread — combined load can exceed real time. The dominant single-speaker case (and this issue's own measurements) is fully covered; continuous cross-talk on a fanless Air is the residual gap, bounded by the JS stdin queue. A shared decode budget belongs with the ANE/threading rework.
- **Cross-family reviewed** (Codex, read-only): no critical findings; the review's medium findings on the failed-decode path, stop-time queue flush, and the Windows-CPU cap are fixed in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Parakeet live partials in pace on slow Apple Silicon by adapting the partial cadence and honoring stdin back-pressure. This prevents live transcript lag and stop-time truncation while keeping finals accurate. Fixes #357.

- **Bug Fixes**
  - Python (`simple_recorder.py`, `_LiveVadPipeline`): stretch the effective partial interval to an EWMA of measured decode time (×1.15 safety, capped at 8s), drop would‑be queued partials, and record decode time even on exceptions. Finals still accumulate every sample.
  - Node (`app/main.js`): respect `stdin.write()` back‑pressure; queue and flush on `drain`, bound the queue and drop oldest audio on genuine stalls, and flush any queued tail before `end()` for clean finals. State is per‑process.

- **Tests**
  - Added `tests/test_live_keep_pace.py` with deterministic coverage for cadence math, failed‑decode behavior, and end‑to‑end throttling using a fake clock.

<sup>Written for commit 0f7e4dc992ead29f23b490a6f5698c0cd2227617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

