### PR TITLE
fix(macos): stop the Keychain "Safe Storage" prompt at every launch

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,18 @@
-const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, powerMonitor, net, session } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, Tray, Menu, nativeImage, powerMonitor, net, session } = require('electron');
+
+// safeStorage is accessed lazily via getSafeStorage(), NOT destructured from the
+// require above. On macOS, merely retrieving the safeStorage binding at load
+// time used to register an app-ready observer that eagerly initialized OSCrypt
+// and touched the login Keychain — popping the "<app> Safe Storage" permission
+// dialog on every launch even for users who had no stored secret at all
+// (Electron 42.0.0 regression, made lazy again in 42.4.1). Keeping the binding
+// out of the top-level destructure means loading main.js can never trigger that
+// access; the first Keychain touch happens only when a credential helper below
+// actually runs (saving a cloud key, org sign-in, calendar connect). require()
+// is cached, so getSafeStorage() is cheap.
+function getSafeStorage() {
+  return require('electron').safeStorage;
+}
 
 // Prevent EPIPE crashes when stdout/stderr pipe is broken (e.g. launching terminal closed)
 process.stdout?.on('error', () => {});
@@ -8017,7 +8031,7 @@ function saveCloudApiKey(key) {
     if (!fs.existsSync(keyDir)) {
       fs.mkdirSync(keyDir, { recursive: true });
     }
-    const encrypted = safeStorage.encryptString(key);
+    const encrypted = getSafeStorage().encryptString(key);
     fs.writeFileSync(getCloudKeyPath(), encrypted);
     return true;
   } catch (error) {
@@ -8032,7 +8046,7 @@ function loadCloudApiKey() {
     migrateLegacyCredentialFile(keyPath, '.cloud-api-key');
     if (!fs.existsSync(keyPath)) return null;
     const encrypted = fs.readFileSync(keyPath);
-    return safeStorage.decryptString(encrypted);
+    return getSafeStorage().decryptString(encrypted);
   } catch (error) {
     console.error('Failed to load cloud API key:', error.message);
     return null;
@@ -9246,7 +9260,7 @@ function saveGoogleTokens(tokens) {
     if (!fs.existsSync(tokenDir)) {
       fs.mkdirSync(tokenDir, { recursive: true });
     }
-    const encrypted = safeStorage.encryptString(JSON.stringify(tokens));
+    const encrypted = getSafeStorage().encryptString(JSON.stringify(tokens));
     fs.writeFileSync(getTokenFilePath(), encrypted);
     console.log('Google tokens saved');
   } catch (error) {
@@ -9260,7 +9274,7 @@ function loadGoogleTokens() {
     migrateLegacyCredentialFile(tokenPath, '.google-tokens');
     if (!fs.existsSync(tokenPath)) return null;
     const encrypted = fs.readFileSync(tokenPath);
-    const decrypted = safeStorage.decryptString(encrypted);
+    const decrypted = getSafeStorage().decryptString(encrypted);
     return JSON.parse(decrypted);
   } catch (error) {
     console.error('Failed to load Google tokens:', error.message);
@@ -9294,7 +9308,7 @@ function saveOutlookTokens(tokens) {
     if (!fs.existsSync(tokenDir)) {
       fs.mkdirSync(tokenDir, { recursive: true });
     }
-    const encrypted = safeStorage.encryptString(JSON.stringify(tokens));
+    const encrypted = getSafeStorage().encryptString(JSON.stringify(tokens));
     fs.writeFileSync(getOutlookTokenFilePath(), encrypted);
     console.log('Outlook tokens saved');
   } catch (error) {
@@ -9308,7 +9322,7 @@ function loadOutlookTokens() {
     migrateLegacyCredentialFile(tokenPath, '.outlook-tokens');
     if (!fs.existsSync(tokenPath)) return null;
     const encrypted = fs.readFileSync(tokenPath);
-    const decrypted = safeStorage.decryptString(encrypted);
+    const decrypted = getSafeStorage().decryptString(encrypted);
     return JSON.parse(decrypted);
   } catch (error) {
     console.error('Failed to load Outlook tokens:', error.message);
@@ -10961,7 +10975,7 @@ function saveOrgSession(session) {
   try {
     const dir = path.dirname(getOrgSessionPath());
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    const encrypted = safeStorage.encryptString(JSON.stringify(session));
+    const encrypted = getSafeStorage().encryptString(JSON.stringify(session));
     fs.writeFileSync(getOrgSessionPath(), encrypted);
     orgSessionGeneration++;
     return true;
@@ -10975,7 +10989,7 @@ function saveOrgSession(session) {
 //   file missing        → { session: null, exists: false, decryptFailed: false }
 //   present, unreadable → { session: null, exists: true,  decryptFailed: true  }
 //   present, readable   → { session,      exists: true,  decryptFailed: false }
-// The middle state matters: safeStorage.decryptString throws while the
+// The middle state matters: getSafeStorage().decryptString throws while the
 // keychain is locked (right after wake / login, or a denied prompt after an
 // app re-sign) — treating that like "signed out" is exactly what used to
 // downgrade signed-in users to local AI via the stale-adapter recovery.
@@ -10991,7 +11005,7 @@ function loadOrgSessionEx() {
     // reset it moments before the decrypt throws, and the catch below
     // would restamp it to now on every call, so the grace window could
     // never elapse and the org lock would stay fail-closed forever.
-    const session = JSON.parse(safeStorage.decryptString(encrypted));
+    const session = JSON.parse(getSafeStorage().decryptString(encrypted));
     orgSessionDecryptFailingSince = null;
     return { session, exists: true, decryptFailed: false };
   } catch (e) {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -46,7 +46,7 @@
         "@vitejs/plugin-react": "^4.7.0",
         "autoprefixer": "^10.5.0",
         "cross-env": "^10.1.0",
-        "electron": "^42.0.0",
+        "electron": "^42.7.1",
         "electron-builder": "^26.0.0",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
@@ -541,6 +541,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -3185,7 +3194,7 @@
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3250,6 +3259,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4586,6 +4596,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5655,14 +5666,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.0.tgz",
-      "integrity": "sha512-in5jnW/Ywy3Rh3FPr4MR80exPEkywKYAmDJRZ/gIKlr8VXEi3zXgiAZbf0Si7KRccHTF2y8euVMRz7M6HqTjMA==",
+      "version": "42.7.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.7.1.tgz",
+      "integrity": "sha512-fmjFv4Ebbs/FNZg6a/IAu25lBb8vo/HBVa2vtE2GvYlgAC7/fu8dx1b2pL2wV1yWlfMI2q3Npe4eVYSFGirnwA==",
       "license": "MIT",
       "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
         "@electron/get": "^5.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@types/node": "^24.9.0"
       },
       "bin": {
         "electron": "cli.js",
@@ -5846,6 +5857,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -6557,6 +6569,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -6656,6 +6669,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -6987,6 +7001,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -9565,6 +9580,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9806,6 +9822,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -10300,6 +10317,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -12223,7 +12241,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -12850,6 +12868,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -12951,6 +12970,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/app/package.json
+++ b/app/package.json
@@ -62,7 +62,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
-    "electron": "^42.0.0",
+    "electron": "^42.7.1",
     "electron-builder": "^26.0.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Problem

On macOS, users get the Keychain permission dialog *"Steno wants to access the key 'stenoai Safe Storage' in your keychain"* on **every launch** - even users with **no stored secret at all** (no cloud API key, no org session, no calendar tokens). Clicking "Allow" (rather than "Always Allow") makes it recur; it's a confusing, scary-looking prompt for a local-first app.

## Root cause

Not our credential code - all four credential helpers gate on the on-disk file existing before touching `safeStorage`, so with no secrets they never decrypt. The trigger is an **Electron 42.0.0 regression**: merely *retrieving the `safeStorage` binding at load time* registered an app-ready observer that eagerly initialized OSCrypt and touched the login Keychain, independent of any `encrypt`/`decrypt` call. And `safeStorage` was in the top-level `require('electron')` destructure. Electron made init lazy again in **42.4.1** ([electron/electron#50419](https://releases.electronjs.org/pr/50419), shipped in [42.4.1](https://releases.electronjs.org/release/v42.4.1)).

(Note: this is *not* Chromium cookie encryption - that fuse is disabled by default, so cookies are plaintext. The shared key *name* is misleading.)

## Fix (belt-and-suspenders)

1. **Bump Electron `42.0.0` → `42.7.1`** - within the existing `^42` major (no Chromium-major change), picks up the lazy-init fix plus later 42.x patches.
2. **Stop destructuring `safeStorage`** from the top-level `require('electron')`; access it lazily via a new `getSafeStorage()` helper inside the four credential helpers (cloud key, Google + Outlook calendar tokens, org session). Loading `main.js` can then never trigger the Keychain access - the first touch happens only when a feature that needs it actually runs.

## Verification

- **Real dev launch on 42.7.1**: app boots with **zero `SecurityAgent` (Keychain prompt) during startup**; clean teardown.
- `app/ipc-contract.test.js` 40/40 (main.js structure intact), unit suite green.
- Cross-family review (independent, read-only): **approve, no findings** - confirmed all 8 `safeStorage` call sites migrated, `getSafeStorage()` hoisting safe, empty-file startup paths return before touching the binding, remaining direct refs are E2E-only, and 42.7.1 has no breaking main-process API changes vs 42.0.

**Pre-merge gate:** a signed-DMG cold start should confirm the prompt is gone on a properly-signed build - Electron doesn't formally guarantee no other component touches OSCrypt post-42.4.1, so this is verified empirically on the release build before shipping.

The lockfile also picks up a benign root-version sync (`0.5.8` → `0.6.2`) that was stale vs `package.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the recurring macOS Keychain “Safe Storage” prompt on startup by upgrading `electron` and deferring `safeStorage` access until credentials are actually used.

- **Bug Fixes**
  - Remove top-level `safeStorage` import; add `getSafeStorage()` and use it in all credential helpers (cloud key, Google/Outlook tokens, org session) to avoid touching the Keychain during app load.

- **Dependencies**
  - Update `electron` from `^42.0.0` to `^42.7.1` to pick up the lazy-init fix for `safeStorage`.

<sup>Written for commit fbb3f7af06c08d2e29343d6d53d8dc71e261c6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

