### PR TITLE
fix(bedrock): fully percent-encode inference profile ARNs in Converse URL

### DIFF
--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -45,18 +45,21 @@ def bedrock_converse_url(region: str, target_id: str) -> str:
     can't drift on the URL-encoding rules — the original release shipped
     with one site only and we got bitten by it.
 
-    URL-encoding subtlety: the safe set MUST include ``/`` alongside the
-    ``:.-`` already needed for system-profile and bare-model ids, because
+    URL-encoding subtlety: the identifier MUST be fully percent-encoded
+    (``safe=""``), including ``:`` → ``%3A`` and ``/`` → ``%2F``, because
     application inference profile ARNs (the standard shape in governed
-    AWS environments) contain a path-style segment:
+    AWS environments) contain both a colon-delimited ARN prefix and a
+    path-style segment:
 
         arn:aws:bedrock:eu-west-2:…:application-inference-profile/abc123
                                                                  ^
 
-    Bedrock's REST router rejects the percent-encoded form (``%2F``) with
-    HTTP 400 "The provided model identifier is invalid". Keeping ``/``
-    literal lets ARNs flow through; non-ARN ids (no slashes) are
-    unaffected because there's nothing to leave alone.
+    Left literal, the slash makes Bedrock's REST router treat the ARN as
+    a longer path and return HTTP 200 with an ``UnknownOperationException``
+    body instead of routing to the Converse operation. Fully encoding the
+    id routes ARNs to Converse correctly; system-profile and bare-model
+    ids (which contain a ``:0`` version suffix) encode to ``%3A0`` and
+    route fine too.
 
     ``region`` must be shaped like a real AWS region code — rejected here
     too (not just in Config.set_bedrock_region()) because this function is
@@ -68,7 +71,7 @@ def bedrock_converse_url(region: str, target_id: str) -> str:
     if not BEDROCK_REGION_RE.fullmatch(region):
         raise ValueError(f"Invalid Bedrock region: {region!r}")
     import urllib.parse
-    encoded = urllib.parse.quote(target_id, safe=":.-/")
+    encoded = urllib.parse.quote(target_id, safe="")
     return f"https://bedrock-runtime.{region}.amazonaws.com/model/{encoded}/converse"
 
 

--- a/tests/test_bedrock_converse_url.py
+++ b/tests/test_bedrock_converse_url.py
@@ -6,8 +6,10 @@ simple_recorder.test_cloud_api — both with the same too-narrow safe set
 (``":.-"``). That worked for system inference profile ids and bare model
 ids, but silently broke for application inference profile ARNs in
 governed AWS environments because the ARN contains a path-style
-``application-inference-profile/<id>`` segment. Percent-encoding the
-slash produced HTTP 400 "model identifier invalid".
+``application-inference-profile/<id>`` segment. Leaving the slash
+literal made Bedrock's router return HTTP 200 with an
+``UnknownOperationException`` body instead of routing to Converse; the
+fix fully percent-encodes the identifier (``safe=""``).
 
 These tests pin the three concrete shapes we expect to construct URLs
 for, so a regression on the safe set surfaces here before it ships.
@@ -18,18 +20,22 @@ from src.summarizer import bedrock_converse_url
 
 
 class BedrockConverseUrlTests(unittest.TestCase):
-    def test_application_inference_profile_arn_keeps_slash(self):
+    def test_application_inference_profile_arn_is_fully_encoded(self):
         arn = (
             "arn:aws:bedrock:eu-west-2:745078845594:"
             "application-inference-profile/acgdk9re2ouo"
         )
         url = bedrock_converse_url("eu-west-2", arn)
-        # The slash inside the ARN survives URL construction. If it got
-        # percent-encoded to %2F, Bedrock returns "model identifier invalid".
-        self.assertNotIn("%2F", url)
-        self.assertNotIn("%2f", url)
-        # Spot-check the segment is intact.
-        self.assertIn("application-inference-profile/acgdk9re2ouo", url)
+        # The ARN is fully percent-encoded: `:` -> %3A, `/` -> %2F. Left
+        # literal, the slash makes Bedrock return HTTP 200 with an
+        # UnknownOperationException instead of routing to Converse.
+        self.assertIn("%3A", url)
+        self.assertIn("%2F", url)
+        self.assertIn(
+            "arn%3Aaws%3Abedrock%3Aeu-west-2%3A745078845594%3A"
+            "application-inference-profile%2Facgdk9re2ouo",
+            url,
+        )
         # Host + path shape.
         self.assertTrue(
             url.startswith("https://bedrock-runtime.eu-west-2.amazonaws.com/model/")
@@ -37,20 +43,20 @@ class BedrockConverseUrlTests(unittest.TestCase):
         self.assertTrue(url.endswith("/converse"))
 
     def test_system_inference_profile_id_unchanged(self):
-        # The Anthropic system profile shape from the AWS docs. No
-        # characters that would be percent-encoded under either old or
-        # new safe set.
+        # The Anthropic system profile shape from the AWS docs. The `:0`
+        # version suffix now percent-encodes to %3A0.
         profile = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        encoded = "us.anthropic.claude-haiku-4-5-20251001-v1%3A0"
         url = bedrock_converse_url("us-east-1", profile)
-        self.assertIn(f"/model/{profile}/converse", url)
+        self.assertIn(f"/model/{encoded}/converse", url)
 
     def test_bare_model_id_unchanged(self):
         # Direct-invoke shape. Same expectations as the system profile —
-        # the test exists so a future "tighten the safe set" change can't
-        # silently break direct invocation either.
+        # the `:0` version suffix percent-encodes to %3A0.
         model = "anthropic.claude-haiku-4-5-20251001-v1:0"
+        encoded = "anthropic.claude-haiku-4-5-20251001-v1%3A0"
         url = bedrock_converse_url("us-east-1", model)
-        self.assertIn(f"/model/{model}/converse", url)
+        self.assertIn(f"/model/{encoded}/converse", url)
 
     def test_region_lands_in_host_segment(self):
         # Defensive — ensures the region argument flows through rather


### PR DESCRIPTION
## Description

The Bedrock Converse URL builder left `/` (and `:`) literal in the model
identifier (`safe=":.-/"`). For **application inference profile ARNs** —
the standard shape in governed AWS environments, which contain a
path-style `application-inference-profile/<id>` segment — the literal
slash made Bedrock's REST router treat the ARN as a longer path and
return **HTTP 200 with an `UnknownOperationException` body** instead of
routing to the Converse operation.

Fix: fully percent-encode the identifier (`safe=""`), so `:` → `%3A` and
`/` → `%2F`. ARNs now route to Converse correctly. Bare-model and
system-profile ids (with a `:0` version suffix) encode to `%3A0` and
continue to route fine.

## Type of Change

- [x] Bug fix

## Testing

- [x] `python -m unittest tests.test_bedrock_converse_url` — all 8 pass
- [x] No breaking changes to existing functionality (region validation
      / rejection cases unaffected)

## Additional Notes

Single-line behavioral change in `src/summarizer.bedrock_converse_url`;
the three affected regression tests were updated to expect the
fully-encoded form.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fully percent-encode the Bedrock model identifier in the Converse URL to fix routing for application inference profile ARNs. Prevents HTTP 200 with UnknownOperationException and ensures ARNs route to Converse correctly.

- **Bug Fixes**
  - Use full percent-encoding for the identifier (`safe=""`) so `:` -> `%3A` and `/` -> `%2F`.
  - Updated tests to expect encoded forms for ARN, system-profile, and bare-model ids.
  - Region validation unchanged; system-profile and bare-model ids still work (now show `%3A0` in URLs).

<sup>Written for commit 863efd0d703b3c01f7763f2519c96c028160f191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

