### PR TITLE
fix(renderer): nav hover contrast, dock alignment, and tooltips

### DIFF
--- a/app/renderer/src/components/AskBar.tsx
+++ b/app/renderer/src/components/AskBar.tsx
@@ -167,7 +167,9 @@ export function TranscriptToggle() {
       aria-label={transcriptOpen ? 'Hide transcript' : 'Show transcript'}
       aria-pressed={transcriptOpen}
       title="Transcript"
-      className="pointer-events-auto inline-flex h-11 shrink-0 cursor-pointer items-center justify-center gap-0.5 rounded-full border-0 px-3 transition-colors"
+      // mb-[3px] optically centers the 44px toggle against the 50px composer
+      // row it sits beside (PrimaryDock aligns the row items-end; see there).
+      className="pointer-events-auto mb-[3px] inline-flex h-11 shrink-0 cursor-pointer items-center justify-center gap-0.5 rounded-full border-0 px-3 transition-colors"
       style={{
         background: transcriptOpen ? 'var(--surface-active)' : 'var(--surface-raised)',
         border: '1px solid var(--border-subtle)',

--- a/app/renderer/src/components/LiveDock.tsx
+++ b/app/renderer/src/components/LiveDock.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ChevronUp, Play, Square } from 'lucide-react';
 import { AudioWave } from '@/components/AudioWave';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { useRecording } from '@/hooks/useRecording';
 import { useLiveTranscript } from '@/hooks/useLiveTranscript';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
@@ -102,46 +103,58 @@ export function LiveDock() {
           drop). There is no manual pause: stop ends the segment and the note
           can be continued later. */}
       {paused && (
-        <button
-          type="button"
-          onClick={onResume}
-          aria-label="Resume recording"
-          title="Resume recording"
-          className="inline-flex size-7 cursor-pointer items-center justify-center rounded-full border-0 transition-colors hover:bg-[color:var(--surface-hover)]"
-          style={{ background: 'transparent', color: 'var(--fg-1)' }}
-        >
-          <Play size={13} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onResume}
+              aria-label="Resume recording"
+              className="inline-flex size-7 cursor-pointer items-center justify-center rounded-full border-0 transition-colors hover:bg-[color:var(--surface-hover)]"
+              style={{ background: 'transparent', color: 'var(--fg-1)' }}
+            >
+              <Play size={13} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">Resume recording</TooltipContent>
+        </Tooltip>
       )}
       {/* Expand — Parakeet only. Whisper recordings have no live drawer
           (post-stop pipeline produces the final transcript on the meeting
           detail page). Hiding the button entirely rather than disabling
           avoids the dead-control. */}
       {liveAvailable && (
-        <button
-          type="button"
-          onClick={toggleTranscript}
-          disabled={stopped}
-          aria-label={transcriptOpen ? 'Hide transcript' : 'Show transcript'}
-          aria-pressed={transcriptOpen}
-          title={transcriptOpen ? 'Hide transcript' : 'Show transcript'}
-          className="inline-flex size-7 cursor-pointer items-center justify-center rounded-full border-0 transition-colors hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
-          style={{ background: 'transparent', color: 'var(--fg-1)' }}
-        >
-          <ChevronUp size={14} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={toggleTranscript}
+              disabled={stopped}
+              aria-label={transcriptOpen ? 'Hide transcript' : 'Show transcript'}
+              aria-pressed={transcriptOpen}
+              className="inline-flex size-7 cursor-pointer items-center justify-center rounded-full border-0 transition-colors hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+              style={{ background: 'transparent', color: 'var(--fg-1)' }}
+            >
+              <ChevronUp size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">{transcriptOpen ? 'Hide transcript' : 'Show transcript'}</TooltipContent>
+        </Tooltip>
       )}
-      <button
-        type="button"
-        onClick={onStop}
-        disabled={stopped}
-        aria-label="Stop recording"
-        title="Stop recording"
-        className="inline-flex size-7 cursor-pointer items-center justify-center rounded-full border-0 transition-colors hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
-        style={{ background: 'transparent', color: 'var(--recording)' }}
-      >
-        <Square size={12} fill="currentColor" stroke="currentColor" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onStop}
+            disabled={stopped}
+            aria-label="Stop recording"
+            className="inline-flex size-7 cursor-pointer items-center justify-center rounded-full border-0 transition-colors hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ background: 'transparent', color: 'var(--recording)' }}
+          >
+            <Square size={12} fill="currentColor" stroke="currentColor" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">Stop recording</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Check, ChevronDown, Copy, Play, Search as SearchIcon, Square } from 'lucide-react';
+import { Check, ChevronDown, Copy, Languages, Play, Search as SearchIcon, Square } from 'lucide-react';
 import { AudioWave } from '@/components/AudioWave';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { useLiveTranscript } from '@/hooks/useLiveTranscript';
 import { useRecording } from '@/hooks/useRecording';
@@ -133,15 +134,19 @@ export function LiveTranscriptBar() {
             <span />
           </span>
           <span className="mv-transcript-label">Transcript</span>
-          <button
-            type="button"
-            className="mv-chat-tool"
-            onClick={() => void copyAll()}
-            aria-label="Copy transcript"
-            title="Copy transcript"
-          >
-            {copied ? <Check size={13} /> : <Copy size={13} />}
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="mv-chat-tool"
+                onClick={() => void copyAll()}
+                aria-label="Copy transcript"
+              >
+                {copied ? <Check size={13} /> : <Copy size={13} />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{copied ? 'Copied!' : 'Copy transcript'}</TooltipContent>
+          </Tooltip>
           <button
             type="button"
             className="mv-chat-tool"
@@ -217,7 +222,7 @@ export function LiveTranscriptBar() {
               onClick={onStop}
               aria-label="Stop recording"
               title="Stop recording"
-              className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full border-0 px-3 text-[13px] font-medium transition-opacity"
+              className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full border-0 px-3 text-[13px] font-medium transition-opacity hover:opacity-90"
               style={{ background: 'var(--recording)', color: '#FFFFFF' }}
             >
               <Square size={12} fill="currentColor" stroke="currentColor" />
@@ -394,21 +399,26 @@ function LanguageSelector() {
 
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            'inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium',
-            'cursor-pointer transition-colors hover:bg-[color:var(--surface-hover)]'
-          )}
-          style={{ color: 'var(--fg-2)' }}
-          aria-label={`Language: ${display}`}
-          title="Change transcript language"
-        >
-          <span style={{ color: 'var(--fg-1)' }}>{display}</span>
-          <ChevronDown size={12} />
-        </button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium',
+                'cursor-pointer transition-colors hover:bg-[color:var(--surface-hover)]'
+              )}
+              style={{ color: 'var(--fg-2)' }}
+              aria-label={`Language: ${display}`}
+            >
+              <Languages size={12} />
+              <span style={{ color: 'var(--fg-1)' }}>{display}</span>
+              <ChevronDown size={12} />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">Transcript language</TooltipContent>
+      </Tooltip>
       <PopoverContent align="end" sideOffset={8} className="w-56 p-1">
         {LANGUAGE_OPTIONS.map((opt) => {
           const active = opt.code === current;

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FileAudio, MessageSquare, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, PencilLine } from 'lucide-react';
+import { FileAudio, MessageSquare, MoreHorizontal, Monitor, PanelLeftClose, PanelLeftOpen, Plus } from 'lucide-react';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -9,6 +9,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import {
   useSetSystemAudio,
   useSystemAudioSetting,
@@ -78,26 +79,32 @@ export function MainToolbar({
             Settings — SettingsNav is non-collapsible, so there's nothing for
             it to toggle. */}
         {!settingsMode && (
-          <button
-            type="button"
-            onClick={onToggleSidebar}
-            aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-            title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-            style={{
-              position: 'fixed',
-              top: 14,
-              left: toggleLeft,
-              zIndex: 30,
-              WebkitAppRegion: 'no-drag',
-            } as React.CSSProperties}
-            className="inline-flex h-[26px] w-7 items-center justify-center rounded-md text-[color:var(--fg-2)] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]"
-          >
-            {sidebarCollapsed ? (
-              <PanelLeftOpen className="size-[15px]" />
-            ) : (
-              <PanelLeftClose className="size-[15px]" />
-            )}
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onToggleSidebar}
+                aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+                style={{
+                  position: 'fixed',
+                  top: 14,
+                  left: toggleLeft,
+                  zIndex: 30,
+                  WebkitAppRegion: 'no-drag',
+                } as React.CSSProperties}
+                className="inline-flex h-[26px] w-7 items-center justify-center rounded-md text-[color:var(--fg-2)] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]"
+              >
+                {sidebarCollapsed ? (
+                  <PanelLeftOpen className="size-[15px]" />
+                ) : (
+                  <PanelLeftClose className="size-[15px]" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+            </TooltipContent>
+          </Tooltip>
         )}
         {/* Starting a new recording with options isn't a Settings action. */}
         {!settingsMode && (
@@ -154,7 +161,7 @@ export function MainToolbar({
               </>
             ) : (
               <>
-                <PencilLine className="size-[13px]" />
+                <Plus className="size-[13px]" />
                 New note
               </>
             )}
@@ -189,17 +196,21 @@ function RecordingOptionsPopover({
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-8"
-          aria-label="Recording options"
-          title="Recording options"
-        >
-          <MoreHorizontal className="size-4" />
-        </Button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-8"
+              aria-label="Recording options"
+            >
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Recording options</TooltipContent>
+      </Tooltip>
       <PopoverContent align="end" className="w-72" data-recording-options>
         <div className="space-y-3">
           <div className="space-y-0.5">

--- a/app/renderer/src/components/PrimaryDock.tsx
+++ b/app/renderer/src/components/PrimaryDock.tsx
@@ -54,7 +54,7 @@ export function PrimaryDock({ showAskBar }: { showAskBar: boolean }) {
   return (
     <div
       data-testid="primary-dock-row"
-      className={cn('flex items-end gap-3', !showAskBar && 'justify-center')}
+      className={cn('flex items-center gap-3', !showAskBar && 'justify-center')}
     >
       {recordingActive ? (
         <div className="shrink-0">

--- a/app/renderer/src/components/PrimaryDock.tsx
+++ b/app/renderer/src/components/PrimaryDock.tsx
@@ -54,10 +54,17 @@ export function PrimaryDock({ showAskBar }: { showAskBar: boolean }) {
   return (
     <div
       data-testid="primary-dock-row"
-      className={cn('flex items-center gap-3', !showAskBar && 'justify-center')}
+      // items-end, not items-center: the AskBar column grows upward in-flow
+      // (chat panel maxHeight 360, suggestion chips), so centering against it
+      // would float the left control mid-column when a chat is expanded. The
+      // left controls instead carry a small mb-* that optically centers them
+      // against the 50px composer row only.
+      className={cn('flex items-end gap-3', !showAskBar && 'justify-center')}
     >
       {recordingActive ? (
-        <div className="shrink-0">
+        // mb-1 only beside the composer - standalone (justify-center) the
+        // pill has nothing to align with.
+        <div className={cn('shrink-0', showAskBar && 'mb-1')}>
           <LiveDock />
         </div>
       ) : (

--- a/app/renderer/src/components/Sidebar.tsx
+++ b/app/renderer/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import { navigate, rememberNonSettingsRoute, toggleSettings } from '@/lib/router
 import { cn, shortcut } from '@/lib/utils';
 import { ipc } from '@/lib/ipc';
 import { LucideIcon, IconPicker } from '@/components/IconPicker';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { useUpdateFolderIcon } from '@/hooks/useFolders';
 import { useOrgLogout, useOrgSession, useSharedNotesGate } from '@/hooks/useOrg';
 import { useCommandPalette } from '@/components/CommandPalette';
@@ -409,15 +410,20 @@ export function Sidebar({
                 <ChevronDown className={cn('size-3 transition-transform', !foldersOpen && '-rotate-90')} />
                 <span>Folders</span>
               </span>
-              <button
-                type="button"
-                className="inline-flex size-5 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[color:var(--surface-active)] [.sb-group-head:hover_&]:opacity-100"
-                onClick={(e) => { e.stopPropagation(); onNewFolder(); }}
-                aria-label="New folder"
-                style={{ color: 'var(--fg-2)' }}
-              >
-                <Plus className="size-3" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex size-5 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[color:var(--surface-active)] [.sb-group-head:hover_&]:opacity-100"
+                    onClick={(e) => { e.stopPropagation(); onNewFolder(); }}
+                    aria-label="New folder"
+                    style={{ color: 'var(--fg-2)' }}
+                  >
+                    <Plus className="size-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">Create folder</TooltipContent>
+              </Tooltip>
             </div>
 
             {foldersOpen &&
@@ -501,7 +507,7 @@ export function Sidebar({
                 rememberNonSettingsRoute(currentRoute);
                 navigate('/settings?tab=organisation');
               }}
-              className="inline-flex h-[26px] min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] transition-colors hover:bg-[color:var(--surface-hover)]"
+              className="inline-flex h-[26px] min-w-0 items-center gap-1.5 rounded-md px-2 text-[12px] transition-colors hover:bg-[color:var(--surface-active)]"
               style={{ color: 'var(--fg-1)' }}
               title="Sign in to share notes with your organisation"
             >
@@ -516,33 +522,41 @@ export function Sidebar({
               on the right) doesn't treat Help as a third independent side and
               spread it away from the Settings cog. */}
           <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => void ipc().shell.openExternal('https://docs.stenoai.co')}
-            aria-label="Help"
-            title="Help"
-            className="inline-flex h-[26px] w-7 items-center justify-center rounded-md transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]"
-            style={{ color: 'var(--fg-2)' }}
-          >
-            <HelpCircle className="size-[15px]" />
-          </button>
-          <button
-            type="button"
-            onClick={() => toggleSettings(currentRoute)}
-            aria-label="Settings"
-            title="Settings"
-            // startsWith so the cog still reads "active" on deep-link routes
-            // like /settings?tab=organisation, not just bare /settings.
-            aria-pressed={currentRoute.startsWith('/settings')}
-            className={cn(
-              'inline-flex h-[26px] w-7 items-center justify-center rounded-md transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]',
-              currentRoute.startsWith('/settings')
-                ? 'bg-[color:var(--surface-active)] text-[color:var(--fg-1)]'
-                : 'text-[color:var(--fg-2)]',
-            )}
-          >
-            <SettingsIcon className="size-[15px]" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => void ipc().shell.openExternal('https://docs.stenoai.co')}
+                aria-label="Help"
+                className="inline-flex h-[26px] w-7 items-center justify-center rounded-md transition-colors hover:bg-[color:var(--surface-active)] hover:text-[color:var(--fg-1)]"
+                style={{ color: 'var(--fg-2)' }}
+              >
+                <HelpCircle className="size-[15px]" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">Documentation</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => toggleSettings(currentRoute)}
+                aria-label="Settings"
+                // startsWith so the cog still reads "active" on deep-link routes
+                // like /settings?tab=organisation, not just bare /settings.
+                aria-pressed={currentRoute.startsWith('/settings')}
+                className={cn(
+                  'inline-flex h-[26px] w-7 items-center justify-center rounded-md transition-colors hover:bg-[color:var(--surface-active)] hover:text-[color:var(--fg-1)]',
+                  currentRoute.startsWith('/settings')
+                    ? 'bg-[color:var(--surface-active)] text-[color:var(--fg-1)]'
+                    : 'text-[color:var(--fg-2)]',
+                )}
+              >
+                <SettingsIcon className="size-[15px]" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">Settings</TooltipContent>
+          </Tooltip>
           </div>
         </div>
 
@@ -613,7 +627,7 @@ function ProfileChip({ email, name, orgId, onSignOut }: ProfileChipProps) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-[color:var(--surface-hover)]"
+        className="flex items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-[color:var(--surface-active)]"
         title={`${name || email} · ${orgId}`}
         aria-haspopup="menu"
         aria-expanded={open}

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -348,16 +348,13 @@
     transition: background var(--dur-fast) var(--ease);
     line-height: 1.3;
   }
-  .sb-row:hover { background: var(--surface-hover); }
+  /* --surface-active, not --surface-hover: sb-row sits on the sidebar's
+     --surface-sunken background, which equals --surface-hover in light mode
+     (both --paper-1) — that hover would be invisible. */
+  .sb-row:hover { background: var(--surface-active); }
   .sb-row.active {
-    background: var(--surface-raised);
-    box-shadow: 0 1px 2px rgba(27,27,25,0.04), 0 0 0 1px var(--border-subtle);
+    background: var(--surface-active);
     font-weight: 500;
-  }
-  .dark .sb-row.active,
-  [data-theme="dark"] .sb-row.active {
-    background: var(--surface-raised);
-    box-shadow: 0 0 0 1px var(--border-subtle);
   }
   .sb-row svg { color: var(--fg-2); flex-shrink: 0; }
   .sb-row.active svg { color: var(--fg-1); }
@@ -591,6 +588,9 @@
     to   { opacity: 1; transform: translateY(0) scale(1); }
   }
 
+  /* Not itself clickable — only the copy/minimize buttons inside are, via
+     .mv-chat-tool's own hover. No cursor/hover here so the row doesn't imply
+     the whole header is a click target. */
   .mv-transcript-head {
     display: flex;
     align-items: center;
@@ -599,13 +599,10 @@
     width: 100%;
     background: transparent;
     border: 0;
-    cursor: pointer;
     font-family: var(--font-sans);
     text-align: left;
     color: var(--fg-1);
-    transition: background var(--dur-fast) var(--ease);
   }
-  .mv-transcript-head:hover { background: var(--surface-hover); }
 
   .mv-transcript-label {
     flex: 1;

--- a/app/renderer/src/routes/Home.tsx
+++ b/app/renderer/src/routes/Home.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, ChevronLeft, ChevronRight, PencilLine, RefreshCw, Search, Square, X } from 'lucide-react';
+import { Calendar, ChevronLeft, ChevronRight, Plus, RefreshCw, Search, Square, X } from 'lucide-react';
 import { cn, isMac } from '@/lib/utils';
 import { MeetingsShell } from '@/components/MeetingsShell';
 import { UpcomingCard } from '@/components/home/UpcomingCard';
@@ -503,7 +503,7 @@ export function Home({ mode }: HomeProps) {
               onClick={onToggleRecording}
               className="gap-2"
             >
-              {isRecording ? <Square className="size-4" /> : <PencilLine className="size-4" />}
+              {isRecording ? <Square className="size-4" /> : <Plus className="size-4" />}
               {isRecording ? 'Stop recording' : 'New note'}
             </Button>
             <p

--- a/app/renderer/src/routes/OrgShared.tsx
+++ b/app/renderer/src/routes/OrgShared.tsx
@@ -171,7 +171,7 @@ export function OrgSharedDetail({ id }: { id: string }) {
       <button
         type="button"
         onClick={() => navigate('/org/shared')}
-        className="mb-5 inline-flex items-center gap-1.5 text-[12px] hover:text-[color:var(--fg-1)]"
+        className="mb-5 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[12px] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]"
         style={{ color: 'var(--fg-2)' }}
       >
         <ArrowLeft size={12} /> Shared notes

--- a/app/renderer/src/routes/Processing.tsx
+++ b/app/renderer/src/routes/Processing.tsx
@@ -173,7 +173,7 @@ export function Processing() {
           <button
             type="button"
             onClick={() => navigate('/')}
-            className="mb-6 inline-flex cursor-pointer items-center gap-1 border-0 bg-transparent text-[13px] transition-colors hover:text-[color:var(--fg-1)]"
+            className="mb-6 inline-flex cursor-pointer items-center gap-1 rounded-md border-0 bg-transparent px-2 py-1 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]"
             style={{ color: 'var(--fg-2)' }}
             aria-label="Back to home"
           >

--- a/app/renderer/src/routes/Recording.tsx
+++ b/app/renderer/src/routes/Recording.tsx
@@ -55,7 +55,7 @@ export function Recording() {
               <button
                 type="button"
                 onClick={() => navigate('/')}
-                className="mb-6 inline-flex cursor-pointer items-center gap-1 border-0 bg-transparent text-[13px] transition-colors hover:text-[color:var(--fg-1)]"
+                className="mb-6 inline-flex cursor-pointer items-center gap-1 rounded-md border-0 bg-transparent px-2 py-1 text-[13px] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]"
                 style={{ color: 'var(--fg-2)' }}
                 aria-label="Back to home"
               >

--- a/app/renderer/src/routes/settings/SettingsNav.tsx
+++ b/app/renderer/src/routes/settings/SettingsNav.tsx
@@ -106,7 +106,7 @@ export function SettingsNav({ activeTab, onSelect, onBack, version }: SettingsNa
           type="button"
           onClick={onBack}
           aria-label="Back"
-          className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-[6px] border-0 bg-transparent transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--fg-1)]"
+          className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-[6px] border-0 bg-transparent transition-colors hover:bg-[color:var(--surface-active)] hover:text-[color:var(--fg-1)]"
           style={{ color: 'var(--fg-2)' }}
         >
           <ArrowLeft size={14} />


### PR DESCRIPTION
## Description

Fixes the sidebar/settings-nav hover effect, which was invisible in light mode because it used the same color as the sidebar's own background. While in there, also flattened the active-row style to match hover, fixed a few other missing/misleading hover states, centered the recording pill with the chat composer, swapped the New note icon to a plus, and added tooltips to a number of previously title-only icon buttons across the sidebar, toolbar, transcript panel, and recording pill.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tested locally with `npm start`
- [ ] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

## Additional Notes

Verified each fix against the running dev app (mocked IPC) with scripted hover/click checks; `typecheck:renderer` and `lint:renderer` both pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invisible nav hovers in light mode and improves clarity with better contrast, anchored dock alignment, clearer icons, and contextual tooltips. Adds hover feedback where it was missing and removes misleading hovers.

- **Bug Fixes**
  - Sidebar/settings row hover is now visible in light mode using `--surface-active`; active row matches hover.
  - Anchored the recording pill and transcript toggle to the composer row with small mb offsets, keeping them centered even when the AskBar expands.
  - Added hover feedback to Stop buttons and back links; removed the header-wide hover on the transcript panel.

- **New Features**
  - Added tooltips to key controls: Help, Settings, folder create, sidebar toggle, recording options, copy transcript, language picker, resume/hide/stop.
  - Replaced the “New note” pen with a plus icon; added a language icon to the transcript language selector.

<sup>Written for commit f739908dc4d1a2387d81a8f6a1c662f3f7a5fdc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

