### PR TITLE
feat(meetings): re-transcribe an existing recording (#266)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -2253,7 +2253,7 @@ ipcMain.handle('clear-state', async () => {
   }
 });
 
-ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, sessionName) => {
+ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, sessionName, retranscribe) => {
   try {
     // Security: symlink-safe containment-check the renderer-supplied summary path
     // before it reaches the backend CLI, and pass the canonical realPath (not the
@@ -2267,6 +2267,10 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
 
     const args = ['reprocess', realPath];
     if (regenerateTitle) args.push('--regenerate-title');
+    // Re-transcribe (#266): re-run ASR on the source recording with the current
+    // settings before re-summarising. The backend emits HEARTBEAT:transcribe:*
+    // during ASR, which the same inactivity watchdog below already resets on.
+    if (retranscribe) args.push('--retranscribe');
 
     sendDebugLog(`🔄 Reprocessing meeting: ${summaryFile}`);
     sendDebugLog(`$ stenoai ${args.join(' ')}`);
@@ -2383,6 +2387,46 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
     return { success: false, error: error.message };
   } finally {
     activeReprocessJobs.delete(summaryFile);
+  }
+});
+
+// Re-transcribe availability (#266): report whether the source recording for a
+// note still exists on disk, so the renderer can offer "Re-transcribe" only when
+// re-running ASR is actually possible (keep-recordings was on). Read-only.
+ipcMain.handle('recording-available', async (event, summaryFile) => {
+  try {
+    // Same containment check the reprocess path uses — the renderer is untrusted.
+    const validated = await validateMeetingFilePath(summaryFile);
+    if (validated.error) {
+      return { success: false, error: validated.error };
+    }
+    // Derive the recording stem from the note filename: <stem>_summary.{md,json}.
+    const base = path.basename(validated.realPath).replace(/\.(md|json)$/, '');
+    const stem = base.endsWith('_summary') ? base.slice(0, -'_summary'.length) : base;
+    // The recording keeps the note's stem with an arbitrary extension (native
+    // .wav, system-audio .webm, imported .m4a/.mp3), so match on stem, not glob.
+    const recordingsDir = resolveRecordingsDir();
+    let available = false;
+    try {
+      for (const dirent of fs.readdirSync(recordingsDir, { withFileTypes: true })) {
+        // Require a regular file — matches the Python _find_recording_for_stem
+        // is_file() check, so a directory named e.g. `<stem>.wav` doesn't offer
+        // a re-transcribe that then fails with RETRANSCRIBE_NO_AUDIO (#266).
+        if (!dirent.isFile()) continue;
+        const name = dirent.name;
+        const dot = name.lastIndexOf('.');
+        const nameStem = dot > 0 ? name.slice(0, dot) : name;
+        if (nameStem === stem) {
+          available = true;
+          break;
+        }
+      }
+    } catch {
+      available = false; // recordings dir may not exist yet
+    }
+    return { success: true, available };
+  } catch (error) {
+    return { success: false, error: error.message };
   }
 });
 

--- a/app/preload.js
+++ b/app/preload.js
@@ -153,6 +153,10 @@ const stenoai = {
     revealFolder: (filePath) => invoke('reveal-meeting-folder', filePath),
     delete: (meeting) => invoke('delete-meeting', meeting),
     reprocess: (summaryFile, regenTitle, name) => invoke('reprocess-meeting', summaryFile, regenTitle, name),
+    // Re-transcribe (#266): re-run ASR on the source recording then re-summarise
+    // (regenTitle false; the retranscribe flag is the trailing arg).
+    retranscribe: (summaryFile, name) => invoke('reprocess-meeting', summaryFile, false, name, true),
+    recordingAvailable: (summaryFile) => invoke('recording-available', summaryFile),
     regenTitle: (summaryFile, name) => invoke('regen-meeting-title', summaryFile, name),
     saveNotes: (name, notes) => invoke('save-meeting-notes', name, notes),
     generateReport: (summaryFile, templateId) => invoke('generate-report-meeting', summaryFile, templateId),

--- a/app/renderer/src/hooks/useMeetings.ts
+++ b/app/renderer/src/hooks/useMeetings.ts
@@ -219,6 +219,29 @@ export function useReprocessMeeting() {
   });
 }
 
+export function useRetranscribeMeeting() {
+  const qc = useQueryClient();
+  return useMutation({
+    // Re-run ASR on the source recording (#266) then re-summarise. Mirrors
+    // useReprocessMeeting's success invalidation so the rewritten note (fresh
+    // transcript + summary) refreshes across list + detail.
+    mutationFn: async (args: { summaryFile: string; name: string }) =>
+      unwrap(await ipc().meetings.retranscribe(args.summaryFile, args.name)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: meetingsKeys.all }),
+  });
+}
+
+/** Whether the source recording for a note still exists on disk, so the UI can
+ *  offer "Re-transcribe" only when re-running ASR is possible (#266). */
+export function useRecordingAvailable(summaryFile: string | null | undefined) {
+  return useQuery({
+    queryKey: [...meetingsKeys.detail(summaryFile ?? ''), 'recording-available'],
+    queryFn: async () =>
+      unwrap(await ipc().meetings.recordingAvailable(summaryFile as string)).available,
+    enabled: Boolean(summaryFile),
+  });
+}
+
 export function useGenerateReport() {
   const qc = useQueryClient();
   return useMutation({

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -871,6 +871,12 @@ export interface StenoaiBridge {
       [summaryFile: string, regenTitle: boolean, name: string],
       Result<{ message: string }>
     >;
+    /** Re-run transcription on the source recording (#266) with the current
+     *  settings, then re-summarise. Only wired when `recordingAvailable` is true. */
+    retranscribe: RequestFn<[summaryFile: string, name: string], Result<{ message: string }>>;
+    /** Whether the source recording for a note still exists on disk, gating the
+     *  re-transcribe action (available only when keep-recordings was on). */
+    recordingAvailable: RequestFn<[summaryFile: string], Result<{ available: boolean }>>;
     saveNotes: RequestFn<[name: string, notes: string], SaveMeetingNotesResponse>;
     exportTranscript: RequestFn<
       [defaultFilename: string, content: string],

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -14,6 +14,7 @@ import {
   Folder as FolderIcon,
   Globe,
   MoreHorizontal,
+  Mic,
   PencilLine,
   RefreshCw,
   Trash2,
@@ -27,6 +28,8 @@ import { Select, SelectContent, SelectItem, SelectSeparator } from '@/components
 import {
   useMeeting,
   useReprocessMeeting,
+  useRetranscribeMeeting,
+  useRecordingAvailable,
   useDeleteMeeting,
   useGenerateReport,
   useSetActiveReport,
@@ -151,6 +154,11 @@ function DetailContent({
   const [deleteOpen, setDeleteOpen] = React.useState(false);
   const deleteMeeting = useDeleteMeeting();
   const reprocess = useReprocessMeeting();
+  const retranscribe = useRetranscribeMeeting();
+  // Re-transcribe (#266) is only offered when the source recording still exists
+  // on disk (keep-recordings was on) — otherwise re-running ASR is impossible.
+  const recordingAvailable = useRecordingAvailable(summaryFile);
+  const [retranscribeOpen, setRetranscribeOpen] = React.useState(false);
   const generateReport = useGenerateReport();
   const setActiveReport = useSetActiveReport();
   const deleteReport = useDeleteReport();
@@ -433,6 +441,45 @@ function DetailContent({
         // could fire to roll the UI back — without this the analyzing/streaming
         // state would be stuck forever with no way to retry (mirrors
         // onGenerateReport's onError below).
+        onError: () => {
+          setStreamPhase('idle');
+          setStreamText('');
+          setChunkProgress(null);
+          streamCache.delete(summaryFile);
+          setReprocessFailed(true);
+        },
+      }
+    );
+  };
+
+  // Re-transcribe (#266): re-run ASR on the source recording with the current
+  // settings, then re-summarise. Reuses the SAME streaming UI as reprocess —
+  // the backend drives summary-chunk/-complete keyed by summaryFile — so we only
+  // swap which mutation fires. Transcription is silent (no CHUNK), so the view
+  // stays in "analyzing" until summarisation streams, matching reprocess's
+  // pre-first-chunk state. Mirrors startReprocess's re-entrancy guard + onError.
+  const startRetranscribe = () => {
+    const cached = streamCache.get(summaryFile);
+    if (
+      retranscribe.isPending ||
+      reprocess.isPending ||
+      streamPhase !== 'idle' ||
+      cached?.phase === 'analyzing' ||
+      cached?.phase === 'generating'
+    ) {
+      return;
+    }
+    setStreamText('');
+    setStreamPhase('analyzing');
+    setChunkProgress(null);
+    setReprocessFailed(false);
+    streamCache.set(summaryFile, { text: '', phase: 'analyzing' });
+    retranscribe.mutate(
+      { summaryFile, name: info.name },
+      {
+        // A rejection means the IPC/backend failed (e.g. RETRANSCRIBE_NO_AUDIO,
+        // or ASR crashed) BEFORE a summary-complete could roll the UI back —
+        // surface the shared reprocess failure affordance. Same as startReprocess.
         onError: () => {
           setStreamPhase('idle');
           setStreamText('');
@@ -777,6 +824,27 @@ function DetailContent({
                   <FileDown className="size-[13px] shrink-0" style={{ color: 'var(--fg-2)' }} />
                   Save notes as PDF…
                 </button>
+                {/* Re-transcribe (#266): only when the source recording still
+                    exists (keep-recordings was on). Disabled while a stream is on
+                    screen or a recording is live on this note. */}
+                {recordingAvailable.data === true && (
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50"
+                    style={{ color: 'var(--fg-1)' }}
+                    data-testid="retranscribe-action"
+                    onClick={() => setRetranscribeOpen(true)}
+                    disabled={
+                      reprocess.isPending ||
+                      retranscribe.isPending ||
+                      streamPhase !== 'idle' ||
+                      isRecordingThisNote
+                    }
+                  >
+                    <Mic className="size-[13px] shrink-0" style={{ color: 'var(--fg-2)' }} />
+                    Re-transcribe recording
+                  </button>
+                )}
                 {orgSession.data?.signedIn &&
                   (isShared ? (
                     <button
@@ -1215,6 +1283,19 @@ function DetailContent({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={retranscribeOpen}
+        onOpenChange={setRetranscribeOpen}
+        title="Re-transcribe this recording?"
+        description="This re-runs transcription with your current transcription settings, replacing the transcript and regenerating the summary."
+        confirmLabel="Re-transcribe"
+        isPending={retranscribe.isPending}
+        onConfirm={() => {
+          setRetranscribeOpen(false);
+          startRetranscribe();
+        }}
+      />
     </article>
   );
 }

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -341,7 +341,17 @@ function DetailContent({
       }
     });
     const offProcessing = ipc().on.processingComplete((e) => {
-      if (e.sessionName !== sessionName) return;
+      // Scope on summaryFile (unique) when the event carries one — the display
+      // name is shareable, so two same-named notes would otherwise clear each
+      // other's stream state mid-run (re-transcribe lengthens the job, widening
+      // the race). Fall back to the sessionName match only when the event has no
+      // summaryFile (the plain recording pipeline may emit none). Mirrors how the
+      // chunk/progress handlers above guard on summaryFile.
+      if (e.summaryFile) {
+        if (e.summaryFile !== summaryFile) return;
+      } else if (e.sessionName !== sessionName) {
+        return;
+      }
       setChunkProgress(null);
       if (!e.success) {
         setStreamPhase('idle');

--- a/e2e/specs/recording-available.t2.spec.ts
+++ b/e2e/specs/recording-available.t2.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '../fixtures/electron';
+import { writeMeetingMarkdown } from '../fixtures/user-config';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * T2 — the re-transcribe availability gate (#266).
+ *
+ * Re-transcribe re-runs ASR on the ORIGINAL recording, so the UI only offers it
+ * when that recording still exists on disk (keep-recordings was on). The
+ * `recording-available` IPC globs the recordings dir for a file whose stem
+ * matches the note's `<stem>_summary.md`, returning `available: true/false`.
+ * This drives the REAL preload bridge + main handler against a seeded (or
+ * absent) recording on disk — model-free (no ASR, no Ollama).
+ *
+ * The real re-transcribe (actual ASR) needs a model and is covered manually
+ * this round — see the @pipeline TODO below.
+ */
+
+type AvailResult = { success: boolean; available?: boolean; error?: string };
+
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      recordingAvailable: (summaryFile: string) => Promise<AvailResult>;
+    };
+  };
+};
+
+const recordingAvailable = (page: import('@playwright/test').Page, file: string) =>
+  page.evaluate((f) => (window as StenoWindow).stenoai.meetings.recordingAvailable(f), file);
+
+test('recording-available is true when the source recording still exists', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const file = writeMeetingMarkdown(userDataDir, 'kept', {
+    name: 'Kept Recording',
+    summaryMarkdown: '## Summary\nKeep-recordings was on.',
+    transcript: 'Some transcript.',
+  });
+  // Seed a matching recording (any extension) under the recordings dir — the
+  // stem must equal the note stem ('kept'), mirroring how the pipeline names it.
+  const recordingsDir = path.join(userDataDir, 'recordings');
+  mkdirSync(recordingsDir, { recursive: true });
+  writeFileSync(path.join(recordingsDir, 'kept.wav'), Buffer.from('fake audio'));
+
+  const { page } = await launchApp();
+
+  const res = await recordingAvailable(page, file);
+  expect(res.success, res.error).toBe(true);
+  expect(res.available).toBe(true);
+});
+
+test('recording-available is false when the source recording is gone', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // A note whose audio was cleaned up (keep-recordings off, the default): the
+  // note exists in output/, but no matching file lives in recordings/.
+  const file = writeMeetingMarkdown(userDataDir, 'gone', {
+    name: 'Discarded Recording',
+    summaryMarkdown: '## Summary\nAudio was discarded after transcribe.',
+    transcript: 'Some transcript.',
+  });
+
+  const { page } = await launchApp();
+
+  const res = await recordingAvailable(page, file);
+  expect(res.success, res.error).toBe(true);
+  expect(res.available).toBe(false);
+});
+
+// TODO(@pipeline): the REAL re-transcribe path (reprocess --retranscribe running
+// actual ASR and rewriting the note with a fresh transcript + summary) needs a
+// model, so it is out of scope for this model-free spec and is covered manually
+// this round. A future @pipeline spec could drive `meetings.retranscribe`
+// end-to-end through the whisper engine and assert a rewritten transcript.

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -220,14 +220,33 @@ def _find_recording_for_stem(recordings_dir, stem: str):
     the match extension-agnostic and avoids treating ``stem`` as a glob pattern.
     Used by re-transcribe (#266) to locate the audio to re-run ASR on; returns
     None when keep-recordings was off and the source is gone (the MVP audio-gate).
+
+    Deterministic + safe when the stem is not unique: collect ALL stem-matching
+    regular files and return one only when there is EXACTLY ONE. If several files
+    share the stem (e.g. a retained ``.wav`` next to an imported ``.m4a``),
+    decline (return None) rather than guess the wrong source — the caller already
+    surfaces ``RETRANSCRIBE_NO_AUDIO``. Symlinks are rejected (``is_symlink()``)
+    to match the JS ``recording-available`` handler's ``Dirent.isFile()`` posture
+    and to never re-transcribe through a symlinked recording. The app enforces
+    stem uniqueness, so the ambiguity guard is defensive.
     """
     from pathlib import Path
+    matches = []
     try:
         for entry in Path(recordings_dir).iterdir():
-            if entry.is_file() and Path(entry.name).stem == stem:
-                return entry
+            # is_file() follows symlinks; also reject symlinks so both sides agree
+            # (the JS handler's Dirent.isFile() does not follow symlinks).
+            if entry.is_file() and not entry.is_symlink() and Path(entry.name).stem == stem:
+                matches.append(entry)
     except (FileNotFoundError, NotADirectoryError):
         return None
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        logger.warning(
+            "Re-transcribe: %d recordings share stem %r in %s; declining as ambiguous",
+            len(matches), stem, recordings_dir,
+        )
     return None
 
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -211,6 +211,26 @@ def _emit_progress(step: int, total: int) -> None:
     sys.stdout.flush()
 
 
+def _find_recording_for_stem(recordings_dir, stem: str):
+    """Return the source recording whose filename stem matches ``stem``, else None.
+
+    The recording filename stem equals the note stem (``<stem>_summary.md`` →
+    ``<stem>``), with an arbitrary extension (native ``.wav``, system-audio
+    ``.webm``, imported ``.m4a`` / ``.mp3``). Iterating and comparing stems keeps
+    the match extension-agnostic and avoids treating ``stem`` as a glob pattern.
+    Used by re-transcribe (#266) to locate the audio to re-run ASR on; returns
+    None when keep-recordings was off and the source is gone (the MVP audio-gate).
+    """
+    from pathlib import Path
+    try:
+        for entry in Path(recordings_dir).iterdir():
+            if entry.is_file() and Path(entry.name).stem == stem:
+                return entry
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    return None
+
+
 def _render_frontmatter(meta: dict) -> list[str]:
     """Render a meeting .md YAML frontmatter block (including the enclosing
     ``---`` fences) from a flat dict, with the type-specific scalar
@@ -2728,7 +2748,10 @@ def list_meetings():
 @cli.command()
 @click.argument('summary_file', required=True)
 @click.option('--regenerate-title', is_flag=True, default=False, help='Also regenerate the meeting title')
-def reprocess(summary_file, regenerate_title):
+@click.option('--retranscribe', is_flag=True, default=False,
+              help='Re-run transcription on the source recording (requires the audio to '
+                   'still exist) with the current settings before re-summarising')
+def reprocess(summary_file, regenerate_title, retranscribe):
     """Reprocess a failed summary by re-running Ollama analysis on existing transcript"""
     import json
     from pathlib import Path
@@ -2749,6 +2772,82 @@ def reprocess(summary_file, regenerate_title):
         else:
             with open(summary_path, 'r') as f:
                 existing_data = json.load(f)
+
+        # Re-transcribe (#266): re-run ASR on the ORIGINAL recording with the
+        # CURRENT global engine/model/language settings, then fall through into
+        # the normal summarise+rewrite path below so the rewritten note carries a
+        # fresh transcript AND a fresh summary (the #249 standard-backup still
+        # runs). MVP gate: only possible when the source audio still exists on
+        # disk (keep-recordings was on); if it's gone, fail cleanly and touch
+        # nothing. The non-retranscribe path is unchanged (flag defaults false).
+        if retranscribe:
+            import asyncio
+            session_name = existing_data.get('session_info', {}).get('name', 'Reprocessed')
+            stem = summary_path.stem
+            if stem.endswith('_summary'):
+                stem = stem[:-len('_summary')]
+            recording = _find_recording_for_stem(recorder.recordings_dir, stem)
+            if recording is None:
+                # Distinct marker so the renderer surfaces "recording no longer
+                # available" rather than a generic failure — nothing is written.
+                print("STREAM_ERROR:RETRANSCRIBE_NO_AUDIO", flush=True)
+                sys.exit(1)
+
+            print(f"Re-transcribing recording: {recording.name}", flush=True)
+            # Keep the Electron inactivity watchdog alive across ASR using the
+            # backend's REAL per-chunk progress signal — the same mechanism
+            # process-streaming uses (not the capped summary heartbeat, which
+            # stops after ~30 beats and could let the 8-min watchdog kill a
+            # genuinely long transcription, e.g. a multi-hour meeting on CPU).
+            # A heartbeat must never break transcription — if the registry can't
+            # even import, transcribe without one.
+            try:
+                from src.parakeet import set_chunk_heartbeat
+            except Exception:
+                def set_chunk_heartbeat(_cb):
+                    pass
+
+            def _transcribe_heartbeat(done, total):
+                sys.stdout.write(f"HEARTBEAT:transcribe:{done}/{total}\n")
+                sys.stdout.flush()
+
+            print("HEARTBEAT:transcribe:start", flush=True)
+            set_chunk_heartbeat(_transcribe_heartbeat)
+            try:
+                transcribe_result = asyncio.run(
+                    recorder.transcribe_audio(str(recording), session_name)
+                )
+            finally:
+                set_chunk_heartbeat(None)
+
+            if transcribe_result.get("transcription_failed"):
+                err_msg = str(
+                    transcribe_result.get("error") or "transcription failed"
+                ).replace('\n', ' ').replace('\r', ' ')
+                print(f"STREAM_ERROR:{err_msg}", flush=True)
+                sys.exit(1)
+
+            # Mirror process_streaming's `## Transcript` content exactly:
+            # diarised text when diarisation ran, else the flat transcript.
+            fresh_transcript = (
+                transcribe_result.get("diarised_text")
+                or transcribe_result.get("transcript_text")
+                or ""
+            )
+            existing_data['transcript'] = fresh_transcript
+            existing_data['is_diarised'] = transcribe_result.get("is_diarised", False)
+            existing_data['diarised_text'] = transcribe_result.get("diarised_text")
+            # Refresh language provenance from the NEW transcribe result — the
+            # transcript changed, so the persisted configured/detected/output
+            # values no longer describe it. resolve_persisted_output_language
+            # (below) then trusts this fresh, pin/engine-backed output_language.
+            _si = existing_data.setdefault('session_info', {})
+            _si['configured_language'] = transcribe_result.get("configured_language")
+            _si['detected_language'] = transcribe_result.get("detected_language")
+            _si['output_language'] = transcribe_result.get("output_language")
+            # A full re-transcribe replaces any live-sourced transcript, so the
+            # live-transcript flag (#207) no longer applies to this note.
+            _si.pop('is_live_transcript', None)
 
         # Get transcript from the data
         transcript = existing_data.get('transcript', '')

--- a/tests/test_retranscribe_gate.py
+++ b/tests/test_retranscribe_gate.py
@@ -1,0 +1,84 @@
+# tests/test_retranscribe_gate.py
+"""Tests for the re-transcribe MVP audio-gate (#266).
+
+Re-transcribe (`reprocess --retranscribe`) re-runs ASR on the ORIGINAL
+recording, so it is only possible when that recording still exists on disk
+(keep-recordings was on). When the audio is gone the command must fail cleanly
+with the distinct `RETRANSCRIBE_NO_AUDIO` marker (so the renderer can say
+"recording no longer available") and touch nothing — no partial rewrite of the
+note. This is the core MVP gate and is model-free: it exits before any ASR or
+summariser is initialised.
+"""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import simple_recorder
+
+_MD_TEMPLATE = """\
+---
+title: My Meeting
+language: en
+duration_seconds: 600
+configured_language: en
+detected_language: en
+---
+## Summary
+
+Existing summary
+
+## Transcript
+
+Alice: hi. Bob: bye.
+"""
+
+
+class RetranscribeNoAudioGateTests(unittest.TestCase):
+    def test_retranscribe_without_recording_prints_marker_and_exits_nonzero(self):
+        """No source recording on disk -> RETRANSCRIBE_NO_AUDIO, non-zero, no write."""
+        with tempfile.TemporaryDirectory() as tmp:
+            # STENOAI_USER_DATA_DIR drives get_data_dirs(), so recorder.recordings_dir
+            # is this (empty) temp dir -> no recording can match the note stem.
+            os.environ["STENOAI_USER_DATA_DIR"] = tmp
+            try:
+                summary = Path(tmp) / "meeting_summary.md"
+                summary.write_text(_MD_TEMPLATE)
+                before = summary.read_text()
+
+                res = CliRunner().invoke(
+                    simple_recorder.reprocess, [str(summary), "--retranscribe"]
+                )
+
+                self.assertNotEqual(res.exit_code, 0, res.output)
+                self.assertIn("STREAM_ERROR:RETRANSCRIBE_NO_AUDIO", res.output)
+                # The gate must touch nothing: the note is byte-for-byte unchanged.
+                self.assertEqual(summary.read_text(), before)
+            finally:
+                os.environ.pop("STENOAI_USER_DATA_DIR", None)
+
+
+class FindRecordingForStemTests(unittest.TestCase):
+    def test_matches_recording_by_stem_any_extension(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            rec = Path(tmp) / "my-note.webm"
+            rec.write_bytes(b"fake audio")
+            found = simple_recorder._find_recording_for_stem(tmp, "my-note")
+            self.assertIsNotNone(found)
+            self.assertEqual(Path(found).name, "my-note.webm")
+
+    def test_returns_none_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "other.wav").write_bytes(b"x")
+            self.assertIsNone(simple_recorder._find_recording_for_stem(tmp, "my-note"))
+
+    def test_returns_none_when_dir_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does-not-exist"
+            self.assertIsNone(simple_recorder._find_recording_for_stem(missing, "my-note"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retranscribe_gate.py
+++ b/tests/test_retranscribe_gate.py
@@ -13,6 +13,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from click.testing import CliRunner
 
@@ -42,8 +43,8 @@ class RetranscribeNoAudioGateTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             # STENOAI_USER_DATA_DIR drives get_data_dirs(), so recorder.recordings_dir
             # is this (empty) temp dir -> no recording can match the note stem.
-            os.environ["STENOAI_USER_DATA_DIR"] = tmp
-            try:
+            # patch.dict save/restores any pre-existing value (CI/dev shells set it).
+            with mock.patch.dict(os.environ, {"STENOAI_USER_DATA_DIR": tmp}):
                 summary = Path(tmp) / "meeting_summary.md"
                 summary.write_text(_MD_TEMPLATE)
                 before = summary.read_text()
@@ -56,8 +57,33 @@ class RetranscribeNoAudioGateTests(unittest.TestCase):
                 self.assertIn("STREAM_ERROR:RETRANSCRIBE_NO_AUDIO", res.output)
                 # The gate must touch nothing: the note is byte-for-byte unchanged.
                 self.assertEqual(summary.read_text(), before)
-            finally:
-                os.environ.pop("STENOAI_USER_DATA_DIR", None)
+
+    def test_retranscribe_with_ambiguous_stem_prints_marker_and_exits_nonzero(self):
+        """Two recordings share the note stem -> ambiguous -> RETRANSCRIBE_NO_AUDIO.
+
+        _find_recording_for_stem declines rather than guessing which source to
+        re-run, so the CLI surfaces the same clean audio-gate marker and writes
+        nothing.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"STENOAI_USER_DATA_DIR": tmp}):
+                # recorder.recordings_dir == get_data_dirs()['recordings'] under tmp.
+                recordings_dir = Path(tmp) / "recordings"
+                recordings_dir.mkdir(parents=True, exist_ok=True)
+                (recordings_dir / "meeting.wav").write_bytes(b"a")
+                (recordings_dir / "meeting.m4a").write_bytes(b"b")
+
+                summary = Path(tmp) / "meeting_summary.md"
+                summary.write_text(_MD_TEMPLATE)
+                before = summary.read_text()
+
+                res = CliRunner().invoke(
+                    simple_recorder.reprocess, [str(summary), "--retranscribe"]
+                )
+
+                self.assertNotEqual(res.exit_code, 0, res.output)
+                self.assertIn("STREAM_ERROR:RETRANSCRIBE_NO_AUDIO", res.output)
+                self.assertEqual(summary.read_text(), before)
 
 
 class FindRecordingForStemTests(unittest.TestCase):
@@ -78,6 +104,26 @@ class FindRecordingForStemTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             missing = Path(tmp) / "does-not-exist"
             self.assertIsNone(simple_recorder._find_recording_for_stem(missing, "my-note"))
+
+    def test_returns_none_when_stem_is_ambiguous(self):
+        """Multiple regular files sharing the stem -> decline (don't guess)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "my-note.wav").write_bytes(b"a")
+            (Path(tmp) / "my-note.m4a").write_bytes(b"b")
+            self.assertIsNone(simple_recorder._find_recording_for_stem(tmp, "my-note"))
+
+    def test_rejects_symlinked_recording(self):
+        """A symlink whose stem matches must be rejected (JS/Python parity)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "real-audio.wav"
+            target.write_bytes(b"a")
+            link = Path(tmp) / "my-note.wav"
+            try:
+                link.symlink_to(target)
+            except (OSError, NotImplementedError) as e:
+                self.skipTest(f"symlinks unavailable: {e}")
+            # The symlink stem matches but is_symlink() is True -> not returned.
+            self.assertIsNone(simple_recorder._find_recording_for_stem(tmp, "my-note"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the MVP of #266.

## What

Re-transcribe an existing recording after changing transcription settings. Today `reprocess` only re-runs summarization on the transcript already in the note — it never touches audio. This adds a **"Re-transcribe recording"** action in the note detail view that re-runs ASR on the original recording with your **current** engine/model/language settings, then re-summarizes from the fresh transcript.

## MVP scope (deliberate)

Re-transcribe is offered **only when the source recording still exists on disk** (i.e. keep-recordings was on). No default is changed and no new audio persistence is introduced — if the recording is gone, the action simply isn't available. (Persisting audio for all notes so this always works is a separate, larger decision, left out of this MVP.)

## How

- A `--retranscribe` flag on the `reprocess` CLI. When set, it re-runs ASR on the source recording (found by stem, any extension) **before** the existing summarize+rewrite path, so the rewritten note carries a fresh transcript *and* summary and the #249 standard-backup snapshot still runs. The transcript field written is mirrored from `process-streaming` (diarised text when diarisation ran, else flat), and language provenance is refreshed from the new transcribe result (`is_live_transcript` cleared). The no-flag path is unchanged.
- **Audio gate:** if no recording matches the note stem, the backend prints `STREAM_ERROR:RETRANSCRIBE_NO_AUDIO` and exits **without writing anything**.
- **Liveness:** ASR emits the real per-chunk `HEARTBEAT:transcribe` signal (same mechanism as `process-streaming`), so a long transcription can't be killed by the inactivity watchdog.
- `main.js`: `reprocess-meeting` gains a `retranscribe` arg; a new read-only `recording-available` IPC (same `validateMeetingFilePath` containment) tells the renderer whether to offer the action. The JS availability check requires a regular file, matching the Python `is_file()` gate.
- Renderer: a `useRetranscribeMeeting` hook + a gated "Re-transcribe" action with a confirm dialog, reusing the existing reprocess streaming UI (no new state machine).

## Tests / verification

- Python (model-free): `reprocess --retranscribe` on a note whose recording is absent → `RETRANSCRIBE_NO_AUDIO`, writes nothing; plus the `_find_recording_for_stem` helper. Existing `test_reprocess_frontmatter` / `test_reprocess_title` stay green (default path unchanged) — 13 tests total.
- New model-free T2 `recording-available.t2` (available true with a seeded recording, false when gone) — 2/2.
- `typecheck:renderer` clean, `lint:renderer` no new warnings, `ipc-contract.test.js` green, ruff clean on changed files.
- Cross-family review (Codex, high effort): no critical; the long-ASR heartbeat fix and the JS/Python file-parity fix were adopted from it.

## Not covered here

The **real** ASR re-transcribe path (running a model and rewriting the note with a fresh transcript) needs a model, so it's not in the model-free suite — a `@pipeline` follow-up. The note-rewrite reuses the proven `reprocess` path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a re-transcribe flow that re-runs transcription on the original recording with current settings, then regenerates the summary. The UI only offers this when a single, regular source audio file exists; defaults and audio persistence are unchanged.

- **New Features**
  - CLI: `reprocess --retranscribe` re-runs ASR before summarization and emits per-chunk `HEARTBEAT:transcribe`; if no audio is found, prints `STREAM_ERROR:RETRANSCRIBE_NO_AUDIO` and writes nothing.
  - UI: Adds a gated “Re-transcribe recording” action with a confirm dialog; disabled during active streams or live recording; reuses the existing streaming UI.
  - IPC: `recording-available` returns true only when exactly one regular file matching the note’s stem exists; preload exposes `retranscribe` and `recordingAvailable`.

- **Bug Fixes**
  - Stream events are now scoped by `summaryFile` (fallback to `sessionName`) to prevent cross-note resets when names collide.
  - Hardened gate: reject symlinked or ambiguous stem matches (e.g., both `.wav` and `.m4a`) and surface `RETRANSCRIBE_NO_AUDIO`; adds unit tests for the gate and e2e tests for `recording-available`.

<sup>Written for commit 5a042b6be5a44dde3edd614159ff6f3af8196d59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

