### PR TITLE
fix(settings): reset to General on bare /settings so browser Back can't strand a stale tab

### DIFF
--- a/app/renderer/src/routes/Settings.tsx
+++ b/app/renderer/src/routes/Settings.tsx
@@ -61,6 +61,17 @@ function resolveTab(id: DeepLinkId): SettingsTabId {
   return id === 'transcription' ? 'ai' : id;
 }
 
+// Resolve the `?tab=` param of a route to a nav tab, or null when absent or
+// not a known deep-link id. Single definition shared by the first-mount
+// initialTab and the route-reactive sync effect so the two can't drift.
+function tabFromRoute(route: string): SettingsTabId | null {
+  const requested = getRouteParam(route, 'tab');
+  if (requested && (DEEP_LINK_IDS as readonly string[]).includes(requested)) {
+    return resolveTab(requested as DeepLinkId);
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Settings page — a full takeover of the main app chrome (Granola/Wispr
 // style): the folder/meeting sidebar is replaced entirely by SettingsNav
@@ -76,23 +87,23 @@ export function Settings() {
   // Used by the sidebar's "Sign in to organisation" CTA to land users
   // directly on the org sign-in form rather than the General tab.
   const route = useRoute();
-  const initialTab = React.useMemo<SettingsTabId>(() => {
-    const requested = getRouteParam(route, 'tab');
-    if (requested && (DEEP_LINK_IDS as readonly string[]).includes(requested)) {
-      return resolveTab(requested as DeepLinkId);
-    }
-    return 'general';
-  }, []); // Intentional — only consume the URL param on first mount.
+  const initialTab = React.useMemo<SettingsTabId>(
+    () => tabFromRoute(route) ?? 'general',
+    [], // Intentional — only consume the URL param on first mount.
+  );
   const [tab, setTab] = React.useState<SettingsTabId>(initialTab);
   // Keep the visible tab in sync when the `?tab=` param changes AFTER mount —
   // e.g. the ⌘K settings search navigates to /settings?tab=<id> while Settings
   // is already open. initialTab (above) only consumes the param on first mount,
   // so without this the hash would update but the tab wouldn't switch.
+  //
+  // A bare `/settings` (no param) resets to General — the same meaning the
+  // absent param has on first mount. This matters for browser Back: nav-rail
+  // clicks push `?tab=` entries onto the hash history (route is the single
+  // source of truth since #411), so Back can land on the bare route and must
+  // not leave a stale tab visible.
   React.useEffect(() => {
-    const requested = getRouteParam(route, 'tab');
-    if (requested && (DEEP_LINK_IDS as readonly string[]).includes(requested)) {
-      setTab(resolveTab(requested as DeepLinkId));
-    }
+    setTab(tabFromRoute(route) ?? 'general');
   }, [route]);
   const version = useAppVersion();
   // Templates' own editor is a full-page takeover with its own header/back

--- a/e2e/specs/settings-cmdk-search.t1.spec.ts
+++ b/e2e/specs/settings-cmdk-search.t1.spec.ts
@@ -106,6 +106,24 @@ test('search still works after a manual nav-rail tab switch (#405 regression)', 
   await expect(page.locator(settingsPage)).not.toContainText('Launch on login');
 });
 
+test('browser Back to bare /settings resets the visible tab to General (#405)', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp(launchOpts);
+  await openSettings(page); // bare /settings → General
+
+  // Nav to AI via the rail — pushes /settings?tab=ai onto the hash history.
+  await page.locator('[data-settings-nav="ai"]').click();
+  await expect(page.locator(settingsPage)).toContainText('AI provider');
+
+  // Browser Back returns to the bare route. The route→tab effect must treat
+  // the absent param like first mount (General), not leave the AI tab stale.
+  await page.goBack();
+  await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#/settings');
+  await expect(page.locator(settingsPage)).toContainText('Launch on login');
+  await expect(page.locator(settingsPage)).not.toContainText('AI provider');
+});
+
 // Drift guard: a few index titles must still match the labels their tabs
 // actually render, so a renamed control can't leave a stale search entry that
 // jumps to a tab where nothing matches. Uses only cross-platform settings.


### PR DESCRIPTION
Follow-up to #411 (which closed #405): one edge of the tab/URL divergence is still reachable.

## The leftover bug

#411 made the route the single source of truth - nav-rail clicks now navigate `/settings?tab=<id>` and push entries onto the hash history. But the route->tab sync effect only reacts to a *valid* `?tab=` param and ignores a bare `/settings`. So:

1. Open Settings (bare `/settings`, General visible).
2. Click any other tab in the nav rail (URL becomes `?tab=ai`).
3. Press browser Back - the URL returns to bare `/settings`, but the AI tab stays visible. Tab and URL have diverged again, and a subsequent `navigate('/settings')` from anywhere bails on the unchanged hash, so nothing ever corrects it.

## Fix

- One shared `tabFromRoute` resolver used by both the first-mount `initialTab` and the route-reactive sync effect, so their semantics can't drift.
- The sync effect now treats an absent (or unknown) `?tab=` the same way first mount does: reset to General.

## Test

New T1 regression in `settings-cmdk-search.t1.spec.ts`: nav to AI via the rail, browser Back, assert the hash is exactly `#/settings` and General is visible again. Verified the test fails on current main and passes with the fix.

## Verification

- `typecheck:renderer` clean; `lint:renderer` identical warning count to main (35/35, no new findings).
- Full `settings-cmdk-search` T1 spec: 5/5 passing (including #411's regression test).
- Cross-family review (Codex, read-only): SHIP, no blocking findings; its test-polish suggestion (exact-hash assert) is included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Settings tab desync when going Back to bare `/settings`. If `?tab=` is missing, the visible tab now resets to General so the tab and URL stay in sync after nav-rail clicks.

- **Bug Fixes**
  - Added shared `tabFromRoute` resolver used by both the initial tab and the route-sync effect to keep behavior aligned.
  - Route-sync treats absent or unknown `?tab=` as General, fixing the leftover edge case from #405 after #411.
  - Added a T1 test that navigates to AI, goes Back, asserts `#/settings`, and verifies General content is shown.

<sup>Written for commit 1c30d6208b7b0adbeae9d9e1165780c451751fdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

