### PR TITLE
test(e2e): assert real summarize-model output in a nightly tier (#382)

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -187,9 +187,17 @@ jobs:
       # Playwright exits 0 when --grep matches no tests. Assert the tagged spec is
       # actually selected so a future rename / dropped @summarize-real tag can't
       # silently run zero tests and pass.
+      # Assert the tagged spec is selected (Playwright exits 0 on a zero-match
+      # --grep). Capture first, then grep — piping straight into `grep -q` lets
+      # grep close the pipe on first match (EPIPE to the node writer) and can
+      # mask a failed/incomplete listing behind grep's exit code. Mirrors the
+      # @long-meeting guard.
       - name: Guard — @summarize-real test is selected
+        shell: bash
         working-directory: app
-        run: npm run test:e2e -- --project=t2 --grep @summarize-real --list | grep -q '@summarize-real'
+        run: |
+          out=$(npm run test:e2e -- --project=t2 --grep @summarize-real --list)
+          echo "$out" | grep -q '@summarize-real'
 
       - name: Run T2 real-summarize (llama3.2:1b)
         working-directory: app

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -112,3 +112,101 @@ jobs:
             app/test-results
           retention-days: 7
           if-no-files-found: ignore
+
+  # Real-summarization smoke (@summarize-real, #382). NIGHTLY-ONLY: it drives a
+  # REAL small Ollama model (llama3.2:1b, CPU) through the actual `reprocess`
+  # prompt-build + response-parse path — the gap the mock-Ollama
+  # summarize-contract.t2 can't cover. Heavy + non-deterministic, so it is kept
+  # OUT of the per-PR lanes (e2e.yml greps @summarize-real out of the model-free
+  # t2 jobs; the @pipeline jobs never select it) and asserts only WEAK
+  # invariants (a non-empty, floored, structurally-parsed summary — never
+  # section-exactness, which a 1B model won't reliably emit). Reuses the macOS
+  # backend bundle the suite just built (download-artifact across the
+  # reusable-workflow boundary), same as long-meeting-windows.
+  summarize-real-macos:
+    name: T2 real-summarize (llama3.2:1b, macOS CPU)
+    runs-on: macos-latest
+    needs: suite
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Download backend bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-backend-macos
+          path: dist/stenoai
+
+      # upload-artifact strips the exec bit — restore it or the app can't launch
+      # the bundled launcher / spawn ollama (mirrors t2-pipeline-macos).
+      - name: Restore exec bits on bundled binaries
+        run: |
+          find dist/stenoai -type f \( -name stenoai -o -name ffmpeg -o -name ollama \) \
+            -exec chmod +x {} +
+          test -x dist/stenoai/stenoai
+
+      - name: Ensure no stray Ollama
+        run: pkill -f ollama || true
+
+      # Cache the pulled model blobs in Ollama's default store (~/.ollama/models)
+      # so only the first nightly pays the ~1.3 GB download; later runs restore
+      # in seconds. start_ollama_server sets no custom OLLAMA_MODELS, so the app's
+      # bundled `ollama serve` reads the same store this pre-pull writes.
+      - name: Cache Ollama summary model
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama/models
+          key: ollama-summary-llama3.2-1b
+
+      - name: Install Electron dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build:renderer
+
+      # Pre-pull the small model, then VERIFY it actually loads + responds on
+      # this runner (verify-model runs a 1-token chat via the HTTP API). This
+      # fails THIS job loudly on an infra problem (bad pull, GPU-less load issue)
+      # instead of letting the spec silently skip green with zero real-summary
+      # coverage — mirrors the whisper/parakeet model guards in e2e.yml.
+      - name: Ensure summary model present
+        run: |
+          ./dist/stenoai/stenoai pull-model llama3.2:1b
+          ./dist/stenoai/stenoai verify-model llama3.2:1b \
+            | python3 -c "import sys,json; sys.exit(0 if json.load(sys.stdin).get('success') else 1)"
+
+      # Playwright exits 0 when --grep matches no tests. Assert the tagged spec is
+      # actually selected so a future rename / dropped @summarize-real tag can't
+      # silently run zero tests and pass.
+      - name: Guard — @summarize-real test is selected
+        working-directory: app
+        run: npm run test:e2e -- --project=t2 --grep @summarize-real --list | grep -q '@summarize-real'
+
+      - name: Run T2 real-summarize (llama3.2:1b)
+        working-directory: app
+        env:
+          # Model was pre-pulled + verify-model'd above; make a not-ready model a
+          # hard failure here (not a green skip), so the nightly can't pass with
+          # zero real-summary coverage.
+          STENOAI_E2E_REQUIRE_SUMMARY_MODEL: '1'
+        run: npm run test:e2e -- --project=t2 --grep '@summarize-real'
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-summarize-real-report
+          path: |
+            app/playwright-report
+            app/test-results
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -221,12 +221,12 @@ jobs:
         working-directory: app
         run: npm run build:renderer
 
-      # Exclude @pipeline — the transcription smoke needs the Parakeet model and
-      # runs in its own model-bearing job (t2-pipeline-macos) so this job stays
-      # fast and model-free.
+      # Exclude @pipeline AND @summarize-real — both need a real model and run in
+      # their own model-bearing jobs (t2-pipeline-macos / the nightly
+      # summarize-real-macos) so this job stays fast and model-free.
       - name: Run T2 (org-lock, model-free)
         working-directory: app
-        run: npm run test:e2e -- --project=t2 --grep-invert @pipeline
+        run: npm run test:e2e -- --project=t2 --grep-invert '@pipeline|@summarize-real'
 
       - name: Upload report on failure
         if: failure()
@@ -415,11 +415,12 @@ jobs:
         working-directory: app
         run: npm run build:renderer
 
-      # Quote '@pipeline': the default Windows shell is pwsh, which treats a bare
+      # Quote the grep: the default Windows shell is pwsh, which treats a bare
       # @word as splatting ($pipeline) and errors. Single quotes make it literal.
+      # Exclude @summarize-real too — it's the nightly real-model summary smoke.
       - name: Run T2 (org-lock, model-free)
         working-directory: app
-        run: npm run test:e2e -- --project=t2 --grep-invert '@pipeline'
+        run: npm run test:e2e -- --project=t2 --grep-invert '@pipeline|@summarize-real'
 
       - name: Upload report on failure
         if: failure()

--- a/e2e/fixtures/summary-model.ts
+++ b/e2e/fixtures/summary-model.ts
@@ -1,0 +1,40 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Summary-model selection for the real-summarization @summarize-real spec (#382).
+ *
+ * A tiny (~1B) instruction model so it summarises a short fixed transcript on a
+ * CPU-only CI runner in seconds. llama3.2:1b is the repo's canonical
+ * "arbitrary user-pulled" summary model: Config.set_model allows any tag (it
+ * only warns for non-registry ids), and resolve_runtime_tag / resolve_num_ctx
+ * pass an unknown tag through unchanged — so config.model can point straight at
+ * it with no backend escape-hatch. Overridable via STENOAI_E2E_SUMMARY_MODEL to
+ * swap in a different small tag.
+ *
+ * The model must already be pulled into Ollama's store: the summarizer
+ * AUTO-PULLS a missing model (src/summarizer.py _ensure_model_available) and, on
+ * a failed pull, FALLS BACK to the heavy bundled gemma models — so a spec that
+ * ran without it present would download weights mid-test. The nightly job
+ * pre-pulls + verifies it; isSummaryModelReady() lets the spec skip loudly
+ * everywhere else instead of triggering that download.
+ */
+export const E2E_SUMMARY_MODEL = process.env.STENOAI_E2E_SUMMARY_MODEL || 'llama3.2:1b';
+
+type SummaryModelWindow = Window & {
+  stenoai: {
+    models: { verify: (name: string) => Promise<{ success: boolean; error: string | null }> };
+  };
+};
+
+/**
+ * Whether the summary model is pulled AND actually loads + responds on this host
+ * (models.verify runs a 1-token chat via the real Ollama HTTP API — it never
+ * auto-pulls, so a false result means "not ready", not "downloading now").
+ */
+export async function isSummaryModelReady(page: Page): Promise<boolean> {
+  return page.evaluate(
+    async (m) =>
+      (await (window as SummaryModelWindow).stenoai.models.verify(m)).success === true,
+    E2E_SUMMARY_MODEL,
+  );
+}

--- a/e2e/specs/summarize-real.t2.spec.ts
+++ b/e2e/specs/summarize-real.t2.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeUserConfig, writeMeetingSummary } from '../fixtures/user-config';
+import { E2E_SUMMARY_MODEL, isSummaryModelReady } from '../fixtures/summary-model';
+import { readFileSync } from 'fs';
+
+/**
+ * T2 @summarize-real — real-summarization smoke (#382). NIGHTLY-ONLY.
+ *
+ * summarize-contract.t2 proves the prompt-build + response-parse contract with a
+ * MOCK Ollama (deterministic, fast, per-PR). This spec closes the "real summary
+ * never asserted" hole: it drives a REAL small summary model (E2E_SUMMARY_MODEL,
+ * default llama3.2:1b) through the actual `reprocess` path — the same
+ * prompt-build + streamed response-parse the app ships — and asserts a usable
+ * summary comes out the other end.
+ *
+ * A real model is HEAVY and NON-DETERMINISTIC, so:
+ *   - It is kept OUT of the per-PR lanes: not tagged @pipeline (so the
+ *     model-bearing pipeline jobs don't pick it up) and grep-inverted out of the
+ *     model-free t2 jobs in e2e.yml. It runs only in the dedicated
+ *     e2e-nightly.yml `summarize-real-macos` job.
+ *   - It asserts ONLY WEAK INVARIANTS. A 1B model does not reliably emit an
+ *     exact section set, so there is NO section-list / exact-heading assertion
+ *     and NO content-quality check — only: a summary was written and is
+ *     non-empty, the response-parse structured it (didn't leak raw markdown),
+ *     its length clears a sane floor, and at least one known section was parsed.
+ *
+ * The model must be pre-pulled (the nightly job does this + verifies it); the
+ * spec skips LOUDLY otherwise rather than triggering the summarizer's mid-test
+ * auto-pull (which would download weights and can fall back to heavy models).
+ */
+
+// A short, fixed transcript with clear, summarisable content. Deterministic
+// input; only the model's phrasing varies run to run (which is why the
+// assertions below are structural, not content-exact).
+const TRANSCRIPT = [
+  'Alice: Welcome everyone. Today we need to lock the launch date for the mobile app.',
+  'Bob: Engineering is on track. We can ship on Friday the 14th if QA signs off by Thursday.',
+  'Alice: Good. Carol, is the marketing page ready?',
+  'Carol: Yes, the landing page goes live Friday morning. I will send the press email at noon.',
+  'Bob: One risk: the payment provider integration still needs a final review.',
+  'Alice: Okay. Bob owns the payment review, Carol owns the press email, and I will confirm the QA sign-off.',
+].join('\n');
+
+// The seeded stale summary the reprocess must overwrite with real model output.
+const STALE_SUMMARY = 'STALE placeholder summary that the real model must replace.';
+
+// A human name (NOT an auto-generated pattern) so reprocess with
+// regenerate_title=false does exactly one summarise call — no extra title call.
+const MEETING_NAME = 'Launch Planning Meeting';
+
+// Sane length floor: a real one/two-sentence summary of the transcript above
+// clears this easily, while an empty or trivially-degenerate parse would not.
+const SUMMARY_FLOOR = 20;
+
+type ReprocessResult = { success: boolean; error?: string };
+type StenoWindow = Window & {
+  stenoai: {
+    meetings: {
+      reprocess: (
+        summaryFile: string,
+        regenTitle: boolean,
+        name: string,
+      ) => Promise<ReprocessResult>;
+    };
+  };
+};
+
+type SummaryDoc = {
+  summary?: unknown;
+  key_points?: unknown;
+  action_items?: unknown;
+};
+
+const readSummary = (file: string): SummaryDoc =>
+  JSON.parse(readFileSync(file, 'utf8')) as SummaryDoc;
+
+/** Summary field if the file is present AND fully-written JSON, else undefined —
+ *  so a poll never throws on a mid-write partial read. */
+const readSummaryTextSafe = (file: string): string | undefined => {
+  try {
+    const s = readSummary(file).summary;
+    return typeof s === 'string' ? s : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+test('@summarize-real a real summary model produces a non-empty, parsed summary through reprocess', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  // A real model cold-load + summarise on a CPU runner (plus PyInstaller cold
+  // start + Ollama serve) can far outlast Playwright's 30 s default.
+  test.setTimeout(300_000);
+
+  const realDirBefore = fileSig(realUserDataDir());
+
+  // Local provider + the small model as the configured summary model. The
+  // summarizer reads config.model in local mode (Config.set_model allows the
+  // arbitrary tag; resolve_runtime_tag / resolve_num_ctx pass it through).
+  writeUserConfig(userDataDir, { ai_provider: 'local', model: E2E_SUMMARY_MODEL });
+
+  const summaryFile = writeMeetingSummary(userDataDir, 'summarize-real', {
+    name: MEETING_NAME,
+    summary: STALE_SUMMARY,
+    transcript: TRANSCRIPT,
+  });
+
+  const { page } = await launchApp();
+
+  // Skip LOUDLY if the model isn't installed/loadable — never let the spec fall
+  // into the summarizer's mid-test auto-pull (weights download + heavy
+  // fallback). The nightly job pre-pulls + verifies the model, so a skip there
+  // is impossible; locally it degrades to a loud skip instead of a slow pull.
+  const modelReady = await isSummaryModelReady(page);
+  // In the nightly job the model is pre-pulled AND verify-model'd before this
+  // spec runs, so a not-ready model here is a real regression, not an
+  // environment gap — REQUIRE it (env set by the workflow) so the run fails
+  // loudly instead of skipping green with zero real-summary coverage. Locally
+  // the env is unset and it degrades to a loud skip below.
+  if (process.env.STENOAI_E2E_REQUIRE_SUMMARY_MODEL) {
+    expect(
+      modelReady,
+      `${E2E_SUMMARY_MODEL} must be installed/loadable when STENOAI_E2E_REQUIRE_SUMMARY_MODEL is set (nightly)`,
+    ).toBe(true);
+  }
+  if (!modelReady) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[t2:@summarize-real] SKIPPED: summary model ${E2E_SUMMARY_MODEL} not installed/loadable on this runner.`,
+    );
+    test.info().annotations.push({
+      type: 'skip-reason',
+      description: `${E2E_SUMMARY_MODEL} not installed`,
+    });
+  }
+  test.skip(!modelReady, `${E2E_SUMMARY_MODEL} not installed`);
+
+  // Pass both args into the browser context — page.evaluate can't close over
+  // Node module-scope consts (they don't exist in the page).
+  const res = await page.evaluate(
+    ([f, name]) => (window as StenoWindow).stenoai.meetings.reprocess(f, false, name),
+    [summaryFile, MEETING_NAME] as const,
+  );
+  expect(res.success).toBe(true);
+
+  // reprocess streams the real model, parses it, then writes the file at
+  // STREAM_COMPLETE — poll until the seeded stale summary is replaced. A string
+  // that differs from the seed is the signal real model output flowed through
+  // the whole prompt-build → stream → parse → write path.
+  await expect
+    .poll(
+      () => {
+        const s = readSummaryTextSafe(summaryFile);
+        return s !== undefined && s.trim().length > 0 && s !== STALE_SUMMARY;
+      },
+      { timeout: 240_000, intervals: [2000] },
+    )
+    .toBe(true);
+
+  const updated = readSummary(summaryFile);
+  const summary = updated.summary;
+
+  // (1) A summary was written and is a non-empty string (not the seeded stale one).
+  expect(typeof summary).toBe('string');
+  const summaryText = (summary as string).trim();
+  expect(summaryText).not.toBe(STALE_SUMMARY);
+  expect(summaryText.length).toBeGreaterThan(0);
+
+  // (2) Length clears a sane floor — guards against a degenerate near-empty parse.
+  expect(summaryText.length).toBeGreaterThanOrEqual(SUMMARY_FLOOR);
+
+  // (3) Response-parse SUCCEEDED (did not fall back to a raw markdown dump): the
+  // structured `summary` field must NOT still contain the section headings the
+  // parser is meant to consume. If parsing had degenerated into dumping the raw
+  // reply, those `## Summary` / `## Key Points` / ... markers would leak in.
+  expect(summaryText).not.toMatch(/(^|\n)\s*##\s+(Summary|Key Points|Action Items|Key Topics)\b/i);
+
+  // Keystone: the real user-data dir is byte-for-byte untouched.
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});


### PR DESCRIPTION
Closes #382.

Adds a **nightly-only** e2e spec (`summarize-real.t2.spec.ts`, tag `@summarize-real`) that drives a real small summary model (`llama3.2:1b`, overridable via `STENOAI_E2E_SUMMARY_MODEL`) through `reprocess` and asserts **weak invariants only** — closing the "the summarizer's real output is never asserted" gap without introducing flake:

1. a summary was written and is non-empty (the seeded stale summary was replaced);
2. length clears a sane floor;
3. response-parse succeeded (the structured `summary` field does not still contain raw `## Section` headings — i.e. no raw-dump fallback).

No exact-section assertion (a 1B model won't reliably emit all four — that would flake).

**Lane isolation:** tagged `@summarize-real`, added as a dedicated `summarize-real-macos` job in `e2e-nightly.yml`, and grep-inverted out of the model-free per-PR `t2-macos`/`t2-windows` lanes. It never runs per-PR or in the release gate. The model registry already accepts an arbitrary tag, so no backend change was needed. The nightly job pre-pulls **and** `verify-model`s the tag to avoid the summarizer's mid-run heavy auto-pull fallback.

**Model selection risk:** this is the repo's first CI job running a real Ollama model on a GPU-less hosted macOS runner. Ollama is llama.cpp-based and runs CPU inference fine on GitHub macOS runners, so I expect a clean CPU fallback — but it is not yet empirically proven in this repo's CI. The `verify-model` preflight fails the *job* loudly if the model can't load, and `STENOAI_E2E_REQUIRE_SUMMARY_MODEL` makes a not-ready model a hard failure in the nightly (no silent skip). If macOS proves problematic, the fix is a one-line runner swap to Windows (already runs real CPU inference for parakeet-onnx).

Independent cross-family review found two issues, both fixed in this branch: the nightly-required gate above (was a silent green skip), and a tautological assertion (removed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nightly-only e2e test that runs a real small Ollama summary model through the actual `reprocess` path and asserts weak invariants to close the “no real output asserted” gap in #382. Isolated to a macOS nightly job so per-PR lanes stay model‑free.

- **New Tests**
  - Added e2e spec `e2e/specs/summarize-real.t2.spec.ts` (tag `@summarize-real`) that drives `llama3.2:1b` (overridable via STENOAI_E2E_SUMMARY_MODEL) and verifies: the stale seed summary was replaced, the result clears a small length floor, and parsing succeeded (no raw `## Section` headings).
  - Added `e2e/fixtures/summary-model.ts` to select the model and gate/skip via `models.verify` when it isn’t installed.

- **CI**
  - New nightly job `summarize-real-macos` in `.github/workflows/e2e-nightly.yml` that pre-pulls and `verify-model`s the tag, caches `~/.ollama/models`, guards test selection, and fails loudly when the model isn’t ready via STENOAI_E2E_REQUIRE_SUMMARY_MODEL.
  - Hardened the selection guard to capture `--list` output before grepping to avoid EPIPE-masked failures.
  - Updated `.github/workflows/e2e.yml` to grep-invert `@summarize-real` (and `@pipeline`) from per-PR `t2` lanes on macOS and Windows.

<sup>Written for commit 507a4707f6681c31d63e2b19ee2205633f15fd89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

