### PR TITLE
ci: run backend unittests and renderer typecheck per-PR (#376)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,6 +125,71 @@ jobs:
         working-directory: app
         run: npm run lint:renderer
 
+  # ---------------------------------------------------------------------------
+  # Deterministic backend/renderer gates (issue #376). These close the CI
+  # enforcement gap: the backend unittest suite and the renderer tsc typecheck
+  # previously ran only on the maintainer's machine, so a green PR page didn't
+  # mean the backend was green. Added NON-REQUIRED (advisory) — like the e2e
+  # tiers, they earn a green streak before any branch-protection promotion
+  # (a maintainer-only admin action, tracked separately). No behaviour change.
+  # A ruff gate is deferred on purpose: bare `ruff check .` has pre-existing
+  # violations on main (mostly in simple_recorder.py), so wiring it now would
+  # be red on day one. It needs a cleanup PR first — tracked as a follow-up.
+  # ---------------------------------------------------------------------------
+
+  # Runs on macos-latest (not ubuntu) on purpose: this is the platform the
+  # maintainer runs `python -m unittest discover tests` on, and it's the only
+  # runner where `pip install -r requirements.txt` is already proven green
+  # (build-backend-macos installs the identical set, incl. the darwin-only
+  # parakeet-mlx path). Bootstrap mirrors build-backend-macos minus the
+  # PyInstaller/binary-download steps the tests don't need. Environment-gated
+  # tests (e.g. the MLX-bundle wrapper) skip loudly when their artifact is absent.
+  python-tests:
+    name: Python (unittest)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run backend unit tests
+        run: python -m unittest discover tests
+
+  # tsc --noEmit over the renderer (the typecheck:renderer script already exists;
+  # CI just never called it). Mirrors the lint-renderer job's node bootstrap.
+  typecheck-renderer:
+    name: Typecheck (renderer)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Typecheck renderer
+        working-directory: app
+        run: npm run typecheck:renderer
+
   build-backend-macos:
     name: Build backend bundle (macOS)
     runs-on: macos-latest

--- a/tests/test_summarizer_logging_privacy.py
+++ b/tests/test_summarizer_logging_privacy.py
@@ -15,7 +15,11 @@ from src.summarizer import OllamaSummarizer
 
 
 def _make_summarizer(model_name="llama3.2:3b", ai_provider="local"):
-    return OllamaSummarizer(model_name=model_name, ai_provider=ai_provider, config=Config())
+    # Patch out the Ollama readiness/start check during construction — these are
+    # unit tests for log-line privacy and must not depend on a live Ollama
+    # server (they mock the chat calls themselves). Keeps the suite hermetic in CI.
+    with mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready"):
+        return OllamaSummarizer(model_name=model_name, ai_provider=ai_provider, config=Config())
 
 
 class TitleLoggingPrivacyTests(unittest.TestCase):

--- a/tests/test_summarizer_map_reduce.py
+++ b/tests/test_summarizer_map_reduce.py
@@ -9,7 +9,12 @@ from src.summarizer import OllamaSummarizer, MAP_PROMPT_OVERHEAD_TOKENS, MAP_OUT
 
 def _make_summarizer(model_name="llama3.2:3b"):
     cfg = Config()
-    return OllamaSummarizer(model_name=model_name, ai_provider="local", config=cfg)
+    # Patch out the Ollama readiness/start check during construction — these are
+    # unit tests for pure helpers (chunk budget, split, prompt build) and must
+    # not depend on a live Ollama server. Matches the pattern the sibling
+    # summarizer test modules already use, and keeps the suite hermetic in CI.
+    with mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready"):
+        return OllamaSummarizer(model_name=model_name, ai_provider="local", config=cfg)
 
 
 class ChunkBudgetTests(unittest.TestCase):


### PR DESCRIPTION
Part of #376 (closes the CI enforcement gap incrementally).

Adds two **non-required** (advisory) jobs to `e2e.yml` so checks that previously ran only on the maintainer's machine now run on every PR:

- **`python-tests`** — `python -m unittest discover tests` (macos-latest, mirrors `build-backend-macos` bootstrap + pip cache). Verified green on main locally (470 tests, 1 skipped).
- **`typecheck-renderer`** — `npm run typecheck:renderer` (`tsc --noEmit`, ubuntu, reuses the `lint-renderer` node bootstrap). Verified green on main.

Both are advisory like the e2e tiers — they earn a green streak before any branch-protection promotion (a maintainer-only admin action, tracked separately). Existing macOS/Windows jobs are untouched.

**A ruff gate is deliberately deferred.** Bare `ruff check .` currently has ~29 pre-existing violations on `main` (mostly in `simple_recorder.py`), so wiring a ruff job now would be red on day one. It needs a cleanup PR first — best done after the current PR queue drains to avoid conflicting with in-flight branches. Noted in a comment in the workflow.

Independent cross-family review: clean (SHIP).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two advisory CI checks to run backend unit tests on macOS and a TypeScript renderer typecheck on Ubuntu for every PR, and make summarizer unit tests hermetic so CI doesn’t require a live Ollama. This closes part of the CI enforcement gap in #376.

- **New Features**
  - `python-tests` — runs `python -m unittest discover tests` on `macos-latest` with pip caching.
  - `typecheck-renderer` — runs `npm run typecheck:renderer` (`tsc --noEmit`) on `ubuntu-latest`, reusing the renderer lint setup.
  - Both checks are non-required; a `ruff` gate is deferred until existing violations are cleaned up.

- **Bug Fixes**
  - Patched `tests/test_summarizer_map_reduce.py` and `tests/test_summarizer_logging_privacy.py` to mock `OllamaSummarizer._ensure_ollama_ready` in `_make_summarizer()`, making the tests hermetic and green without a running Ollama.

<sup>Written for commit dbb90db9d3b9e3937ae26bdd75ece162b5b3e9ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

