### PR TITLE
feat(auto-detect): gate meeting auto-detect to macOS 14+ (#116)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -42,7 +42,7 @@ const { createDebugLog } = require('./debug-log');
 const { createTeardownRegistry } = require('./teardown');
 const { registerFoldersIpc } = require('./folders-ipc');
 const processingLog = require('./processing-log');
-const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
+const { isMeetingApp, allowsDeviceLevelFallback, isMacos14Plus } = require('./meeting-detect');
 const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
 const { userNotesFilePath } = require('./notes-file');
 const { makeLineReader } = require('./backend-stream');
@@ -136,6 +136,21 @@ function isCoreAudioTapSupported() {
     return maj > 14 || (maj === 14 && min >= 4);
   } catch (_) {
     return false;
+  }
+}
+
+// Whether the auto-detect-meetings watcher may run on this OS. Gated to
+// macOS 14+ because the mic-monitor only has a reliable per-app signal there;
+// on macOS 12/13 it falls back to a coarse device-level signal that misfires
+// (see #116). Pure version logic lives in ./meeting-detect (unit-tested).
+function isAutoDetectSupported() {
+  try {
+    return isMacos14Plus(process.platform, process.getSystemVersion());
+  } catch (_) {
+    // A getSystemVersion() throw is treated like an unparseable version:
+    // permissive (true) so a real 14+ user never loses the feature over a
+    // probe hiccup — mirrors isMacos14Plus's parse-failure direction.
+    return true;
   }
 }
 
@@ -5690,6 +5705,10 @@ function setupAutoMeetingDetector() {
     sendDebugLog('[auto-detect] disabled in settings; not starting');
     return;
   }
+  if (!isAutoDetectSupported()) {
+    sendDebugLog('[auto-detect] requires macOS 14 (Sonoma) or later; not starting');
+    return;
+  }
   startMicMonitor();
 }
 
@@ -7197,6 +7216,8 @@ ipcMain.handle('set-auto-detect-meetings', async (_event, enabled) => {
           sendDebugLog('[auto-detect] E2E mode; setting saved but watcher not started');
         } else if (!app.isPackaged && !process.env[AUTO_DETECT_ENV]) {
           sendDebugLog(`[auto-detect] dev mode without ${AUTO_DETECT_ENV}=1; setting saved but watcher not started`);
+        } else if (!isAutoDetectSupported()) {
+          sendDebugLog('[auto-detect] requires macOS 14 (Sonoma) or later; setting saved but watcher not started');
         } else {
           startMicMonitor();
         }

--- a/app/main.js
+++ b/app/main.js
@@ -147,10 +147,11 @@ function isAutoDetectSupported() {
   try {
     return isMacos14Plus(process.platform, process.getSystemVersion());
   } catch (_) {
-    // A getSystemVersion() throw is treated like an unparseable version:
-    // permissive (true) so a real 14+ user never loses the feature over a
-    // probe hiccup — mirrors isMacos14Plus's parse-failure direction.
-    return true;
+    // A getSystemVersion() throw is treated like an unparseable version, but
+    // only PERMISSIVELY on darwin (a real 14+ Mac must never lose the feature
+    // over a probe hiccup). On non-darwin the feature is unsupported regardless,
+    // so a throw there stays false — consistent with isMacos14Plus.
+    return process.platform === 'darwin';
   }
 }
 

--- a/app/meeting-detect.js
+++ b/app/meeting-detect.js
@@ -39,10 +39,28 @@ function allowsDeviceLevelFallback(platform, systemVersion) {
   return major < 14;
 }
 
+// Whether the auto-detect-meetings watcher may run on this OS. The mic-monitor
+// only has a reliable per-app signal on macOS 14+; on macOS 12/13 it falls back
+// to a coarse device-level ("an app") signal that misfires (see #116, #262), so
+// we gate the whole feature to macOS 14+ and never spawn the watcher below it.
+// Non-darwin returns false — auto-detect is a macOS-only feature.
+//
+// Parse direction on failure is PERMISSIVE: an unparseable version returns true.
+// Auto-detect is opt-in and the <14 device-level path is exactly what we're
+// removing, so a parse hiccup must not silently disable the feature for a real
+// 14+ user. The worst case — a genuinely old-but-unparseable system — is the
+// pre-existing coarse fallback, which the mic-monitor binary itself still guards.
+function isMacos14Plus(platform, systemVersion) {
+  if (platform !== 'darwin') return false;
+  const major = parseInt(String(systemVersion).split('.')[0], 10);
+  if (!Number.isFinite(major)) return true; // permissive on parse failure — see above
+  return major >= 14;
+}
+
 function isMeetingApp(evt, { allowDeviceLevelFallback = false } = {}) {
   if (!evt) return false;
   if (!evt.app_id) return allowDeviceLevelFallback;
   return MEETING_APP_ALLOWLIST.some((re) => re.test(evt.app_id));
 }
 
-module.exports = { MEETING_APP_ALLOWLIST, isMeetingApp, allowsDeviceLevelFallback };
+module.exports = { MEETING_APP_ALLOWLIST, isMeetingApp, allowsDeviceLevelFallback, isMacos14Plus };

--- a/app/meeting-detect.test.js
+++ b/app/meeting-detect.test.js
@@ -1,7 +1,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 
-const { isMeetingApp, allowsDeviceLevelFallback } = require('./meeting-detect');
+const { isMeetingApp, allowsDeviceLevelFallback, isMacos14Plus } = require('./meeting-detect');
 
 test('isMeetingApp accepts a known meeting app bundle id', () => {
   assert.strictEqual(isMeetingApp({ app_id: 'us.zoom.xos' }), true);
@@ -63,4 +63,29 @@ test('allowsDeviceLevelFallback is false off macOS', () => {
 test('allowsDeviceLevelFallback is false for an unparseable version (fail safe)', () => {
   assert.strictEqual(allowsDeviceLevelFallback('darwin', ''), false);
   assert.strictEqual(allowsDeviceLevelFallback('darwin', undefined), false);
+});
+
+test('isMacos14Plus is true on macOS 14+', () => {
+  assert.strictEqual(isMacos14Plus('darwin', '14.0'), true);
+  assert.strictEqual(isMacos14Plus('darwin', '14.5'), true);
+  assert.strictEqual(isMacos14Plus('darwin', '15.0'), true);
+  assert.strictEqual(isMacos14Plus('darwin', '26.1'), true);
+});
+
+test('isMacos14Plus is false on legacy macOS 12/13', () => {
+  assert.strictEqual(isMacos14Plus('darwin', '13.6.1'), false);
+  assert.strictEqual(isMacos14Plus('darwin', '12.0'), false);
+});
+
+test('isMacos14Plus is false off macOS (macOS-only feature)', () => {
+  assert.strictEqual(isMacos14Plus('win32', '10.0.22631'), false);
+  assert.strictEqual(isMacos14Plus('linux', '6.1'), false);
+});
+
+test('isMacos14Plus is permissive (true) for an unparseable version on darwin', () => {
+  // Auto-detect is opt-in and the <14 path is what we're removing, so a parse
+  // hiccup must NOT silently disable a working 14+ user's feature — see #116.
+  assert.strictEqual(isMacos14Plus('darwin', ''), true);
+  assert.strictEqual(isMacos14Plus('darwin', undefined), true);
+  assert.strictEqual(isMacos14Plus('darwin', 'garbage'), true);
 });

--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -57,8 +57,17 @@ const h = vi.hoisted(() => {
       data: {
         supported: true,
         osVersion: '14.4',
+        platform: 'darwin',
         screenPermission: 'granted' as string,
         screenPermissionAtLaunch: 'granted' as string,
+      } as {
+        supported: boolean;
+        osVersion: string;
+        // Optional so the existing (platform-less) reassignments below and the
+        // new macOS-14-gate cases (which set platform) both typecheck (#116).
+        platform?: string;
+        screenPermission: string;
+        screenPermissionAtLaunch: string;
       },
       refetch: vi.fn(),
     },
@@ -525,5 +534,33 @@ describe('GeneralTab Record system audio — Screen Recording permission', () =>
     expect(screen.queryByRole('button', { name: 'Open Settings' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Check Again' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Relaunch' })).toBeNull();
+  });
+
+  test('auto-detect: shows a "Requires macOS 14" note on macOS < 14 (#116)', () => {
+    // The mic-monitor only has a reliable per-app signal on macOS 14+, so the
+    // Auto-detected meetings row is gated below that — see isMacos14Plus.
+    h.systemAudioSupport.data = {
+      supported: false,
+      osVersion: '13.6.1',
+      platform: 'darwin',
+      screenPermission: 'granted',
+      screenPermissionAtLaunch: 'granted',
+    };
+    render(<GeneralTab />);
+    expect(
+      screen.getByText(/Requires macOS 14 \(Sonoma\) or later, you're on 13\.6\.1\./),
+    ).toBeTruthy();
+  });
+
+  test('auto-detect: no macOS-14 note on macOS 14+', () => {
+    h.systemAudioSupport.data = {
+      supported: true,
+      osVersion: '14.4',
+      platform: 'darwin',
+      screenPermission: 'granted',
+      screenPermissionAtLaunch: 'granted',
+    };
+    render(<GeneralTab />);
+    expect(screen.queryByText(/Requires macOS 14 \(Sonoma\) or later/)).toBeNull();
   });
 });

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -98,14 +98,17 @@ export function GeneralTab() {
   })();
   const autoDetect = useAutoDetectMeetingsSetting();
   const setAutoDetect = useSetAutoDetectMeetings();
-  // Auto-detect is gated to macOS 14+ (mic-monitor only has a reliable per-app
-  // signal there — see #116). Derive support from the system-audio probe's
-  // platform + osVersion so the toggle reflects the same gate main.js enforces.
-  // Only claim unsupported once we know the OS is darwin < 14; while the probe
-  // is loading (data undefined) we don't disable, matching the existing rows.
+  // Auto-detect is a macOS-14+ feature (the mic-monitor binary is macOS-only and
+  // only has a reliable per-app signal on 14+ — see #116). Mirror main's
+  // isAutoDetectSupported() exactly so the toggle isn't a no-op-but-enabled
+  // control: non-darwin is unsupported (main never spawns the watcher there), and
+  // darwin < 14 is unsupported. While the probe is loading (data undefined) we
+  // don't disable (matching the other rows); a darwin osVersion that won't parse
+  // stays permissive (a real 14+ user must never lose the feature over a hiccup).
   const autoDetectSupported = (() => {
     const data = systemAudioSupport.data;
-    if (!data || data.platform !== 'darwin') return true;
+    if (!data) return true; // probe still loading — don't disable prematurely
+    if (data.platform !== 'darwin') return false; // macOS-only feature
     const major = parseInt(String(data.osVersion).split('.')[0], 10);
     if (!Number.isFinite(major)) return true; // permissive on parse failure
     return major >= 14;

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -98,6 +98,18 @@ export function GeneralTab() {
   })();
   const autoDetect = useAutoDetectMeetingsSetting();
   const setAutoDetect = useSetAutoDetectMeetings();
+  // Auto-detect is gated to macOS 14+ (mic-monitor only has a reliable per-app
+  // signal there — see #116). Derive support from the system-audio probe's
+  // platform + osVersion so the toggle reflects the same gate main.js enforces.
+  // Only claim unsupported once we know the OS is darwin < 14; while the probe
+  // is loading (data undefined) we don't disable, matching the existing rows.
+  const autoDetectSupported = (() => {
+    const data = systemAudioSupport.data;
+    if (!data || data.platform !== 'darwin') return true;
+    const major = parseInt(String(data.osVersion).split('.')[0], 10);
+    if (!Number.isFinite(major)) return true; // permissive on parse failure
+    return major >= 14;
+  })();
   const launchOnLogin = useLaunchOnLoginSetting();
   const setLaunchOnLogin = useSetLaunchOnLogin();
   const silenceAutoStop = useSilenceAutoStopSetting();
@@ -360,12 +372,18 @@ export function GeneralTab() {
 
       <SettingRow
         label="Auto-detected meetings"
-        description="Watch for other apps using your microphone and notify you when a call starts, with a one-click button to record."
+        description={
+          autoDetectSupported
+            ? 'Watch for other apps using your microphone and notify you when a call starts, with a one-click button to record.'
+            : `Watch for other apps using your microphone and notify you when a call starts. Requires macOS 14 (Sonoma) or later${
+                systemAudioSupport.data?.osVersion ? `, you're on ${systemAudioSupport.data.osVersion}` : ''
+              }.`
+        }
       >
         <Switch
-          checked={autoDetect.data ?? true}
+          checked={autoDetectSupported && (autoDetect.data ?? true)}
           onCheckedChange={(v) => setAutoDetect.mutate(v)}
-          disabled={autoDetect.data === undefined}
+          disabled={autoDetect.data === undefined || !autoDetectSupported}
         />
       </SettingRow>
 


### PR DESCRIPTION
Implements **Part 1** of #116.

## What

Gate the auto-detect-meetings feature to **macOS 14+**. On macOS 12/13 the `mic-monitor` only has a coarse device-level ("an app") fallback that misfires and can't attribute the app — bad enough UX that those users would ignore it. This stops spawning the watcher below macOS 14.

- New pure, unit-tested `isMacos14Plus(platform, systemVersion)` in `app/meeting-detect.js` (mirrors the existing `allowsDeviceLevelFallback`). Non-darwin → false. **Permissive on an unparseable version** (returns true) so a real 14+ user never loses the feature over a probe hiccup — the worst case (genuinely old + unparseable) is still guarded by the mic-monitor binary itself.
- `main.js`: `isAutoDetectSupported()` wraps it and gates **both** `setupAutoMeetingDetector()` and the `set-auto-detect-meetings` live-restart branch, so toggling on at runtime on <14 persists the preference but never spawns.
- `GeneralTab`: on darwin <14 the toggle is disabled with a "Requires macOS 14 (Sonoma) or later" note (derived from the existing system-audio probe's `osVersion` — no new IPC). Non-darwin stays permissive so Windows behavior is unchanged.

## Scope

Part 1 only. **Part 2** (raising `LSMinimumSystemVersion` to 14.4 and dropping `NSScreenCaptureUsageDescription`) is deliberately left out — the issue itself flags it as a product call needing install-base data. `package.json` / `Info.plist` / entitlements are untouched.

Deferred follow-up: the now-unreachable Swift/JS device-level fallback (`mic_monitor.swift`, `allowsDeviceLevelFallback`) is left in place — removing it is dead-code cleanup that needs a `mic-monitor` binary rebuild.

## Tests / verification
- `node --test app/meeting-detect.test.js` — new `isMacos14Plus` cases (14/15/26 → true; 12/13/non-darwin → false; unparseable → permissive true).
- `GeneralTab.test.tsx` — 2 new cases; full file 22/22.
- `typecheck:renderer` clean, `lint:renderer` no new warnings. Config persistence of the toggle is unchanged (the gate sits only on the spawn branch; the e2e `IS_E2E` early-return is unaffected).
- Cross-family review (Codex): no critical; a stale test-mock typecheck failure it caught was fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate meeting auto-detect to macOS 14+ and treat non‑macOS as unsupported; the watcher never starts on macOS 12/13 or other platforms, and the Settings toggle is disabled with a clear requirement note. Implements Part 1 of #116.

- **New Features**
  - Add `isMacos14Plus(platform, systemVersion)` to gate auto-detect; non‑darwin → false, unparseable versions on darwin → true (permissive).
  - Main: `isAutoDetectSupported()` wraps startup and live-restart paths; catches `getSystemVersion()` errors (permissive on darwin only) and logs when blocked.
  - Settings: disable the toggle when unsupported (macOS <14 or non‑darwin) and show “Requires macOS 14 (Sonoma) or later,” including the detected OS version when available.
  - Tests: unit tests for `isMacos14Plus` and renderer tests for the gated toggle; updated types to allow optional `platform` in the system-audio probe.

<sup>Written for commit 37125e01b1031c6803255348a9a3b9c8c1b81d60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

