### PR TITLE
fix(release): make the Discord announcer robust to notes format

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -204,10 +204,19 @@ jobs:
         if [ -z "$MSG" ]; then
           MSG=$(git for-each-ref --format='%(contents:subject)' "refs/tags/${{ github.ref_name }}")
         fi
+        # Full contents (subject + body) for the Discord announcer: the tag
+        # SUBJECT is the release's one-line summary, and %(contents:body) drops
+        # it — which left the announcement with a generic fallback summary. The
+        # GitHub Release body still uses `text` (body only); the announcer uses
+        # `text_full` so its summary line survives.
+        FULL=$(git for-each-ref --format='%(contents)' "refs/tags/${{ github.ref_name }}")
         {
           echo 'text<<STENO_RELEASE_EOF'
           echo "$MSG"
           echo 'STENO_RELEASE_EOF'
+          echo 'text_full<<STENO_RELEASE_FULL_EOF'
+          echo "$FULL"
+          echo 'STENO_RELEASE_FULL_EOF'
         } >> "$GITHUB_OUTPUT"
 
     - name: Download all build artifacts
@@ -293,5 +302,5 @@ jobs:
         DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         VERSION: ${{ github.event.inputs.version || steps.package_version.outputs.version }}
         RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version || steps.package_version.outputs.version }}
-        RELEASE_NOTES: ${{ steps.tag_body.outputs.text }}
+        RELEASE_NOTES: ${{ steps.tag_body.outputs.text_full }}
       run: node scripts/discord-release-announce.mjs

--- a/scripts/discord-release-announce.mjs
+++ b/scripts/discord-release-announce.mjs
@@ -36,14 +36,22 @@ if (!webhook) {
 const lines = notes.split('\n').map((l) => l.replace(/\r$/, ''));
 
 // 1. Summary = the first non-empty line that isn't a heading or a bullet.
-const summary =
+//    A leading "v1.2.3 — " / "Steno v1.2.3 — " prefix is dropped so the summary
+//    doesn't just repeat the version already in the greeting + embed title. If
+//    the notes carry no prose summary line at all, we omit it rather than print
+//    a redundant "Steno vX is out." (the greeting already says that).
+const summary = (
   lines.find((l) => {
     const t = l.trim();
     return t && !t.startsWith('#') && !t.startsWith('-') && !t.startsWith('>');
-  })?.trim() || `Steno v${version} is out.`;
+  })?.trim() || ''
+).replace(/^(?:steno\s+)?v?\d+\.\d+\.\d+\s*[—:-]\s*/i, '').trim();
 
-// 2. Headline features = the first few "- **Name** — desc" bullets, skipping the
-//    "Upgrade notes" and "Thanks to our contributors" sections (not features).
+// 2. Headline features. Preferred shape is "- **Name** — desc" bullets (skipping
+//    the Upgrade / Thanks sections). If a release's notes instead use a
+//    "### Feature\n- description" shape (section header IS the feature), we fall
+//    back to synthesising one feature per content section — so the announcement
+//    never silently loses its features section over a formatting slip.
 const featureBullets = [];
 let section = '';
 for (const line of lines) {
@@ -59,6 +67,32 @@ for (const line of lines) {
     const desc = (m[2] || '').trim().replace(/\s+/g, ' ');
     featureBullets.push(desc ? `• **${name}** — ${truncate(desc, 140)}` : `• **${name}**`);
   }
+}
+if (featureBullets.length === 0) {
+  // Fallback: section title = feature name, its bullet text = description.
+  let sec = '';
+  let desc = [];
+  const flush = () => {
+    if (sec && desc.length) {
+      featureBullets.push(`• **${sec}** — ${truncate(desc.join(' ').replace(/\s+/g, ' '), 140)}`);
+    }
+    sec = '';
+    desc = [];
+  };
+  for (const line of lines) {
+    const h = line.match(/^###\s+(.*)$/);
+    if (h) {
+      flush();
+      const t = h[1].trim();
+      sec = /upgrade|contributor/i.test(t) ? '' : t;
+      continue;
+    }
+    if (sec) {
+      const b = line.match(/^-\s+(.*)$/);
+      if (b) desc.push(b[1].trim());
+    }
+  }
+  flush();
 }
 const features = featureBullets.slice(0, 4);
 
@@ -85,7 +119,8 @@ const greeting = `🚀 Hey @here — **Steno v${version}** is out!`;
 
 // The embed carries the substance: summary, headline features, contributor
 // thanks, and a link to the full notes.
-const parts = [truncate(summary, 300)];
+const parts = [];
+if (summary) parts.push(truncate(summary, 300));
 if (features.length) parts.push(`**A bunch of great features:**\n${features.join('\n')}`);
 if (contributors) parts.push(contributors);
 parts.push(`[Full release notes →](${releaseUrl})`);

--- a/scripts/discord-release-announce.mjs
+++ b/scripts/discord-release-announce.mjs
@@ -47,53 +47,50 @@ const summary = (
   })?.trim() || ''
 ).replace(/^(?:steno\s+)?v?\d+\.\d+\.\d+\s*[—:-]\s*/i, '').trim();
 
-// 2. Headline features. Preferred shape is "- **Name** — desc" bullets (skipping
-//    the Upgrade / Thanks sections). If a release's notes instead use a
-//    "### Feature\n- description" shape (section header IS the feature), we fall
-//    back to synthesising one feature per content section — so the announcement
-//    never silently loses its features section over a formatting slip.
+// 2. Headline features — a single pass that supports BOTH note shapes, even
+//    mixed in one release (skipping the Upgrade / Thanks sections):
+//     - "- **Name** — desc" bullets each become a feature (works with or
+//       without an enclosing "### Section").
+//     - a "### Feature\n- description" section (the header IS the feature, with
+//       only plain bullets) becomes one feature: title = name, bullet text = desc.
+//    A section that has any bold bullet uses those and ignores its plain bullets,
+//    so the two shapes never double-count the same section.
 const featureBullets = [];
-let section = '';
+let sectionTitle = ''; // '' when outside a named content section
+let excluded = false; // current section is Upgrade / Thanks (not a feature)
+let sectionHasBold = false;
+let plainDesc = [];
+const flushSection = () => {
+  if (sectionTitle && !excluded && !sectionHasBold && plainDesc.length) {
+    featureBullets.push(
+      `• **${sectionTitle}** — ${truncate(plainDesc.join(' ').replace(/\s+/g, ' '), 140)}`,
+    );
+  }
+  sectionHasBold = false;
+  plainDesc = [];
+};
 for (const line of lines) {
   const h = line.match(/^###\s+(.*)$/);
   if (h) {
-    section = h[1].trim().toLowerCase();
+    flushSection();
+    const t = h[1].trim();
+    excluded = /upgrade|contributor/i.test(t);
+    sectionTitle = excluded ? '' : t;
     continue;
   }
-  if (section.includes('upgrade') || section.includes('contributor')) continue;
-  const m = line.match(/^-\s+\*\*(.+?)\*\*\s*(?:[—-]\s*(.*))?$/);
-  if (m) {
-    const name = m[1].trim();
-    const desc = (m[2] || '').trim().replace(/\s+/g, ' ');
+  if (excluded) continue;
+  const bold = line.match(/^-\s+\*\*(.+?)\*\*\s*(?:[—-]\s*(.*))?$/);
+  if (bold) {
+    sectionHasBold = true;
+    const name = bold[1].trim();
+    const desc = (bold[2] || '').trim().replace(/\s+/g, ' ');
     featureBullets.push(desc ? `• **${name}** — ${truncate(desc, 140)}` : `• **${name}**`);
+    continue;
   }
+  const plain = line.match(/^-\s+(.*)$/);
+  if (plain && sectionTitle) plainDesc.push(plain[1].trim());
 }
-if (featureBullets.length === 0) {
-  // Fallback: section title = feature name, its bullet text = description.
-  let sec = '';
-  let desc = [];
-  const flush = () => {
-    if (sec && desc.length) {
-      featureBullets.push(`• **${sec}** — ${truncate(desc.join(' ').replace(/\s+/g, ' '), 140)}`);
-    }
-    sec = '';
-    desc = [];
-  };
-  for (const line of lines) {
-    const h = line.match(/^###\s+(.*)$/);
-    if (h) {
-      flush();
-      const t = h[1].trim();
-      sec = /upgrade|contributor/i.test(t) ? '' : t;
-      continue;
-    }
-    if (sec) {
-      const b = line.match(/^-\s+(.*)$/);
-      if (b) desc.push(b[1].trim());
-    }
-  }
-  flush();
-}
+flushSection();
 const features = featureBullets.slice(0, 4);
 
 // 3. Contributors = the paragraph under the "Thanks to our contributors" heading.


### PR DESCRIPTION
## Why

The **v0.6.3** Discord announcement shipped broken — no "A bunch of great features:" section and a generic "Steno v0.6.3 is out." summary (screenshot in thread). Root causes:

1. The workflow fed the announcer `%(contents:body)` — the tag **body**, which excludes line 1 (git's tag *subject* = the summary). So the summary was never seen → generic fallback.
2. The feature parser only matched `- **Name** — desc` bullets. v0.6.3's notes used `### Feature` headers + plain `- description` bullets → **zero** features matched → the whole section vanished.

## Fix (release-infra only)

- **Workflow:** add a `text_full` output (`%(contents)`, subject + body) and point `RELEASE_NOTES` at it so the summary line survives. The GitHub Release body still uses body-only `text`.
- **Announcer:** fall back to synthesising one feature per `### Section` (title = name, bullet text = description) when no bold bullets exist — so an empty features section can never ship again. Also strip a redundant leading `vX.Y.Z —` from the summary and omit the summary rather than printing `Steno vX is out.` when the notes carry none.

## Verified

`DISCORD_DRY_RUN` against both note styles:
- **v0.6.3** (section-header): now renders summary + 4 feature bullets + contributor line.
- **v0.6.0** (bold-bullet): unchanged — bold-bullet features + combined `This release includes work from @… 🙏`.

Note: v0.6.3's post already went out; this fixes future releases (I can manually re-post a corrected v0.6.3 announcement if you want).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Discord release announcer so summaries and feature lists render correctly. We now pass full tag contents and parse mixed note formats (bold bullets + section headers) without double-counting.

- **Bug Fixes**
  - Workflow: add `text_full` from `%(contents)` and point `RELEASE_NOTES` at it to keep the summary line; GitHub Release body stays body-only.
  - Announcer: single-pass parser handles bold bullets and `### Section` + plain bullets together; a section becomes one feature only if it has no bold bullets; skip Upgrade/Contributors.
  - Announcer: strip a leading "vX.Y.Z —"/"Steno vX.Y.Z —" in the summary and omit it entirely if the notes provide none.

<sup>Written for commit 653f07111a16ffa4c4c59ba46720a3bcf2f93b8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

