### PR TITLE
refactor(main): extract settings-toggle IPC into settings-ipc.js (RFC #327 Phase 2.2)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -41,6 +41,7 @@ const { spawn, killProcessTree, createBackendCli } = require('./backend-cli');
 const { createDebugLog } = require('./debug-log');
 const { createTeardownRegistry } = require('./teardown');
 const { registerFoldersIpc } = require('./folders-ipc');
+const { registerSettingsIpc } = require('./settings-ipc');
 const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
 const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
@@ -6744,67 +6745,14 @@ ipcMain.handle('pull-parakeet-model', async (event, modelId) => {
   }
 });
 
-ipcMain.handle('get-keep-recordings', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-keep-recordings'], true);
-    const jsonData = JSON.parse(result.trim());
-    return { success: true, ...jsonData };
-  } catch (e) { return { success: false, error: e.message }; }
-});
-
-ipcMain.handle('set-keep-recordings', async (event, enabled) => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['set-keep-recordings', enabled.toString()]);
-    const jsonData = JSON.parse(result.trim());
-    return { success: true, ...jsonData };
-  } catch (e) { return { success: false, error: e.message }; }
-});
-
-ipcMain.handle('get-auto-summarize', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-auto-summarize'], true);
-    const jsonData = JSON.parse(result.trim());
-    return { success: true, ...jsonData };
-  } catch (e) { return { success: false, error: e.message }; }
-});
-
-ipcMain.handle('set-auto-summarize', async (event, enabled) => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['set-auto-summarize', enabled.toString()]);
-    const jsonData = JSON.parse(result.trim());
-    return { success: true, ...jsonData };
-  } catch (e) { return { success: false, error: e.message }; }
-});
-
-ipcMain.handle('get-silence-auto-stop', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-silence-auto-stop'], true);
-    const jsonData = JSON.parse(result.trim());
-    return { success: true, ...jsonData };
-  } catch (e) { return { success: false, error: e.message }; }
-});
-
-ipcMain.handle('set-silence-auto-stop-enabled', async (_event, enabled) => {
-  try {
-    const result = await runPythonScript(
-      'simple_recorder.py',
-      ['set-silence-auto-stop-enabled', enabled ? 'True' : 'False']
-    );
-    const jsonData = JSON.parse(result.trim());
-    return jsonData;
-  } catch (e) { return { success: false, error: e.message }; }
-});
-
-ipcMain.handle('set-silence-auto-stop-minutes', async (_event, minutes) => {
-  try {
-    const result = await runPythonScript(
-      'simple_recorder.py',
-      ['set-silence-auto-stop-minutes', String(minutes)]
-    );
-    const jsonData = JSON.parse(result.trim());
-    return jsonData;
-  } catch (e) { return { success: false, error: e.message }; }
-});
+// Settings-toggle IPC handlers (RFC #327 Phase 2.2) — the self-contained config
+// get/set toggles (keep-recordings, auto-summarize, silence-auto-stop,
+// system-audio, language, microphone, user-name, privacy-notice-seen) extracted
+// to ./settings-ipc and registered here in place, so registration timing +
+// behavior are identical to the inline handlers this replaces. Settings-shaped
+// handlers coupled to another domain (telemetry, models, mic-monitor, calendar,
+// tray) deliberately stay in main.js until that domain's own extraction.
+registerSettingsIpc({ ipcMain, runPythonScript, sendDebugLog });
 
 // Fired by the renderer's silence detector. The renderer has already
 // asked main to stop the recording via pause/stop; this just surfaces
@@ -6965,31 +6913,6 @@ ipcMain.handle('get-telemetry', async () => {
   }
 });
 
-ipcMain.handle('get-privacy-notice-seen', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-privacy-notice-seen']);
-    const jsonData = JSON.parse(result);
-    return {
-      success: true,
-      privacy_notice_seen: jsonData.privacy_notice_seen
-    };
-  } catch (error) {
-    sendDebugLog(`Error getting privacy notice state: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('set-privacy-notice-seen', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['set-privacy-notice-seen']);
-    const jsonData = JSON.parse(result);
-    return jsonData;
-  } catch (error) {
-    sendDebugLog(`Error marking privacy notice seen: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
 // Where the telemetry toggle was flipped -- 'setup' names the Setup.tsx
 // screen and 'consent' names the one-time privacy notice modal. 'setup' is
 // also reachable later via "run setup wizard" from Settings (see
@@ -7143,32 +7066,6 @@ ipcMain.handle('set-menu-bar-icon', async (event, enabled) => {
 });
 
 // System audio capture IPC handlers
-ipcMain.handle('get-system-audio', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-system-audio'], true);
-    const jsonData = JSON.parse(result);
-    return { success: true, ...jsonData };
-  } catch (error) {
-    sendDebugLog(`Error getting system audio setting: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('set-system-audio', async (event, enabled) => {
-  try {
-    sendDebugLog(`Setting system audio to: ${enabled}`);
-    const result = await runPythonScript('simple_recorder.py', ['set-system-audio', enabled ? 'True' : 'False']);
-    const jsonMatch = result.match(/\{.*\}/s);
-    if (jsonMatch) {
-      return JSON.parse(jsonMatch[0]);
-    }
-    return { success: true, system_audio_enabled: enabled };
-  } catch (error) {
-    sendDebugLog(`Error setting system audio: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
 ipcMain.handle('get-auto-detect-meetings', async () => {
   try {
     const result = await runPythonScript('simple_recorder.py', ['get-auto-detect-meetings'], true);
@@ -7272,90 +7169,6 @@ ipcMain.handle('set-launch-on-login', async (_event, enabled) => {
 });
 
 // Language IPC handlers
-ipcMain.handle('get-language', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-language'], true);
-    const jsonData = JSON.parse(result);
-    return { success: true, ...jsonData };
-  } catch (error) {
-    sendDebugLog(`Error getting language setting: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('set-language', async (event, languageCode) => {
-  try {
-    sendDebugLog(`Setting language to: ${languageCode}`);
-    const result = await runPythonScript('simple_recorder.py', ['set-language', languageCode]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    if (jsonMatch) {
-      return JSON.parse(jsonMatch[0]);
-    }
-    return { success: true, language: languageCode };
-  } catch (error) {
-    sendDebugLog(`Error setting language: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
-// Microphone selection IPC handlers
-ipcMain.handle('get-microphone', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-microphone'], true);
-    const jsonData = JSON.parse(result);
-    return { success: true, ...jsonData };
-  } catch (error) {
-    sendDebugLog(`Error getting microphone setting: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('set-microphone', async (event, deviceId, label) => {
-  try {
-    sendDebugLog(`Setting microphone to: ${deviceId ?? 'default'}`);
-    // '--' ends Click's option parsing: without it, a device label starting
-    // with '--' (e.g. "--help") is parsed as a flag, the subcommand prints
-    // help and exits 0 without saving, and the fallback below would then
-    // report a false success.
-    const result = await runPythonScript('simple_recorder.py', [
-      'set-microphone',
-      '--',
-      deviceId ?? '',
-      label ?? '',
-    ]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    if (jsonMatch) {
-      return JSON.parse(jsonMatch[0]);
-    }
-    const normalizedId = deviceId && deviceId !== 'default' ? deviceId : null;
-    return { success: true, device_id: normalizedId, label: normalizedId ? label ?? null : null };
-  } catch (error) {
-    sendDebugLog(`Error setting microphone: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('get-user-name', async () => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['get-user-name'], true);
-    const jsonData = JSON.parse(result.trim());
-    return { success: true, ...jsonData };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('set-user-name', async (event, name) => {
-  try {
-    const result = await runPythonScript('simple_recorder.py', ['set-user-name', String(name ?? '')]);
-    const jsonMatch = result.match(/\{.*\}/s);
-    if (jsonMatch) return JSON.parse(jsonMatch[0]);
-    return { success: true, user_name: String(name ?? '').trim() };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
 // AI Provider IPC handlers
 
 // One-time forward-migration of an app-managed credential from its pre-fix

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/settings-ipc.js
+++ b/app/settings-ipc.js
@@ -1,0 +1,224 @@
+'use strict';
+
+/**
+ * Settings-toggle IPC handlers (RFC #327 Phase 2.2) — the self-contained config
+ * get/set toggles that are pure backend passthrough: each handler just shells a
+ * `simple_recorder.py` config subcommand and returns the parsed result. Like the
+ * Folders pilot, a single `registerSettingsIpc(deps)` entry point that main.js
+ * calls once, in place, so registration timing + behavior are identical to the
+ * inline handlers this replaces (ZERO behavior change).
+ *
+ * Scope is deliberately the pure toggles only. Settings-shaped handlers that
+ * reach into another domain stay in main.js until that domain's own extraction:
+ *   - notifications / launch-on-login  → telemetry identity (Phase 2.5)
+ *   - transcription-engine / whisper-model → trackEvent + models (Phase 2.3)
+ *   - auto-detect-meetings → mic-monitor (Phase 2.7)
+ *   - premeeting-notifications → calendar scheduler (Phase 2.8)
+ *   - dock-icon / menu-bar-icon → tray/window composition root (stay in main.js)
+ *
+ * Cross-cutting seams are injected — main.js stays the only place that wires
+ * them:
+ *   - runPythonScript  the bundled-backend invoker (backend-cli seam)
+ *   - sendDebugLog     the debug-panel log sink (debug-log seam)
+ */
+
+function registerSettingsIpc({ ipcMain, runPythonScript, sendDebugLog }) {
+  ipcMain.handle('get-keep-recordings', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-keep-recordings'], true);
+      const jsonData = JSON.parse(result.trim());
+      return { success: true, ...jsonData };
+    } catch (e) { return { success: false, error: e.message }; }
+  });
+
+  ipcMain.handle('set-keep-recordings', async (event, enabled) => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['set-keep-recordings', enabled.toString()]);
+      const jsonData = JSON.parse(result.trim());
+      return { success: true, ...jsonData };
+    } catch (e) { return { success: false, error: e.message }; }
+  });
+
+  ipcMain.handle('get-auto-summarize', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-auto-summarize'], true);
+      const jsonData = JSON.parse(result.trim());
+      return { success: true, ...jsonData };
+    } catch (e) { return { success: false, error: e.message }; }
+  });
+
+  ipcMain.handle('set-auto-summarize', async (event, enabled) => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['set-auto-summarize', enabled.toString()]);
+      const jsonData = JSON.parse(result.trim());
+      return { success: true, ...jsonData };
+    } catch (e) { return { success: false, error: e.message }; }
+  });
+
+  ipcMain.handle('get-silence-auto-stop', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-silence-auto-stop'], true);
+      const jsonData = JSON.parse(result.trim());
+      return { success: true, ...jsonData };
+    } catch (e) { return { success: false, error: e.message }; }
+  });
+
+  ipcMain.handle('set-silence-auto-stop-enabled', async (_event, enabled) => {
+    try {
+      const result = await runPythonScript(
+        'simple_recorder.py',
+        ['set-silence-auto-stop-enabled', enabled ? 'True' : 'False']
+      );
+      const jsonData = JSON.parse(result.trim());
+      return jsonData;
+    } catch (e) { return { success: false, error: e.message }; }
+  });
+
+  ipcMain.handle('set-silence-auto-stop-minutes', async (_event, minutes) => {
+    try {
+      const result = await runPythonScript(
+        'simple_recorder.py',
+        ['set-silence-auto-stop-minutes', String(minutes)]
+      );
+      const jsonData = JSON.parse(result.trim());
+      return jsonData;
+    } catch (e) { return { success: false, error: e.message }; }
+  });
+
+  ipcMain.handle('get-privacy-notice-seen', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-privacy-notice-seen']);
+      const jsonData = JSON.parse(result);
+      return {
+        success: true,
+        privacy_notice_seen: jsonData.privacy_notice_seen
+      };
+    } catch (error) {
+      sendDebugLog(`Error getting privacy notice state: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('set-privacy-notice-seen', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['set-privacy-notice-seen']);
+      const jsonData = JSON.parse(result);
+      return jsonData;
+    } catch (error) {
+      sendDebugLog(`Error marking privacy notice seen: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('get-system-audio', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-system-audio'], true);
+      const jsonData = JSON.parse(result);
+      return { success: true, ...jsonData };
+    } catch (error) {
+      sendDebugLog(`Error getting system audio setting: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('set-system-audio', async (event, enabled) => {
+    try {
+      sendDebugLog(`Setting system audio to: ${enabled}`);
+      const result = await runPythonScript('simple_recorder.py', ['set-system-audio', enabled ? 'True' : 'False']);
+      const jsonMatch = result.match(/\{.*\}/s);
+      if (jsonMatch) {
+        return JSON.parse(jsonMatch[0]);
+      }
+      return { success: true, system_audio_enabled: enabled };
+    } catch (error) {
+      sendDebugLog(`Error setting system audio: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('get-language', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-language'], true);
+      const jsonData = JSON.parse(result);
+      return { success: true, ...jsonData };
+    } catch (error) {
+      sendDebugLog(`Error getting language setting: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('set-language', async (event, languageCode) => {
+    try {
+      sendDebugLog(`Setting language to: ${languageCode}`);
+      const result = await runPythonScript('simple_recorder.py', ['set-language', languageCode]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      if (jsonMatch) {
+        return JSON.parse(jsonMatch[0]);
+      }
+      return { success: true, language: languageCode };
+    } catch (error) {
+      sendDebugLog(`Error setting language: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  // Microphone selection IPC handlers
+  ipcMain.handle('get-microphone', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-microphone'], true);
+      const jsonData = JSON.parse(result);
+      return { success: true, ...jsonData };
+    } catch (error) {
+      sendDebugLog(`Error getting microphone setting: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('set-microphone', async (event, deviceId, label) => {
+    try {
+      sendDebugLog(`Setting microphone to: ${deviceId ?? 'default'}`);
+      // '--' ends Click's option parsing: without it, a device label starting
+      // with '--' (e.g. "--help") is parsed as a flag, the subcommand prints
+      // help and exits 0 without saving, and the fallback below would then
+      // report a false success.
+      const result = await runPythonScript('simple_recorder.py', [
+        'set-microphone',
+        '--',
+        deviceId ?? '',
+        label ?? '',
+      ]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      if (jsonMatch) {
+        return JSON.parse(jsonMatch[0]);
+      }
+      const normalizedId = deviceId && deviceId !== 'default' ? deviceId : null;
+      return { success: true, device_id: normalizedId, label: normalizedId ? label ?? null : null };
+    } catch (error) {
+      sendDebugLog(`Error setting microphone: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('get-user-name', async () => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['get-user-name'], true);
+      const jsonData = JSON.parse(result.trim());
+      return { success: true, ...jsonData };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('set-user-name', async (event, name) => {
+    try {
+      const result = await runPythonScript('simple_recorder.py', ['set-user-name', String(name ?? '')]);
+      const jsonMatch = result.match(/\{.*\}/s);
+      if (jsonMatch) return JSON.parse(jsonMatch[0]);
+      return { success: true, user_name: String(name ?? '').trim() };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+}
+
+module.exports = { registerSettingsIpc };

--- a/app/settings-ipc.test.js
+++ b/app/settings-ipc.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { registerSettingsIpc } = require('./settings-ipc');
+
+// Minimal fakes: capture handlers by channel, record backend calls + debug logs,
+// and let each test drive one handler and assert its argv/seam usage. No electron.
+function harness(overrides = {}) {
+  const handlers = {};
+  const calls = { py: [], debug: [] };
+  const deps = {
+    ipcMain: {
+      handle: (ch, fn) => {
+        // Mirror Electron: registering the same channel twice throws. Guards the
+        // "exactly 17" assertion against an in-module duplicate that would
+        // otherwise be silently overwritten (and so counted once).
+        if (Object.prototype.hasOwnProperty.call(handlers, ch)) {
+          throw new Error(`duplicate ipcMain.handle registration for '${ch}'`);
+        }
+        handlers[ch] = fn;
+      },
+    },
+    runPythonScript: async (script, args, silent) => {
+      calls.py.push({ script, args, silent });
+      if (overrides.pyThrows) throw new Error(overrides.pyThrows);
+      return overrides.pyResult ?? '{"success": true}';
+    },
+    sendDebugLog: (msg) => { calls.debug.push(msg); },
+  };
+  registerSettingsIpc(deps);
+  return { handlers, calls };
+}
+
+const CHANNELS = [
+  'get-keep-recordings', 'set-keep-recordings',
+  'get-auto-summarize', 'set-auto-summarize',
+  'get-silence-auto-stop', 'set-silence-auto-stop-enabled', 'set-silence-auto-stop-minutes',
+  'get-privacy-notice-seen', 'set-privacy-notice-seen',
+  'get-system-audio', 'set-system-audio',
+  'get-language', 'set-language',
+  'get-microphone', 'set-microphone',
+  'get-user-name', 'set-user-name',
+];
+
+test('registers exactly the 17 settings-toggle handlers', () => {
+  const { handlers } = harness();
+  assert.deepStrictEqual(Object.keys(handlers).sort(), [...CHANNELS].sort());
+});
+
+// Every spread-getter reads its own subcommand SILENTLY and returns
+// { success:true, ...jsonData }. Covers all seven (privacy-notice-seen differs
+// and has its own test below).
+const SPREAD_GETTERS = [
+  'get-keep-recordings', 'get-auto-summarize', 'get-silence-auto-stop',
+  'get-user-name', 'get-system-audio', 'get-language', 'get-microphone',
+];
+
+test('every spread getter reads its own subcommand silently and spreads the parsed result', async () => {
+  for (const ch of SPREAD_GETTERS) {
+    const { handlers, calls } = harness({ pyResult: '{"value": 1}' });
+    const res = await handlers[ch]();
+    assert.deepStrictEqual(calls.py[0].args, [ch], `${ch} argv is its own subcommand`);
+    assert.strictEqual(calls.py[0].script, 'simple_recorder.py', `${ch} targets the CLI`);
+    assert.strictEqual(calls.py[0].silent, true, `${ch} must read silently`);
+    assert.deepStrictEqual(res, { success: true, value: 1 }, `${ch} spreads result`);
+  }
+});
+
+test('set-keep-recordings / set-auto-summarize stringify the boolean into argv and wrap the result', async () => {
+  const keep = harness({ pyResult: '{"keep_recordings": true}' });
+  const rk = await keep.handlers['set-keep-recordings']({}, true);
+  assert.deepStrictEqual(keep.calls.py[0].args, ['set-keep-recordings', 'true']);
+  assert.strictEqual(keep.calls.py[0].silent, undefined); // mutations stream to debug panel
+  assert.deepStrictEqual(rk, { success: true, keep_recordings: true }); // {success:true, ...jsonData}
+
+  const auto = harness({ pyResult: '{"auto_summarize": false}' });
+  const ra = await auto.handlers['set-auto-summarize']({}, false);
+  assert.deepStrictEqual(auto.calls.py[0].args, ['set-auto-summarize', 'false']);
+  assert.deepStrictEqual(ra, { success: true, auto_summarize: false });
+});
+
+test('silence-auto-stop setters map to Python True/False and String(minutes), returning the raw result', async () => {
+  const enabled = harness({ pyResult: '{"silence_auto_stop": true}' });
+  const r1 = await enabled.handlers['set-silence-auto-stop-enabled']({}, true);
+  assert.deepStrictEqual(enabled.calls.py[0].args, ['set-silence-auto-stop-enabled', 'True']);
+  assert.deepStrictEqual(r1, { silence_auto_stop: true }); // returns jsonData verbatim, not wrapped
+
+  const disabled = harness();
+  await disabled.handlers['set-silence-auto-stop-enabled']({}, false);
+  assert.deepStrictEqual(disabled.calls.py[0].args, ['set-silence-auto-stop-enabled', 'False']);
+
+  const minutes = harness({ pyResult: '{"silence_auto_stop_minutes": 5}' });
+  const rm = await minutes.handlers['set-silence-auto-stop-minutes']({}, 5);
+  assert.deepStrictEqual(minutes.calls.py[0].args, ['set-silence-auto-stop-minutes', '5']);
+  assert.deepStrictEqual(rm, { silence_auto_stop_minutes: 5 }); // returns jsonData verbatim
+});
+
+test('set-system-audio / set-language parse the first JSON object out of noisy stdout', async () => {
+  const sys = harness({ pyResult: 'log line\n{"success": true, "system_audio_enabled": true}\n' });
+  const r1 = await sys.handlers['set-system-audio']({}, true);
+  assert.deepStrictEqual(sys.calls.py[0].args, ['set-system-audio', 'True']);
+  assert.deepStrictEqual(r1, { success: true, system_audio_enabled: true });
+
+  // Fallback path: no JSON in stdout -> synthesised success echoing the input.
+  const noJson = harness({ pyResult: 'no json here' });
+  const r2 = await noJson.handlers['set-system-audio']({}, false);
+  assert.deepStrictEqual(r2, { success: true, system_audio_enabled: false });
+
+  const lang = harness({ pyResult: '{"language": "de"}' });
+  const r3 = await lang.handlers['set-language']({}, 'de');
+  assert.deepStrictEqual(lang.calls.py[0].args, ['set-language', 'de']);
+  assert.deepStrictEqual(r3, { language: 'de' });
+});
+
+test('set-microphone inserts the `--` argv delimiter and coalesces null id/label', async () => {
+  const picked = harness({ pyResult: 'not json' });
+  const r1 = await picked.handlers['set-microphone']({}, 'dev-1', 'USB Mic');
+  assert.deepStrictEqual(picked.calls.py[0].args, ['set-microphone', '--', 'dev-1', 'USB Mic']);
+  assert.deepStrictEqual(r1, { success: true, device_id: 'dev-1', label: 'USB Mic' });
+
+  // 'default' / undefined normalise to a null selection with a null label.
+  const cleared = harness({ pyResult: 'not json' });
+  const r2 = await cleared.handlers['set-microphone']({}, 'default', undefined);
+  assert.deepStrictEqual(cleared.calls.py[0].args, ['set-microphone', '--', 'default', '']);
+  assert.deepStrictEqual(r2, { success: true, device_id: null, label: null });
+});
+
+test('set-user-name coerces nullish names to an empty string and trims the echoed fallback', async () => {
+  const named = harness({ pyResult: 'noise' });
+  const r1 = await named.handlers['set-user-name']({}, '  Ben  ');
+  assert.deepStrictEqual(named.calls.py[0].args, ['set-user-name', '  Ben  ']);
+  assert.deepStrictEqual(r1, { success: true, user_name: 'Ben' });
+
+  const nullish = harness({ pyResult: 'noise' });
+  const r2 = await nullish.handlers['set-user-name']({}, null);
+  assert.deepStrictEqual(nullish.calls.py[0].args, ['set-user-name', '']);
+  assert.deepStrictEqual(r2, { success: true, user_name: '' });
+});
+
+test('privacy-notice handlers use the non-silent backend read and return raw set result', async () => {
+  const get = harness({ pyResult: '{"privacy_notice_seen": true}' });
+  const r1 = await get.handlers['get-privacy-notice-seen']();
+  assert.strictEqual(get.calls.py[0].silent, undefined);
+  assert.deepStrictEqual(r1, { success: true, privacy_notice_seen: true });
+
+  const set = harness({ pyResult: '{"success": true, "privacy_notice_seen": true}' });
+  const r2 = await set.handlers['set-privacy-notice-seen']();
+  assert.deepStrictEqual(set.calls.py[0].args, ['set-privacy-notice-seen']);
+  assert.deepStrictEqual(r2, { success: true, privacy_notice_seen: true });
+});
+
+test('backend failures surface as { success:false, error } and log via the injected sink', async () => {
+  const { handlers, calls } = harness({ pyThrows: 'backend exploded' });
+  // A handler that logs on error (system-audio) records to the debug sink.
+  const r1 = await handlers['get-system-audio']();
+  assert.deepStrictEqual(r1, { success: false, error: 'backend exploded' });
+  assert.ok(calls.debug.some((m) => m.includes('backend exploded')));
+
+  // A handler with no error logging (keep-recordings) still fails soft.
+  const r2 = await handlers['get-keep-recordings']();
+  assert.deepStrictEqual(r2, { success: false, error: 'backend exploded' });
+});


### PR DESCRIPTION
Implements **RFC #327 Phase 2.2 — Settings toggles**, the next serial slice after the merged Folders pilot (#356). **Zero behavior change**: the handler bodies are moved verbatim; the only new code is the `registerSettingsIpc(deps)` factory wired once in `main.js`, exactly like `folders-ipc.js`.

### What moves out of `main.js`

`app/settings-ipc.js` — `registerSettingsIpc({ ipcMain, runPythonScript, sendDebugLog })` with the **17 self-contained settings-toggle handlers** (pure `simple_recorder.py` config passthrough, no shared state, no cross-domain coupling):

- `get`/`set-keep-recordings`
- `get`/`set-auto-summarize`
- `get-silence-auto-stop`, `set-silence-auto-stop-enabled`, `set-silence-auto-stop-minutes`
- `get`/`set-system-audio`
- `get`/`set-language`
- `get`/`set-microphone`
- `get`/`set-user-name`
- `get`/`set-privacy-notice-seen`

`main.js`: 11,324 -> 11,137 lines, 160 -> 143 `ipcMain` registrations.

### Scope — what deliberately stays in `main.js`

Settings-*shaped* handlers that reach into another domain are left for that domain's own phase, so this PR stays a clean pure-config slice:

- `notifications` / `launch-on-login` -> telemetry identity (`refreshIdentitySuperProperties`) — **Phase 2.5**
- `transcription-engine` / `whisper-model` -> `trackEvent('model_changed')` + models analytics — **Phase 2.3**
- `auto-detect-meetings` -> mic-monitor (`startMicMonitor`/`stopMicMonitor`) — **Phase 2.7**
- `premeeting-notifications` -> calendar scheduler — **Phase 2.8**
- `dock-icon` / `menu-bar-icon` -> `app.dock` / tray lifecycle — **composition root (stays permanently)**

### Dependency map (RFC ground rule 7)

Every extracted handler reads/writes only via the injected `runPythonScript` (backend-cli seam) and `sendDebugLog` (debug-log seam). No module-scope `main.js` state is read or mutated; no in-file helper is called. Registration happens once, in place, in the same synchronous startup evaluation.

### Tests

- New `app/settings-ipc.test.js` — 9 unit tests: exact-17-handler registration (with a duplicate-registration guard that mirrors Electron), per-handler argv / `silent`-flag / return-shape assertions (the `--` microphone delimiter, silence `True`/`False`, `String(minutes)`/`String(name)`, spread vs. raw vs. synthesized-fallback returns), and the soft-fail + debug-log error path. Wired into `test:unit`.
- `ipc-contract.test.js` (required gate) stays green — its `*-ipc.js` union auto-discovers the new module, and the reachability assertion confirms it is required **and** invoked in `main.js`. All 17 channels remain reachable from the preload bridge.

### Verification

- Unit: **`settings-ipc` 9/9**, **`ipc-contract` 7/7** (no dup registrations, preload reachability, reachability), full `test:unit` (node:test suite + 111 vitest) green.
- **`settings-roundtrip.t2` 4/4** against a freshly built backend bundle — the extracted setters persist each value to the right `config.json` key end-to-end.
- Independent cross-family review (Codex, read-only) of the full diff: **no critical/medium findings, no production behavior divergence** (argv, silent flags, return shapes, error/logging all match the `main` originals verbatim). Its two low test-thoroughness notes are folded in (dup guard + broadened assertions).

### Notes for review

- **Sequencing:** like every extraction PR this touches `main.js`, so it conflicts with in-flight `main.js` PRs — merge timing is yours.
- Happy to keep the series going (Phase 2.3 Models, or 2.4 Auto-update) once this lands.

Refs #327.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted 17 self-contained settings IPC handlers from `app/main.js` into `app/settings-ipc.js` and registered them via `registerSettingsIpc(...)` for RFC #327 Phase 2.2. No behavior changes; same startup timing and responses, with a slimmer `main.js`.

- **Refactors**
  - Moved pure config handlers: keep-recordings, auto-summarize, silence-auto-stop, system-audio, language, microphone, user-name, privacy-notice-seen.
  - Added `registerSettingsIpc({ ipcMain, runPythonScript, sendDebugLog })`; invoked once in `main.js`.
  - Left coupled settings in `main.js` for their phases: telemetry/launch-on-login (2.5), models/engine (2.3), auto-detect (2.7), premeeting (2.8), dock/tray (composition root).
  - Added `app/settings-ipc.test.js` and wired it into `test:unit` in `app/package.json`.

<sup>Written for commit 4cd3fce6e9ffdcbeda05ab29711e323311d21fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

