### PR TITLE
feat(settings): warn when a local model may exceed available memory (#248)

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -636,6 +636,9 @@ function install({ ipcMain }) {
       success: true,
       current_model: 'gemma4:e2b-it-qat',
       provider: 'local',
+      // A 16 GB Mac: enough for the small models but not gemma4:12b / gpt-oss:20b,
+      // which drives the "May exceed memory" badge (see model-memory.ts, #248).
+      total_ram_gb: 16,
       supported_models: {
         'gemma4:e2b-it-qat': {
           name: 'Gemma 4 E2B (QAT)',

--- a/app/main.js
+++ b/app/main.js
@@ -6366,6 +6366,15 @@ ipcMain.handle('list-models', async () => {
     const result = await runPythonScript('simple_recorder.py', ['list-models']);
     const jsonData = JSON.parse(result);
 
+    // Machine RAM (GB), used by the renderer to flag local models that may
+    // exceed available memory. macOS-only: the heuristic + the "your Mac" copy
+    // are calibrated for Apple Silicon unified memory; on Windows the field is
+    // omitted so no badge shows (Windows VRAM/DirectML detection is out of
+    // scope — #248). Computed once per Settings-open list() call.
+    if (process.platform === 'darwin') {
+      jsonData.total_ram_gb = os.totalmem() / (1024 ** 3);
+    }
+
     return {
       success: true,
       ...jsonData

--- a/app/renderer/src/hooks/useModels.ts
+++ b/app/renderer/src/hooks/useModels.ts
@@ -42,7 +42,12 @@ function parseSizeGb(size?: string): number | undefined {
 export function useModels() {
   return useQuery({
     queryKey: modelsKeys.list(),
-    queryFn: async (): Promise<{ models: ListedModel[]; current: string; provider: string }> => {
+    queryFn: async (): Promise<{
+      models: ListedModel[];
+      current: string;
+      provider: string;
+      totalRamGb?: number;
+    }> => {
       const raw = unwrap(await ipc().models.list());
       const models: ListedModel[] = Object.entries(raw.supported_models).map(([id, info]) => ({
         name: id,
@@ -59,7 +64,7 @@ export function useModels() {
         mlxSizeGb: parseSizeGb(info.mlx_size),
         ggufInstalled: info.gguf_installed,
       }));
-      return { models, current: raw.current_model, provider: raw.provider };
+      return { models, current: raw.current_model, provider: raw.provider, totalRamGb: raw.total_ram_gb };
     },
   });
 }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -439,6 +439,9 @@ export type ListModelsResponse = Result<{
   supported_models: Record<string, RawSupportedModel>;
   current_model: string;
   provider: string;
+  // Machine RAM in GB (main.js attaches os.totalmem()); used to flag local
+  // models that may exceed available memory. Absent -> never warn.
+  total_ram_gb?: number;
 }>;
 export type GetCurrentModelResponse = Result<{ model: string }>;
 

--- a/app/renderer/src/routes/settings/AiTab.tsx
+++ b/app/renderer/src/routes/settings/AiTab.tsx
@@ -58,6 +58,7 @@ import {
 import { useOrgSession } from '@/hooks/useOrg';
 import { COMPACT_BTN, COMPACT_INPUT, COMPACT_TRIGGER, SectionHeading, SettingRow } from './primitives';
 import { ModelCard, formatModelSize, isDefaultModel, parsePullPercent } from './model-card';
+import { modelMayExceedMemory } from './model-memory';
 import { LANGUAGES_PARAKEET, LANGUAGES_WHISPER } from './languages';
 
 export function AiTab() {
@@ -890,6 +891,11 @@ function ModelList() {
   }
 
   const isRemote = models.data.provider === 'remote';
+  // The RAM-suitability badge only makes sense for the bundled local Ollama:
+  // for remote-Ollama or any cloud provider the model runs off-machine, so
+  // this Mac's memory is irrelevant. Gate strictly on 'local'.
+  const isLocal = models.data.provider === 'local';
+  const totalRamGb = models.data.totalRamGb;
   const sorted = [...models.data.models].sort(
     (a, b) => (a.deprecated ? 1 : 0) - (b.deprecated ? 1 : 0),
   );
@@ -935,6 +941,7 @@ function ModelList() {
     // size is what's really on disk.
     const showMlxSize = m.mlxTag && m.mlxSizeGb !== undefined && (m.mlxInstalled || !m.ggufInstalled);
     const sizeLabel = formatModelSize(showMlxSize ? m.mlxSizeGb : m.size_gb);
+    const memoryWarning = isLocal && modelMayExceedMemory(m.size_gb, totalRamGb);
     const fasterBuildBlocked =
       Boolean(fasterBuild.activeTag) &&
       !isFasterBuildActive &&
@@ -976,6 +983,7 @@ function ModelList() {
         isCurrent={isCurrent}
         isDefault={isDefault}
         deprecated={Boolean(m.deprecated)}
+        memoryWarning={memoryWarning}
         isDownloading={isDownloading}
         downloadProgress={downloadProgress}
         downloadBytesPerSecond={pull.bytesPerSecond[pullTarget]}

--- a/app/renderer/src/routes/settings/model-card.tsx
+++ b/app/renderer/src/routes/settings/model-card.tsx
@@ -163,6 +163,11 @@ interface ModelCardProps {
   fasterBuildBlocked?: boolean;
   onSwitchToFasterBuild?: () => void;
   onCancelFasterBuild?: () => void;
+  // Non-blocking caution: the model's footprint likely exceeds this Mac's
+  // usable memory, so summarising with it may run slowly or fail. Only set for
+  // local Ollama models (the RAM check is meaningless for remote/cloud). Shows
+  // a subtle badge next to the name — never disables selection (see #248).
+  memoryWarning?: boolean;
 }
 
 export function ModelCard({
@@ -189,6 +194,7 @@ export function ModelCard({
   fasterBuildBlocked = false,
   onSwitchToFasterBuild,
   onCancelFasterBuild,
+  memoryWarning = false,
 }: ModelCardProps) {
   return (
     <div
@@ -273,6 +279,19 @@ export function ModelCard({
               }}
             >
               MLX model
+            </span>
+          )}
+          {memoryWarning && (
+            <span
+              className="rounded-[3px] px-1.5 py-px text-[11px]"
+              title="This model may exceed your Mac's available memory and could run slowly or fail."
+              style={{
+                background: 'var(--danger-bg)',
+                color: 'var(--danger)',
+                border: '1px solid var(--danger)',
+              }}
+            >
+              May exceed memory
             </span>
           )}
         </div>

--- a/app/renderer/src/routes/settings/model-memory.test.ts
+++ b/app/renderer/src/routes/settings/model-memory.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'vitest';
+import { modelMayExceedMemory } from './model-memory';
+
+// Pins the memory-suitability heuristic behind the "May exceed memory" badge
+// (#248): on a 16 GB Mac the two large local models (gemma4:12b 7.2 GB,
+// gpt-oss:20b 14 GB) warn, while the small ones (e2b/e4b/qwen <= 6.6 GB) do
+// not; on a 64 GB Mac nothing warns; and any unknown input never warns (the
+// badge must stay non-blocking).
+describe('modelMayExceedMemory', () => {
+  test('16 GB Mac: warns on models too large, not on small ones', () => {
+    const ram = 16;
+    // Small models — fit comfortably.
+    expect(modelMayExceedMemory(4.3, ram)).toBe(false); // gemma4:e2b
+    expect(modelMayExceedMemory(6.1, ram)).toBe(false); // gemma4:e4b
+    expect(modelMayExceedMemory(6.6, ram)).toBe(false); // qwen3.5:9b
+    // Large models — over the usable budget.
+    expect(modelMayExceedMemory(7.2, ram)).toBe(true); // gemma4:12b
+    expect(modelMayExceedMemory(14, ram)).toBe(true); // gpt-oss:20b
+  });
+
+  test('64 GB Mac: nothing warns', () => {
+    const ram = 64;
+    for (const size of [4.3, 6.1, 6.6, 7.2, 14]) {
+      expect(modelMayExceedMemory(size, ram)).toBe(false);
+    }
+  });
+
+  test('unknown or zero inputs never warn (non-blocking)', () => {
+    expect(modelMayExceedMemory(undefined, 16)).toBe(false);
+    expect(modelMayExceedMemory(7.2, undefined)).toBe(false);
+    expect(modelMayExceedMemory(undefined, undefined)).toBe(false);
+    // Zero is treated as "unknown" (falsy) — never warn.
+    expect(modelMayExceedMemory(0, 16)).toBe(false);
+    expect(modelMayExceedMemory(7.2, 0)).toBe(false);
+  });
+
+  test('exact boundary does not warn (strict >)', () => {
+    // 6.6 + 3 === 16 * 0.6 === 9.6 -> not strictly greater, so no warn.
+    expect(modelMayExceedMemory(6.6, 16)).toBe(false);
+  });
+});

--- a/app/renderer/src/routes/settings/model-memory.ts
+++ b/app/renderer/src/routes/settings/model-memory.ts
@@ -1,0 +1,16 @@
+// Heuristic: a local model "may exceed memory" when its on-disk (GGUF)
+// size plus runtime headroom exceeds the fraction of unified memory the OS
+// will realistically let the model use. Calibrated so a 16 GB Mac warns on
+// gemma4:12b (7.2 GB) + gpt-oss:20b (14 GB) but not e2b/e4b/qwen (<=6.6 GB).
+// Apple Silicon unified memory is dynamically GPU-capped (~67-75%); this is
+// a deliberately conservative heuristic, not an exact measurement.
+export const RAM_USABLE_FRACTION = 0.6;
+export const RUNTIME_HEADROOM_GB = 3;
+
+export function modelMayExceedMemory(
+  sizeGb: number | undefined,
+  totalRamGb: number | undefined,
+): boolean {
+  if (!sizeGb || !totalRamGb) return false; // unknown -> never warn (non-blocking)
+  return sizeGb + RUNTIME_HEADROOM_GB > totalRamGb * RAM_USABLE_FRACTION;
+}

--- a/e2e/specs/model-memory-warning.t1.spec.ts
+++ b/e2e/specs/model-memory-warning.t1.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 — renderer-only, mock IPC, no backend. Proves the "May exceed memory"
+ * badge (#248): the mocked `list-models` reports a 16 GB Mac (total_ram_gb: 16)
+ * with the full local Ollama catalog, so the two large models
+ * (gemma4:12b 7.2 GB, gpt-oss:20b 14 GB) get the caution badge while the small
+ * default (gemma4:e2b 4.3 GB) does not. The badge is non-blocking — the pure
+ * heuristic itself is unit-tested in model-memory.test.ts; this pins the
+ * provider gate + prop wiring through the real card UI.
+ */
+test('flags local models that may exceed this Mac\'s memory', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true });
+
+  await page.evaluate(() => {
+    window.location.hash = '#/settings?tab=ai';
+  });
+
+  const aiSection = page.locator('[data-settings-tab="ai"]');
+  await expect(aiSection).toBeVisible();
+
+  // Each model row is a card whose root carries the rounded-[8px] class; filter
+  // by the model id to scope to a single card.
+  const card = (id: string) => aiSection.locator('div.rounded-\\[8px\\]', { hasText: id });
+
+  // Wait for the list to render before asserting badge presence/absence.
+  await expect(card('gemma4:e2b-it-qat')).toBeVisible();
+
+  // Large models warn.
+  await expect(card('gemma4:12b-it-qat').getByText('May exceed memory')).toBeVisible();
+  await expect(card('gpt-oss:20b').getByText('May exceed memory')).toBeVisible();
+
+  // The small default does not.
+  await expect(card('gemma4:e2b-it-qat').getByText('May exceed memory')).toHaveCount(0);
+});


### PR DESCRIPTION
Fixes #248.

## Problem

Selecting a local model that's too large for the machine (e.g. `gemma4:12b` on a 16 GB Mac) makes summarization silently time out or OOM — the error only surfaces after a multi-minute wait. There's no upfront signal that the selected model is likely too big.

## Fix

A non-blocking **"May exceed memory"** badge next to over-large models in the local-Ollama model picker, exactly as the issue proposes:

- **Machine RAM** via `os.totalmem()`, attached to the `list-models` response in `main.js` (dependency-free, computed once at Settings-open — no per-render cost). **macOS-only**: the heuristic + copy are calibrated for Apple Silicon unified memory, so the field is omitted on Windows (Windows VRAM/DirectML detection is out of scope per the issue).
- **Model size** reuses the existing on-disk `size_gb` from `useModels`.
- **Threshold** (`app/renderer/src/routes/settings/model-memory.ts`): `size_gb + 3 > totalRamGb × 0.6`, calibrated on the real registry so a 16 GB Mac warns on `gemma4:12b` (7.2 GB) + `gpt-oss:20b` (14 GB) but not e2b (4.3) / e4b (6.1) / qwen (6.6).
- Gated strictly to `provider === 'local'` — the badge never shows for remote-Ollama or cloud providers, where the local-RAM check is meaningless. Selection is never blocked.

## Tests
- Vitest unit test for the pure `modelMayExceedMemory` helper (calibration + undefined/zero/boundary inputs).
- Model-free T1 spec asserting the badge shows on the 12b/20b cards and not on e2b.

## Verification
- `typecheck:renderer` clean, `lint:renderer` no new warnings, renderer unit suite green, T1 badge spec green.
- Cross-family review (Codex, high effort): no critical; the macOS platform-gate + a zero-input test case were adopted from it.

## Notes
- Badge uses the `--danger` tokens for the caution — open to a softer amber if preferred (no amber token exists yet).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a non-blocking “May exceed memory” badge in the local model picker to warn when a model likely won’t fit your Mac’s RAM, avoiding long timeouts and OOMs. Addresses #248.

- **New Features**
  - macOS only: expose `total_ram_gb` from `list-models` using `os.totalmem()`; omitted on Windows.
  - Heuristic: `size_gb + 3 > totalRamGb * 0.6`; uses existing on-disk `size_gb`.
  - Gated to `provider === 'local'`; badge never blocks selection and never shows for remote/cloud.

<sup>Written for commit b72af714ae33383ab19cbbdd491bece75e8bb690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

