### PR TITLE
fix(parser): port reasoning-tag normalization to the JS detail parser (#346)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -2030,6 +2030,30 @@ async function readReportsSidecar(meetingPath, allowedOutputDirs) {
   }
 }
 
+// Port of simple_recorder._REASONING_TAG_HEADER_PATTERN / _normalize_markdown_for_parsing.
+// A reasoning-model summary can emit its closing think tag inline with the first
+// header (e.g. `</thought>## Summary`); without a break the section-splitter never
+// sees the `## ` at line start and drops the whole summary. This pushes the header
+// onto its own line before splitting. Scoped to think/thought/thinking/reasoning so
+// unrelated inline markup can't trigger a spurious break.
+//   Kept equivalent to the Python side for the ASCII tags + whitespace that
+//   actually occur in model output (same tag set: `i` = Python re.IGNORECASE,
+//   `g` = re.sub replaces all occurrences, `\s` spans the space/newline between
+//   tag and header). JS and Python `\s`/IGNORECASE differ only on exotic Unicode
+//   whitespace and non-ASCII case folds, which don't appear here. Any edit MUST
+//   be mirrored in simple_recorder._normalize_markdown_for_parsing (see #346).
+const REASONING_TAG_HEADER_PATTERN = /(<\/(?:think|thought|thinking|reasoning)>)\s*(#{1,6}\s)/gi;
+
+function normalizeMarkdownForParsing(mdText) {
+  // Ensure headers immediately following a reasoning tag start on a new line.
+  return mdText.replace(REASONING_TAG_HEADER_PATTERN, '$1\n$2');
+}
+
+// Mirrors simple_recorder._parse_meeting_markdown so the detail page (get-meeting)
+// can render .md meetings without a Python round-trip. The two parsers MUST stay
+// byte-for-byte equivalent on everything they surface into session_info / the
+// meeting dict — they drift silently otherwise (see #346, and #313 for a prior
+// drift). Any change here has to land in _parse_meeting_markdown too.
 function parseMeetingMarkdown(content, mdPath) {
   // Split frontmatter
   const meta = {};
@@ -2067,6 +2091,8 @@ function parseMeetingMarkdown(content, mdPath) {
       }
     }
   }
+
+  body = normalizeMarkdownForParsing(body);
 
   // Parse markdown body into sections keyed by lowercased `## ` heading.
   const sections = {};

--- a/e2e/specs/meeting-detail-flags.t2.spec.ts
+++ b/e2e/specs/meeting-detail-flags.t2.spec.ts
@@ -17,14 +17,24 @@ import { writeMeetingMarkdown } from '../fixtures/user-config';
  * Model-free: pure markdown parse, no ASR / Ollama.
  */
 
+type SessionInfo = {
+  summary_file: string;
+  notes_stale?: boolean;
+  processing?: boolean;
+  is_live_transcript?: boolean;
+  notes_generated?: boolean;
+  [key: string]: unknown;
+};
 type Meeting = {
-  session_info: {
-    summary_file: string;
-    notes_stale?: boolean;
-    processing?: boolean;
-    is_live_transcript?: boolean;
-    notes_generated?: boolean;
-  };
+  session_info: SessionInfo;
+  summary?: string;
+  participants?: string[];
+  discussion_areas?: Array<{ title: string; analysis: string }>;
+  key_points?: string[];
+  action_items?: string[];
+  is_diarised?: boolean;
+  user_notes?: string | null;
+  folders?: string[];
   transcript?: string;
 };
 type GetResult = { success: boolean; meeting?: Meeting; error?: string };
@@ -154,4 +164,90 @@ test('LIST (Python parser) and DETAIL (JS parser) agree on the session_info mark
   });
   // ...and must agree with each other (drift guard).
   expect(detailMarkers).toEqual(markers(listed!.session_info));
+});
+
+test('LIST and DETAIL agree on the FULL parsed contract, incl. reasoning-tag normalization (#346)', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // The stronger drift guard. The marker-only test above missed Instance 2: the
+  // Python parser normalizes an inline reasoning-close tag (`</think>## Summary`
+  // on one line) onto its own line before section-splitting, the JS parser did
+  // not — so the summary split in LIST but vanished in DETAIL. Seed a note whose
+  // summary body starts with that inline tag and assert both parsers surface the
+  // SAME contract (summary text + markers + every field both surface), not just
+  // the three flags.
+  const file = writeMeetingMarkdown(userDataDir, 'reasoning', {
+    name: 'Reasoning Note',
+    // Inline reasoning-close tag glued to the first header — the normalization
+    // trigger. Without the JS port the `## Summary` header is not at line start,
+    // so DETAIL drops the summary entirely while LIST keeps it.
+    summaryMarkdown: [
+      '</think>## Summary',
+      'The team confirmed the reasoning-model path renders correctly.',
+      '',
+      '## Participants',
+      'Alice, Bob',
+      '',
+      '## Key Points',
+      '- Ship the parser parity fix',
+      '- Keep both parsers in sync',
+      '',
+      '## Action Items',
+      '- [ ] Land the JS normalization port',
+    ].join('\n'),
+    transcript: 'Full transcript of the reasoning-model discussion.',
+    frontmatter: { notes_stale: true, is_live_transcript: true, notes_generated: false },
+  });
+
+  const { page } = await launchApp();
+
+  const detail = await getMeeting(page, file);
+  expect(detail.success, detail.error).toBe(true);
+
+  const listed = (await listMeetings(page)).meetings.find(
+    (m) => m.session_info.summary_file === file,
+  );
+  expect(listed, 'seeded note present in list').toBeTruthy();
+
+  // Restrict to the fields both parsers surface. list-meetings strips the
+  // transcript (fetched lazily by get-meeting) and adds has_transcript, and the
+  // Python session_info carries configured_language/detected_language that the JS
+  // side does not — those are out of scope here, so compare the intersection.
+  const contract = (m: Meeting) => {
+    const si = m.session_info;
+    return {
+      // Every session_info field the JS parser surfaces (the intersection).
+      session_info: {
+        name: si.name,
+        processed_at: si.processed_at,
+        duration_seconds: si.duration_seconds,
+        // Compare by basename only: the two IPC surfaces legitimately attach the
+        // path in different forms (get-meeting resolves the realpath, e.g.
+        // /var -> /private/var on macOS or the 8.3-short vs long name on Windows;
+        // list-meetings echoes the glob path). That path-plumbing difference is
+        // not the #346 parse-contract drift, and it is not OS-portable to
+        // normalize, so key identity on the filename the parsers surface.
+        summary_file: String(si.summary_file).split(/[\\/]/).pop(),
+        output_language: si.output_language ?? null,
+        notes_stale: si.notes_stale ?? false,
+        is_live_transcript: si.is_live_transcript ?? false,
+        notes_generated: si.notes_generated ?? true,
+      },
+      summary: m.summary ?? '',
+      participants: m.participants ?? [],
+      discussion_areas: m.discussion_areas ?? [],
+      key_points: m.key_points ?? [],
+      action_items: m.action_items ?? [],
+      is_diarised: m.is_diarised ?? false,
+      user_notes: m.user_notes ?? null,
+      folders: m.folders ?? [],
+    };
+  };
+
+  const detailContract = contract(detail.meeting!);
+  // Sanity: the normalization actually fired — the summary survived the inline tag.
+  expect(detailContract.summary).toContain('renders correctly');
+  // Full-contract parity: LIST (Python) and DETAIL (JS) must agree byte-for-byte.
+  expect(detailContract).toEqual(contract(listed!));
 });

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -157,6 +157,9 @@ _AUTO_NAMED_PATTERN = re.compile(
 # tags specifically (not any HTML-like tag) so unrelated inline markup in the
 # model's output can't be mistaken for a reasoning block and get a spurious
 # section break inserted ahead of it.
+#   Mirrored in app/main.js as REASONING_TAG_HEADER_PATTERN /
+#   normalizeMarkdownForParsing (the detail-page parser). The two MUST stay
+#   equivalent — see #346. Any edit here has to land there too.
 _REASONING_TAG_HEADER_PATTERN = re.compile(r'(</(?:think|thought|thinking|reasoning)>)\s*(#{1,6}\s)', re.IGNORECASE)
 
 def _normalize_markdown_for_parsing(md_text: str) -> str:
@@ -2484,7 +2487,14 @@ def test():
 
 
 def _parse_meeting_markdown(md_path):
-    """Parse a .md meeting file into the standard meeting dict."""
+    """Parse a .md meeting file into the standard meeting dict.
+
+    Mirrored by parseMeetingMarkdown in app/main.js (the detail-page /
+    get-meeting parser, which reads the .md directly to avoid a Python
+    round-trip). The two MUST surface the same session_info / meeting-dict
+    contract — they drift silently otherwise (see #346, and #313 for a prior
+    drift). Any change here has to land there too.
+    """
     content = md_path.read_text(encoding='utf-8')
 
     # Split frontmatter


### PR DESCRIPTION
Fixes #346.

## The bug
The meeting-markdown → `session_info` contract is parsed twice by hand: Python `_parse_meeting_markdown` (used by `list-meetings`, the note **LIST**) and JS `parseMeetingMarkdown` (used by the `get-meeting` IPC handler, the note **DETAIL** page). They must stay equivalent, but the Python parser runs `_normalize_markdown_for_parsing` before section-splitting and the JS one had no equivalent. So a reasoning-model summary whose body starts with an inline close tag like `</think>## Summary` split correctly in LIST but not in DETAIL — the `## Summary` header was never at line-start there, so **the summary vanished on the detail page** while the list showed it fine. (This is the still-open Instance 2 from #346; Instance 1 was the `notes_stale`/`processing` marker drop fixed in #313.)

## The fix
Ported the normalization into the JS parser, applied at the same point (after the frontmatter split, before the section loop):

```js
const REASONING_TAG_HEADER_PATTERN = /(<\/(?:think|thought|thinking|reasoning)>)\s*(#{1,6}\s)/gi;
// body = body.replace(pat, '$1\n$2')
```

Equivalent to the Python `re.IGNORECASE` pattern for the ASCII tags + whitespace that occur in model output (`i` = IGNORECASE, `g` = global sub). The two `\s`/IGNORECASE engines differ only on exotic Unicode whitespace / non-ASCII case folds that don't appear between a reasoning tag and a header — noted in a code comment rather than over-claimed. Added cross-link comments on both parsers so a future edit to one is mirrored in the other.

## Test
Strengthened the LIST-vs-DETAIL parity contract test in `e2e/specs/meeting-detail-flags.t2.spec.ts` (the existing case only compared three marker flags): a new case seeds a note whose summary body starts with `</think>## Summary` and asserts LIST (Python) and DETAIL (JS) agree on the surfaced contract — summary text, participants, key points, action items, and the markers — not just the flags. Deliberately scoped out of the comparison: `transcript` (LIST strips it) and `configured_language`/`detected_language` (a separate pre-existing Python-only field the renderer doesn't consume, out of #346's scope). **Fail-before / pass-after** confirmed against the real bundled backend + live `main.js`: without the JS normalization call the new case fails (DETAIL summary empty); with it, all 5 specs pass.

## Review
Independent cross-family review (Codex): no critical/medium findings; it independently verified the fail-before/pass-after and the no-behavior-change on normal summaries. Its two low notes (the Unicode-whitespace equivalence caveat, and that the parity test is a targeted-not-exhaustive contract subset) are addressed / accepted as scoped.

## Verification
- `typecheck:renderer`, `lint:renderer` (0 new), `test:unit` (174 node + 111 vitest) — pass.
- T2 `meeting-detail-flags.t2.spec.ts` — 5 passed; new case fails-before/passes-after.
- `ruff check simple_recorder.py` — comments-only change, zero new errors.
- Touches `app/main.js` around the parser (~2043), clear of the settings handlers near 6700+, so no conflict with the in-flight #364.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports reasoning-tag normalization from Python to the JS detail parser so summaries that start with `</think>` before a header are parsed correctly. Restores LIST (Python) and DETAIL (JS) parity and fixes the missing summary on the detail page (Fixes #346).

- **Bug Fixes**
  - Added `REASONING_TAG_HEADER_PATTERN` and `normalizeMarkdownForParsing` to `app/main.js`, invoked after frontmatter split and before section parsing.
  - Regex mirrors Python `_normalize_markdown_for_parsing` (case-insensitive tags `think|thought|thinking|reasoning`) to insert a newline before headers; added cross-link comments in both parsers (`app/main.js` and `simple_recorder.py`).
  - Strengthened e2e test to compare the full parsed contract between LIST and DETAIL using a `</think>## Summary` fixture; includes `summary_file` basename normalization; fail-before/pass-after confirmed.

<sup>Written for commit 8d7bedbfe0045e766642e8ca4ba37b7596ece1fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

