### PR TITLE
Show connected account email in Calendar settings

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -474,13 +474,17 @@ const POSTHOG_HOST = 'https://us.i.posthog.com';
 // Google Calendar OAuth2 configuration
 const GOOGLE_CLIENT_ID = '281073275073-20da4u5t9luk2366vd5ai0a2r55d5pf5.apps.googleusercontent.com';
 const GOOGLE_CLIENT_SECRET = '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';
-const GOOGLE_SCOPES = 'https://www.googleapis.com/auth/calendar.readonly';
+// `openid` + the email scope get an `id_token` back in the token exchange
+// response, which we decode locally to read the connected account's email —
+// no extra userinfo API call needed.
+const GOOGLE_SCOPES = 'openid https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/userinfo.email';
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 
 // Outlook Calendar OAuth2 configuration (PKCE public client — no client secret)
 const OUTLOOK_CLIENT_ID = '53a8ba1f-3a2e-4fc9-afb1-b9b8ff13de19';
-const OUTLOOK_SCOPES = 'Calendars.Read offline_access';
+// See GOOGLE_SCOPES comment — openid/email here for the same id_token decode.
+const OUTLOOK_SCOPES = 'Calendars.Read offline_access openid email';
 const OUTLOOK_AUTH_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize';
 const OUTLOOK_TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
 
@@ -8601,6 +8605,16 @@ ipcMain.handle('open-external', async (event, url) => {
     return { success: false, error: error.message };
   }
 });
+// Decodes the payload of a JWT (e.g. an OAuth id_token) without verifying
+// its signature — safe here because the token came straight from the
+// provider's own token endpoint over TLS, not from an untrusted party.
+// Used only to read the `email`/`preferred_username` claim; best-effort,
+// callers must not let a decode failure block the OAuth flow.
+function decodeJwtPayload(jwt) {
+  const payload = jwt.split('.')[1];
+  return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+}
+
 // ── Google Calendar: Token Storage ──────────────────────────────────────
 
 function getTokenFilePath() {
@@ -8787,6 +8801,14 @@ function startGoogleAuth() {
           res.end('<html><body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;"><h2>Cancelled</h2><p>You can close this tab.</p></body></html>');
           return;
         }
+        if (tokens.id_token) {
+          try {
+            const claims = decodeJwtPayload(tokens.id_token);
+            if (claims && claims.email) tokens.email = claims.email;
+          } catch (e) {
+            console.error('Failed to decode Google id_token:', e.message);
+          }
+        }
         saveGoogleTokens(tokens);
 
         res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -8938,6 +8960,11 @@ async function getValidAccessToken() {
     // Preserve the refresh token (Google may not return it again)
     newTokens.refresh_token = newTokens.refresh_token || tokens.refresh_token;
     newTokens.expires_at = Date.now() + (newTokens.expires_in * 1000);
+    // Preserve the email captured at connect time — a refresh response
+    // doesn't reliably carry a fresh id_token, and even if it did, a
+    // refresh grant can't upgrade a pre-existing connection to scopes it
+    // wasn't originally consented to.
+    newTokens.email = newTokens.email || tokens.email;
     saveGoogleTokens(newTokens);
     return newTokens.access_token;
   } catch (error) {
@@ -9187,6 +9214,17 @@ function startOutlookAuth() {
           res.end('<html><body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;"><h2>Cancelled</h2><p>You can close this tab.</p></body></html>');
           return;
         }
+        if (tokens.id_token) {
+          try {
+            const claims = decodeJwtPayload(tokens.id_token);
+            // Work/school accounts often have a null `email` claim but a
+            // usable `preferred_username` (the UPN, which is email-shaped).
+            const email = claims && (claims.email || claims.preferred_username);
+            if (email) tokens.email = email;
+          } catch (e) {
+            console.error('Failed to decode Outlook id_token:', e.message);
+          }
+        }
         saveOutlookTokens(tokens);
 
         res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -9326,6 +9364,9 @@ async function getValidOutlookAccessToken() {
     const newTokens = await refreshOutlookAccessToken(tokens.refresh_token);
     newTokens.refresh_token = newTokens.refresh_token || tokens.refresh_token;
     newTokens.expires_at = Date.now() + (newTokens.expires_in * 1000);
+    // See the Google counterpart — preserve the email captured at connect
+    // time rather than relying on the refresh response to carry it again.
+    newTokens.email = newTokens.email || tokens.email;
     saveOutlookTokens(newTokens);
     return newTokens.access_token;
   } catch (error) {
@@ -9600,7 +9641,7 @@ ipcMain.handle('google-auth-start', async () => {
 ipcMain.handle('google-auth-status', async () => {
   try {
     const tokens = loadGoogleTokens();
-    return { success: true, connected: !!tokens };
+    return { success: true, connected: !!tokens, email: tokens?.email ?? null };
   } catch (error) {
     return { success: false, connected: false };
   }
@@ -10239,7 +10280,7 @@ ipcMain.handle('outlook-auth-start', async () => {
 ipcMain.handle('outlook-auth-status', async () => {
   try {
     const tokens = loadOutlookTokens();
-    return { success: true, connected: !!tokens };
+    return { success: true, connected: !!tokens, email: tokens?.email ?? null };
   } catch (error) {
     return { success: false, connected: false };
   }

--- a/app/main.js
+++ b/app/main.js
@@ -484,7 +484,10 @@ const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 // Outlook Calendar OAuth2 configuration (PKCE public client — no client secret)
 const OUTLOOK_CLIENT_ID = '53a8ba1f-3a2e-4fc9-afb1-b9b8ff13de19';
 // See GOOGLE_SCOPES comment — openid/email here for the same id_token decode.
-const OUTLOOK_SCOPES = 'Calendars.Read offline_access openid email';
+// `profile` is required for the `preferred_username` claim to be populated
+// (Microsoft's id_token claims reference) — the fallback we use when a
+// work/school account has no `email` claim.
+const OUTLOOK_SCOPES = 'Calendars.Read offline_access openid email profile';
 const OUTLOOK_AUTH_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize';
 const OUTLOOK_TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
 
@@ -9385,11 +9388,18 @@ async function getValidOutlookAccessToken() {
 
 function refreshOutlookAccessToken(refreshToken) {
   return new Promise((resolve, reject) => {
+    // No `scope` param: Microsoft defaults a refresh to whatever the
+    // refresh_token was originally granted. Sending OUTLOOK_SCOPES here
+    // would ask pre-existing connections (granted before openid/email were
+    // added) for scope they never consented to, and Microsoft rejects
+    // that — breaking their calendar connection the next time the access
+    // token expires. New connections still get the full scope, since it's
+    // requested at initial authorization (startOutlookAuth) and a refresh
+    // without `scope` inherits it.
     const postData = new URLSearchParams({
       client_id: OUTLOOK_CLIENT_ID,
       refresh_token: refreshToken,
-      grant_type: 'refresh_token',
-      scope: OUTLOOK_SCOPES
+      grant_type: 'refresh_token'
     }).toString();
 
     const tokenUrl = new URL(OUTLOOK_TOKEN_URL);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stenoai",
-  "version": "0.5.8",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stenoai",
-      "version": "0.5.8",
+      "version": "0.6.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/app/renderer/src/hooks/useCalendarEvents.ts
+++ b/app/renderer/src/hooks/useCalendarEvents.ts
@@ -67,7 +67,7 @@ export function useGoogleCalendarAuth() {
     queryFn: async () => {
       const res = await ipc().calendar.google.status();
       if (!res.success) throw new Error(res.error);
-      return { connected: res.connected };
+      return { connected: res.connected, email: res.email ?? null };
     },
   });
   const connect = useMutation({
@@ -94,7 +94,7 @@ export function useOutlookCalendarAuth() {
     queryFn: async () => {
       const res = await ipc().calendar.outlook.status();
       if (!res.success) throw new Error(res.error);
-      return { connected: res.connected };
+      return { connected: res.connected, email: res.email ?? null };
     },
   });
   const connect = useMutation({

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -543,7 +543,7 @@ export type GetAiProviderResponse = Result<{
   bedrock_supported_models: string[];
 }>;
 
-export type AuthStatusResponse = Result<{ connected: boolean }>;
+export type AuthStatusResponse = Result<{ connected: boolean; email?: string | null }>;
 export type GetCalendarEventsResponse =
   | { success: true; events: CalendarEvent[] }
   | { success: false; needsAuth: true }

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -154,6 +154,13 @@ export function GeneralTab() {
     : outlook.status.data?.connected
       ? 'Outlook'
       : null;
+  // Only populated for connections made after the email-capture change —
+  // pre-existing connections fall back to the provider name below.
+  const calendarEmail = google.status.data?.connected
+    ? google.status.data.email
+    : outlook.status.data?.connected
+      ? outlook.status.data.email
+      : null;
 
   const [oauth, setOauth] = React.useState<
     | {
@@ -293,7 +300,7 @@ export function GeneralTab() {
         label="Connect calendar"
         description={
           calendarConnected
-            ? `Connected to ${calendarProvider}`
+            ? `Connected to ${calendarEmail || calendarProvider}`
             : 'Show upcoming meetings on the home screen'
         }
         noBorder

--- a/e2e/specs/calendar-auth.t2.spec.ts
+++ b/e2e/specs/calendar-auth.t2.spec.ts
@@ -13,7 +13,7 @@ import path from 'path';
  * isolation fix (tokens must land in the temp dir, never the real one).
  */
 
-type StatusResult = { success: boolean; connected: boolean };
+type StatusResult = { success: boolean; connected: boolean; email?: string | null };
 type AutoDetect = { success: boolean; auto_detect_meetings_enabled?: boolean };
 
 type StenoWindow = Window & {
@@ -40,10 +40,12 @@ test('clean profile is disconnected; auto-detect-meetings toggle round-trips; re
   expect(await page.evaluate(() => (window as StenoWindow).stenoai.calendar.google.status())).toEqual({
     success: true,
     connected: false,
+    email: null,
   });
   expect(await page.evaluate(() => (window as StenoWindow).stenoai.calendar.outlook.status())).toEqual({
     success: true,
     connected: false,
+    email: null,
   });
 
   // Auto-detect toggle: default on -> set off -> persisted + reflected.
@@ -96,9 +98,13 @@ test('a seeded Google token reads as connected (in the temp dir) and disconnect 
   const tokenPath = path.join(userDataDir, '.google-tokens');
   writeFileSync(tokenPath, Buffer.from(encBytes));
 
-  expect(
-    (await page.evaluate(() => (window as StenoWindow).stenoai.calendar.google.status())).connected,
-  ).toBe(true);
+  const statusAfterSeed = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.calendar.google.status(),
+  );
+  expect(statusAfterSeed.connected).toBe(true);
+  // No `email` in the seeded token (pre-existing connections predating the
+  // email-capture change) -> status falls back to null, not a crash.
+  expect(statusAfterSeed.email).toBeNull();
 
   // Disconnect removes the token and reports disconnected again.
   const disc = await page.evaluate(() =>
@@ -112,4 +118,33 @@ test('a seeded Google token reads as connected (in the temp dir) and disconnect 
 
   // Keystone: the seeded token + disconnect stayed entirely in the temp dir.
   expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});
+
+test('a seeded Google token carrying an email surfaces it via status', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const { app, page } = await launchApp();
+
+  const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
+    safeStorage.isEncryptionAvailable(),
+  );
+  test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
+
+  // Mirrors what the app itself writes after decoding the OAuth id_token at
+  // connect time (see decodeJwtPayload in main.js) — status reads it back
+  // from the local token file with no network call.
+  const encBytes = await app.evaluate(({ safeStorage }) =>
+    Array.from(
+      safeStorage.encryptString(
+        JSON.stringify({ refresh_token: 'fake-refresh', email: 'person@example.com' }),
+      ),
+    ),
+  );
+  const tokenPath = path.join(userDataDir, '.google-tokens');
+  writeFileSync(tokenPath, Buffer.from(encBytes));
+
+  const status = await page.evaluate(() => (window as StenoWindow).stenoai.calendar.google.status());
+  expect(status.connected).toBe(true);
+  expect(status.email).toBe('person@example.com');
 });

--- a/e2e/specs/calendar-auth.t2.spec.ts
+++ b/e2e/specs/calendar-auth.t2.spec.ts
@@ -126,9 +126,19 @@ test('a seeded Google token carrying an email surfaces it via status', async ({
 }) => {
   const { app, page } = await launchApp();
 
+  // Seeding needs safeStorage. Skip LOUDLY where it's unavailable rather
+  // than emit a silent green — see the sibling test above.
   const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
     safeStorage.isEncryptionAvailable(),
   );
+  if (!encryptionAvailable) {
+    // eslint-disable-next-line no-console
+    console.warn('[t2] SKIPPED calendar token seed: safeStorage unavailable on this runner.');
+    test.info().annotations.push({
+      type: 'skip-reason',
+      description: 'safeStorage unavailable; cannot seed/encrypt a calendar token',
+    });
+  }
   test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
 
   // Mirrors what the app itself writes after decoding the OAuth id_token at


### PR DESCRIPTION
## Description

Settings → General → Calendar now shows "Connected to will@example.com" instead of just "Connected to Google" / "Connected to Outlook", so it's clear which account is linked. The email is read from the OAuth id_token at connect time (decoded locally, no extra API call) and persisted alongside the token; pre-existing connections fall back to the provider name until reconnected. Status checks remain fully local/deterministic — no network calls added.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

Extended `e2e/specs/calendar-auth.t2.spec.ts` with coverage for the new `email` field on both the disconnected and connected status responses, plus a case for a token that carries an email. `typecheck:renderer` and `lint:renderer` pass clean.

## Additional Notes

The Google Calendar branded icon on the Disconnect button (visible in an earlier screenshot as missing) was already correct on `main` — confirmed with the user, no icon changes needed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calendar settings now show the connected account email (e.g., "Connected to will@example.com") instead of just the provider, decoding it locally from the OAuth `id_token` with no network calls. Also fixes an Outlook refresh regression that broke pre‑existing connections.

- **New Features**
  - Capture and persist account email by adding `openid` + email scopes and decoding the `id_token` locally for Google and Outlook; add `profile` for Outlook so `preferred_username` is available; `google.status`/`outlook.status` now return `{ connected, email }`.
  - Settings use the email when available and fall back to the provider name for older connections; email is preserved across token refreshes, and Outlook refresh now inherits original scopes (no `scope` param) to keep existing connections working.

- **Migration**
  - Existing connections will show the provider name until the user reconnects to grant the new scopes.

<sup>Written for commit 73bde62aa6d3a9add02a3f0a97c7604a0fe743f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

