### PR TITLE
feat(audio): drop the Screen Recording requirement for system audio, min macOS 14.4 (#116 Part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu)
 
 ## Installation
 
-Download the latest release (**Apple Silicon Mac, macOS 12 Monterey or later**):
+Download the latest release (**Apple Silicon Mac, macOS 14.4 or later**):
 
 - [Apple Silicon (M1-M5)](https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg)
 
@@ -283,9 +283,9 @@ log stream --predicate 'eventMessage CONTAINS "ollama" OR process CONTAINS "Sten
 ### Common Issues
 
 - **Update didn't install**: Auto-updates are applied on next quit. Quit via the **Steno → Quit** menu (not just closing the window), then reopen.
-- **No system audio / no `[Others]` speaker labels**: macOS needs **Screen Recording** permission. Go to **System Settings → Privacy & Security → Screen & System Audio Recording**, enable Steno, and relaunch the app.
+- **No system audio / no `[Others]` speaker labels**: On macOS, allow Steno to record system audio in **System Settings → Privacy & Security → Screen & System Audio Recording**. Screen Recording access is not required.
 - **`stenoai://` deep link doesn't start recording**: Make sure Steno has launched at least once after install so the URL scheme is registered. If it still fails, check the terminal log for `Protocol handler registration` output.
-- **Recording stops early**: Check microphone permissions, Screen Recording permission (if using system audio), and available disk space.
+- **Recording stops early**: Check microphone permission, System Audio Recording permission (if recording system audio), and available disk space.
 - **"Processing failed"**: Usually an Ollama service or model issue — check the terminal logs.
 - **Empty transcripts**: Whisper couldn't detect speech — verify audio input levels.
 - **Slow processing**: Normal for longer recordings; Ollama is CPU-intensive. If summaries are unusually slow, switch to a lighter model in Settings → AI (Gemma 4 E2B is the lightest/fastest).

--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -122,6 +122,24 @@ test('main.js has no duplicate ipcMain registrations (Electron throws on the 2nd
   assert.deepStrictEqual(dups, [], `duplicate ipcMain registration(s): ${dups.join(', ')}`);
 });
 
+test('custom loopback handler avoids screen capture and catches callback failures', () => {
+  const initMainAt = MAIN.indexOf("initMain({ forceCoreAudioTap: process.platform === 'darwin' });");
+  const removePackageHandlerAt = MAIN.indexOf("ipcMain.removeHandler('enable-loopback-audio');");
+  const windowsSetupAt = MAIN.indexOf('// Windows taskbar identity.');
+  assert.ok(initMainAt >= 0, 'expected electron-audio-loopback initMain call');
+  assert.ok(
+    removePackageHandlerAt > initMainAt && removePackageHandlerAt < windowsSetupAt,
+    'custom enable-loopback-audio handler must replace the package handler immediately after initMain',
+  );
+
+  const handler = MAIN.slice(removePackageHandlerAt, windowsSetupAt);
+  assert.match(handler, /ipcMain\.handle\('enable-loopback-audio',\s*\(\)\s*=>\s*{/);
+  assert.match(handler, /setDisplayMediaRequestHandler\(\(request,\s*callback\)\s*=>\s*{/);
+  assert.match(handler, /try\s*{\s*callback\(\{\s*video:\s*request\.frame,\s*audio:\s*'loopback'\s*}\);/s);
+  assert.match(handler, /catch\s*\(err\)\s*{\s*console\.error\(/s);
+  assert.doesNotMatch(handler, /desktopCapturer|getSources/);
+});
+
 test('every renderer-callable channel (preload invoke/send) is registered in main.js', () => {
   const registered = new Set(mainRegistrations());
   const missing = [...preloadInvokeChannels()].filter(

--- a/app/main.js
+++ b/app/main.js
@@ -7012,7 +7012,7 @@ ipcMain.handle('show-system-audio-mic-only-notification', async () => {
     if (!(await notificationsEnabled())) return { success: true, shown: false };
     const notif = new Notification({
       title: 'Recording mic-only',
-      body: 'System audio could not be captured. Check Steno’s System Audio Recording access in System Settings.',
+      body: 'System audio could not be captured. Check Steno’s Screen & System Audio Recording access in System Settings.',
       iconType: 'alert',
     });
     notif.on('click', () => {

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, powerMonitor, net, session, desktopCapturer } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, globalShortcut, safeStorage, Tray, Menu, nativeImage, powerMonitor, net, session } = require('electron');
 
 // Prevent EPIPE crashes when stdout/stderr pipe is broken (e.g. launching terminal closed)
 process.stdout?.on('error', () => {});
@@ -117,6 +117,29 @@ if (!app.isPackaged) {
 // Windows that's irrelevant (Chromium uses WASAPI loopback) and passing it is
 // at best a no-op, so we don't.
 initMain({ forceCoreAudioTap: process.platform === 'darwin' });
+
+/*
+ * electron-audio-loopback's enable handler obtains a real screen source for
+ * the video track, which unnecessarily couples system-audio recording to the
+ * macOS Screen Recording permission. The renderer still requests video:true,
+ * so the callback must include request.frame: an audio-only response throws
+ * after consuming the one-shot callback. Electron also invokes the display
+ * media handler without awaiting it, so callback failures must be caught here
+ * to avoid an unhandled rejection crashing the main process.
+ *
+ * Keep this override platform-neutral: audio:'loopback' retains the package's
+ * semantics on Windows while avoiding the same callback crash landmine.
+ */
+ipcMain.removeHandler('enable-loopback-audio');
+ipcMain.handle('enable-loopback-audio', () => {
+  session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
+    try {
+      callback({ video: request.frame, audio: 'loopback' });
+    } catch (err) {
+      console.error('[loopback] display media callback failed:', err);
+    }
+  });
+});
 
 // Windows taskbar identity. Without an explicit AppUserModelID matching the
 // installer's, the taskbar shows a default/Electron icon (and groups the window
@@ -360,13 +383,6 @@ let shortcutQueue = [];
 let pendingShortcutUrls = [];
 let rendererShortcutReady = false;
 let launchedByShortcut = false;
-// Screen Recording permission as of process launch, frozen once at startup.
-// macOS doesn't apply a mid-session grant to the running process — only a
-// relaunch picks it up — so gates that decide "is loopback usable this
-// session" must read this, not the live systemPreferences status, or a
-// mid-session grant re-enables a code path (electron-audio-loopback's
-// setDisplayMediaRequestHandler) that's still broken until the app restarts.
-let screenPermissionAtLaunch = 'granted';
 // true when this launch was triggered by the OS login item (auto-launch).
 // Set once at startup (before the app_opened event). On a login launch we
 // suppress the first window show so Steno starts hidden in the tray/menu bar,
@@ -1471,9 +1487,6 @@ if (!gotSingleInstanceLock) {
   });
 
   app.whenReady().then(async () => {
-    if (process.platform === 'darwin') {
-      try { screenPermissionAtLaunch = systemPreferences.getMediaAccessStatus('screen'); } catch (_) {}
-    }
     // Resolve whether this launch was an OS login-item auto-launch BEFORE the
     // app_opened event and the first window show below. macOS reports it via
     // wasOpenedAtLogin (the deprecated openAsHidden no longer works on 13+);
@@ -1939,11 +1952,9 @@ ipcMain.handle('get-system-audio-support', async () => {
     // Windows loopback works but is pending hardware verification, so the UI
     // labels it experimental and ships it opt-in (default off).
     const experimental = process.platform === 'win32';
-    let screenPermission = 'unknown';
     let osVersion = '';
     if (process.platform === 'darwin') {
       try { osVersion = process.getSystemVersion(); } catch (_) {}
-      try { screenPermission = systemPreferences.getMediaAccessStatus('screen'); } catch (_) {}
     } else {
       try { osVersion = process.getSystemVersion(); } catch (_) {}
     }
@@ -1953,69 +1964,10 @@ ipcMain.handle('get-system-audio-support', async () => {
       experimental,
       platform: process.platform,
       osVersion,
-      screenPermission,
-      screenPermissionAtLaunch,
     };
   } catch (error) {
     return { success: false, error: error.message };
   }
-});
-
-// Safely triggers macOS's native Screen Recording permission prompt for a
-// 'not-determined' user, by calling desktopCapturer.getSources() directly in
-// a plain try/caught async handler. Deliberately NOT the same code path as
-// the recording capture flow: electron-audio-loopback's own request handler
-// makes this same call inside an async function passed straight to
-// session.setDisplayMediaRequestHandler, which Electron invokes without
-// awaiting/catching — a failure there becomes an unhandled rejection that
-// used to crash the whole app (see useSystemAudioCapture.ts's
-// screenPermissionOk gate). Calling it here, in an ordinary ipcMain.handle,
-// has no such landmine: a rejection is just a normal rejected promise this
-// handler catches like any other. Only meaningful on macOS — 'not-determined'
-// only exists there.
-ipcMain.handle('request-screen-recording-permission', async () => {
-  if (process.platform !== 'darwin') {
-    return { success: true, screenPermission: 'granted' };
-  }
-  try {
-    await desktopCapturer.getSources({ types: ['screen'] });
-  } catch (error) {
-    sendDebugLog(`[loopback] screen recording permission request failed: ${error.message}`);
-  }
-  let screenPermission = 'unknown';
-  try { screenPermission = systemPreferences.getMediaAccessStatus('screen'); } catch (_) {}
-  return { success: true, screenPermission };
-});
-
-// Once denied/restricted, macOS will not re-prompt — the user has to flip it
-// in System Settings themselves. Deep-links straight to the Screen Recording
-// pane. The URL is a fixed literal (not renderer-supplied), so this is safe
-// despite the generic 'open-external' handler restricting to http/https only.
-ipcMain.handle('open-screen-recording-settings', async () => {
-  if (process.platform !== 'darwin') {
-    return { success: false, error: 'macOS only' };
-  }
-  try {
-    await shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture');
-    return { success: true };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-});
-
-// Screen Recording permission changes don't take effect for an already-running
-// process (unlike mic/camera) — macOS requires a full relaunch. Offered as a
-// one-click follow-up after granting so the user doesn't have to know that.
-ipcMain.handle('relaunch-app', async () => {
-  if (process.platform !== 'darwin') {
-    return { success: false, error: 'macOS only' };
-  }
-  // app.quit() (not app.exit()) so before-quit/will-quit still run: the
-  // recording-in-progress confirmation, WebM finalization, Ollama pid-tree
-  // kill, and telemetry flush all live there.
-  app.relaunch();
-  app.quit();
-  return { success: true };
 });
 
 // Debug functionality handled by side panel now
@@ -7050,19 +7002,17 @@ ipcMain.handle('show-silence-auto-stop-notification', async (_event, payload) =>
   }
 });
 
-// Fired by useSystemAudioCapture.ts at the start of a recording whenever it's
-// about to fall back to mic-only specifically because Screen Recording
-// permission isn't granted (not when the user has the "Record system audio"
-// toggle off, and not on unsupported macOS versions — those are the user's
-// own choice / a hardware limit, not a surprise). Clicking it opens Settings
-// via the same tray-open-settings event the tray menu uses, so the user lands
-// on the row with the Grant Access / Open Settings actions.
+// Fired by useSystemAudioCapture.ts when an enabled loopback acquisition
+// genuinely fails (for example, System Audio Recording permission is denied).
+// It is not fired when the user turns system audio off or the OS is unsupported.
+// Clicking it opens Settings via the same tray-open-settings event the tray
+// menu uses.
 ipcMain.handle('show-system-audio-mic-only-notification', async () => {
   try {
     if (!(await notificationsEnabled())) return { success: true, shown: false };
     const notif = new Notification({
       title: 'Recording mic-only',
-      body: 'Screen Recording permission is needed to capture both sides of the call. Click to fix this in Settings.',
+      body: 'System audio could not be captured. Check Steno’s System Audio Recording access in System Settings.',
       iconType: 'alert',
     });
     notif.on('click', () => {

--- a/app/package.json
+++ b/app/package.json
@@ -165,8 +165,7 @@
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Steno needs microphone access to record and transcribe meetings.",
         "NSAudioCaptureUsageDescription": "Steno needs audio capture access to record system audio from virtual meetings.",
-        "NSScreenCaptureUsageDescription": "Steno needs screen capture access for the loopback-audio feature detection on macOS.",
-        "LSMinimumSystemVersion": "12.3.0"
+        "LSMinimumSystemVersion": "14.4.0"
       }
     },
     "win": {

--- a/app/preload.js
+++ b/app/preload.js
@@ -58,7 +58,6 @@ const stenoai = {
 
   app: {
     getVersion: () => invoke('get-app-version'),
-    relaunch: () => invoke('relaunch-app'),
   },
 
   window: {
@@ -99,8 +98,6 @@ const stenoai = {
   perm: {
     checkMicrophone: () => invoke('check-microphone-permission'),
     requestMicrophone: () => invoke('request-microphone-permission'),
-    requestScreenRecording: () => invoke('request-screen-recording-permission'),
-    openScreenRecordingSettings: () => invoke('open-screen-recording-settings'),
   },
 
   recording: {

--- a/app/renderer/src/hooks/useSettings.ts
+++ b/app/renderer/src/hooks/useSettings.ts
@@ -141,36 +141,6 @@ export function useSystemAudioSupport() {
   });
 }
 
-/** macOS only: safely triggers the native Screen Recording prompt for a
- *  'not-determined' user (see ipc.ts for why this must NOT go through the
- *  recording capture path). Re-fetches systemAudioSupport afterward so the
- *  Settings row's message updates immediately — actually using the
- *  permission still needs a relaunch (see useRelaunchApp usage below). */
-export function useRequestScreenRecordingPermission() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async () => unwrap(await ipc().perm.requestScreenRecording()),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.systemAudioSupport() }),
-  });
-}
-
-/** Deep-links to System Settings > Screen Recording for the denied/restricted
- *  case, where macOS won't show the native prompt again. */
-export function useOpenScreenRecordingSettings() {
-  return useMutation({
-    mutationFn: async () => unwrap(await ipc().perm.openScreenRecordingSettings()),
-  });
-}
-
-/** The process exits before this ever resolves — callers fire-and-forget. */
-export function useRelaunchApp() {
-  return useMutation({
-    mutationFn: async () => {
-      void ipc().app.relaunch();
-    },
-  });
-}
-
 export function useAutoDetectMeetingsSetting() {
   return useQuery({
     queryKey: settingsKeys.autoDetectMeetings(),

--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -66,30 +66,13 @@ export function useSystemAudioCapture() {
   // When the support query is still loading we assume supported so a fast user
   // who records before the IPC resolves still gets loopback.
   const loopbackSupported = systemAudioSupport.data?.supported ?? true;
-  // macOS also needs Screen Recording permission for the CoreAudio Process Tap
-  // (desktopCapturer.getSources() needs it) — 'granted' required; anything
-  // else (denied/not-determined/restricted) means getDisplayMedia() would
-  // fail at the OS level in a way that crashes the WHOLE APP rather than
-  // rejecting cleanly (electron-audio-loopback's internal request handler
-  // re-throws inside an async callback Electron never awaits/catches, so a
-  // getSources() failure becomes an unhandled rejection in the main process).
-  // Unlike loopbackSupported above, this must NOT default optimistically
-  // while loading: a wrong "true" assumption here reaches that broken crash
-  // path, whereas loopbackSupported's wrong-default failure mode is just a
-  // silent/broken system-audio channel (non-fatal). A wrong "false" here
-  // only costs a fast user their very first recording's system-audio side
-  // right after a cold launch — self-correcting on the next recording once
-  // this near-instant local IPC call resolves.
-  // Gates on screenPermissionAtLaunch (frozen main-side at process start),
-  // not the live screenPermission: macOS doesn't apply a mid-session grant
-  // to the already-running process, so treating a live 'granted' as usable
-  // here would re-enable loopback (and the broken getSources() code path
-  // above) before the relaunch that's actually required for it to work.
-  const screenPermissionOk = isMac
-    ? systemAudioSupport.data?.screenPermissionAtLaunch === 'granted'
-    : true;
+  // main.js replaces electron-audio-loopback's display-media handler with one
+  // that supplies the requesting frame as the required video track and catches
+  // callback failures. That keeps the CoreAudio Process Tap independent of
+  // Screen Recording permission; this renderer gate only needs the user's
+  // setting and the OS support check.
   const loopbackEnabled = isMac
-    ? (systemAudio.data ?? true) && loopbackSupported && screenPermissionOk
+    ? (systemAudio.data ?? true) && loopbackSupported
     : loopbackSupported;
   // Read into a ref so startCapture (closed over once) sees the current value
   // without the capture effect depending on it — toggling mid-recording must
@@ -98,26 +81,6 @@ export function useSystemAudioCapture() {
   React.useEffect(() => {
     loopbackEnabledRef.current = loopbackEnabled;
   }, [loopbackEnabled]);
-
-  // True specifically when we KNOW (systemAudioSupport.data has loaded — not
-  // merely "screenPermissionOk is false," which is also true while loading,
-  // per its conservative default above) that the user wants system audio,
-  // the OS supports it, and Screen Recording permission is the actual
-  // blocker — as opposed to the toggle being off, the OS being too old, or
-  // the query simply not having resolved yet, none of which is a surprise
-  // worth interrupting a recording start for. Drives the one-shot "Recording
-  // mic-only" notification below (Settings also surfaces the same state
-  // passively via GeneralTab's Record-system-audio row).
-  const screenPermissionBlocked =
-    isMac &&
-    !!systemAudioSupport.data &&
-    systemAudioSupport.data.screenPermissionAtLaunch !== 'granted' &&
-    (systemAudio.data ?? true) &&
-    loopbackSupported;
-  const screenPermissionBlockedRef = React.useRef(screenPermissionBlocked);
-  React.useEffect(() => {
-    screenPermissionBlockedRef.current = screenPermissionBlocked;
-  }, [screenPermissionBlocked]);
 
   // The pinned microphone device (Settings > Microphone). Kept mounted here
   // (App-level, per this hook's own docstring) purely to warm react-query's
@@ -287,9 +250,9 @@ export function useSystemAudioCapture() {
         // 2. System audio loopback — OPTIONAL + BEST-EFFORT. Skipped entirely
         //    when loopback is disabled (macOS toggle off) or the OS doesn't
         //    support it; otherwise attempted via getDisplayMedia (intercepted by
-        //    electron-audio-loopback's setDisplayMediaRequestHandler and served
-        //    via CoreAudio Process Taps when `forceCoreAudioTap` is set). video:
-        //    true is required by the API; we drop the track immediately.
+        //    main.js's setDisplayMediaRequestHandler and served via CoreAudio
+        //    Process Taps when `forceCoreAudioTap` is set). video:true is
+        //    required by the API; we drop the requesting-frame track immediately.
         //
         //    If loopback is disabled OR unavailable (permission denied, no tap,
         //    no audio track) we record MIC-ONLY rather than failing: sysStream
@@ -298,12 +261,6 @@ export function useSystemAudioCapture() {
         //    failure above still aborts.
         try {
           if (!loopbackEnabledRef.current) {
-            // Surface it right when it actually affects THIS recording,
-            // rather than only passively in Settings — fire-and-forget, the
-            // main-process handler itself gates on notifications_enabled.
-            if (screenPermissionBlockedRef.current) {
-              void bridge.settings.showSystemAudioMicOnlyNotification();
-            }
             throw new Error('loopback disabled');
           }
           await bridge.recording.enableLoopbackAudio();
@@ -326,6 +283,12 @@ export function useSystemAudioCapture() {
           // mic-only case — don't log it as a failure; only a genuine
           // unavailability warrants a warning.
           if (loopbackEnabledRef.current) {
+            // Acquisition was requested and genuinely failed (for example,
+            // System Audio Recording access was denied). Surface the mic-only
+            // fallback fire-and-forget; main gates on notifications_enabled.
+            // macOS only: the notification copy points at macOS System
+            // Settings, and Windows never fired it before this change.
+            if (isMac) void bridge.settings.showSystemAudioMicOnlyNotification();
             // eslint-disable-next-line no-console
             console.warn('[systemAudioCapture] loopback unavailable, continuing mic-only', loopbackErr);
           }

--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -283,12 +283,20 @@ export function useSystemAudioCapture() {
           // mic-only case — don't log it as a failure; only a genuine
           // unavailability warrants a warning.
           if (loopbackEnabledRef.current) {
-            // Acquisition was requested and genuinely failed (for example,
-            // System Audio Recording access was denied). Surface the mic-only
-            // fallback fire-and-forget; main gates on notifications_enabled.
-            // macOS only: the notification copy points at macOS System
-            // Settings, and Windows never fired it before this change.
-            if (isMac) void bridge.settings.showSystemAudioMicOnlyNotification();
+            // Only a genuine permission denial should surface the "grant Screen
+            // & System Audio Recording access" guidance. Everything else — the
+            // enableLoopbackAudio IPC call failing, an absent audio track, an
+            // unsupported host, or any unexpected error — falls back to mic-only
+            // SILENTLY; firing the permission toast for those would misdirect the
+            // user to a setting that isn't the cause. macOS raises a
+            // NotAllowedError from getDisplayMedia when Screen & System Audio
+            // Recording is denied. main gates the notification on
+            // notifications_enabled; it's macOS-only (Windows never fired it).
+            const accessDenied =
+              loopbackErr instanceof DOMException && loopbackErr.name === 'NotAllowedError';
+            if (accessDenied && isMac) {
+              void bridge.settings.showSystemAudioMicOnlyNotification();
+            }
             // eslint-disable-next-line no-console
             console.warn('[systemAudioCapture] loopback unavailable, continuing mic-only', loopbackErr);
           }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -322,7 +322,6 @@ export type SetupCheckResponse = Result<{
 
 export type MicPermissionResponse = Result<{ status: MicPermissionStatus }>;
 export type MicPermissionGrantResponse = Result<{ granted: boolean }>;
-export type ScreenRecordingPermissionResponse = Result<{ screenPermission: string }>;
 
 /** Mirrors RECORDING_TRIGGERS in main.js -- what UI action started the
  *  recording, so PostHog can tell whether the meeting-detected nudge
@@ -755,10 +754,6 @@ export interface StenoaiBridge {
 
   app: {
     getVersion: RequestFn<[], AppVersionResponse>;
-    /** Screen Recording permission changes don't apply to an already-running
-     *  process on macOS — this is the one-click "apply it now" follow-up.
-     *  Never actually resolves (the process exits first). */
-    relaunch: RequestFn<[], void>;
   };
 
   window: { focus: SendFn<[]>; readyToShow: SendFn<[]> };
@@ -795,14 +790,6 @@ export interface StenoaiBridge {
   perm: {
     checkMicrophone: RequestFn<[], MicPermissionResponse>;
     requestMicrophone: RequestFn<[], MicPermissionGrantResponse>;
-    /** macOS only: safely triggers the native prompt for a 'not-determined'
-     *  user by calling desktopCapturer.getSources() in an ordinary, properly
-     *  try/caught main-process handler — deliberately NOT the same code path
-     *  recording capture uses (see main.js for why that one can't do this). */
-    requestScreenRecording: RequestFn<[], ScreenRecordingPermissionResponse>;
-    /** Deep-links to System Settings > Screen Recording — macOS won't
-     *  re-prompt once denied/restricted, so this is the only way back. */
-    openScreenRecordingSettings: RequestFn<[], Result<Record<string, never>>>;
   };
 
   recording: {
@@ -827,12 +814,6 @@ export interface StenoaiBridge {
       Result<{
         supported: boolean;
         osVersion: string;
-        screenPermission: string;
-        // Screen Recording permission as of process launch (macOS only;
-        // frozen at startup — a mid-session grant only takes effect after a
-        // relaunch, so consumers gating loopback usability must read this,
-        // not the live `screenPermission`).
-        screenPermissionAtLaunch: string;
         experimental?: boolean;
         platform?: string;
       }>
@@ -999,9 +980,8 @@ export interface StenoaiBridge {
       [payload: { minutes: number; sessionName: string | null }],
       Result<Record<string, never>>
     >;
-    /** Fired at recording start when loopback is skipped specifically because
-     *  Screen Recording permission isn't granted (see main.js — not fired for
-     *  the toggle-off or OS-unsupported cases, which aren't a surprise). */
+    /** Fired when an enabled loopback acquisition genuinely fails; not fired
+     *  for the toggle-off or OS-unsupported cases. */
     showSystemAudioMicOnlyNotification: RequestFn<[], Result<Record<string, never>>>;
     showNoteReadyNotification: RequestFn<
       [

--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -53,27 +53,22 @@ const h = vi.hoisted(() => {
     microphone: { data: { device_id: null as string | null, label: null as string | null } },
     setMicrophone: { mutate: vi.fn() },
     audioInputDevices: [] as { deviceId: string; label: string }[],
+    systemAudio: { data: true as boolean | undefined },
+    setSystemAudio: { mutate: vi.fn() },
     systemAudioSupport: {
       data: {
         supported: true,
         osVersion: '14.4',
         platform: 'darwin',
-        screenPermission: 'granted' as string,
-        screenPermissionAtLaunch: 'granted' as string,
       } as {
         supported: boolean;
         osVersion: string;
-        // Optional so the existing (platform-less) reassignments below and the
-        // new macOS-14-gate cases (which set platform) both typecheck (#116).
+        // Optional so the platform-less reassignments (beforeEach + the plain
+        // system-audio cases) and the macOS-14-gate cases (which set platform)
+        // both typecheck (#116).
         platform?: string;
-        screenPermission: string;
-        screenPermissionAtLaunch: string;
       },
-      refetch: vi.fn(),
     },
-    requestScreenRecording: { mutate: vi.fn(), isPending: false },
-    openScreenRecordingSettings: { mutate: vi.fn() },
-    relaunchApp: { mutate: vi.fn() },
   };
 });
 
@@ -102,12 +97,9 @@ vi.mock('@/hooks/useSettings', () => {
     useSetNotifications: m,
     usePremeetingNotificationsSetting: () => q(true),
     useSetPremeetingNotifications: m,
-    useSystemAudioSetting: () => q(true),
-    useSetSystemAudio: m,
+    useSystemAudioSetting: () => h.systemAudio,
+    useSetSystemAudio: () => h.setSystemAudio,
     useSystemAudioSupport: () => h.systemAudioSupport,
-    useRequestScreenRecordingPermission: () => h.requestScreenRecording,
-    useOpenScreenRecordingSettings: () => h.openScreenRecordingSettings,
-    useRelaunchApp: () => h.relaunchApp,
     useAutoDetectMeetingsSetting: () => q(true),
     useSetAutoDetectMeetings: m,
     useLaunchOnLoginSetting: () => q(true),
@@ -153,17 +145,12 @@ beforeEach(() => {
   h.microphone.data = { device_id: null, label: null };
   h.setMicrophone.mutate.mockReset();
   h.audioInputDevices = [];
+  h.systemAudio.data = true;
+  h.setSystemAudio.mutate.mockReset();
   h.systemAudioSupport.data = {
     supported: true,
     osVersion: '14.4',
-    screenPermission: 'granted',
-    screenPermissionAtLaunch: 'granted',
   };
-  h.systemAudioSupport.refetch.mockReset();
-  h.requestScreenRecording.mutate.mockReset();
-  h.requestScreenRecording.isPending = false;
-  h.openScreenRecordingSettings.mutate.mockReset();
-  h.relaunchApp.mutate.mockReset();
 });
 
 // hidden:true because once the OAuth dialog is open (modal), Radix marks the
@@ -427,113 +414,29 @@ describe('GeneralTab Microphone setting', () => {
   // unconditionally, including for the already-selected value).
 });
 
-describe('GeneralTab Record system audio — Screen Recording permission', () => {
-  test('granted: plain toggle description, no action buttons', () => {
+describe('GeneralTab Record system audio', () => {
+  test('supported: toggle remains enabled and updates the setting', async () => {
     render(<GeneralTab />);
     expect(screen.getByText('Capture both sides of a call. Turn off to record your mic only.')).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Grant Access' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Open Settings' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Relaunch' })).toBeNull();
-  });
-
-  test('not-determined: shows a "Grant Access" button that requests permission', async () => {
-    h.systemAudioSupport.data = { supported: true, osVersion: '14.4', screenPermission: 'not-determined', screenPermissionAtLaunch: 'not-determined' };
-    render(<GeneralTab />);
-
-    expect(
-      screen.getByText(/Needs Screen Recording access first/),
-    ).toBeTruthy();
-
+    const row = screen.getByText('Record system audio').parentElement?.parentElement;
+    const toggle = row?.querySelector('[role="switch"]') as HTMLButtonElement | null;
+    expect(toggle?.disabled).toBe(false);
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Grant Access' }));
+      fireEvent.click(toggle!);
     });
-    expect(h.requestScreenRecording.mutate).toHaveBeenCalledTimes(1);
+    expect(h.setSystemAudio.mutate).toHaveBeenCalledWith(false);
   });
 
-  test('denied: shows "Check Again" and "Open Settings" buttons', async () => {
-    h.systemAudioSupport.data = { supported: true, osVersion: '14.4', screenPermission: 'denied', screenPermissionAtLaunch: 'denied' };
-    render(<GeneralTab />);
-
-    expect(screen.getByText(/Screen Recording access was denied/)).toBeTruthy();
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }));
-    });
-    expect(h.openScreenRecordingSettings.mutate).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Check Again' }));
-    });
-    expect(h.systemAudioSupport.refetch).toHaveBeenCalledTimes(1);
-  });
-
-  test('restricted: same treatment as denied (MDM/parental controls)', () => {
-    h.systemAudioSupport.data = { supported: true, osVersion: '14.4', screenPermission: 'restricted', screenPermissionAtLaunch: 'restricted' };
-    render(<GeneralTab />);
-    expect(screen.getByRole('button', { name: 'Open Settings' })).toBeTruthy();
-  });
-
-  test('permission flips to granted mid-session: prompts to relaunch instead of re-showing the request button', async () => {
-    h.systemAudioSupport.data = { supported: true, osVersion: '14.4', screenPermission: 'not-determined', screenPermissionAtLaunch: 'not-determined' };
-    const { rerender } = render(<GeneralTab />);
-    expect(screen.getByRole('button', { name: 'Grant Access' })).toBeTruthy();
-
-    // Permission granted (e.g. the user answered the native prompt) — the
-    // query refetches and now reports 'granted'. screenPermissionAtLaunch
-    // stays 'not-determined' — it's frozen at process start and only a
-    // relaunch updates it, which is exactly what this test is asserting.
-    h.systemAudioSupport.data = {
-      supported: true,
-      osVersion: '14.4',
-      screenPermission: 'granted',
-      screenPermissionAtLaunch: 'not-determined',
-    };
-    await act(async () => {
-      rerender(<GeneralTab />);
-    });
-
-    expect(screen.getByText(/relaunch Steno to start capturing/)).toBeTruthy();
-    const relaunchBtn = screen.getByRole('button', { name: 'Relaunch' });
-    expect(relaunchBtn).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Grant Access' })).toBeNull();
-
-    await act(async () => {
-      fireEvent.click(relaunchBtn);
-    });
-    expect(h.relaunchApp.mutate).toHaveBeenCalledTimes(1);
-  });
-
-  test('permission already granted when the app launched: no relaunch prompt', () => {
-    // Distinguishes "was already granted at launch" from "granted mid-session"
-    // — the whole point of needsRelaunchForScreenRecording tracking the
-    // FIRST observed value, not just the current one.
-    h.systemAudioSupport.data = {
-      supported: true,
-      osVersion: '14.4',
-      screenPermission: 'granted',
-      screenPermissionAtLaunch: 'granted',
-    };
-    render(<GeneralTab />);
-    expect(screen.queryByRole('button', { name: 'Relaunch' })).toBeNull();
-  });
-
-  test('unsupported macOS version: no permission action buttons even if screenPermission reads not-determined/denied', () => {
-    // getMediaAccessStatus('screen') predates the 14.4 loopback requirement,
-    // so it can still return a non-'granted' value on an unsupported OS —
-    // the toggle below is already disabled for OS-version reasons, so no
-    // actionable-looking button should appear alongside it.
+  test('unsupported macOS version: toggle is disabled with the version explanation', () => {
     h.systemAudioSupport.data = {
       supported: false,
       osVersion: '13.0',
-      screenPermission: 'not-determined',
-      screenPermissionAtLaunch: 'not-determined',
     };
     render(<GeneralTab />);
     expect(screen.getByText(/requires macOS 14.4\+/)).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Grant Access' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Open Settings' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Check Again' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Relaunch' })).toBeNull();
+    const row = screen.getByText('Record system audio').parentElement?.parentElement;
+    const toggle = row?.querySelector('[role="switch"]') as HTMLButtonElement | null;
+    expect(toggle?.disabled).toBe(true);
   });
 
   test('auto-detect: shows a "Requires macOS 14" note on macOS < 14 (#116)', () => {
@@ -543,8 +446,6 @@ describe('GeneralTab Record system audio — Screen Recording permission', () =>
       supported: false,
       osVersion: '13.6.1',
       platform: 'darwin',
-      screenPermission: 'granted',
-      screenPermissionAtLaunch: 'granted',
     };
     render(<GeneralTab />);
     expect(
@@ -557,8 +458,6 @@ describe('GeneralTab Record system audio — Screen Recording permission', () =>
       supported: true,
       osVersion: '14.4',
       platform: 'darwin',
-      screenPermission: 'granted',
-      screenPermissionAtLaunch: 'granted',
     };
     render(<GeneralTab />);
     expect(screen.queryByText(/Requires macOS 14 \(Sonoma\) or later/)).toBeNull();

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -28,10 +28,7 @@ import {
   useLaunchOnLoginSetting,
   useMicrophoneSetting,
   useNotificationsSetting,
-  useOpenScreenRecordingSettings,
   usePremeetingNotificationsSetting,
-  useRelaunchApp,
-  useRequestScreenRecordingPermission,
   useSetAutoDetectMeetings,
   useSetDockIcon,
   useSetLaunchOnLogin,
@@ -67,32 +64,9 @@ export function GeneralTab() {
   const systemAudio = useSystemAudioSetting();
   const setSystemAudio = useSetSystemAudio();
   const systemAudioSupport = useSystemAudioSupport();
-  const requestScreenRecording = useRequestScreenRecordingPermission();
-  const openScreenRecordingSettings = useOpenScreenRecordingSettings();
-  const relaunchApp = useRelaunchApp();
-  // Screen Recording permission changes don't apply to an already-running
-  // process — `screenPermissionAtLaunch` is frozen main-side at startup, so
-  // comparing it to the live `screenPermission` tells apart "granted before
-  // launch" from "granted mid-session, needs a relaunch to take effect."
-  // (Deliberately not component state: that broke on tab remount, since a
-  // freshly-mounted component would re-seed its "initial" value from the
-  // now-live 'granted' status and silently lose the relaunch prompt.)
-  const needsRelaunchForScreenRecording =
-    systemAudioSupport.data?.screenPermissionAtLaunch !== 'granted' &&
-    systemAudioSupport.data?.screenPermission === 'granted';
-  const screenPermission = systemAudioSupport.data?.screenPermission;
   const systemAudioDescription = (() => {
     if (systemAudioSupport.data && !systemAudioSupport.data.supported) {
       return `Capture both sides of a call (requires macOS 14.4+, you're on ${systemAudioSupport.data.osVersion || 'an older version'}). Mic-only recording still works.`;
-    }
-    if (needsRelaunchForScreenRecording) {
-      return 'Screen Recording access granted — relaunch Steno to start capturing both sides of a call.';
-    }
-    if (screenPermission === 'not-determined') {
-      return 'Capture both sides of a call. Needs Screen Recording access first — mic-only recording still works either way.';
-    }
-    if (screenPermission === 'denied' || screenPermission === 'restricted') {
-      return 'Capture both sides of a call. Screen Recording access was denied — enable it in System Settings, then relaunch Steno. Mic-only recording still works either way.';
     }
     return 'Capture both sides of a call. Turn off to record your mic only.';
   })();
@@ -461,59 +435,11 @@ export function GeneralTab() {
           mic+system (toggle hidden), so this control isn't shown there. */}
       {isMac && (
         <SettingRow label="Record system audio" description={systemAudioDescription}>
-          <div className="flex items-center gap-2">
-            {/* Only offer permission actions when the OS actually supports the
-                feature — on an unsupported macOS version, screenPermission can
-                still read 'not-determined'/'denied' (that API predates the
-                14.4 loopback requirement), but granting it wouldn't do
-                anything: the toggle below is already disabled for OS reasons,
-                so the description explaining "requires macOS 14.4+" should be
-                the only thing shown, not an actionable-looking button. */}
-            {systemAudioSupport.data?.supported === false ? null : needsRelaunchForScreenRecording ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className={COMPACT_BTN}
-                onClick={() => relaunchApp.mutate()}
-              >
-                Relaunch
-              </Button>
-            ) : screenPermission === 'not-determined' ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className={COMPACT_BTN}
-                onClick={() => requestScreenRecording.mutate()}
-                disabled={requestScreenRecording.isPending}
-              >
-                Grant Access
-              </Button>
-            ) : screenPermission === 'denied' || screenPermission === 'restricted' ? (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={COMPACT_BTN}
-                  onClick={() => void systemAudioSupport.refetch()}
-                >
-                  Check Again
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className={COMPACT_BTN}
-                  onClick={() => openScreenRecordingSettings.mutate()}
-                >
-                  Open Settings
-                </Button>
-              </>
-            ) : null}
-            <Switch
-              checked={(systemAudio.data ?? true) && (systemAudioSupport.data?.supported ?? true)}
-              onCheckedChange={(v) => setSystemAudio.mutate(v)}
-              disabled={systemAudio.data === undefined || systemAudioSupport.data?.supported === false}
-            />
-          </div>
+          <Switch
+            checked={(systemAudio.data ?? true) && (systemAudioSupport.data?.supported ?? true)}
+            onCheckedChange={(v) => setSystemAudio.mutate(v)}
+            disabled={systemAudio.data === undefined || systemAudioSupport.data?.supported === false}
+          />
         </SettingRow>
       )}
 


### PR DESCRIPTION
Closes #116 (Part 2 - Part 1 was the auto-detect gate in #390). As agreed on Discord: raise the minimum macOS and drop the Screen Recording requirement for system audio.

## What was actually wrong

The CoreAudio Process Tap never needed Screen Recording. electron-audio-loopback's `enable-loopback-audio` handler pulls a REAL screen source via `desktopCapturer.getSources({types:['screen']})` and returns it as the (immediately discarded) video track - that call is the only thing that trips the Screen Recording TCC, and it's why the empirical test with screen recording denied failed ("It doesn't run"). Verified on a real Mac (macOS 26, screen recording explicitly denied): with the handler below, a 440 Hz test tone recorded onto the system channel at -25 dB RMS, and macOS prompted only for Microphone + System Audio Recording.

## Changes

- **Own display-media handler (main.js)**, replacing the package's: answers `getDisplayMedia` with the requesting frame as the throwaway video track plus `audio: 'loopback'`. Two hard constraints discovered while building it:
  - an audio-only response throws (`Video was requested, but no video stream was provided`) because the renderer requests `video: true`, and the one-shot callback is consumed by the throw;
  - Electron invokes the handler without awaiting it, so any throw inside it is an unhandled rejection that crashes the whole app - this is exactly the crash landmine the old `screenPermissionOk` gate worked around. The new handler wraps the callback in try/catch, fixing that class of crash structurally.
  - The override is deliberately platform-neutral: same `audio:'loopback'` semantics on Windows (WASAPI), same landmine removed there. A new `ipc-contract.test.js` guard pins the handler shape (no getSources, try/catch present).
- **Screen-permission machinery removed**: the renderer gate in `useSystemAudioCapture`, the Settings grant/relaunch wizard in GeneralTab, and the `request-screen-recording-permission` / `open-screen-recording-settings` / `relaunch-app` IPC surface (the wizard was relaunch's only consumer).
- **Mic-only notification** now fires when an enabled loopback acquisition genuinely fails (the new failure mode: System Audio Recording denied). macOS-only, as before.
- **`LSMinimumSystemVersion` 12.3 -> 14.4** and `NSScreenCaptureUsageDescription` dropped. README troubleshooting updated.

## Migration / release notes

- **The DMG now requires macOS 14.4+** (CoreAudio Process Taps). Users on 12.3-14.3 keep their installed version but won't be offered a working update path on their OS - worth a line in the release notes.
- Existing users lose nothing else: mic + System Audio Recording are the only permissions used. Already-granted Screen Recording permission simply becomes unused.
- Known limitation (unchanged from today's behavior for other permissions): if a user revokes System Audio Recording later, there's no Settings surface detecting it - they get the "Recording mic-only" notification at record time.

## Verification

- typecheck + lint clean (identical warning count to main), `ipc-contract.test.js` 8/8, GeneralTab vitest 15/15, full T1 e2e 43/43, `recording-lifecycle.t2` 2/2 (drives the real renderer capture path through the new handler).
- On-device end-to-end proof: recording with Screen Recording denied captures system audio (tone at -41 dB RMS on the system channel in the final integrated run; -25 dB RMS in the isolated handler experiment).
- Windows: not run locally; the handler change is platform-neutral and CI's Windows T2 + pipeline lanes cover the recording path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the Screen Recording requirement for system audio by replacing `electron-audio-loopback`’s display-media handler and raises the minimum macOS to 14.4. This simplifies permissions, removes a crash path, and keeps Windows behavior unchanged. Part 2 of #116.

- **New Features**
  - Custom `enable-loopback-audio` handler uses `session.setDisplayMediaRequestHandler` and returns `{ video: request.frame, audio: 'loopback' }`, wrapped in try/catch to avoid unhandled rejections and Screen Recording TCC.
  - Removed Screen Recording UI and IPC (`request/open/relaunch`) and the renderer gate; Settings now only has the toggle. Tests updated.
  - Mic-only notification now triggers only on a real permission denial (getDisplayMedia `NotAllowedError`); other failures fall back silently. Copy updated to match “Screen & System Audio Recording.”
  - Added an IPC contract test to pin the handler shape and ensure no `desktopCapturer.getSources` call.

- **Migration**
  - Minimum macOS is now 14.4+ (`LSMinimumSystemVersion` raised; `NSScreenCaptureUsageDescription` removed). Users on 12.3–14.3 stay on their current version.
  - Only Microphone and System Audio Recording permissions are used; existing Screen Recording grants are ignored.
  - README and troubleshooting updated to reference System Audio Recording only.

<sup>Written for commit c57d6af7c8f0410d9256d2773ad0c58de3cb6352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

