### PR TITLE
test(e2e): widen T2/T3 expect.poll timeout to de-flake real-backend polls

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -31,8 +31,20 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   projects: [
+    // T1 is renderer-only with mock IPC — instant, so it keeps Playwright's 5s
+    // default expect timeout (a slow T1 assertion is a real UI regression to
+    // catch fast, not to hide behind a wider budget).
     { name: 't1', testMatch: /.*\.t1\.spec\.ts$/ },
-    { name: 't2', testMatch: /.*\.t2\.spec\.ts$/ },
-    { name: 't3', testMatch: /.*\.t3\.spec\.ts$/ },
+    // T2/T3 assertions poll IPC calls that each spawn a fresh `stenoai`
+    // subprocess; under CI-runner load a single call can spike past 5s and
+    // flake an otherwise-correct poll (the same reason ai-provider.t2's
+    // blob-file poll already carries an explicit 10s). Give these projects a
+    // wider default poll budget — applied local + CI alike so a borderline
+    // spec can't pass locally yet flake on CI; a passing poll resolves as soon
+    // as its predicate is true, so this never slows a green run. A genuinely
+    // stuck poll still fails at 15s, well under the 30s per-test timeout, and
+    // `retries: 2` stays the backstop.
+    { name: 't2', testMatch: /.*\.t2\.spec\.ts$/, expect: { timeout: 15_000 } },
+    { name: 't3', testMatch: /.*\.t3\.spec\.ts$/, expect: { timeout: 15_000 } },
   ],
 });


### PR DESCRIPTION
De-flakes the recurring T2 failures seen across several PRs today (ai-provider `cloud_api_key_set`, meetings-crud list length, premeeting-notification `shown`).

**Root cause.** T2/T3 assertions poll IPC calls that each spawn a fresh `stenoai` subprocess. Under CI-runner load a single call can spike past Playwright's 5s default `expect.poll` timeout and flake an otherwise-correct poll. `ai-provider.t2` already carries an explicit `{ timeout: 10_000 }` on its adjacent blob-file poll for exactly this reason — the sibling poll was just left on the 5s default. `workers: 1` rules out cross-spec parallel contention; the failures are borderline timing (they pass on retry and always pass locally in 1-8s).

**Fix.** Raise the default `expect` timeout to 15s, scoped to the **t2/t3 projects only**:
- T1 (mock IPC, instant) keeps the 5s default — a slow T1 assertion is a real UI regression to catch fast, not hide.
- Applied local + CI alike so a borderline spec can't pass locally yet flake on CI.
- A passing poll resolves as soon as its predicate is true, so this never slows a green run; a genuinely stuck poll still fails at 15s (< the 30s per-test timeout) and `retries: 2` stays the backstop.

**Verification.** The four flaky specs pass locally with the change; config parses (114 tests listed). The real proof is CI flake-rate over several runs — local doesn't reproduce the flake.

**Out of scope:** the rarer `ai-provider.t2:51` "Target page has been closed" (an intermittent app close/crash, not a poll timeout) is a separate failure mode, not addressed here.

Independent cross-family Codex review (FIX-FIRST) applied: scope to t2/t3 instead of global, drop the local/CI divergence, correct an inaccurate comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `expect.poll` timeout to 15s for `t2` and `t3` e2e projects to reduce CI flakes from real-backend IPC polls. `t1` stays at 5s to catch UI regressions fast.

- **Bug Fixes**
  - Set `expect: { timeout: 15_000 }` for `t2` and `t3` in `e2e/playwright.config.ts`; `t1` unchanged.
  - Applies locally and CI; resolves flakes seen in ai-provider `cloud_api_key_set`, meetings-crud list length, and premeeting-notification `shown`; green runs unaffected, stuck polls still fail under existing test budgets.

<sup>Written for commit 2c4ea14cbdf2db331668c91b3c91a1e4c7777762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

