### PR TITLE
feat(home): letter-avatars in the Previous Notes list (from #349)

### DIFF
--- a/app/renderer/src/components/home/PreviousRow.tsx
+++ b/app/renderer/src/components/home/PreviousRow.tsx
@@ -1,4 +1,4 @@
-import { FileText, Folder as FolderIcon, Loader2 } from 'lucide-react';
+import { Folder as FolderIcon, Loader2 } from 'lucide-react';
 import type { Meeting } from '@/lib/ipc';
 import { navigate } from '@/lib/router';
 import { useMeetingsList } from '@/lib/meetingsListContext';
@@ -57,15 +57,16 @@ export function PreviousRow({ meeting, folderName }: PreviousRowProps) {
       }}
     >
       <div className="flex min-w-0 flex-1 items-center gap-3.5">
-        {/* Neutral note glyph — paper+ink, no per-note colour. Notes are told
-            apart by title + preview, not an arbitrary hash colour (which read
-            as meaningful and collided with the reserved status hues). */}
+        {/* Letter avatar — the note title's first initial, native-macOS-style.
+            Still paper+ink with no per-note colour: notes are told apart by
+            title + preview, not an arbitrary hash colour (which read as
+            meaningful and collided with the reserved status hues). */}
         <div
           aria-hidden="true"
-          className="flex size-9 flex-shrink-0 items-center justify-center rounded-lg"
+          className="flex size-9 flex-shrink-0 items-center justify-center rounded-lg text-[15px] font-medium"
           style={{ background: 'var(--surface-sunken)', color: 'var(--fg-2)' }}
         >
-          <FileText className="size-[17px]" />
+          {title.charAt(0).toUpperCase()}
         </div>
         
         <div className="flex min-w-0 flex-col gap-1">


### PR DESCRIPTION
Replaces the generic file glyph in the Previous Notes rows with the note title's first initial — a native-macOS touch. Still paper+ink, no per-note colour (notes are distinguished by title + preview, and hash colours would collide with the reserved status hues).

Extracted from @Vassista's #349 (the rest of that PR is being split into separate, current-design PRs). Renderer-only, additive; typecheck green.

Credit: @Vassista (#349).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the generic file icon in the Previous Notes list with a letter avatar showing the note title’s first initial, matching native macOS. Keeps the paper+ink style with no per-note color.

<sup>Written for commit e12283aa15ad8066628397591494ff3e9c3b742e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

