### PR TITLE
fix(processing): break the forever-spinner when a stop produced no job (#343)

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -229,20 +229,50 @@ function install({ ipcMain }) {
       }
       return { success: true };
     },
-    'get-queue-status': async () => ({
-      success: true,
-      isProcessing: rec.processing,
-      queueSize: 0,
-      currentJob: rec.processing ? rec.sessionName : null,
-      currentReprocesses: [],
-      hasRecording: rec.active,
-      isPaused: rec.paused,
-      elapsedSeconds: rec.active
-        ? Math.floor(((rec.paused ? rec.pausedAt : Date.now()) - rec.startedAt) / 1000)
-        : 0,
-      sessionName: rec.active || rec.processing ? rec.sessionName : null,
-      recordingSummaryFile: rec.active ? rec.appendTo : null,
-    }),
+    // Scripted-sequence seam for the processing-watchdog T1: when
+    // STENOAI_E2E_QUEUE_STATE_PATH points at a JSON file, each poll returns that
+    // file's contents (merged over the idle defaults) so a spec can drive the
+    // real stop→enqueue state SEQUENCE over time (optimistic processing → a
+    // legitimate idle+empty handoff gap → late enqueue) by rewriting the file
+    // between polls. Falls through to the rec-based machine if the file is
+    // absent/unreadable (e.g. not yet written on the first poll).
+    'get-queue-status': async () => {
+      const statePath = process.env.STENOAI_E2E_QUEUE_STATE_PATH;
+      if (statePath) {
+        try {
+          const override = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+          return {
+            success: true,
+            isProcessing: false,
+            queueSize: 0,
+            currentJob: null,
+            currentReprocesses: [],
+            hasRecording: false,
+            isPaused: false,
+            elapsedSeconds: 0,
+            sessionName: null,
+            recordingSummaryFile: null,
+            ...override,
+          };
+        } catch {
+          /* file not ready yet — fall through to the rec-based default below */
+        }
+      }
+      return {
+        success: true,
+        isProcessing: rec.processing,
+        queueSize: 0,
+        currentJob: rec.processing ? rec.sessionName : null,
+        currentReprocesses: [],
+        hasRecording: rec.active,
+        isPaused: rec.paused,
+        elapsedSeconds: rec.active
+          ? Math.floor(((rec.paused ? rec.pausedAt : Date.now()) - rec.startedAt) / 1000)
+          : 0,
+        sessionName: rec.active || rec.processing ? rec.sessionName : null,
+        recordingSummaryFile: rec.active ? rec.appendTo : null,
+      };
+    },
 
     // Live transcript backfill. Real main.js populates liveTranscriptState from
     // the ASR sidecar (a model) — unreachable in T1 — so we seed it here. With

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -270,6 +270,12 @@ export function useRecording() {
      *  Set rather than array so consumers can do O(1) membership checks
      *  inside the meetings list map. */
     reprocessingSummaryFiles: reprocessingSummaryFiles,
+    /** True once the queue poll has resolved successfully at least once. The
+     *  processing-screen watchdog must not count "idle+empty" ticks before real
+     *  data has arrived — absent query data defaults to status:'idle' /
+     *  queueSize:0, so a slow first IPC would otherwise look like a no-job
+     *  dead-end (issue #343). */
+    isQueueSuccess: queue.isSuccess,
     startRecording,
     stopRecording,
     pauseRecording,

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -246,6 +246,12 @@ export function useRecording() {
   return {
     status,
     elapsed: queue.data?.elapsedSeconds ?? 0,
+    /** Number of jobs waiting in the processing queue. Combined with `status`
+     *  it tells the processing screen whether a job actually exists — a
+     *  post-stop screen with `status==='idle' && queueSize===0` means the stop
+     *  produced no job (nothing was captured), which the watchdog uses to
+     *  break out of an otherwise-forever spinner (issue #343). */
+    queueSize: queue.data?.queueSize ?? 0,
     // Fall back to currentJob (the in-flight processing session) when no
     // recording is active. Keeps `sessionName` populated through the full
     // recording → processing → done lifecycle so the synthetic in-progress

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -96,6 +96,30 @@ export function Processing() {
   // hard-crash copy.
   const [nothingRecorded, setNothingRecorded] = React.useState(false);
 
+  // Reset per-session UI state when a NEW session takes over this still-mounted
+  // route (back-to-back recordings swap activeSession in place — see above —
+  // without a remount). Without this, a user looking at "Nothing to process"
+  // who starts another recording would stay stuck on that panel even after the
+  // new job queues fine. Done during render (React's documented "adjust state
+  // when a value changes" pattern, like the setActiveSession above) so the new
+  // session paints fresh with no flash of the prior error state. The watchdog's
+  // ref + interval re-arm lives in an effect below (refs can't be reset during
+  // render); the 8-tick threshold, isQueueSuccess gate, and hidden-window guard
+  // all still apply, so this can't reintroduce a false trip.
+  const [uiSession, setUiSession] = React.useState<string | null>(activeSession);
+  if (activeSession !== uiSession) {
+    setUiSession(activeSession);
+    if (activeSession) {
+      setStage('transcribing');
+      setNothingRecorded(false);
+      setStreamText('');
+      setStreamedTitle(null);
+      setChunkProgress(null);
+      setRetryAudioFile(null);
+      setRetryError(null);
+    }
+  }
+
   // Buffer streamed chunks and flush at most every 50ms (~20fps). At a
   // typical token rate of 30-60 tokens/sec, this batches ~3 tokens per
   // commit which keeps the UI smooth without re-parsing the entire markdown
@@ -215,6 +239,24 @@ export function Processing() {
     return () => setGaveUp(false);
   }, [setGaveUp]);
 
+  // Re-arm the watchdog for a NEW session WITHOUT a remount (see the UI-state
+  // reset above for the why). Refs can't be reset during render, so the
+  // watchdog's latched signals + the shared "gave up" flag are cleared here on a
+  // genuine session transition; the interval effect below re-arms on
+  // activeSession too, resetting its consecutive-tick counter. sawActivityRef is
+  // the important one — it latches true in the error state and would otherwise
+  // keep the re-armed interval permanently disarmed for the new session.
+  const prevSessionRef = React.useRef<string | null>(activeSession);
+  React.useEffect(() => {
+    if (activeSession === prevSessionRef.current) return;
+    prevSessionRef.current = activeSession;
+    if (!activeSession) return;
+    pendingChunkRef.current = '';
+    sawActivityRef.current = false;
+    idleEmptyRef.current = false;
+    setGaveUp(false);
+  }, [activeSession, setGaveUp]);
+
   React.useEffect(() => {
     let idleTicks = 0;
     const id = setInterval(() => {
@@ -244,7 +286,9 @@ export function Processing() {
       }
     }, WATCHDOG_TICK_MS);
     return () => clearInterval(id);
-  }, [setGaveUp]);
+    // activeSession is a dep so the interval re-arms (resetting its local
+    // idleTicks counter) for a new session started without a remount.
+  }, [activeSession, setGaveUp]);
 
   // Actually re-run the failed job: re-queue the preserved source audio via the
   // same import pipeline a stopped recording uses. Its copy-then-queue semantics

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -24,6 +24,19 @@ const STAGE_LABEL: Record<ProcessingStage, string> = {
   error: 'Couldn’t process this recording.',
 };
 
+// Queue-state watchdog (issue #343). Stopping a recording navigates here
+// unconditionally, but a processing job is only queued when the capture
+// actually produced a file. A stop that produced nothing (e.g. Stop hit while
+// getUserMedia was still pending, or system-audio capture returned no file)
+// emits no processing-complete, so without this the screen spins forever. We
+// watch for a genuinely idle-and-empty queue rather than a wall clock — long
+// transcriptions have quiet stretches that a time-based timeout would
+// false-trip. A tick cadence independent of the queue poll keeps the arithmetic
+// simple; 3 consecutive idle ticks (~4.5s) comfortably covers the brief
+// stop→enqueue gap so a normal recording never trips it.
+const WATCHDOG_TICK_MS = 1500;
+const WATCHDOG_IDLE_TICKS = 3;
+
 export function Processing() {
   const navigate = useNavigate();
   const recording = useRecording();
@@ -56,6 +69,10 @@ export function Processing() {
   const [retryAudioFile, setRetryAudioFile] = React.useState<string | null>(null);
   const [retrying, setRetrying] = React.useState(false);
   const [retryError, setRetryError] = React.useState<string | null>(null);
+  // Set by the watchdog below when it concludes nothing was ever captured, so
+  // the error panel shows a calm "nothing to process" message instead of the
+  // hard-crash copy.
+  const [nothingRecorded, setNothingRecorded] = React.useState(false);
 
   // Buffer streamed chunks and flush at most every 50ms (~20fps). At a
   // typical token rate of 30-60 tokens/sec, this batches ~3 tokens per
@@ -132,6 +149,47 @@ export function Processing() {
     ];
     return () => offs.forEach((fn) => fn());
   }, [activeSession, updateMeeting]);
+
+  // Watchdog. Any real processing activity — a streamed chunk, chunk progress,
+  // a stage move past 'transcribing' (summaryComplete/processingComplete) —
+  // permanently disarms it for this screen visit.
+  const sawActivity =
+    stage !== 'transcribing' || streamText !== '' || chunkProgress !== null;
+  // "The queue is genuinely idle and empty, and we've seen nothing yet."
+  const idleEmpty =
+    !sawActivity && recording.status === 'idle' && recording.queueSize === 0;
+  // Mirror the freshest signals into refs so the interval below can read them
+  // without becoming a dependency that would tear itself down and restart (and
+  // reset the consecutive-tick counter) on every queue poll.
+  const sawActivityRef = React.useRef(false);
+  const idleEmptyRef = React.useRef(false);
+  React.useEffect(() => {
+    if (sawActivity) sawActivityRef.current = true;
+    idleEmptyRef.current = idleEmpty;
+  });
+
+  React.useEffect(() => {
+    let idleTicks = 0;
+    const id = setInterval(() => {
+      if (sawActivityRef.current) {
+        clearInterval(id);
+        return;
+      }
+      if (idleEmptyRef.current) {
+        idleTicks += 1;
+        if (idleTicks >= WATCHDOG_IDLE_TICKS) {
+          clearInterval(id);
+          setNothingRecorded(true);
+          setStage('error');
+        }
+      } else {
+        // Not idle right now (a job exists, or we're still in the stop→enqueue
+        // gap) — reset so only *consecutive* idle ticks count.
+        idleTicks = 0;
+      }
+    }, WATCHDOG_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
 
   // Actually re-run the failed job: re-queue the preserved source audio via the
   // same import pipeline a stopped recording uses. Its copy-then-queue semantics
@@ -213,6 +271,7 @@ export function Processing() {
             canRetry={Boolean(retryAudioFile && activeSession)}
             retrying={retrying}
             error={retryError}
+            nothingRecorded={nothingRecorded}
           />
         ) : (
           <StageCard stage={stage} streamText={streamText} chunkProgress={chunkProgress} />
@@ -354,27 +413,35 @@ function ErrorPanel({
   canRetry,
   retrying,
   error,
+  nothingRecorded,
 }: {
   onRetry: () => void;
   canRetry: boolean;
   retrying: boolean;
   error: string | null;
+  nothingRecorded: boolean;
 }) {
+  // The watchdog case is not a failure — nothing was lost because nothing was
+  // captured — so it gets a calmer heading and copy than the hard-crash path.
+  const heading = nothingRecorded ? 'Nothing to process' : STAGE_LABEL.error;
+  const detail = nothingRecorded
+    ? 'This recording didn’t capture any audio, so there’s nothing to process. Nothing was lost. Head back to Home to start a new note.'
+    : canRetry
+      ? 'Try again to re-run processing on this recording.'
+      : 'This recording couldn’t be recovered automatically. Try importing the audio file again from Home.';
   return (
     <div className="py-3">
       <p
         className="text-[17px]"
         style={{ color: 'var(--fg-1)', fontFamily: 'var(--font-sans)' }}
       >
-        {STAGE_LABEL.error}
+        {heading}
       </p>
       <p
         className="mt-1 text-[14px]"
         style={{ color: 'var(--fg-2)' }}
       >
-        {canRetry
-          ? 'Try again to re-run processing on this recording.'
-          : 'This recording couldn’t be recovered automatically. Try importing the audio file again from Home.'}
+        {detail}
       </p>
       {error && (
         <p

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -96,28 +96,51 @@ export function Processing() {
   // hard-crash copy.
   const [nothingRecorded, setNothingRecorded] = React.useState(false);
 
-  // Reset per-session UI state when a NEW session takes over this still-mounted
-  // route (back-to-back recordings swap activeSession in place — see above —
-  // without a remount). Without this, a user looking at "Nothing to process"
-  // who starts another recording would stay stuck on that panel even after the
-  // new job queues fine. Done during render (React's documented "adjust state
-  // when a value changes" pattern, like the setActiveSession above) so the new
-  // session paints fresh with no flash of the prior error state. The watchdog's
-  // ref + interval re-arm lives in an effect below (refs can't be reset during
-  // render); the 8-tick threshold, isQueueSuccess gate, and hidden-window guard
-  // all still apply, so this can't reintroduce a false trip.
-  const [uiSession, setUiSession] = React.useState<string | null>(activeSession);
-  if (activeSession !== uiSession) {
-    setUiSession(activeSession);
-    if (activeSession) {
-      setStage('transcribing');
-      setNothingRecorded(false);
-      setStreamText('');
-      setStreamedTitle(null);
-      setChunkProgress(null);
-      setRetryAudioFile(null);
-      setRetryError(null);
-    }
+  // ── New-session generation (name-INDEPENDENT) ──────────────────────────
+  // This route stays mounted across back-to-back recordings, so the watchdog +
+  // per-session UI must reset when a new session takes over. Session identity is
+  // only a collidable display name, so a single name check is insufficient: two
+  // default-named notes (both 'Note') would not change activeSession. We fold
+  // TWO signals into a monotonic `generation`:
+  //   1. activeSession changes to a new non-null name (distinct-name case), and
+  //   2. recording.status transitions INTO 'recording' (same-name case: a
+  //      second recording reusing the name doesn't move activeSession, but its
+  //      start still surfaces via useRecording as idle/processing → 'recording').
+  // Tracked in state (React's "adjust state when a value changes" pattern, like
+  // the setActiveSession above) so no ref is mutated during render.
+  const [genState, setGenState] = React.useState({
+    generation: 0,
+    session: activeSession,
+    status: recording.status,
+  });
+  if (genState.session !== activeSession || genState.status !== recording.status) {
+    const isNewSession = activeSession != null && activeSession !== genState.session;
+    const startedRecording =
+      recording.status === 'recording' && genState.status !== 'recording';
+    setGenState({
+      generation: genState.generation + (isNewSession || startedRecording ? 1 : 0),
+      session: activeSession,
+      status: recording.status,
+    });
+  }
+  const generation = genState.generation;
+
+  // Reset per-session UI state on each new generation. Done during render so the
+  // new session paints fresh with no flash of the prior "Nothing to process"
+  // panel. The watchdog's ref + interval re-arm lives in an effect below (refs
+  // can't be reset during render); the 8-tick threshold, isQueueSuccess gate,
+  // and hidden-window guard all still apply, so recovery can't reintroduce a
+  // false trip.
+  const [uiGen, setUiGen] = React.useState(generation);
+  if (generation !== uiGen) {
+    setUiGen(generation);
+    setStage('transcribing');
+    setNothingRecorded(false);
+    setStreamText('');
+    setStreamedTitle(null);
+    setChunkProgress(null);
+    setRetryAudioFile(null);
+    setRetryError(null);
   }
 
   // Buffer streamed chunks and flush at most every 50ms (~20fps). At a
@@ -239,23 +262,22 @@ export function Processing() {
     return () => setGaveUp(false);
   }, [setGaveUp]);
 
-  // Re-arm the watchdog for a NEW session WITHOUT a remount (see the UI-state
+  // Re-arm the watchdog for a NEW generation WITHOUT a remount (see the UI-state
   // reset above for the why). Refs can't be reset during render, so the
   // watchdog's latched signals + the shared "gave up" flag are cleared here on a
-  // genuine session transition; the interval effect below re-arms on
-  // activeSession too, resetting its consecutive-tick counter. sawActivityRef is
-  // the important one — it latches true in the error state and would otherwise
-  // keep the re-armed interval permanently disarmed for the new session.
-  const prevSessionRef = React.useRef<string | null>(activeSession);
+  // genuine transition; the interval effect below re-arms on generation too,
+  // resetting its consecutive-tick counter. sawActivityRef is the important one
+  // — it latches true in the error state and would otherwise keep the re-armed
+  // interval permanently disarmed for the new session.
+  const prevGenRef = React.useRef(generation);
   React.useEffect(() => {
-    if (activeSession === prevSessionRef.current) return;
-    prevSessionRef.current = activeSession;
-    if (!activeSession) return;
+    if (generation === prevGenRef.current) return;
+    prevGenRef.current = generation;
     pendingChunkRef.current = '';
     sawActivityRef.current = false;
     idleEmptyRef.current = false;
     setGaveUp(false);
-  }, [activeSession, setGaveUp]);
+  }, [generation, setGaveUp]);
 
   React.useEffect(() => {
     let idleTicks = 0;
@@ -286,9 +308,10 @@ export function Processing() {
       }
     }, WATCHDOG_TICK_MS);
     return () => clearInterval(id);
-    // activeSession is a dep so the interval re-arms (resetting its local
-    // idleTicks counter) for a new session started without a remount.
-  }, [activeSession, setGaveUp]);
+    // generation is a dep so the interval re-arms (resetting its local idleTicks
+    // counter) for a new session started without a remount — including a
+    // same-name second recording, which only surfaces via the generation bump.
+  }, [generation, setGaveUp]);
 
   // Actually re-run the failed job: re-queue the preserved source audio via the
   // same import pipeline a stopped recording uses. Its copy-then-queue semantics

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -7,6 +7,7 @@ import {
   PencilLine,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
+import { create } from 'zustand';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import { useNavigate } from '@/lib/router';
 import { useRecording } from '@/hooks/useRecording';
@@ -16,6 +17,19 @@ import { ipc } from '@/lib/ipc';
 import { stripReasoning } from '@/lib/markdown';
 
 type ProcessingStage = 'transcribing' | 'summarizing' | 'finalizing' | 'error';
+
+// Shared flag so the sibling ProcessingDock (the bottom "Processing" chip,
+// rendered by App while on this route) can hide once the watchdog concludes
+// nothing was captured — otherwise the dock keeps animating "Processing" under
+// a "Nothing to process" panel. Set by the Processing screen, read by the dock;
+// reset on each screen visit.
+const useProcessingWatchdogStore = create<{
+  gaveUp: boolean;
+  setGaveUp: (v: boolean) => void;
+}>((set) => ({
+  gaveUp: false,
+  setGaveUp: (gaveUp) => set({ gaveUp }),
+}));
 
 const STAGE_LABEL: Record<ProcessingStage, string> = {
   transcribing: 'Analyzing transcript',
@@ -27,15 +41,23 @@ const STAGE_LABEL: Record<ProcessingStage, string> = {
 // Queue-state watchdog (issue #343). Stopping a recording navigates here
 // unconditionally, but a processing job is only queued when the capture
 // actually produced a file. A stop that produced nothing (e.g. Stop hit while
-// getUserMedia was still pending, or system-audio capture returned no file)
-// emits no processing-complete, so without this the screen spins forever. We
-// watch for a genuinely idle-and-empty queue rather than a wall clock — long
-// transcriptions have quiet stretches that a time-based timeout would
-// false-trip. A tick cadence independent of the queue poll keeps the arithmetic
-// simple; 3 consecutive idle ticks (~4.5s) comfortably covers the brief
-// stop→enqueue gap so a normal recording never trips it.
+// getUserMedia was still pending → stopCapture early-returns with no blob, or
+// processSystemAudio resolves {success:false}) emits no processing-complete, so
+// without this the screen spins forever. We watch for a genuinely idle-and-empty
+// queue rather than a wall clock — long transcriptions have quiet stretches that
+// a time-based timeout would false-trip.
+//
+// The threshold must clear the NORMAL stop→enqueue handoff, which is not
+// instant: main flushes the recorder + closes the file, then
+// process-system-audio-recording waits up to ~8s for the live-transcript
+// sidecar to drain (app/main.js) BEFORE addToProcessingQueue runs. During that
+// window main has already cleared the recording state but not yet enqueued, so
+// a queue poll legitimately returns idle+empty for a recording that really has
+// speech. Requiring 8 consecutive idle ticks at a 1500ms cadence (~12s) clears
+// that bounded ~8s drain with comfortable margin; a genuine no-job dead-end
+// stays idle+empty indefinitely, so it still trips (just a few seconds later).
 const WATCHDOG_TICK_MS = 1500;
-const WATCHDOG_IDLE_TICKS = 3;
+const WATCHDOG_IDLE_TICKS = 8;
 
 export function Processing() {
   const navigate = useNavigate();
@@ -96,6 +118,12 @@ export function Processing() {
     };
     const offs = [
       ipc().on.summaryChunk((e) => {
+        // This screen shows the fresh-recording queue job, which emits bare
+        // (no-summaryFile) chunks. A concurrent reprocess/report of a DIFFERENT
+        // meeting emits summaryFile-scoped chunks — ignore those so an unrelated
+        // reprocess can't move this screen's stage and latch the watchdog's
+        // "saw activity" flag (which would hide a real no-job dead-end).
+        if (e.summaryFile) return;
         if (activeSession && e.sessionName !== activeSession) return;
         pendingChunkRef.current += e.chunk;
         setStage((s) => (s === 'transcribing' ? 'summarizing' : s));
@@ -108,6 +136,10 @@ export function Processing() {
         setStreamedTitle(e.title);
       }),
       ipc().on.summaryComplete((e) => {
+        // Same reprocess guard as summaryChunk above — a summaryFile-scoped
+        // completion belongs to another meeting's reprocess, not this
+        // fresh-recording job.
+        if (e.summaryFile) return;
         if (activeSession && e.sessionName !== activeSession) return;
         setStage((s) => (s === 'error' ? s : 'finalizing'));
       }),
@@ -155,9 +187,15 @@ export function Processing() {
   // permanently disarms it for this screen visit.
   const sawActivity =
     stage !== 'transcribing' || streamText !== '' || chunkProgress !== null;
-  // "The queue is genuinely idle and empty, and we've seen nothing yet."
+  // "The queue has resolved real data at least once AND it is genuinely idle and
+  // empty AND we've seen nothing yet." The isQueueSuccess gate matters because
+  // absent query data defaults to status:'idle'/queueSize:0 — without it a slow
+  // first IPC would look like a no-job dead-end.
   const idleEmpty =
-    !sawActivity && recording.status === 'idle' && recording.queueSize === 0;
+    !sawActivity &&
+    recording.isQueueSuccess &&
+    recording.status === 'idle' &&
+    recording.queueSize === 0;
   // Mirror the freshest signals into refs so the interval below can read them
   // without becoming a dependency that would tear itself down and restart (and
   // reset the consecutive-tick counter) on every queue poll.
@@ -168,6 +206,15 @@ export function Processing() {
     idleEmptyRef.current = idleEmpty;
   });
 
+  const setGaveUp = useProcessingWatchdogStore((s) => s.setGaveUp);
+  // Reset the shared "gave up" flag at the start of each screen visit (and clear
+  // it on leave) so a fresh recording's dock never inherits a prior visit's
+  // watchdog conclusion.
+  React.useEffect(() => {
+    setGaveUp(false);
+    return () => setGaveUp(false);
+  }, [setGaveUp]);
+
   React.useEffect(() => {
     let idleTicks = 0;
     const id = setInterval(() => {
@@ -175,21 +222,29 @@ export function Processing() {
         clearInterval(id);
         return;
       }
-      if (idleEmptyRef.current) {
+      // Don't count while the window is hidden: the queue poll cadence drops to
+      // 10s and react-query lets the cache go stale, so a job enqueued during a
+      // hidden stretch could be missed. Reading document.visibilityState live
+      // (not a render-synced ref) avoids any staleness window.
+      const hidden =
+        typeof document !== 'undefined' && document.visibilityState === 'hidden';
+      if (idleEmptyRef.current && !hidden) {
         idleTicks += 1;
         if (idleTicks >= WATCHDOG_IDLE_TICKS) {
           clearInterval(id);
           setNothingRecorded(true);
           setStage('error');
+          setGaveUp(true);
         }
       } else {
-        // Not idle right now (a job exists, or we're still in the stop→enqueue
-        // gap) — reset so only *consecutive* idle ticks count.
+        // Not counting right now (a job exists, still in the stop→enqueue
+        // handoff, the queue hasn't loaded, or the window is hidden) — reset so
+        // only *consecutive* idle ticks count.
         idleTicks = 0;
       }
     }, WATCHDOG_TICK_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [setGaveUp]);
 
   // Actually re-run the failed job: re-queue the preserved source audio via the
   // same import pipeline a stopped recording uses. Its copy-then-queue semantics
@@ -261,7 +316,10 @@ export function Processing() {
             <Chip icon={<Clock size={11} />}>
               <ElapsedTimer startedAt={startedAt} fallbackElapsed={recording.elapsed} />
             </Chip>
-            <ProcessingChip />
+            {/* Hide the animated "Processing" chip once we've stopped: an error
+                (crash or the watchdog's "nothing to process") means nothing is
+                actively processing, so the chip would mislead. */}
+            {stage !== 'error' && <ProcessingChip />}
           </div>
         </header>
 
@@ -472,6 +530,7 @@ function ErrorPanel({
 function ProcessingChip() {
   return (
     <span
+      data-testid="processing-chip"
       className="inline-flex items-center gap-1.5 px-2 py-1 text-[12px]"
       style={{
         color: 'var(--fg-2)',
@@ -520,6 +579,10 @@ export function ProcessingDock() {
   );
   const startedAt = draft ? new Date(draft.startedAtMs) : null;
 
+  // Once the watchdog concluded nothing was captured, the screen shows a
+  // "Nothing to process" panel — don't keep animating "Processing" beneath it.
+  const gaveUp = useProcessingWatchdogStore((s) => s.gaveUp);
+  if (gaveUp) return null;
 
   return (
     <div className="flex justify-center pointer-events-none">

--- a/e2e/specs/processing-watchdog.t1.spec.ts
+++ b/e2e/specs/processing-watchdog.t1.spec.ts
@@ -27,6 +27,9 @@ import { test, expect } from '../fixtures/electron';
 // Queue-status shapes the mock merges over its idle defaults.
 const PROCESSING = { isProcessing: true, currentJob: 'Watchdog Note', sessionName: 'Watchdog Note' };
 const IDLE_EMPTY = { isProcessing: false, queueSize: 0, hasRecording: false };
+// A DIFFERENT session — its distinct sessionName is what makes Processing.tsx
+// swap activeSession in place (no remount), the case the recovery spec drives.
+const PROCESSING_2 = { isProcessing: true, currentJob: 'Second Note', sessionName: 'Second Note' };
 
 function makeStateFile(initial: object): string {
   const dir = mkdtempSync(path.join(tmpdir(), 'stenoai-queue-'));
@@ -62,6 +65,38 @@ test('idle+empty that persists past the handoff trips the watchdog', async ({ la
   // "Processing" chip is gone — nothing is actually processing.
   await expect(page.getByRole('button', { name: 'Try again' })).toBeDisabled();
   await expect(page.getByTestId('processing-chip')).toHaveCount(0);
+
+  rmSync(path.dirname(stateFile), { recursive: true, force: true });
+});
+
+test('a new session after "Nothing to process" recovers without a remount', async ({
+  launchApp,
+}) => {
+  test.setTimeout(45_000);
+  // Trip the watchdog first (idle+empty past threshold)…
+  const stateFile = makeStateFile(PROCESSING);
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1', STENOAI_E2E_QUEUE_STATE_PATH: stateFile },
+  });
+  await page.evaluate(() => {
+    window.location.hash = '#/meetings/processing';
+  });
+  writeFileSync(stateFile, JSON.stringify(IDLE_EMPTY), 'utf-8');
+  await expect(page.getByText('Nothing to process', { exact: true })).toBeVisible({
+    timeout: 22_000,
+  });
+
+  // …then the user starts ANOTHER recording on the same (still-mounted) route.
+  // Its distinct sessionName swaps activeSession in place; the screen must leave
+  // the "Nothing to process" panel and show the spinner for the new session
+  // rather than staying stuck.
+  writeFileSync(stateFile, JSON.stringify(PROCESSING_2), 'utf-8');
+  await expect(page.getByText('Nothing to process', { exact: true })).toHaveCount(0, {
+    timeout: 10_000,
+  });
+  await expect(page.getByText('Analyzing transcript')).toBeVisible();
+  await expect(page.getByTestId('processing-chip')).toBeVisible();
 
   rmSync(path.dirname(stateFile), { recursive: true, force: true });
 });

--- a/e2e/specs/processing-watchdog.t1.spec.ts
+++ b/e2e/specs/processing-watchdog.t1.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 — the processing-screen watchdog (issue #343). Stopping a recording
+ * navigates to /meetings/processing unconditionally, but a processing job is
+ * only queued if the capture produced a file. When a stop produces NO job
+ * (Stop hit while getUserMedia was still pending, or system-audio capture
+ * returned nothing), no `processing-complete` ever fires and the screen used
+ * to spin forever — the only escape was the Home button.
+ *
+ * The watchdog (app/renderer/src/routes/Processing.tsx, driven by useRecording's
+ * queue signals) detects a genuinely idle-and-empty queue with no real
+ * processing activity and swaps the spinner for a calm "nothing to process"
+ * panel. It must NOT trip while a job is actually queued (isProcessing:true).
+ *
+ * Mock IPC's default get-queue-status is idle+empty (app/e2e-mock-ipc.js),
+ * which is exactly the stuck end-state a no-job stop leaves behind; the stop
+ * flow parks in isProcessing:true for the no-false-positive case.
+ */
+
+const ENV = { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' };
+
+test('idle+empty queue with no processing-complete trips the watchdog', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({ mockIpc: true, env: ENV });
+
+  // Land on the processing screen the way a no-job stop leaves the user: the
+  // queue reports idle+empty (the mock default) and no processing-complete
+  // ever fires.
+  await page.evaluate(() => {
+    window.location.hash = '#/meetings/processing';
+  });
+
+  // The watchdog needs a few consecutive idle ticks (~4.5s) before it fires,
+  // so give the assertion room beyond the default 5s expect timeout. exact:true
+  // pins the heading — the body copy also contains "nothing to process".
+  await expect(page.getByText('Nothing to process', { exact: true })).toBeVisible({
+    timeout: 12_000,
+  });
+
+  // "Try again" stays disabled — there is no backing job to re-run.
+  await expect(page.getByRole('button', { name: 'Try again' })).toBeDisabled();
+});
+
+test('an active processing job never trips the watchdog', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true, env: ENV });
+
+  // Start then stop: the mock parks in isProcessing:true (a genuinely queued
+  // job) and useRecording.stopRecording navigates to /meetings/processing.
+  await page.evaluate(() => window.stenoai.recording.start('Watchdog Note'));
+  const pill = page.getByTestId('transcription-pill');
+  await expect(pill).toBeVisible();
+  await pill.getByRole('button', { name: 'Stop recording' }).click();
+
+  await expect
+    .poll(() => page.evaluate(() => window.location.hash), { timeout: 10_000 })
+    .toBe('#/meetings/processing');
+
+  // The normal processing spinner is up…
+  await expect(page.getByText('Analyzing transcript')).toBeVisible();
+
+  // …and stays up well past the watchdog window — no false "nothing to process".
+  await page.waitForTimeout(7000);
+  await expect(page.getByText('Nothing to process', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Analyzing transcript')).toBeVisible();
+});

--- a/e2e/specs/processing-watchdog.t1.spec.ts
+++ b/e2e/specs/processing-watchdog.t1.spec.ts
@@ -30,6 +30,10 @@ const IDLE_EMPTY = { isProcessing: false, queueSize: 0, hasRecording: false };
 // A DIFFERENT session — its distinct sessionName is what makes Processing.tsx
 // swap activeSession in place (no remount), the case the recovery spec drives.
 const PROCESSING_2 = { isProcessing: true, currentJob: 'Second Note', sessionName: 'Second Note' };
+// A SAME-name second recording actively recording — status transitions into
+// 'recording' with the SAME display name, so activeSession never changes; only
+// the name-independent generation bump can recover the screen.
+const RECORDING_SAME = { hasRecording: true, isProcessing: false, sessionName: 'Watchdog Note' };
 
 function makeStateFile(initial: object): string {
   const dir = mkdtempSync(path.join(tmpdir(), 'stenoai-queue-'));
@@ -97,6 +101,42 @@ test('a new session after "Nothing to process" recovers without a remount', asyn
   });
   await expect(page.getByText('Analyzing transcript')).toBeVisible();
   await expect(page.getByTestId('processing-chip')).toBeVisible();
+
+  rmSync(path.dirname(stateFile), { recursive: true, force: true });
+});
+
+test('a SAME-name new recording after "Nothing to process" recovers', async ({ launchApp }) => {
+  test.setTimeout(45_000);
+  // Session identity is only a collidable display name, so recovery must not
+  // hinge on the name changing. Trip the watchdog, then start a NEW recording
+  // reusing the SAME sessionName — activeSession never changes, so only the
+  // name-independent status→'recording' generation bump can rescue the screen.
+  const stateFile = makeStateFile(PROCESSING);
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1', STENOAI_E2E_QUEUE_STATE_PATH: stateFile },
+  });
+  await page.evaluate(() => {
+    window.location.hash = '#/meetings/processing';
+  });
+  writeFileSync(stateFile, JSON.stringify(IDLE_EMPTY), 'utf-8');
+  await expect(page.getByText('Nothing to process', { exact: true })).toBeVisible({
+    timeout: 22_000,
+  });
+
+  // Same-name recording begins (status → 'recording', identical name)…
+  writeFileSync(stateFile, JSON.stringify(RECORDING_SAME), 'utf-8');
+  await expect(page.getByText('Nothing to process', { exact: true })).toHaveCount(0, {
+    timeout: 10_000,
+  });
+  await expect(page.getByText('Analyzing transcript')).toBeVisible();
+  await expect(page.getByTestId('processing-chip')).toBeVisible();
+
+  // …and then it stops into processing (same name) — still recovered, no relapse.
+  writeFileSync(stateFile, JSON.stringify(PROCESSING), 'utf-8');
+  await page.waitForTimeout(2000);
+  await expect(page.getByText('Nothing to process', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Analyzing transcript')).toBeVisible();
 
   rmSync(path.dirname(stateFile), { recursive: true, force: true });
 });

--- a/e2e/specs/processing-watchdog.t1.spec.ts
+++ b/e2e/specs/processing-watchdog.t1.spec.ts
@@ -1,53 +1,115 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
 import { test, expect } from '../fixtures/electron';
 
 /**
  * T1 — the processing-screen watchdog (issue #343). Stopping a recording
  * navigates to /meetings/processing unconditionally, but a processing job is
  * only queued if the capture produced a file. When a stop produces NO job
- * (Stop hit while getUserMedia was still pending, or system-audio capture
- * returned nothing), no `processing-complete` ever fires and the screen used
- * to spin forever — the only escape was the Home button.
+ * (Stop hit while getUserMedia was still pending → no blob, or system-audio
+ * capture resolved {success:false}), no `processing-complete` ever fires and
+ * the screen used to spin forever — the only escape was the Home button.
  *
  * The watchdog (app/renderer/src/routes/Processing.tsx, driven by useRecording's
- * queue signals) detects a genuinely idle-and-empty queue with no real
- * processing activity and swaps the spinner for a calm "nothing to process"
- * panel. It must NOT trip while a job is actually queued (isProcessing:true).
+ * queue signals) detects a genuinely idle-and-empty queue that PERSISTS past the
+ * normal stop→enqueue handoff (main waits up to ~8s for the live-transcript
+ * sidecar to drain before enqueuing, so a brief idle+empty gap is legitimate),
+ * then swaps the spinner for a calm "nothing to process" panel. It must NOT trip
+ * during that handoff, nor while a job is actually queued.
  *
- * Mock IPC's default get-queue-status is idle+empty (app/e2e-mock-ipc.js),
- * which is exactly the stuck end-state a no-job stop leaves behind; the stop
- * flow parks in isProcessing:true for the no-false-positive case.
+ * These specs drive the real state SEQUENCE via a scripted get-queue-status: the
+ * mock reads STENOAI_E2E_QUEUE_STATE_PATH each poll (app/e2e-mock-ipc.js), so the
+ * spec rewrites that file over time to move through optimistic-processing →
+ * idle+empty → (late) enqueue exactly as main does.
  */
 
-const ENV = { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' };
+// Queue-status shapes the mock merges over its idle defaults.
+const PROCESSING = { isProcessing: true, currentJob: 'Watchdog Note', sessionName: 'Watchdog Note' };
+const IDLE_EMPTY = { isProcessing: false, queueSize: 0, hasRecording: false };
 
-test('idle+empty queue with no processing-complete trips the watchdog', async ({
-  launchApp,
-}) => {
-  const { page } = await launchApp({ mockIpc: true, env: ENV });
+function makeStateFile(initial: object): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'stenoai-queue-'));
+  const file = path.join(dir, 'queue.json');
+  writeFileSync(file, JSON.stringify(initial), 'utf-8');
+  return file;
+}
 
-  // Land on the processing screen the way a no-job stop leaves the user: the
-  // queue reports idle+empty (the mock default) and no processing-complete
-  // ever fires.
+test('idle+empty that persists past the handoff trips the watchdog', async ({ launchApp }) => {
+  test.setTimeout(45_000);
+  // Start on the optimistic-processing state main writes at stop…
+  const stateFile = makeStateFile(PROCESSING);
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1', STENOAI_E2E_QUEUE_STATE_PATH: stateFile },
+  });
   await page.evaluate(() => {
     window.location.hash = '#/meetings/processing';
   });
 
-  // The watchdog needs a few consecutive idle ticks (~4.5s) before it fires,
-  // so give the assertion room beyond the default 5s expect timeout. exact:true
-  // pins the heading — the body copy also contains "nothing to process".
+  // …then the queue settles to idle+empty and STAYS there — the stop produced
+  // no job, so nothing is ever enqueued.
+  writeFileSync(stateFile, JSON.stringify(IDLE_EMPTY), 'utf-8');
+
+  // The watchdog needs 8 consecutive idle ticks (~12s) plus poll latency, so
+  // give the assertion generous room. exact:true pins the heading — the body
+  // copy also contains "nothing to process".
   await expect(page.getByText('Nothing to process', { exact: true })).toBeVisible({
-    timeout: 12_000,
+    timeout: 22_000,
   });
 
-  // "Try again" stays disabled — there is no backing job to re-run.
+  // "Try again" stays disabled (no backing job) and the animated header
+  // "Processing" chip is gone — nothing is actually processing.
   await expect(page.getByRole('button', { name: 'Try again' })).toBeDisabled();
+  await expect(page.getByTestId('processing-chip')).toHaveCount(0);
+
+  rmSync(path.dirname(stateFile), { recursive: true, force: true });
+});
+
+test('a late enqueue during the handoff does NOT trip the watchdog', async ({ launchApp }) => {
+  test.setTimeout(45_000);
+  // The critical regression guard. Reproduce the NORMAL stop of a real
+  // recording: optimistic processing → a legitimate idle+empty handoff gap
+  // (main draining the live-transcript sidecar) → the job is finally enqueued.
+  const stateFile = makeStateFile(PROCESSING);
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1', STENOAI_E2E_QUEUE_STATE_PATH: stateFile },
+  });
+  await page.evaluate(() => {
+    window.location.hash = '#/meetings/processing';
+  });
+
+  // Idle+empty for ~7s (longer than the OLD 4.5s threshold, shorter than the
+  // real ~8s drain) — the watchdog must ride this out without giving up.
+  writeFileSync(stateFile, JSON.stringify(IDLE_EMPTY), 'utf-8');
+  await page.waitForTimeout(7000);
+  // The spinner is still up mid-handoff — no premature "nothing to process".
+  await expect(page.getByText('Nothing to process', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Analyzing transcript')).toBeVisible();
+
+  // The job is finally enqueued (a real recording's speech is now processing).
+  writeFileSync(stateFile, JSON.stringify(PROCESSING), 'utf-8');
+
+  // Well past the point the old 4.5s watchdog would have fired: still no false
+  // "nothing to process", spinner intact.
+  await page.waitForTimeout(9000);
+  await expect(page.getByText('Nothing to process', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Analyzing transcript')).toBeVisible();
+
+  rmSync(path.dirname(stateFile), { recursive: true, force: true });
 });
 
 test('an active processing job never trips the watchdog', async ({ launchApp }) => {
-  const { page } = await launchApp({ mockIpc: true, env: ENV });
+  test.setTimeout(45_000);
+  // No file seam here — drive the mock's own recording state machine: start
+  // then stop parks in isProcessing:true (a genuinely queued job) and
+  // useRecording.stopRecording navigates to /meetings/processing.
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' },
+  });
 
-  // Start then stop: the mock parks in isProcessing:true (a genuinely queued
-  // job) and useRecording.stopRecording navigates to /meetings/processing.
   await page.evaluate(() => window.stenoai.recording.start('Watchdog Note'));
   const pill = page.getByTestId('transcription-pill');
   await expect(pill).toBeVisible();
@@ -61,7 +123,7 @@ test('an active processing job never trips the watchdog', async ({ launchApp }) 
   await expect(page.getByText('Analyzing transcript')).toBeVisible();
 
   // …and stays up well past the watchdog window — no false "nothing to process".
-  await page.waitForTimeout(7000);
+  await page.waitForTimeout(15_000);
   await expect(page.getByText('Nothing to process', { exact: true })).toHaveCount(0);
   await expect(page.getByText('Analyzing transcript')).toBeVisible();
 });


### PR DESCRIPTION
Fixes #343.

## The bug
Stopping a recording navigates to the processing screen unconditionally, but a job is only queued if the capture actually produced a file. When a stop produces **no** job (Stop hit while `getUserMedia` is still pending → `stopCapture` early-returns with no blob; or `processSystemAudio` resolves `{success:false}`), no `processing-complete` ever fires and the screen spins forever. The only escape was the Home button. No data is lost (nothing was captured) — it's a confusing dead end with no explanation.

## The fix — a queue-state watchdog (renderer-only)
`Processing.tsx` now watches for a genuinely idle-and-empty queue rather than a wall clock (long transcriptions have quiet stretches a time-based timeout would false-trip). When the queue stays `status==='idle' && queueSize===0` with no processing activity for a sustained window, it swaps the spinner for a calm **"Nothing to process"** panel (distinct from the crash copy; "Try again" stays disabled since there's no backing job).

The threshold is the subtle part. The normal stop→enqueue handoff is **not instant**: after stop, main clears the recording state but `process-system-audio-recording` waits up to **~8s** for the live-transcript sidecar to drain before `addToProcessingQueue` runs. During that window a queue poll legitimately returns idle+empty for a recording that really has speech. So the watchdog:
- requires **8 consecutive idle ticks (~12s)** to clear that bounded ~8s drain with margin (a genuine dead-end stays idle+empty indefinitely, so it still trips, just a few seconds later);
- only counts once the queue has **successfully loaded real data** (absent query data defaults to idle/empty — a slow first IPC must not look like a dead-end);
- **does not count while the window is hidden** (the poll cadence drops to 10s and the cache goes stale);
- permanently disarms on any real activity (a streamed chunk, progress, or a stage move past `transcribing`), and ignores `summaryFile`-scoped events so a concurrent reprocess of another meeting can't disarm it.

`useRecording` now exposes `queueSize` and `isQueueSuccess`; the header/dock "Processing" chips hide once the watchdog concludes nothing was captured.

## Tests
New `e2e/specs/processing-watchdog.t1.spec.ts` (T1, renderer + mock IPC) drives the real state **sequence** via a scripted `get-queue-status` (a small `STENOAI_E2E_QUEUE_STATE_PATH` seam in `e2e-mock-ipc.js`):
- idle+empty that persists past the handoff → trips → "Nothing to process", "Try again" disabled, chip gone;
- **late-enqueue regression guard:** optimistic processing → idle+empty handoff gap → late enqueue → must NOT trip (verified fail-before with the old ~4.5s threshold, pass-after with ~12s);
- an actively-processing job never trips.

## Review
Independent cross-family review (Codex) caught a critical false-positive in the first draft — the original ~4.5s threshold fired during the legitimate ~8s handoff and would have declared a real recording empty. That, plus a concurrent-reprocess disarm gap and a test that didn't reproduce the real handoff sequence, are all fixed here.

## Verification
- `typecheck:renderer`, `lint:renderer` (0 errors in changed files), `build:renderer` — clean.
- T1 watchdog spec — 3 passed. `instant-stop.t1` + `pill-dock.t1` regression — 9 passed.
- Renderer-only; no `app/main.js` change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the infinite spinner on the Processing screen when a stop produces no job by adding a queue-state watchdog and a clear “Nothing to process” state. Also recovers cleanly when a new recording starts without a remount, even if it reuses the same name. Fixes #343.

- **Bug Fixes**
  - Added a queue-state watchdog in `Processing.tsx` that shows “Nothing to process” after 8 consecutive idle+empty ticks (~12s) once the queue has loaded; it pauses while the window is hidden, disarms on real activity, and ignores `summaryFile`-scoped events.
  - Recover across new sessions without a remount, including same-name sessions: reset per-session UI and re-arm the watchdog via a name-independent generation; hide the header chip and `ProcessingDock` once nothing was captured.
  - Exposed `queueSize` and `isQueueSuccess` from `useRecording`; disabled “Try again” in the “Nothing to process” state with calmer copy; hid the header “Processing” chip in error.
  - Introduced an e2e seam via `STENOAI_E2E_QUEUE_STATE_PATH`; added T1 specs for: watchdog trip, late-enqueue handoff (no false trip), active processing (never trips), recovery after a new session, and recovery when the new recording reuses the same name.

<sup>Written for commit 0489b64fe77f7008bb85ad53bff69a9a762ea94c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

