### PR TITLE
refactor(cli): narrow best-effort except clusters in simple_recorder.py (#379)

### DIFF
--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -346,7 +346,7 @@ Summary output language: {config.get_language_name(output_language)}
                     if text:
                         logger.info(f"Loaded user notes ({len(text)} chars)")
                         return text
-                except Exception:
+                except (OSError, UnicodeDecodeError):
                     pass
                 break
         return None
@@ -563,7 +563,7 @@ Summary output language: {config.get_language_name(output_language)}
         if state_file.exists():
             try:
                 state_file.unlink()
-            except Exception:
+            except OSError:
                 pass
 
         return {
@@ -649,7 +649,7 @@ Summary output language: {config.get_language_name(output_language)}
             if not gate_config.get_keep_recordings():
                 try:
                     audio_path.unlink()
-                except Exception:
+                except OSError:
                     pass
             print("SUMMARY_SKIPPED", flush=True)
             print(f"SAVED:{summary_path}", flush=True)
@@ -746,14 +746,14 @@ Summary output language: {config.get_language_name(output_language)}
             try:
                 audio_path.unlink()
                 print(f"🗑️ Cleaned up audio file: {audio_path}")
-            except Exception:
+            except OSError:
                 pass
 
         state_file = Path("recorder_state.json")
         if state_file.exists():
             try:
                 state_file.unlink()
-            except Exception:
+            except OSError:
                 pass
 
         print(f"✅ Complete processing saved: {summary_path}")
@@ -911,7 +911,7 @@ def _read_existing_user_notes(summary_path: Path):
         if not summary_path.exists():
             return None
         content = summary_path.read_text(encoding='utf-8')
-    except Exception:
+    except (OSError, UnicodeDecodeError):
         return None
     idx = content.find('\n## User Notes')
     if idx == -1:
@@ -1135,7 +1135,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
             if not is_live_transcript and not _get_config().get_keep_recordings():
                 try:
                     audio_path.unlink()
-                except Exception:
+                except OSError:
                     pass
             print("SUMMARY_SKIPPED", flush=True)
             print(f"SAVED:{append_to}", flush=True)
@@ -1188,7 +1188,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
             if not is_live_transcript and not gate_config.get_keep_recordings():
                 try:
                     audio_path.unlink()
-                except Exception:
+                except OSError:
                     pass
 
             print("SUMMARY_SKIPPED", flush=True)
@@ -1306,7 +1306,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
         if not is_live_transcript and not get_config().get_keep_recordings():
             try:
                 audio_path.unlink()
-            except Exception:
+            except OSError:
                 pass
 
         print(f"SAVED:{summary_path}", flush=True)
@@ -3400,6 +3400,8 @@ def chat_global_streaming(question, folder):
             summaries.append((f, data))
             seen.add(f.stem.replace('_summary', ''))
         except Exception:
+            # Best-effort listing: a single malformed/legacy note must never
+            # break the whole meeting list — skip it and keep scanning.
             continue
     for f in sorted(output_dir.glob("*_summary.json")):
         if f.stem.replace('_summary', '') in seen:
@@ -3407,7 +3409,7 @@ def chat_global_streaming(question, folder):
         try:
             with open(f, 'r', encoding='utf-8') as fh:
                 summaries.append((f, json.load(fh)))
-        except Exception:
+        except (OSError, ValueError):
             continue
 
     # Folder scoping. Each meeting record carries a 'folders' array of IDs;
@@ -3855,6 +3857,9 @@ def list_models():
             import ollama as ollama_pkg
             installed_names = {getattr(m, 'model', '') for m in (getattr(ollama_pkg.list(), 'models', []) or [])}
         except Exception:
+            # Best-effort: Ollama may be absent, not running, or unreachable
+            # (import or HTTP/connection errors) — treat nothing as installed
+            # rather than failing the model-status listing.
             installed_names = set()
         from src.config import is_apple_silicon, Config
         apple_silicon = provider == "local" and is_apple_silicon()
@@ -4732,6 +4737,8 @@ def test_cloud_api():
                 try:
                     detail = he.read().decode("utf-8", errors="replace")[:300]
                 except Exception:
+                    # Best-effort error-detail extraction; must never mask the
+                    # HTTPError we're about to report to the user.
                     pass
                 print(json.dumps({
                     "success": False,


### PR DESCRIPTION
Closes #379.

Audits the broad `except Exception:` clusters in `simple_recorder.py`. Each site was classified by what its `try` body can actually raise:

- **Narrowed (9 sites):** `Path.unlink()` best-effort cleanup → `OSError`; optional-notes `read_text()` → `(OSError, UnicodeDecodeError)`; legacy `.json` load → `(OSError, ValueError)`. Unexpected programming errors (TypeError/AttributeError/…) now propagate instead of being silently swallowed — preserving the honest-failure posture.
- **Kept broad, with a justifying comment (4 sites):** the meeting-list markdown scan (a single malformed/legacy file must not break the whole listing), the Ollama `list_models` integration (import/HTTP/connection errors → "nothing installed"), and HTTP-error-detail extraction (must never mask the `HTTPError` being reported).

No behaviour change on any real user failure path — narrowing only stops masking bugs. Diff is strictly per-site minimal (no reformatting) to avoid conflicting with other in-flight PRs touching this file.

Verified: `python -m unittest discover tests` green (470); no new ruff violations. Independent cross-family review: clean (SHIP).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed broad exception handling in `simple_recorder.py` to specific, expected errors to avoid masking bugs while keeping user-facing behavior unchanged. Kept a few broad catches with clear comments where fail-safe behavior is required.

- **Refactors**
  - Tightened nine sites: cleanup `unlink()` now catches `OSError`; reading user notes catches `(OSError, UnicodeDecodeError)`; legacy JSON loads catch `(OSError, ValueError)`.
  - Kept broad catches with justification for: meeting-list markdown scan, `ollama` model listing, and HTTP error-detail extraction.
  - Programming errors (e.g., `TypeError`, `AttributeError`) now surface instead of being swallowed.

<sup>Written for commit f6b6627277003a4afe2777ce9db65f32f98d4104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

