### PR TITLE
fix(security): deny window.open + block foreign navigation on all BrowserWindows (#377)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1445,12 +1445,15 @@ function recoverPendingDeletesOnLaunch() {
 // from the bundled renderer. Deny window.open outright, and cancel any full-page
 // navigation — the SPA uses in-app routing, so a will-navigate here is a
 // foreign/injected navigation, never a real route change. Interactive windows still
-// let a genuine http(s)/mailto link (a target=_blank "Report an issue", or a link
+// let a genuine http(s) link (a target=_blank "Report an issue", or a link
 // inside a note) open in the user's browser instead of silently dying.
 function hardenWindow(win, { allowExternalLinks = false } = {}) {
   const wc = win.webContents;
   wc.setWindowOpenHandler(({ url }) => {
-    if (allowExternalLinks && /^(https?|mailto):/i.test(url)) {
+    // HTTP(S) only — matches the will-navigate branch below and the established
+    // `open-external` IPC policy (no mailto/other schemes; nothing legitimate in
+    // the renderer opens a non-http(s) popup). #377 review.
+    if (allowExternalLinks && /^https?:/i.test(url)) {
       shell.openExternal(url);
     }
     return { action: 'deny' };

--- a/app/main.js
+++ b/app/main.js
@@ -315,6 +315,10 @@ class Notification extends EventEmitter {
       },
     });
     notificationWindow = win;
+    // Deny window.open + block foreign navigation on the toast window too, so the
+    // security guards cover EVERY BrowserWindow (#377). allowExternalLinks lets a
+    // Join/meeting link route out via shell.openExternal.
+    hardenWindow(win, { allowExternalLinks: true });
     win._activeCustomNotification = this;
     // Also pin the window to the notification instance so a handler bound to
     // THIS notif (e.g. the pre-meeting 'close' dismissal-telemetry handler) can
@@ -1435,6 +1439,35 @@ function recoverPendingDeletesOnLaunch() {
   }
 }
 
+// #377 — harden every BrowserWindow against untrusted navigation. The renderer
+// routes all real external links through the `open-external` IPC (shell.openExternal),
+// so nothing legitimately relies on window.open or on navigating the window away
+// from the bundled renderer. Deny window.open outright, and cancel any full-page
+// navigation — the SPA uses in-app routing, so a will-navigate here is a
+// foreign/injected navigation, never a real route change. Interactive windows still
+// let a genuine http(s)/mailto link (a target=_blank "Report an issue", or a link
+// inside a note) open in the user's browser instead of silently dying.
+function hardenWindow(win, { allowExternalLinks = false } = {}) {
+  const wc = win.webContents;
+  wc.setWindowOpenHandler(({ url }) => {
+    if (allowExternalLinks && /^(https?|mailto):/i.test(url)) {
+      shell.openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+  wc.on('will-navigate', (event) => {
+    // Electron 42: read the target off the event (the positional `url` arg is
+    // deprecated). will-navigate only fires on a real document navigation — the
+    // SPA's hash routing never reaches here, so anything that does is foreign.
+    const url = event.url;
+    if (url === wc.getURL()) return; // reload of the exact trusted document is fine
+    event.preventDefault();
+    if (allowExternalLinks && /^https?:/i.test(url)) {
+      shell.openExternal(url);
+    }
+  });
+}
+
 function createWindow(options = {}) {
   rendererShortcutReady = false;
 
@@ -1480,6 +1513,7 @@ function createWindow(options = {}) {
   }
 
   mainWindow = new BrowserWindow(windowOpts);
+  hardenWindow(mainWindow, { allowExternalLinks: true });
 
   const rendererDist = path.join(__dirname, 'renderer', 'dist', 'index.html');
   const hash = process.env.STENOAI_RENDERER_HASH;
@@ -3693,6 +3727,10 @@ async function renderHtmlToPdf(html) {
       // renderer-supplied document to PDF.
     },
   });
+  // Background render of renderer-supplied HTML: deny any popup and block any
+  // navigation the document might attempt (no openExternal — this is not an
+  // interactive window and must never spawn a browser tab on its own).
+  hardenWindow(win);
   try {
     const render = (async () => {
       // Load the HTML directly as a data URL (self-contained: CSS, font, and

--- a/e2e/specs/security-window-guards.t1.spec.ts
+++ b/e2e/specs/security-window-guards.t1.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 — renderer-only, mock IPC, no backend. Proves the #377 BrowserWindow
+ * hardening: the main window's `setWindowOpenHandler` denies every popup, so a
+ * renderer `window.open(...)` (or a `target="_blank"` link) can never spawn a
+ * chrome-less in-app Electron window. `about:blank` is used deliberately — it is
+ * not an http(s)/mailto URL, so the deny path runs without the interactive
+ * window's `shell.openExternal` fallback launching a real browser tab in CI.
+ *
+ * Scope: this asserts the popup-deny guard, which is the primary renderer-
+ * reachable risk surface. The companion `will-navigate` guard (defense-in-depth
+ * against full-page navigation away from the bundled renderer) is deliberately
+ * NOT asserted here: modern Chromium already blocks the only hermetic navigation
+ * vectors (`data:`/`about:blank`/missing `file:`), so a fail-before-provable test
+ * isn't achievable without a networked http target (side effects). That guard is
+ * verified by code review + reasoning, not a test that would pass regardless.
+ */
+test('window.open is denied — no popup BrowserWindow is created (#377)', async ({
+  launchApp,
+}) => {
+  const { app, page } = await launchApp({ mockIpc: true });
+
+  const windowsBefore = app.windows().length;
+
+  // If the deny handler failed, a new window would appear and fire this event.
+  // We assert the *absence* of that event within a bounded window (event-race,
+  // not a fixed sleep in the assertion).
+  const popupAppeared = app
+    .waitForEvent('window', { timeout: 1500 })
+    .then(() => true)
+    .catch(() => false);
+
+  await page.evaluate(() => {
+    window.open('about:blank', '_blank');
+  });
+
+  expect(await popupAppeared).toBe(false);
+  expect(app.windows().length).toBe(windowsBefore);
+});


### PR DESCRIPTION
Closes #377.

## What

Adds navigation/window-open guards to every `BrowserWindow`. Previously none of the three windows denied `window.open` or blocked in-app navigation, so a `target="_blank"` link, a `window.open`, or a foreign top-level navigation could spawn a chrome-less Electron window or navigate the app frame away from the bundled renderer.

A single `hardenWindow(win, { allowExternalLinks })` helper is applied at all three creation sites:

- **mainWindow** and **notificationWindow** (`allowExternalLinks: true`) — deny every popup, but route a genuine `http(s)`/`mailto` target (e.g. the `target="_blank"` "Report an issue" link in `Setup.tsx`, or a link inside a note) through `shell.openExternal` so it opens in the user's browser instead of silently dying.
- **PDF render window** (`allowExternalLinks: false`) — pure deny/block; this background render of renderer-supplied HTML must never spawn a browser tab on its own.

`setWindowOpenHandler` returns `deny` (so `did-create-window` can't fire); `will-navigate` cancels any navigation away from the current committed document (reads the target off `event.url`, the non-deprecated Electron 42 accessor).

## Why it's safe

- The renderer already routes all real external links through the `open-external` IPC (`shell.openExternal`), so nothing legitimately relies on `window.open`.
- The SPA uses hash routing, so `will-navigate` never fires on a real route change — anything reaching it is a foreign/injected navigation.
- `loadFile` (main/notification) and the PDF `loadURL(data:)` are main-process programmatic loads, which don't emit `will-navigate`.

## Testing

- New T1 spec `security-window-guards.t1.spec.ts`: asserts `window.open` is denied (no popup `BrowserWindow` created). Verified fail-before (flipping the handler to `allow` makes it fail).
- The companion `will-navigate` guard is intentionally not asserted by a test: modern Chromium already blocks the only hermetic navigation vectors (`data:` / `about:blank` / missing `file:`), so a fail-before-provable test isn't achievable without a networked http target. It's covered by review + reasoning instead of a test that would pass regardless. (Rationale is in the spec's docblock.)
- Full unit suite green (111 passed); cross-family (Codex) review returned no blockers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened all Electron `BrowserWindow`s: deny `window.open` popups and block foreign navigations. In interactive windows, only HTTP(S) links open in the default browser. Addresses #377.

- **Bug Fixes**
  - Added `hardenWindow(win, { allowExternalLinks })`; applied to `mainWindow`/`notificationWindow` (`true`) and the PDF render window (`false`).
  - `setWindowOpenHandler` always returns `deny`; when allowed, routes only HTTP(S) targets via `shell.openExternal` (no `mailto:` or other schemes).
  - `will-navigate` cancels navigation away from the current document; allowed HTTP(S) URLs open via `shell.openExternal`.
  - New e2e spec `e2e/specs/security-window-guards.t1.spec.ts` asserts popup denial.

<sup>Written for commit a1687fba276aa063f21a44f198c459a88fb489d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

