### PR TITLE
fix(meetings): drop the delete confirm step now that Undo exists (#234)

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -179,6 +179,12 @@ function install({ ipcMain }) {
   // tab in T1 (summaryFile → { user_notes }). The real handler persists to the
   // note file; the T1 seeds are consts, so we overlay here instead.
   const meetingOverlay = {};
+
+  // In-flight soft-deletes (#234), id → the deleted meeting. Mirrors main's
+  // pendingDelete map just far enough for undo to hand the row back.
+  const pendingDeletes = {};
+  let pendingDeleteSeq = 0;
+
   const applyOverlay = (m) => {
     if (!m || !m.session_info) return m;
     const o = meetingOverlay[m.session_info.summary_file];
@@ -355,6 +361,33 @@ function install({ ipcMain }) {
         ? { success: true, meeting: applyOverlay(m) }
         : { success: false, error: 'meeting not found' };
     },
+
+    // Soft-delete (#234). The permissive unknown-channel default would answer
+    // `{success:true}` with no `id`, and useDeleteMeeting skips the Undo toast
+    // without one — so the delete-UX T1 needs the real response shape here.
+    // State is per-launch: the id counter and store let undo/commit key off it
+    // the way main's pendingDelete map does.
+    'delete-meeting': async (_event, meeting) => {
+      const id = `e2e-delete-${++pendingDeleteSeq}`;
+      pendingDeletes[id] = meeting;
+      // Long enough that the window can't expire mid-assertion; the spec drives
+      // undo/dismiss explicitly rather than waiting this out.
+      return { success: true, id, deadline: Date.now() + 60_000 };
+    },
+    'undo-delete-meeting': async (_event, id) => {
+      const meeting = pendingDeletes[id];
+      if (!meeting) return { success: false, error: 'no pending delete' };
+      delete pendingDeletes[id];
+      return { success: true, meeting };
+    },
+    'commit-delete-meeting': async (_event, id) => {
+      delete pendingDeletes[id];
+      return { success: true };
+    },
+    // Nothing survives a mock launch, so there is never a window to restore —
+    // but answer with the real shape (`pending: []`) rather than letting the
+    // permissive default hand the toast an undefined array to map over.
+    'list-pending-deletes': async () => ({ success: true, pending: [] }),
 
     // My notes autosave: persist the overlay so a follow-up get-meeting sees
     // the edit (mirrors the real update-meeting body-section upsert).

--- a/app/renderer/src/components/MeetingsShell.tsx
+++ b/app/renderer/src/components/MeetingsShell.tsx
@@ -82,11 +82,14 @@ export function MeetingsShell({
     { type: 'folder' | 'meeting'; id: string; current: string; itemRect: DOMRectReadOnly } | null
   >(null);
   const [context, setContext] = React.useState<SidebarContextAction | null>(null);
-  const [deleteTarget, setDeleteTarget] = React.useState<
-    | { type: 'folder'; id: string; name: string; meetingCount: number }
-    | { type: 'meeting'; id: string; name: string }
-    | null
-  >(null);
+  // Folders only: deleting a folder is NOT undoable, so it keeps a confirm step.
+  // Notes delete straight away and are caught by the Undo toast instead (#234).
+  const [deleteTarget, setDeleteTarget] = React.useState<{
+    type: 'folder';
+    id: string;
+    name: string;
+    meetingCount: number;
+  } | null>(null);
 
   // Sidebar shows only folder rows + counts. buildSidebar gives us folder
   // metadata (name + meeting count); the per-folder meetings array is unused.
@@ -159,7 +162,7 @@ export function MeetingsShell({
     }
   };
 
-  const openDeleteConfirm = () => {
+  const onDeleteAction = () => {
     if (!context) return;
     if (context.type === 'folder') {
       const folder = folders.data?.find((f) => f.id === context.id);
@@ -167,31 +170,31 @@ export function MeetingsShell({
       const meetingCount =
         meetings.data?.filter((m) => (m.folders ?? []).includes(context.id)).length ?? 0;
       setDeleteTarget({ type: 'folder', id: context.id, name: folder.name, meetingCount });
-    } else {
-      const target = meetings.data?.find((m) => m.session_info.summary_file === context.id);
-      if (!target) return setContext(null);
-      setDeleteTarget({
-        type: 'meeting',
-        id: context.id,
-        name: target.session_info.name || 'Untitled Meeting',
-      });
+      setContext(null);
+      return;
     }
+    // Notes: no confirm step — the soft-delete's Undo toast is the safety net,
+    // so asking first would just add a click to an already reversible action.
+    const target = meetings.data?.find((m) => m.session_info.summary_file === context.id);
     setContext(null);
+    if (!target) return;
+    const summaryFile = target.session_info.summary_file;
+    void deleteMeeting
+      .mutateAsync(target)
+      .then(() => {
+        if (activeSummaryFile === summaryFile) navigate('/');
+      })
+      .catch((err) => {
+        // A refused delete (main's busy-guard) leaves the row in place. Log it
+        // rather than throwing an unhandled rejection; the row staying put is
+        // the user-visible signal here, and MeetingDetail surfaces the reason.
+        console.error('Delete failed:', err);
+      });
   };
 
-  const handleConfirmDelete = async () => {
+  const handleConfirmDeleteFolder = async () => {
     if (!deleteTarget) return;
-    if (deleteTarget.type === 'folder') {
-      await deleteFolder.mutateAsync(deleteTarget.id);
-    } else {
-      const target = meetings.data?.find(
-        (m) => m.session_info.summary_file === deleteTarget.id,
-      );
-      if (target) {
-        await deleteMeeting.mutateAsync(target);
-        if (activeSummaryFile === deleteTarget.id) navigate('/');
-      }
-    }
+    await deleteFolder.mutateAsync(deleteTarget.id);
     setDeleteTarget(null);
   };
 
@@ -233,7 +236,7 @@ export function MeetingsShell({
           action={context}
           onClose={() => setContext(null)}
           onRename={(label) => openRename(context.type, context.id, label, context.itemRect)}
-          onDelete={openDeleteConfirm}
+          onDelete={onDeleteAction}
           folders={folders.data ?? []}
           meetings={meetings.data ?? []}
         />
@@ -242,35 +245,22 @@ export function MeetingsShell({
       <ConfirmDialog
         open={!!deleteTarget}
         onOpenChange={(o) => !o && setDeleteTarget(null)}
-        title={
-          deleteTarget?.type === 'folder'
-            ? `Delete folder "${deleteTarget.name}"?`
-            : deleteTarget
-              ? `Delete note "${deleteTarget.name}"?`
-              : ''
-        }
+        title={deleteTarget ? `Delete folder "${deleteTarget.name}"?` : ''}
         description={
-          deleteTarget?.type === 'folder' ? (
-            deleteTarget.meetingCount > 0 ? (
-              <>
-                {deleteTarget.meetingCount} meeting
-                {deleteTarget.meetingCount === 1 ? '' : 's'} will be moved back to All Notes. No
-                recordings or transcripts will be deleted.
-              </>
-            ) : (
-              <>No recordings or transcripts will be deleted.</>
-            )
-          ) : (
+          deleteTarget && deleteTarget.meetingCount > 0 ? (
             <>
-              This will remove the transcript, summary, and all associated files. You can undo this
-              for a few seconds after deleting.
+              {deleteTarget.meetingCount} meeting
+              {deleteTarget.meetingCount === 1 ? '' : 's'} will be moved back to All Notes. No
+              recordings or transcripts will be deleted.
             </>
+          ) : (
+            <>No recordings or transcripts will be deleted.</>
           )
         }
         confirmLabel="Delete"
         destructive
-        onConfirm={handleConfirmDelete}
-        isPending={deleteFolder.isPending || deleteMeeting.isPending}
+        onConfirm={handleConfirmDeleteFolder}
+        isPending={deleteFolder.isPending}
       />
 
       <Dialog open={newFolderOpen} onOpenChange={setNewFolderOpen}>

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -151,7 +151,10 @@ function DetailContent({
   const date = formatDetailDate(info);
   const duration = formatDuration(info.duration_seconds);
   const [copied, setCopied] = React.useState(false);
-  const [deleteOpen, setDeleteOpen] = React.useState(false);
+  // Surfaces a refused delete (e.g. main's busy-guard while the note is
+  // recording/processing). Without the old confirm dialog there is no other
+  // place for that failure to show, so it must not stay silent.
+  const [deleteError, setDeleteError] = React.useState<string | null>(null);
   const deleteMeeting = useDeleteMeeting();
   const reprocess = useReprocessMeeting();
   const retranscribe = useRetranscribeMeeting();
@@ -889,11 +892,27 @@ function DetailContent({
                           : `Share with ${orgSession.data.orgId}`}
                     </button>
                   ))}
+                {/* Deletes straight away, no confirm step: the delete is a
+                    soft-delete and the Undo toast (#234) is the safety net.
+                    Asking first *and* offering undo made the flow feel heavy
+                    (maintainer feedback) — one or the other, not both. */}
                 <button
                   type="button"
-                  className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-[color:var(--surface-hover)]"
+                  className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-[color:var(--surface-hover)] disabled:opacity-50"
                   style={{ color: 'var(--danger)' }}
-                  onClick={() => setDeleteOpen(true)}
+                  disabled={deleteMeeting.isPending}
+                  onClick={async () => {
+                    setDeleteError(null);
+                    try {
+                      await deleteMeeting.mutateAsync(meeting);
+                    } catch (err) {
+                      setDeleteError(
+                        `Delete failed: ${err instanceof Error ? err.message : String(err)}`,
+                      );
+                      return;
+                    }
+                    navigate('/');
+                  }}
                 >
                   <Trash2 className="size-[13px] shrink-0" />
                   Delete note
@@ -906,6 +925,12 @@ function DetailContent({
         {exportError && (
           <p role="alert" className="text-[12.5px]" style={{ color: 'var(--danger)' }}>
             {exportError}
+          </p>
+        )}
+
+        {deleteError && (
+          <p role="alert" className="text-[12.5px]" style={{ color: 'var(--danger)' }}>
+            {deleteError}
           </p>
         )}
 
@@ -1235,33 +1260,6 @@ function DetailContent({
       {tab === 'notes' && (
         <MyNotesEditor summaryFile={routeSummaryFile} initialNotes={meeting.user_notes ?? ''} />
       )}
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete this note?</DialogTitle>
-            <DialogDescription>
-              This removes the recording, transcript, and summary. You can undo this for a few
-              seconds after deleting.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="ghost">Cancel</Button>
-            </DialogClose>
-            <Button
-              variant="destructive"
-              disabled={deleteMeeting.isPending}
-              onClick={async () => {
-                await deleteMeeting.mutateAsync(meeting);
-                navigate('/');
-              }}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       <Dialog open={unshareOpen} onOpenChange={setUnshareOpen}>
         <DialogContent className="max-w-sm">

--- a/e2e/specs/meeting-delete-ux.t1.spec.ts
+++ b/e2e/specs/meeting-delete-ux.t1.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '../fixtures/electron';
+import type { Page } from '@playwright/test';
+
+/**
+ * T1 — renderer-only, mock IPC, no backend. Pins the DELETE INTERACTION itself
+ * (#234): a note deletes on ONE click, with no confirm step, and the Undo toast
+ * is what makes that safe.
+ *
+ * Why a UI spec when meeting-undo-delete.t2 already covers the backend
+ * contract: that spec drives the preload bridge, so it would stay green even if
+ * the button stopped deleting — or if a confirm dialog came back. The risk here
+ * is the interaction (a destructive action fires without asking), so it has to
+ * be asserted through the real UI. The rule of the flow is one-or-the-other:
+ * either you confirm first OR you get an undo, never both (maintainer feedback
+ * on #391 — confirm + undo "feels like overkill").
+ *
+ * Seams (mirrors of the real ones, see app/e2e-mock-ipc.js):
+ *  - STENOAI_E2E_SEED_MEETING=1 makes list-meetings/get-meeting return one known
+ *    note, so #/meetings/<summary_file> resolves.
+ *  - delete-meeting answers with the real {id, deadline} shape, so the Undo
+ *    toast appears exactly as it does against main's pendingDelete map.
+ */
+
+const SUMMARY_FILE = 'epsilon_summary.json';
+const MEETING_NAME = 'Epsilon Planning';
+
+async function openDetail(page: Page) {
+  await page.evaluate((f) => {
+    window.location.hash = `#/meetings/${encodeURIComponent(f)}`;
+  }, SUMMARY_FILE);
+  await expect(page.getByTestId('meeting-detail-title')).toContainText(MEETING_NAME);
+}
+
+async function clickDeleteNote(page: Page) {
+  await page.getByRole('button', { name: 'More options' }).click();
+  await page.getByRole('button', { name: 'Delete note' }).click();
+}
+
+test('deleting a note takes one click — no confirm step, Undo is the safety net', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({ mockIpc: true, env: { STENOAI_E2E_SEED_MEETING: '1' } });
+  await openDetail(page);
+
+  await clickDeleteNote(page);
+
+  // The Undo toast is the proof the delete actually fired on that single click.
+  const toast = page.getByRole('status').filter({ hasText: 'Note deleted' });
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText(MEETING_NAME);
+
+  // No confirm dialog stood between the click and the delete. Asserted by name
+  // (the old copy) AND by role, so re-introducing *any* modal here fails.
+  await expect(page.getByText('Delete this note?')).toHaveCount(0);
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+
+  // Deleting from the detail route navigates home — the note it showed is gone.
+  await expect(page).toHaveURL(/#\/$/);
+});
+
+test('Undo restores the note and clears the toast', async ({ launchApp }) => {
+  const { page } = await launchApp({ mockIpc: true, env: { STENOAI_E2E_SEED_MEETING: '1' } });
+  await openDetail(page);
+
+  await clickDeleteNote(page);
+
+  const toast = page.getByRole('status').filter({ hasText: 'Note deleted' });
+  await expect(toast).toBeVisible();
+
+  await toast.getByRole('button', { name: 'Undo' }).click();
+
+  // Toast clears on a successful undo, and the restored row is back on Home —
+  // the note survived a delete that was never confirmed.
+  await expect(toast).toHaveCount(0);
+  await expect(page.getByText(MEETING_NAME).first()).toBeVisible();
+});
+
+test('deleting from the sidebar context menu also skips the confirm step', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({ mockIpc: true, env: { STENOAI_E2E_SEED_MEETING: '1' } });
+
+  // Under mock IPC the app lands on the setup wizard (no model installed), which
+  // has no notes list. Go to Home; the one-shot setup gate already fired on
+  // launch, so it won't redirect us back.
+  await page.evaluate(() => {
+    window.location.hash = '#/';
+  });
+
+  // Home lists the seeded note; right-click opens the row's context menu.
+  const row = page.getByText(MEETING_NAME).first();
+  await expect(row).toBeVisible();
+  await row.click({ button: 'right' });
+
+  await page.getByRole('button', { name: 'Delete' }).click();
+
+  await expect(page.getByRole('status').filter({ hasText: 'Note deleted' })).toBeVisible();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+});


### PR DESCRIPTION
Follow-up to #391 (merged), addressing maintainer feedback: with the soft-delete
in place, a note now asked for confirmation **and** then offered an undo. One or
the other — not both.

This drops the confirm step for notes and leans on the Undo toast as the safety
net (the Gmail pattern the soft-delete was built for).

## What changed

- **`MeetingDetail`** — "Delete note" deletes straight from the menu. A refused
  delete (main's busy-guard while the note is recording/processing) now surfaces
  as an inline error: the dialog used to be the only place such a failure could
  show, so removing it without this would turn a refusal into a silent no-op.
- **`MeetingsShell`** — the sidebar / context-menu path deletes a note directly.
  **Folder delete keeps its confirm** (there is no undo for folders), as does
  report delete. `deleteTarget` narrows to folders only.
- **`e2e-mock-ipc`** — mocks the delete / undo / commit / list-pending-deletes
  channels with their real response shapes, so the Undo toast can be driven
  under T1. Without an `id` in the response the toast is skipped, and the
  permissive unknown-channel default doesn't return one.

## Testing

New `meeting-delete-ux.t1` spec pins the **interaction itself**: one click
deletes, the Undo toast proves the delete actually fired, no dialog stands in
between, Undo restores the note, and the sidebar path behaves the same.

`meeting-undo-delete.t2` drives the preload bridge, so it would stay green if
the button stopped deleting — or if a confirm dialog came back. That is why this
one goes through the real UI.

- Typecheck clean, lint 0 errors
- Unit: 191 node:test + 120 vitest, all passing
- **T1 suite: 48/48** (macOS, local)

T2 is CI's to run — this branch adds no backend surface.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the confirm dialog when deleting a note. Deleting now happens on one click and relies on the Undo toast; folder and report deletes still require confirmation.

- **Bug Fixes**
  - Note delete in `MeetingDetail` and sidebar fires immediately; if the active note is deleted, navigate home.
  - Busy/blocked deletes now show an inline error in `MeetingDetail`; sidebar path logs the error and keeps the row.
  - Folder delete keeps the confirm step (no undo); `deleteTarget` narrowed to folders.
  - `e2e-mock-ipc` adds real-shaped `delete-meeting`, `undo-delete-meeting`, `commit-delete-meeting`, and `list-pending-deletes` channels to drive the Undo toast.
  - New T1 spec `meeting-delete-ux.t1` verifies one-click delete, no dialog, Undo restores the note, and sidebar path behaves the same.

<sup>Written for commit 1de586f21fad819b7b4afa31d3401bfa07c3b344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

