### PR TITLE
fix(org): skip /policy fetch + seed on steady-state auto-backup (#192)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -11158,33 +11158,62 @@ ipcMain.handle('org-try-auto-backup', async (_event, payload) => {
     const session = loadOrgSession();
     if (!session) return { attempted: false, reason: 'not-signed-in' };
 
-    // Close the sign-in seeding race (cubic P1): the sign-in handler seeds
-    // the auto-backup default fire-and-forget, so a recording that finishes
-    // right after sign-in could reach this gate before the org's
-    // auto_share_default has been written — and the read below treats an
-    // unset pref as enabled (!== false), which would auto-share against an
-    // org policy of auto_share_default=false. seedOrgAutoBackupDefault is
-    // idempotent (writes only when no pref exists, swallows its own errors),
-    // so awaiting it here deterministically materialises the policy default
-    // before we decide. The adapter is necessarily reachable on the path
-    // that actually uploads, so this fetch is the same reachability the
-    // share itself needs.
-    await seedOrgAutoBackupDefault();
-
+    // Read the stored preference first. get-org-auto-backup reports whether a
+    // preference actually exists (org_auto_backup_preference_set), which lets
+    // us skip the /policy fetch + seed subprocess entirely once one does —
+    // steady-state backups only need the stored value (issue #192).
+    //
     // Fail closed: any error / unparseable output treats the toggle as
     // disabled. A privacy + sharing setting should never default ON via a
-    // transient read failure — if the user enabled it, they can do so
-    // again explicitly. The regex match guards against stray Python
-    // stderr/stdout noise around the JSON payload.
-    let enabled = false;
-    try {
+    // transient read failure — if the user enabled it, they can do so again
+    // explicitly. The regex match guards against stray Python stderr/stdout
+    // noise around the JSON payload.
+    const readAutoBackup = async () => {
       const cfg = await runPythonScript('simple_recorder.py', ['get-org-auto-backup']);
       const jsonMatch = cfg.match(/\{.*\}/s);
-      enabled = jsonMatch
-        ? JSON.parse(jsonMatch[0])?.org_auto_backup_enabled !== false
-        : false;
+      const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : null;
+      return {
+        enabled: parsed ? parsed.org_auto_backup_enabled !== false : false,
+        isSet: parsed ? parsed.org_auto_backup_preference_set === true : false,
+      };
+    };
+
+    let enabled = false;
+    let isSet = false;
+    try {
+      ({ enabled, isSet } = await readAutoBackup());
     } catch (_) {
       sendDebugLog('org-try-auto-backup: failed to read auto-backup pref, treating as disabled');
+      return { attempted: false, reason: 'disabled' };
+    }
+
+    // Only when the preference is genuinely unset do we close the sign-in
+    // seeding race (cubic P1): the sign-in handler seeds the auto-backup
+    // default fire-and-forget, so a recording that finishes right after
+    // sign-in could reach this gate before the org's auto_share_default has
+    // been written — and an unset pref reads as enabled (!== false), which
+    // would auto-share against an org policy of auto_share_default=false.
+    // seedOrgAutoBackupDefault is idempotent (writes only when no pref exists,
+    // swallows its own errors), so awaiting it here deterministically
+    // materialises the policy default before we re-read and decide. The
+    // adapter is necessarily reachable on the path that actually uploads, so
+    // this fetch is the same reachability the share itself needs. Once a
+    // preference exists we skip this entirely.
+    if (!isSet) {
+      await seedOrgAutoBackupDefault();
+      try {
+        ({ enabled, isSet } = await readAutoBackup());
+      } catch (_) {
+        sendDebugLog('org-try-auto-backup: failed to read auto-backup pref, treating as disabled');
+        return { attempted: false, reason: 'disabled' };
+      }
+      // If the seed didn't actually materialise a preference — adapter
+      // unreachable, seed subprocess failure, or a failed config write —
+      // the pref is still unset and `enabled` is only the historical default
+      // (true). Fail closed rather than auto-share against an org policy of
+      // auto_share_default=false that we couldn't read/persist. The user can
+      // re-enable explicitly, and the next recording re-attempts the seed.
+      if (!isSet) return { attempted: false, reason: 'disabled' };
     }
     if (!enabled) return { attempted: false, reason: 'disabled' };
 

--- a/e2e/fixtures/mock-adapter.js
+++ b/e2e/fixtures/mock-adapter.js
@@ -49,7 +49,7 @@ const json = (res, status, body) => {
  * @param {object} [opts.policy] override the /policy response.
  * @param {boolean} [opts.failS3Put] start with the S3 PUT returning 500 (used
  *   to exercise the upload-failure path). Toggle at runtime via setFailS3Put.
- * @returns {Promise<{ url: string, close: () => Promise<void>, s3Puts: () => number, setFailS3Put: (v: boolean) => void }>}
+ * @returns {Promise<{ url: string, close: () => Promise<void>, s3Puts: () => number, policyFetches: () => number, setFailS3Put: (v: boolean) => void }>}
  */
 function startMockAdapter(opts = {}) {
   const policy = opts.policy || { auto_share_default: true, shared_notes_enabled: true };
@@ -57,6 +57,7 @@ function startMockAdapter(opts = {}) {
   let idSeq = 0;
   let keySeq = 0;
   let s3PutCount = 0;
+  let policyFetchCount = 0;
   let failS3Put = Boolean(opts.failS3Put);
   let baseUrl = '';
 
@@ -85,6 +86,7 @@ function startMockAdapter(opts = {}) {
           });
         }
         if (method === 'GET' && url === '/policy') {
+          policyFetchCount++;
           return json(res, 200, policy);
         }
 
@@ -152,6 +154,7 @@ function startMockAdapter(opts = {}) {
         url: baseUrl,
         close: () => new Promise((r) => server.close(() => r())),
         s3Puts: () => s3PutCount,
+        policyFetches: () => policyFetchCount,
         setFailS3Put: (v) => {
           failS3Put = Boolean(v);
         },

--- a/e2e/specs/org-backup-seed-skip.t2.spec.ts
+++ b/e2e/specs/org-backup-seed-skip.t2.spec.ts
@@ -162,6 +162,13 @@ test('org auto_share_default=false is honored: gate stays fail-closed and nothin
       })
       .toBe(false);
 
+    // Baseline /policy fetches after the sign-in seed has settled, so we can
+    // prove the DISABLED path also skips the fetch (not just the enabled path
+    // in the first test) — a regression that re-fetched /policy but still read
+    // the cached disabled value would pass the fail-closed assertions below yet
+    // reintroduce the HTTP call #192 eliminates.
+    const policyFetchesBefore = adapter.policyFetches();
+
     const summaryFile = path.join(userDataDir, 'output', 'policy-false-note_summary.json');
     const result = await page.evaluate(
       (sf) =>
@@ -177,6 +184,9 @@ test('org auto_share_default=false is honored: gate stays fail-closed and nothin
     expect(result.attempted).toBe(false);
     if (!result.attempted) expect(result.reason).toBe('disabled');
     expect(adapter.s3Puts()).toBe(0); // nothing was auto-shared against the policy
+    // ...and the disabled path did NOT re-fetch /policy: the stored preference
+    // was read first and the seed skipped entirely (the whole point of #192).
+    expect(adapter.policyFetches()).toBe(policyFetchesBefore);
   } finally {
     await adapter.close();
   }

--- a/e2e/specs/org-backup-seed-skip.t2.spec.ts
+++ b/e2e/specs/org-backup-seed-skip.t2.spec.ts
@@ -78,9 +78,14 @@ test('steady-state auto-backup skips the /policy fetch + seed once a preference 
     // preference has actually materialised so the backup below is a genuine
     // steady-state read, not the one-time unset window.
     await expect
-      .poll(async () =>
-        (await page.evaluate(() => (window as StenoWindow).stenoai.org.getAutoBackup()))
-          .org_auto_backup_preference_set,
+      .poll(
+        async () =>
+          (await page.evaluate(() => (window as StenoWindow).stenoai.org.getAutoBackup()))
+            .org_auto_backup_preference_set,
+        // The sign-in seed is fire-and-forget (a /policy fetch + a seed
+        // subprocess); on a loaded CI runner it can exceed the default poll
+        // window, so give it a generous timeout rather than flaking.
+        { timeout: 30_000 },
       )
       .toBe(true);
 
@@ -154,12 +159,17 @@ test('org auto_share_default=false is honored: gate stays fail-closed and nothin
     // (return null until preference_set flips true, so the poll doesn't match
     // the pre-seed unset state), then assert the seeded value is disabled.
     await expect
-      .poll(async () => {
-        const ab = await page.evaluate(() =>
-          (window as StenoWindow).stenoai.org.getAutoBackup(),
-        );
-        return ab.org_auto_backup_preference_set === true ? ab.org_auto_backup_enabled : null;
-      })
+      .poll(
+        async () => {
+          const ab = await page.evaluate(() =>
+            (window as StenoWindow).stenoai.org.getAutoBackup(),
+          );
+          return ab.org_auto_backup_preference_set === true ? ab.org_auto_backup_enabled : null;
+        },
+        // Fire-and-forget sign-in seed — generous timeout so a slow CI runner
+        // doesn't flake this (see the first test).
+        { timeout: 30_000 },
+      )
       .toBe(false);
 
     // Baseline /policy fetches after the sign-in seed has settled, so we can

--- a/e2e/specs/org-backup-seed-skip.t2.spec.ts
+++ b/e2e/specs/org-backup-seed-skip.t2.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from '../fixtures/electron';
+import { startMockAdapter } from '../fixtures/mock-adapter';
+import path from 'path';
+
+/**
+ * T2 — steady-state auto-backup does NOT re-fetch /policy or re-seed.
+ *
+ * Issue #192: `org-try-auto-backup` used to `await seedOrgAutoBackupDefault()`
+ * on EVERY completed-recording backup — a GET /policy round-trip + a
+ * `seed-org-auto-backup` subprocess — even after the preference was already
+ * stored, where the seed is a no-op write. The fix reads the preference first
+ * (get-org-auto-backup now reports `org_auto_backup_preference_set`) and only
+ * pays the /policy fetch + seed in the genuinely-unset sign-in window.
+ *
+ * This drives the real gate against the mock adapter and asserts that once a
+ * preference exists (sign-in already seeds it), a backup performs zero extra
+ * /policy fetches — guarding the fix against regression. Model-free.
+ */
+
+type Result = { success: boolean; error?: string };
+type Meeting = { id: string; title?: string };
+type AutoBackupResult =
+  | { attempted: true; meeting: Meeting; s3_key: string }
+  | { attempted: false; reason: string; error?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    org: {
+      login: (
+        url: string,
+        email: string,
+        password: string,
+      ) => Promise<Result & { signedIn?: boolean }>;
+      status: () => Promise<{ signedIn: boolean }>;
+      getAutoBackup: () => Promise<
+        Result & { org_auto_backup_enabled?: boolean; org_auto_backup_preference_set?: boolean }
+      >;
+      tryAutoBackup: (payload: unknown) => Promise<AutoBackupResult>;
+    };
+  };
+};
+
+test('steady-state auto-backup skips the /policy fetch + seed once a preference exists', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const adapter = await startMockAdapter();
+  try {
+    const { app, page } = await launchApp();
+
+    // .org-session needs safeStorage; skip LOUDLY on a headless runner with no
+    // usable keyring (mirrors org-backup-failure.t2 — the org path can't
+    // persist there).
+    const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
+      safeStorage.isEncryptionAvailable(),
+    );
+    if (!encryptionAvailable) {
+      // eslint-disable-next-line no-console
+      console.warn('[t2] SKIPPED org-backup-seed-skip: safeStorage unavailable on this runner.');
+      test.info().annotations.push({
+        type: 'skip-reason',
+        description: 'safeStorage unavailable; org session cannot persist',
+      });
+    }
+    test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
+
+    const login = await page.evaluate(
+      (url) => (window as StenoWindow).stenoai.org.login(url, 'e2e@example.com', 'hunter2'),
+      adapter.url,
+    );
+    expect(login.success).toBe(true);
+    await expect
+      .poll(async () =>
+        (await page.evaluate(() => (window as StenoWindow).stenoai.org.status())).signedIn,
+      )
+      .toBe(true);
+
+    // Sign-in seeds the auto-backup default fire-and-forget. Wait until the
+    // preference has actually materialised so the backup below is a genuine
+    // steady-state read, not the one-time unset window.
+    await expect
+      .poll(async () =>
+        (await page.evaluate(() => (window as StenoWindow).stenoai.org.getAutoBackup()))
+          .org_auto_backup_preference_set,
+      )
+      .toBe(true);
+
+    // Baseline the /policy count AFTER the sign-in seed has settled.
+    const policyFetchesBefore = adapter.policyFetches();
+
+    const summaryFile = path.join(userDataDir, 'output', 'steady-note_summary.json');
+    const result = await page.evaluate(
+      (sf) =>
+        (window as StenoWindow).stenoai.org.tryAutoBackup({
+          summaryFile: sf,
+          title: 'Steady Note',
+          body: '# Steady Note\n\nbody',
+          visibility: 'org',
+        }),
+      summaryFile,
+    );
+
+    // The backup itself still works (default policy = auto_share_default true).
+    expect(result.attempted).toBe(true);
+    expect(adapter.s3Puts()).toBe(1);
+
+    // ...and it did NOT re-fetch /policy: the preference already existed, so
+    // the seed was skipped entirely. This is the whole point of issue #192.
+    expect(adapter.policyFetches()).toBe(policyFetchesBefore);
+  } finally {
+    await adapter.close();
+  }
+});
+
+test('org auto_share_default=false is honored: gate stays fail-closed and nothing uploads', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // The privacy-critical direction: an org whose policy disables auto-share
+  // must never have a note auto-backed-up. Sign-in seeds the (false) default
+  // into the local preference; the gate must then read disabled and upload
+  // nothing — this is the invariant the #192 read-first-then-seed refactor
+  // must preserve.
+  const adapter = await startMockAdapter({
+    policy: { auto_share_default: false, shared_notes_enabled: true },
+  });
+  try {
+    const { app, page } = await launchApp();
+
+    const encryptionAvailable = await app.evaluate(({ safeStorage }) =>
+      safeStorage.isEncryptionAvailable(),
+    );
+    if (!encryptionAvailable) {
+      // eslint-disable-next-line no-console
+      console.warn('[t2] SKIPPED org-backup-seed-skip (policy-false): safeStorage unavailable.');
+      test.info().annotations.push({
+        type: 'skip-reason',
+        description: 'safeStorage unavailable; org session cannot persist',
+      });
+    }
+    test.skip(!encryptionAvailable, 'safeStorage unavailable on this runner');
+
+    const login = await page.evaluate(
+      (url) => (window as StenoWindow).stenoai.org.login(url, 'e2e@example.com', 'hunter2'),
+      adapter.url,
+    );
+    expect(login.success).toBe(true);
+    await expect
+      .poll(async () =>
+        (await page.evaluate(() => (window as StenoWindow).stenoai.org.status())).signedIn,
+      )
+      .toBe(true);
+
+    // Sign-in seeds the org's false default; wait until it has materialised
+    // (return null until preference_set flips true, so the poll doesn't match
+    // the pre-seed unset state), then assert the seeded value is disabled.
+    await expect
+      .poll(async () => {
+        const ab = await page.evaluate(() =>
+          (window as StenoWindow).stenoai.org.getAutoBackup(),
+        );
+        return ab.org_auto_backup_preference_set === true ? ab.org_auto_backup_enabled : null;
+      })
+      .toBe(false);
+
+    const summaryFile = path.join(userDataDir, 'output', 'policy-false-note_summary.json');
+    const result = await page.evaluate(
+      (sf) =>
+        (window as StenoWindow).stenoai.org.tryAutoBackup({
+          summaryFile: sf,
+          title: 'Policy False Note',
+          body: '# Policy False Note\n\nbody',
+          visibility: 'org',
+        }),
+      summaryFile,
+    );
+
+    expect(result.attempted).toBe(false);
+    if (!result.attempted) expect(result.reason).toBe('disabled');
+    expect(adapter.s3Puts()).toBe(0); // nothing was auto-shared against the policy
+  } finally {
+    await adapter.close();
+  }
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4059,7 +4059,10 @@ def get_org_auto_backup():
     from src.config import get_config
 
     config = get_config()
-    print(json.dumps({"org_auto_backup_enabled": config.get_org_auto_backup_enabled()}))
+    print(json.dumps({
+        "org_auto_backup_enabled": config.get_org_auto_backup_enabled(),
+        "org_auto_backup_preference_set": config.has_org_auto_backup_preference(),
+    }))
 
 
 @cli.command()

--- a/src/config.py
+++ b/src/config.py
@@ -993,6 +993,13 @@ class Config:
         self._config["org_auto_backup_enabled"] = enabled
         return self._save()
 
+    def has_org_auto_backup_preference(self) -> bool:
+        """Whether a stored auto-backup preference exists yet. Distinguishes
+        an unset pref (no key) from an explicit False, so the desktop can skip
+        the sign-in `/policy` fetch + seed once a preference exists and only
+        pays it in the genuinely-unset sign-in window (see issue #192)."""
+        return "org_auto_backup_enabled" in self._config
+
     def seed_org_auto_backup_default(self, default: bool) -> bool:
         """Seed the auto-backup preference from the enterprise adapter's
         `auto_share_default` policy, but ONLY if the user has no stored

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -408,6 +408,29 @@ class ConfigOrgAutoBackupTests(unittest.TestCase):
             self.assertTrue(config.seed_org_auto_backup_default(False))
             self.assertTrue(config.get_org_auto_backup_enabled())
 
+    def test_has_preference_distinguishes_unset_from_explicit_false(self):
+        """The gate skips the /policy fetch + seed once a preference exists, so
+        'unset' must be distinguishable from an explicit False (issue #192)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.json"
+            config = Config(config_path=path)
+            # Fresh config: no stored preference (get still defaults to True).
+            self.assertFalse(config.has_org_auto_backup_preference())
+            self.assertTrue(config.get_org_auto_backup_enabled())
+            # An explicit False is a real preference, not "unset".
+            self.assertTrue(config.set_org_auto_backup_enabled(False))
+            self.assertTrue(config.has_org_auto_backup_preference())
+            self.assertTrue(Config(config_path=path).has_org_auto_backup_preference())
+
+    def test_has_preference_true_after_seed(self):
+        """Seeding the org default materialises a preference, so subsequent
+        backups can skip the seed."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = Config(config_path=Path(tmp_dir) / "config.json")
+            self.assertFalse(config.has_org_auto_backup_preference())
+            config.seed_org_auto_backup_default(True)
+            self.assertTrue(config.has_org_auto_backup_preference())
+
 
 class ConfigKeepRecordingsTests(unittest.TestCase):
     def test_default_keep_recordings_is_false(self):


### PR DESCRIPTION
Fixes #192.

## Problem

`org-try-auto-backup` in `app/main.js` `await`ed `seedOrgAutoBackupDefault()` on **every** completed-recording backup — a `GET /policy` round-trip **plus** a `seed-org-auto-backup` Python subprocess — even after the user's auto-backup preference was already stored, where the seed is a no-op write. The handler then also spawned `get-org-auto-backup`. So a steady-state backup paid an HTTP fetch + 2 subprocess spawns when it only needed the stored preference, compounding across many recordings per day.

The `await` couldn't simply be dropped: it deliberately closes the Cubic **P1** sign-in seeding race (a recording finishing right after sign-in could read the pref before the org default was seeded, and an unset pref reads as enabled → auto-share against an org `auto_share_default=false`).

## Fix

The issue's prescribed "safer direction": only fetch `/policy` + seed when the preference is genuinely **unset**.

- **`src/config.py`** — new `has_org_auto_backup_preference()` distinguishes "unset" (no key) from an explicit `False`.
- **`simple_recorder.py`** — `get-org-auto-backup` now also emits `org_auto_backup_preference_set`.
- **`app/main.js`** — the gate reads the preference first and only pays the `/policy` fetch + seed in the genuinely-unset sign-in window (P1). Once a preference exists (user choice **or** a prior seed), the seed is skipped entirely.
  - Steady state: `1` subprocess, `0` HTTP (was `1` HTTP + `2` subprocess).
  - After seeding in the unset path, the code now **requires the preference to have materialised** (`isSet === true`) before allowing backup — closing a latent fail-open when the seed can't persist (adapter unreachable, subprocess failure, or a failed config write), so we never auto-share against an org policy we couldn't read/persist.

Manual Share (`org-share-meeting`) and the settings toggle are untouched; the new JSON field is additive.

## Tests

- **`tests/test_config.py`** — `has_org_auto_backup_preference` distinguishes unset / explicit-false / post-seed.
- **`e2e/specs/org-backup-seed-skip.t2.spec.ts`** (new, model-free T2 via the preload bridge):
  - steady-state backup performs **zero** extra `/policy` fetches (new `policyFetches()` counter on the mock adapter);
  - `auto_share_default=false` stays **fail-closed** — nothing is uploaded (`s3Puts === 0`).
- `org-backup-failure.t2` still green (no regression).

## Verification

- Real backend CLI: `unset → {enabled:true, preference_set:false}`, `explicit false → {enabled:false, preference_set:true}`.
- Rebuilt the PyInstaller bundle so T2 exercises the real backend; T2 suite **3/3 pass**; config unit tests **5/5 pass**; `ruff` clean on touched files.
- Cross-family review (Codex, high effort): no critical; one medium (the fail-open above) + one low (coverage) — both adopted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the `/policy` fetch and seed on steady-state org auto-backups by reading the stored preference first and only seeding when it’s unset. This reduces work per backup and closes a fail-open edge case; addresses #192.

- **Bug Fixes**
  - Gate reads the stored preference via `get-org-auto-backup` (new `org_auto_backup_preference_set`) and seeds only when truly unset.
  - After seeding, requires the preference to exist before proceeding (fail-closed to prevent unintended auto-share).
  - Steady state now does 0 HTTP calls and 1 subprocess (was 1 HTTP + 2 subprocess).
  - Added `has_org_auto_backup_preference()` in config and exposed it in `simple_recorder.py`; T2 covers enabled and disabled paths, asserting no `/policy` re-fetch with `policyFetches()` and using a longer poll timeout to avoid CI flakes.

<sup>Written for commit d43c7e45d7f25f4ae954f846e09601b50fcb11ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

