### PR TITLE
fix(update-toast): expand clickable area on Restart button

### DIFF
--- a/app/renderer/src/components/UpdateToast.tsx
+++ b/app/renderer/src/components/UpdateToast.tsx
@@ -34,7 +34,13 @@ export function UpdateToast() {
         border: '1px solid var(--border-subtle)',
         boxShadow: 'var(--shadow-md)',
         fontFamily: 'var(--font-sans)',
-      }}
+        // Overlaps MainToolbar's draggable top strip. Without an explicit
+        // no-drag here, macOS's window-drag hit test (computed from CSS
+        // regions, not paint z-order) swallows clicks on the upper portion
+        // of the buttons below — only the sliver poking below the strip
+        // was clickable.
+        WebkitAppRegion: 'no-drag',
+      } as React.CSSProperties}
       role="status"
       aria-live="polite"
     >


### PR DESCRIPTION
## Description

The update-ready toast's Restart button only responded to clicks on its bottom half. `UpdateToast` is `position: fixed` at the top-right, overlapping the strip `MainToolbar` marks `-webkit-app-region: drag` for window dragging. Electron computes that drag region from CSS, independent of visual stacking/z-index, so without an explicit `no-drag` opt-out, macOS's window-drag hit test intercepted clicks on the upper portion of the pill — only the sliver poking below the toolbar's drag strip was clickable.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Verified via a standalone browser repro of the toast markup, confirming the fix aligns the clickable hit box with the visible pill
- [x] Renderer typecheck passes (`npm run typecheck:renderer`)
- [ ] Not yet verified in the packaged Electron app (drag-region behavior is Electron-specific and wasn't re-tested there)

## Additional Notes

Same class of bug already called out in `Sidebar.tsx`/`MainToolbar.tsx` for the sidebar toggle button — any `position: fixed` element overlapping a draggable strip needs an explicit `no-drag` opt-out.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the update toast so the Restart and Dismiss buttons are fully clickable. The toast container now sets `WebkitAppRegion: 'no-drag'` to prevent the top toolbar’s drag region from intercepting clicks.

<sup>Written for commit 2116fd6eb1106ed9036315be1172e3b758e0c8a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

