### PR TITLE
feat(notifications): route all notifications through the in-app toast (from #349)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -276,6 +276,11 @@ class Notification extends EventEmitter {
     });
     notificationWindow = win;
     win._activeCustomNotification = this;
+    // Also pin the window to the notification instance so a handler bound to
+    // THIS notif (e.g. the pre-meeting 'close' dismissal-telemetry handler) can
+    // read its OWN window's flags rather than the module-level `notificationWindow`,
+    // which a superseding toast reassigns out from under a not-yet-fired 'close'.
+    this._window = win;
     // Set true by close-notification-window / the action+body IPC handlers.
     // Scoped to this window instance (not a module-level flag) so a superseding
     // toast can't leak interaction state across windows. Only the pre-meeting
@@ -10247,8 +10252,15 @@ async function firePreMeetingNotification(event) {
   // _analyticsInteracted via close-notification-window — so skip it here to
   // avoid double-counting. This is the same split the old createNotificationWindow
   // used, preserved verbatim.
+  //
+  // Read THIS notif's own window (notif._window), never the module-level
+  // `notificationWindow`: when this toast is superseded, the successor reassigns
+  // `notificationWindow` (and resets its `_analyticsInteracted` to false) before
+  // this 'close' fires, so reading the module-level var would attribute this
+  // toast's dismissal to the NEXT toast's interaction flag — dropping or
+  // duplicating the dismiss. The per-instance window keeps the flag correct.
   notif.on('close', () => {
-    if (!notificationWindow || !notificationWindow._analyticsInteracted) {
+    if (!notif._window || !notif._window._analyticsInteracted) {
       trackEvent('notification_dismissed', { type: 'premeeting' });
     }
   });

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, Notification, powerMonitor, net, session, desktopCapturer } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, powerMonitor, net, session, desktopCapturer } = require('electron');
 
 // Prevent EPIPE crashes when stdout/stderr pipe is broken (e.g. launching terminal closed)
 process.stdout?.on('error', () => {});
@@ -185,6 +185,149 @@ function getOutputDir() {
 
 let mainWindow;
 let notificationWindow;
+
+// ── Custom notification toast ────────────────────────────────────────────────
+// Drop-in replacement for Electron's `Notification` that renders our OWN
+// frameless BrowserWindow toast (renderer route `/notification` →
+// NotificationToast.tsx) instead of an OS banner, so every notification is
+// visually consistent and theme-aware on macOS AND Windows. It mirrors the
+// slice of Electron's Notification API the app relies on:
+//   new Notification({ title, body, actions, iconType })
+//   .show() / .close() / .on('click'|'action'|'close') / static isSupported()
+// Being API-compatible means every existing call site — and
+// trackNotificationLifecycle — keeps working unchanged; they just render a
+// custom UI. See app/renderer/src/components/NotificationToast.tsx for the view.
+//
+// Events (kept identical to Electron's Notification so trackNotificationLifecycle
+// still tells an interaction from a passive dismiss):
+//   'click'  — the toast body was tapped        (renderer → notification-body-clicked)
+//   'action' — an action button was tapped      (renderer → notification-action-clicked, index arg)
+//   'close'  — the toast went away by ANY means (body/action click-through, the
+//              X button, the 15s auto-close, or being superseded)
+//
+// Single-toast semantics: only one toast window exists at a time; showing a new
+// one supersedes (closes) the current one — matching the pre-existing
+// pre-meeting toast.
+//
+// Cross-platform: the window options (transparent, alwaysOnTop, skipTaskbar,
+// focusable:false, hasShadow:false, positioned top-right via workArea) and the
+// setVisibleOnAllWorkspaces/setAlwaysOnTop calls are all valid on macOS AND
+// Windows — the `visibleOnFullScreen` option and the `'screen-saver'` level are
+// macOS-only but are harmlessly ignored on Windows. This is the exact window
+// config the pre-meeting toast already shipped with on both platforms, so
+// there's no new platform-specific surface to gate.
+const { EventEmitter } = require('events');
+
+class Notification extends EventEmitter {
+  constructor(options = {}) {
+    super();
+    this.options = options;
+    this.payload = {
+      id: `n_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`,
+      title: options.title || '',
+      body: options.body || options.subtitle || '',
+      actions: (options.actions || []).map((a) => ({
+        // Electron actions have no id; key by text (the app's actions are all
+        // single-button with a unique label, so this is stable).
+        id: a.text,
+        text: a.text,
+        type: a.type,
+      })),
+    };
+    if (options.iconType) this.payload.iconType = options.iconType;
+  }
+
+  show() {
+    // Supersede any current toast (single-toast semantics).
+    if (notificationWindow && !notificationWindow.isDestroyed()) {
+      notificationWindow.close();
+    }
+
+    const { screen } = require('electron');
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const { width } = primaryDisplay.workAreaSize;
+    const { x, y } = primaryDisplay.workArea;
+
+    // Capture the window in a local `win` so the ready-to-show / closed
+    // closures below always reference THIS toast's window — never a later one
+    // that superseded it via the module-level `notificationWindow`. Reading the
+    // module-level var inside those closures was the original closure bug: a
+    // fast-following toast reassigned it, and the earlier toast's timers/handlers
+    // then acted on the wrong window (closing the new toast, leaking the old).
+    const win = new BrowserWindow({
+      width: 400,
+      height: 70,
+      x: x + width - 425,
+      y: y + 1,
+      frame: false,
+      transparent: true,
+      alwaysOnTop: true,
+      resizable: false,
+      skipTaskbar: true,
+      focusable: false,
+      hasShadow: false,
+      backgroundColor: '#00000000',
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+        preload: path.join(__dirname, 'preload.js'),
+      },
+    });
+    notificationWindow = win;
+    win._activeCustomNotification = this;
+    // Set true by close-notification-window / the action+body IPC handlers.
+    // Scoped to this window instance (not a module-level flag) so a superseding
+    // toast can't leak interaction state across windows. Only the pre-meeting
+    // path reads it (to avoid double-counting a renderer-tracked dismiss against
+    // the main-side auto-close dismiss); the other notifications rely on
+    // trackNotificationLifecycle's own click/dismiss bookkeeping.
+    win._analyticsInteracted = false;
+
+    const rendererDist = path.join(__dirname, 'renderer', 'dist', 'index.html');
+    win.loadFile(rendererDist, { hash: '/notification' });
+
+    let autoCloseTimer;
+    // Registered immediately (not inside ready-to-show) so a toast superseded
+    // BEFORE it finishes loading still emits 'close' and clears the module-level
+    // ref — the auto-close timer simply hasn't been armed yet in that case.
+    win.on('closed', () => {
+      if (autoCloseTimer) clearTimeout(autoCloseTimer);
+      this.emit('close');
+      if (notificationWindow === win) notificationWindow = null;
+    });
+
+    win.once('ready-to-show', () => {
+      win.showInactive();
+      win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+      win.setAlwaysOnTop(true, 'screen-saver', 1);
+
+      // Keep the 15s auto-close (matches the pre-existing pre-meeting toast).
+      autoCloseTimer = setTimeout(() => {
+        if (!win.isDestroyed()) win.close();
+      }, 15000);
+
+      win.webContents.send('show-notification', this.payload);
+    });
+  }
+
+  close() {
+    // Only act if we're still the active toast — a superseded toast's window is
+    // already gone, so this is a harmless no-op in that case.
+    if (
+      notificationWindow &&
+      notificationWindow._activeCustomNotification === this &&
+      !notificationWindow.isDestroyed()
+    ) {
+      notificationWindow.close();
+    }
+  }
+
+  static isSupported() {
+    return true;
+  }
+}
+
 let pythonProcess;
 let tray = null;
 let isQuitting = false;
@@ -5084,8 +5227,9 @@ function showSleepPausedNotification() {
   const notif = new Notification({
     title: 'Recording paused',
     body: 'Paused while your computer was asleep. Resume to keep capturing.',
-    // `actions` renders on macOS only; the click handler below covers
-    // Windows, where the whole notification is the affordance.
+    iconType: 'alert',
+    // The Resume action button is always rendered by the custom toast (both
+    // platforms); the click handler below covers a body tap as well.
     actions: [{ type: 'button', text: 'Resume' }],
   });
   const resume = () => {
@@ -6837,6 +6981,7 @@ ipcMain.handle('show-silence-auto-stop-notification', async (_event, payload) =>
     const notif = new Notification({
       title: 'Recording stopped',
       body,
+      iconType: 'recording',
     });
     notif.on('click', () => {
       if (mainWindow && !mainWindow.isDestroyed()) {
@@ -6866,6 +7011,7 @@ ipcMain.handle('show-system-audio-mic-only-notification', async () => {
     const notif = new Notification({
       title: 'Recording mic-only',
       body: 'Screen Recording permission is needed to capture both sides of the call. Click to fix this in Settings.',
+      iconType: 'alert',
     });
     notif.on('click', () => {
       if (mainWindow && !mainWindow.isDestroyed()) {
@@ -6916,6 +7062,7 @@ ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
         : failed
           ? 'Your recording was preserved — open the note for details.'
           : (title || 'Your note has finished processing'),
+      iconType: (hardFailure || failed) ? 'alert' : 'success',
     });
     notif.on('click', () => {
       if (mainWindow && !mainWindow.isDestroyed()) {
@@ -8066,6 +8213,7 @@ function showRecordingFailedNotification(body) {
     new Notification({
       title: 'Steno',
       body: body || "Recording couldn't start.",
+      iconType: 'alert',
     }).show();
   } catch (error) {
     console.error('Failed to show recording-failed notification:', error.message);
@@ -10080,7 +10228,31 @@ async function firePreMeetingNotification(event) {
     return false;
   }
 
-  createNotificationWindow(event);
+  const notif = new Notification({ title: event.title || 'Meeting starting' });
+  // The pre-meeting toast carries a richer payload (time / meeting URL /
+  // attendees) and keeps its legacy renderer-side handlers (Join & take notes,
+  // focus-on-body-tap) plus its own click/dismiss analytics. `premeeting: true`
+  // tells NotificationToast to use that path instead of the generic
+  // action/body-click bridge the other notifications use.
+  notif.payload.premeeting = true;
+  notif.payload.time = event.start
+    ? new Date(event.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : '';
+  notif.payload.meeting_url = event.meeting_url;
+  notif.payload.attendees = event.attendees
+    ? event.attendees.map((a) => a.name || a.email).join(', ')
+    : '';
+  // Only count a PASSIVE dismiss here (15s auto-close or being superseded). An
+  // active click/X-dismiss is tracked by the renderer, which also flags
+  // _analyticsInteracted via close-notification-window — so skip it here to
+  // avoid double-counting. This is the same split the old createNotificationWindow
+  // used, preserved verbatim.
+  notif.on('close', () => {
+    if (!notificationWindow || !notificationWindow._analyticsInteracted) {
+      trackEvent('notification_dismissed', { type: 'premeeting' });
+    }
+  });
+  notif.show();
   trackEvent('notification_shown', { type: 'premeeting' });
 
   // Mark fired only after we've actually shown it, so an unshowable notif
@@ -10089,86 +10261,42 @@ async function firePreMeetingNotification(event) {
   return true;
 }
 
-function createNotificationWindow(event) {
-  if (notificationWindow && !notificationWindow.isDestroyed()) {
-    notificationWindow.close();
-  }
-
-  const { screen } = require('electron');
-  const primaryDisplay = screen.getPrimaryDisplay();
-  const { width } = primaryDisplay.workAreaSize;
-  const { x, y } = primaryDisplay.workArea;
-
-  notificationWindow = new BrowserWindow({
-    width: 400,
-    height: 70,
-    x: x + width - 425,
-    y: y + 1,
-    frame: false,
-    transparent: true,
-    alwaysOnTop: true,
-    resizable: false,
-    skipTaskbar: true,
-    focusable: false,
-    hasShadow: false,
-    backgroundColor: '#00000000',
-    webPreferences: {
-      nodeIntegration: false,
-      contextIsolation: true,
-      sandbox: true,
-      preload: path.join(__dirname, 'preload.js'),
-    },
-  });
-
-  const rendererDist = path.join(__dirname, 'renderer', 'dist', 'index.html');
-  notificationWindow.loadFile(rendererDist, { hash: '/notification' });
-
-  const win = notificationWindow;
-  // Set true by close-notification-window (the renderer's Join/Focus/Close
-  // handlers all route through it, and each already tracks its own
-  // notification_clicked/_dismissed via the analytics bridge before calling
-  // it). Scoped to this window instance -- not a module-level flag -- so a
-  // new notification superseding an unactioned old one can't leak state
-  // across windows. Stays false only when the window closes via the 15s
-  // auto-close timer with no interaction at all, which is the passive-
-  // dismiss path the native Notification lifecycle already tracks but this
-  // custom BrowserWindow-based notification previously didn't.
-  win._analyticsInteracted = false;
-  let autoCloseTimer;
-  win.once('ready-to-show', () => {
-    win.showInactive();
-    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
-    win.setAlwaysOnTop(true, 'screen-saver', 1);
-
-    autoCloseTimer = setTimeout(() => {
-      if (!win.isDestroyed()) {
-        win.close();
-      }
-    }, 15000);
-
-    win.on('closed', () => {
-      if (autoCloseTimer) clearTimeout(autoCloseTimer);
-      if (!win._analyticsInteracted) {
-        trackEvent('notification_dismissed', { type: 'premeeting' });
-      }
-      if (notificationWindow === win) {
-        notificationWindow = null;
-      }
-    });
-
-    win.webContents.send('show-notification', {
-      title: event.title || 'Meeting starting',
-      time: event.start ? new Date(event.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '',
-      meeting_url: event.meeting_url,
-      attendees: event.attendees ? event.attendees.map(a => a.name || a.email).join(', ') : '',
-    });
-  });
-}
-
+// Renderer → main: the active toast was closed by an explicit user action (a
+// Join/body tap, an action button, or the X). Flags _analyticsInteracted so the
+// pre-meeting path doesn't ALSO count a passive dismiss for the same toast, then
+// closes the window (which fires the notification's 'close' event).
 ipcMain.handle('close-notification-window', () => {
   if (notificationWindow && !notificationWindow.isDestroyed()) {
     notificationWindow._analyticsInteracted = true;
     notificationWindow.close();
+  }
+});
+
+// Renderer → main: an action button was tapped on the generic (non-pre-meeting)
+// toast. Re-emit as the notification's 'action' event (with the button index,
+// matching Electron's Notification 'action' signature) so the call site's
+// existing `.on('action', ...)` handler + trackNotificationLifecycle both fire.
+ipcMain.on('notification-action-clicked', (_event, { actionId, notifId } = {}) => {
+  if (notificationWindow && !notificationWindow.isDestroyed()) {
+    const notif = notificationWindow._activeCustomNotification;
+    if (notif && notif.payload.id === notifId) {
+      notificationWindow._analyticsInteracted = true;
+      const index = notif.payload.actions.findIndex((a) => a.id === actionId);
+      notif.emit('action', {}, index);
+    }
+  }
+});
+
+// Renderer → main: the body of the generic toast was tapped. Re-emit as the
+// notification's 'click' event so the call site's `.on('click', ...)` handler +
+// trackNotificationLifecycle both fire.
+ipcMain.on('notification-body-clicked', (_event, { notifId } = {}) => {
+  if (notificationWindow && !notificationWindow.isDestroyed()) {
+    const notif = notificationWindow._activeCustomNotification;
+    if (notif && notif.payload.id === notifId) {
+      notificationWindow._analyticsInteracted = true;
+      notif.emit('click');
+    }
   }
 });
 

--- a/app/preload.js
+++ b/app/preload.js
@@ -343,6 +343,8 @@ const stenoai = {
 
   notification: {
     close: () => invoke('close-notification-window'),
+    actionClicked: (actionId, notifId) => send('notification-action-clicked', { actionId, notifId }),
+    bodyClicked: (notifId) => send('notification-body-clicked', { notifId }),
   },
 
   // All main-driven events. Every subscribe returns an unsubscribe fn.

--- a/app/renderer/src/components/NotificationToast.test.tsx
+++ b/app/renderer/src/components/NotificationToast.test.tsx
@@ -30,5 +30,6 @@ describe('notificationIconMeta', () => {
     // @ts-expect-error - intentionally exercising an out-of-contract value
     const meta = notificationIconMeta('bogus');
     expect(meta?.Icon).toBe(Info);
+    expect(meta?.className).toContain('gray');
   });
 });

--- a/app/renderer/src/components/NotificationToast.test.tsx
+++ b/app/renderer/src/components/NotificationToast.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { AlertCircle, CheckCircle2, Mic, Info } from 'lucide-react';
+import { notificationIconMeta } from './NotificationToast';
+
+describe('notificationIconMeta', () => {
+  it('returns null for the brand app icon (unset or "app")', () => {
+    expect(notificationIconMeta(undefined)).toBeNull();
+    expect(notificationIconMeta('app')).toBeNull();
+  });
+
+  it('maps alert -> red AlertCircle', () => {
+    const meta = notificationIconMeta('alert');
+    expect(meta?.Icon).toBe(AlertCircle);
+    expect(meta?.className).toContain('red');
+  });
+
+  it('maps success -> green CheckCircle2', () => {
+    const meta = notificationIconMeta('success');
+    expect(meta?.Icon).toBe(CheckCircle2);
+    expect(meta?.className).toContain('green');
+  });
+
+  it('maps recording -> blue Mic', () => {
+    const meta = notificationIconMeta('recording');
+    expect(meta?.Icon).toBe(Mic);
+    expect(meta?.className).toContain('blue');
+  });
+
+  it('falls back to Info for an unknown iconType', () => {
+    // @ts-expect-error - intentionally exercising an out-of-contract value
+    const meta = notificationIconMeta('bogus');
+    expect(meta?.Icon).toBe(Info);
+  });
+});

--- a/app/renderer/src/components/NotificationToast.tsx
+++ b/app/renderer/src/components/NotificationToast.tsx
@@ -1,12 +1,56 @@
 import * as React from 'react';
 import { ipc } from '@/lib/ipc';
 import { useTheme } from '@/hooks/useTheme';
+import { AppIcon } from '@/components/ui/app-icon';
+import { AlertCircle, CheckCircle2, Mic, Info } from 'lucide-react';
+
+export type NotificationIconType = 'app' | 'alert' | 'success' | 'recording';
+
+interface NotificationAction {
+  id: string;
+  text: string;
+  type?: 'primary' | 'secondary';
+}
 
 interface NotificationData {
+  id?: string;
   title: string;
-  time: string;
+  body?: string;
+  time?: string;
   meeting_url?: string;
   attendees?: string;
+  /** The pre-meeting reminder keeps its bespoke Join / focus behavior + its own
+   *  analytics; every other notification is a "generic" toast routed through the
+   *  action/body-click bridge and tracked entirely main-side. */
+  premeeting?: boolean;
+  iconType?: NotificationIconType;
+  color?: string;
+  actions?: NotificationAction[];
+}
+
+type IconComponent = React.ComponentType<{ size?: number; className?: string }>;
+
+/**
+ * Map an `iconType` to the lucide icon + tint shown on a generic toast that has
+ * no action buttons. `'app'` (or unset) renders the brand mark instead, so this
+ * returns `null` for that case. Exported + pure for unit testing.
+ */
+export function notificationIconMeta(
+  iconType?: NotificationIconType,
+): { Icon: IconComponent; className: string } | null {
+  switch (iconType) {
+    case 'alert':
+      return { Icon: AlertCircle, className: 'text-red-500' };
+    case 'success':
+      return { Icon: CheckCircle2, className: 'text-green-500' };
+    case 'recording':
+      return { Icon: Mic, className: 'text-blue-500' };
+    case 'app':
+    case undefined:
+      return null; // brand AppIcon
+    default:
+      return { Icon: Info, className: 'text-gray-400' };
+  }
 }
 
 export function NotificationToast() {
@@ -22,13 +66,20 @@ export function NotificationToast() {
 
   if (!data) return null;
 
+  const isPremeeting = !!data.premeeting;
+  const hasValidUrl = !!(data.meeting_url && /^https?:\/\//i.test(data.meeting_url));
+  const hasActions = !!(data.actions && data.actions.length > 0);
+
   const handleClose = (e?: React.MouseEvent) => {
     e?.stopPropagation();
-    ipc().analytics.track('notification_dismissed', { type: 'premeeting' });
+    // Pre-meeting tracks its own dismiss (main only counts a PASSIVE dismiss for
+    // it). Generic notifications are tracked entirely main-side via
+    // trackNotificationLifecycle, so the renderer must NOT double-track them.
+    if (isPremeeting) {
+      ipc().analytics.track('notification_dismissed', { type: 'premeeting' });
+    }
     ipc().notification.close();
   };
-
-  const hasValidUrl = !!(data.meeting_url && /^https?:\/\//i.test(data.meeting_url));
 
   const handleJoin = (e?: React.MouseEvent) => {
     e?.stopPropagation();
@@ -40,13 +91,26 @@ export function NotificationToast() {
     ipc().notification.close();
   };
 
-  const handleFocusMain = () => {
-    ipc().analytics.track('notification_clicked', { type: 'premeeting' });
-    ipc().window.focus();
+  const handleGenericAction = (actionId: string, e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    // The button's side effect lives on the main-side notification's 'action'
+    // handler; the renderer only relays the tap, then closes.
+    ipc().notification.actionClicked(actionId, data.id);
+    ipc().notification.close();
+  };
+
+  const handleBody = () => {
+    if (isPremeeting) {
+      ipc().analytics.track('notification_clicked', { type: 'premeeting' });
+      ipc().window.focus();
+    } else {
+      ipc().notification.bodyClicked(data.id);
+    }
     ipc().notification.close();
   };
 
   const getEventColor = (title: string) => {
+    if (data.color) return data.color;
     const colors = ['#10B981', '#3B82F6', '#8B5CF6', '#EC4899', '#F59E0B', '#EF4444', '#06B6D4'];
     let hash = 0;
     for (let i = 0; i < title.length; i++) {
@@ -56,6 +120,7 @@ export function NotificationToast() {
   };
 
   const barColor = getEventColor(data.title);
+  const iconMeta = notificationIconMeta(data.iconType);
 
   return (
     <>
@@ -65,56 +130,80 @@ export function NotificationToast() {
         }
       `}</style>
       <div className="flex h-screen w-screen items-center justify-center bg-transparent p-3">
-        <div 
-        className="group relative flex w-full cursor-pointer items-center justify-between rounded-[20px] bg-white p-2.5 pr-3 border border-gray-200 dark:bg-[#1E1E1E] dark:border-white/10"
-        style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
-        onClick={handleFocusMain}
-      >
-        <button
-          onClick={handleClose}
-          className="absolute -top-1.5 -left-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow-sm border border-gray-200 text-gray-500 opacity-0 transition-opacity hover:bg-gray-50 hover:text-gray-700 group-hover:opacity-100 dark:bg-[#2C2C2E] dark:border-white/10 dark:text-gray-400 dark:hover:bg-[#3C3C3E] dark:hover:text-gray-200"
-          title="Close"
+        <div
+          className="group relative flex w-full cursor-pointer items-center justify-between rounded-[20px] bg-white p-2.5 pr-3 border border-gray-200 shadow-sm dark:bg-[#1E1E1E] dark:border-white/10"
+          style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
+          onClick={handleBody}
         >
-          <svg width="8" height="8" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 1L13 13M1 13L13 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-          </svg>
-        </button>
-
-        <div className="flex items-center">
-          <div 
-            className="h-8 w-1 rounded-full ml-1 shrink-0" 
-            style={{ backgroundColor: barColor }}
-          ></div>
-          <div className="flex flex-col justify-center ml-3">
-            <span className="text-[14px] font-medium text-gray-900 tracking-tight leading-tight truncate max-w-[150px] dark:text-gray-100">
-              {data.title}
-            </span>
-            <span className="text-[12px] font-normal text-gray-500 leading-tight mt-0.5 dark:text-gray-400">
-              {data.time}
-            </span>
-          </div>
-        </div>
-
-        {hasValidUrl && (
           <button
-            onClick={handleJoin}
-            className="flex items-center gap-2 rounded-[10px] border border-gray-200 bg-white px-3 py-1.5 text-[13px] font-medium text-gray-900 transition-all hover:bg-gray-50 hover:shadow-sm active:bg-gray-100 active:scale-[0.98] shrink-0 dark:border-white/10 dark:bg-[#2C2C2E] dark:text-gray-100 dark:hover:bg-[#3C3C3E] dark:active:bg-[#1C1C1E]"
+            onClick={handleClose}
+            className="absolute -top-1.5 -left-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow-sm border border-gray-200 text-gray-500 opacity-0 transition-opacity hover:bg-gray-50 hover:text-gray-700 group-hover:opacity-100 dark:bg-[#2C2C2E] dark:border-white/10 dark:text-gray-400 dark:hover:bg-[#3C3C3E] dark:hover:text-gray-200"
+            title="Close"
           >
-            <ProfessionalCameraIcon className="h-5 w-5" backgroundColor={barColor} />
-            <span>Join & take notes</span>
+            <svg width="8" height="8" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M1 1L13 13M1 13L13 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
           </button>
-        )}
+
+          <div className="flex items-center min-w-0">
+            <div
+              className="h-8 w-1 rounded-full ml-1 shrink-0"
+              style={{ backgroundColor: barColor }}
+            ></div>
+            <div className="flex flex-col justify-center ml-3 min-w-0">
+              <span className="text-[14px] font-medium text-gray-900 tracking-tight leading-tight truncate max-w-[220px] dark:text-gray-100">
+                {data.title}
+              </span>
+              {(data.body || data.time) && (
+                <span className="text-[12px] font-normal text-gray-500 leading-tight mt-0.5 truncate max-w-[220px] dark:text-gray-400">
+                  {data.body || data.time}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {hasActions ? (
+            <div className="flex items-center gap-1.5 shrink-0 pl-2">
+              {data.actions!.map((action) => (
+                <button
+                  key={action.id}
+                  onClick={(e) => handleGenericAction(action.id, e)}
+                  className="flex items-center justify-center rounded-[10px] border border-gray-200 bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 transition-all hover:bg-gray-50 hover:shadow-sm active:bg-gray-100 active:scale-[0.98] shrink-0 dark:border-white/10 dark:bg-[#2C2C2E] dark:text-gray-100 dark:hover:bg-[#3C3C3E] dark:active:bg-[#1C1C1E]"
+                >
+                  {action.text}
+                </button>
+              ))}
+            </div>
+          ) : isPremeeting ? (
+            hasValidUrl ? (
+              <button
+                onClick={handleJoin}
+                className="flex items-center gap-2 rounded-[10px] border border-gray-200 bg-white px-3 py-1.5 text-[13px] font-medium text-gray-900 transition-all hover:bg-gray-50 hover:shadow-sm active:bg-gray-100 active:scale-[0.98] shrink-0 dark:border-white/10 dark:bg-[#2C2C2E] dark:text-gray-100 dark:hover:bg-[#3C3C3E] dark:active:bg-[#1C1C1E]"
+              >
+                <ProfessionalCameraIcon className="h-5 w-5" backgroundColor={barColor} />
+                <span>Join &amp; take notes</span>
+              </button>
+            ) : null
+          ) : (
+            <div className="flex items-center justify-center shrink-0 pr-1 text-gray-500 dark:text-gray-400">
+              {iconMeta ? (
+                <iconMeta.Icon size={20} className={iconMeta.className} />
+              ) : (
+                <AppIcon size={24} color="currentColor" />
+              )}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
     </>
   );
 }
 
-function ProfessionalCameraIcon({ className, backgroundColor = '#10B981' }: { className?: string, backgroundColor?: string }) {
+function ProfessionalCameraIcon({ className, backgroundColor = '#10B981' }: { className?: string; backgroundColor?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect width="24" height="24" rx="5.5" fill={backgroundColor}/>
-      <path d="M15.5 10.5V8C15.5 7.17157 14.8284 6.5 14 6.5H6C5.17157 6.5 4.5 7.17157 4.5 8V16C4.5 16.8284 5.17157 17.5 6 17.5H14C14.8284 17.5 15.5 16.8284 15.5 16V13.5L19.5 16.5V7.5L15.5 10.5Z" fill="white"/>
+      <rect width="24" height="24" rx="5.5" fill={backgroundColor} />
+      <path d="M15.5 10.5V8C15.5 7.17157 14.8284 6.5 14 6.5H6C5.17157 6.5 4.5 7.17157 4.5 8V16C4.5 16.8284 5.17157 17.5 6 17.5H14C14.8284 17.5 15.5 16.8284 15.5 16V13.5L19.5 16.5V7.5L15.5 10.5Z" fill="white" />
     </svg>
   );
 }

--- a/app/renderer/src/components/ui/app-icon.tsx
+++ b/app/renderer/src/components/ui/app-icon.tsx
@@ -3,9 +3,13 @@ import { cn } from '@/lib/utils';
 interface AppIconProps {
   size?: number;
   className?: string;
+  /** Stroke color for the mark. Defaults to the themed foreground token;
+   *  pass `currentColor` to inherit the parent's text color (e.g. inside the
+   *  notification toast, which recolors it per state). */
+  color?: string;
 }
 
-export function AppIcon({ size = 80, className }: AppIconProps) {
+export function AppIcon({ size = 80, className, color = 'var(--fg-1)' }: AppIconProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -18,7 +22,7 @@ export function AppIcon({ size = 80, className }: AppIconProps) {
       aria-label="Steno"
       role="img"
       className={cn('shrink-0', className)}
-      style={{ color: 'var(--fg-1)' }}
+      style={{ color }}
     >
       <path d="M209.447 166.845C216.663 178.772 218.44 193.966 219.417 213.035C219.422 213.129 219.42 213.225 219.412 213.319C214.789 263.829 206.174 314.234 212.902 339.223C216.552 352.776 220.264 365.163 222.752 376.169C223.295 378.571 226.99 378.494 227.504 376.086C230.284 363.077 235.173 350.435 238.631 339.223C244.283 320.903 234.784 262.669 231.647 213.178C232.645 196.737 231.398 182.538 241.126 166.845M198.971 149.906C168.786 114.986 141.601 89.6233 93.21 90.3707C44.8194 91.1182 56.9695 115.86 74.0034 131.971C91.0372 148.081 141.627 159.331 184.18 158.423C165.298 159.389 201.563 157.91 131.124 159.87C60.7551 161.828 59.9172 224.098 127.681 209.733C127.81 209.705 127.945 209.663 128.065 209.611C168.511 192.126 188.231 177.43 218.676 143.678M231.647 125.494C278.527 72.0571 171.372 66.055 217.429 124.498C240.809 154.72 227.634 146.076 285.026 191.257C342.419 236.437 456.639 176.062 271.806 158.873C290.471 159.304 302.167 161.07 317.703 157.628C434.433 128.215 403.63 47.4569 282.532 121.508C268.291 131.274 261.97 137.712 252.35 150.155" />
     </svg>

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -1107,10 +1107,16 @@ export interface StenoaiBridge {
     trayOpenSettings: Subscribe<void>;
     showQuitDialog: Subscribe<{ type: 'recording' | 'processing'; jobCount?: number }>;
     showNotification: Subscribe<{
+      id?: string;
       title: string;
-      time: string;
+      body?: string;
+      time?: string;
       meeting_url?: string;
       attendees?: string;
+      premeeting?: boolean;
+      iconType?: 'app' | 'alert' | 'success' | 'recording';
+      color?: string;
+      actions?: { id: string; text: string; type?: 'primary' | 'secondary' }[];
     }>;
   };
 
@@ -1140,6 +1146,8 @@ export interface StenoaiBridge {
 
   notification: {
     close: RequestFn<[], void>;
+    actionClicked: SendFn<[actionId: string, notifId?: string]>;
+    bodyClicked: SendFn<[notifId?: string]>;
   };
 
   subscribeQueryStream: (


### PR DESCRIPTION
## Summary

Routes **all** app notifications through Steno's own frameless React toast (the one already used for pre-meeting reminders), instead of native OS notifications. Extracted from @Vassista's #349, adapted and made cross-platform-safe.

## Approach (low-blast-radius)
Rather than rip out every call site, this replaces Electron's native `Notification` with an **API-compatible shadow class** (extends `EventEmitter`, same `new Notification({title,body,…})` / `.show()` / `.close()` / `.on('click'|'action'|'close')` / `static isSupported()`). All 8 existing call sites and `trackNotificationLifecycle` keep working unchanged; two new send channels relay action/body taps back so each site's handlers + analytics still fire. The pre-meeting reminder moves onto the same class.

All 8 sites preserved with equivalent actions + icon types: shortcut, sleep-paused (Resume), silence auto-stop, system-audio mic-only (→Settings), note-ready (→note), meeting-detected (Take Notes), meeting-ended (Summarise), recording-failed.

## Cross-platform
Reuses the exact window config the pre-meeting toast already shipped on both OSes (transparent, alwaysOnTop, skipTaskbar, focusable:false, top-right via workArea DIPs). The mac-only bits (`visibleOnFullScreen`, `'screen-saver'` level) are ignored on Windows; the mac-only shortcut-notification gate is untouched.

## Closure-bug fix
`show()` captures the window locally so `closed`/auto-close closures never touch a module-level ref a superseding toast reassigned; the `closed` handler is registered immediately so a superseded-before-load toast still emits `close`. 15s auto-close kept; passive dismissals still tracked.

## Tests
- Generalized `NotificationToast.tsx` + `app-icon.tsx` color prop; new vitest for the icon mapping (5/5).
- `notifications.t2` still passes (the enabled-toggle `shown`-signal gating intact).
- `typecheck:renderer` + `ipc-contract` (7/7) green.

## ⚠️ Reviewer: an intentional behavior change
The 7 previously-native notifications **no longer appear in the OS Notification Center, have no notification sound, and auto-dismiss after 15s**. Most consequential for the **sleep-paused "Recording paused"** notice, which previously persisted until dismissed. This trade-off is inherent to the feature (in-app toast vs. native). Flagging for an explicit decision before merge — everything else is behavior-preserving.

Credit: @Vassista (#349).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all app notifications through our in‑app toast instead of native OS banners. Preserves existing handlers and makes notifications consistent on macOS and Windows.

- **New Features**
  - API‑compatible `Notification` replacement renders a frameless toast; all 8 call sites continue to work.
  - Pre‑meeting uses the same class (`premeeting` flag). Generic toasts relay body/actions via `notification-body-clicked` and `notification-action-clicked`; added state icons (`alert`, `success`, `recording`) and optional action buttons; `AppIcon` supports a `color` prop.
  - Behavior change: no OS Notification Center or system sound; toasts auto‑dismiss after 15s.

- **Bug Fixes**
  - Fixed a closure bug by capturing the toast window locally so `close` always applies to the right toast; maintains single‑toast supersede behavior and passive‑dismiss tracking.
  - Correctly attribute superseded pre‑meeting dismiss telemetry by reading the per‑instance flag on `notif._window`.

<sup>Written for commit 41a4f074a622ecc5fb9861feb339add540a1f60b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

