### PR TITLE
perf(settings): make toggles respond instantly instead of after two backend calls

### DIFF
--- a/app/renderer/src/hooks/useSettings.test.tsx
+++ b/app/renderer/src/hooks/useSettings.test.tsx
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import * as React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * Settings toggles write optimistically (see `useToggleSetting`).
+ *
+ * The property under test is a performance one, so it needs pinning: a toggle
+ * must NOT read its value back after writing it. Each `set-*`/`get-*` pair
+ * spawns a backend process (~315 ms packaged), so the old
+ * `onSuccess: invalidateQueries` shape cost two processes per click and left
+ * the switch frozen until the second returned. A regression that re-adds the
+ * invalidate is invisible in behaviour tests — only the call count catches it.
+ */
+
+const h = vi.hoisted(() => ({
+  getNotifications: vi.fn(),
+  setNotifications: vi.fn(),
+}));
+
+vi.mock('@/lib/ipc', () => ({
+  ipc: () => ({
+    settings: {
+      getNotifications: h.getNotifications,
+      setNotifications: h.setNotifications,
+    },
+  }),
+}));
+
+import { useNotificationsSetting, useSetNotifications } from './useSettings';
+
+function wrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+/** Both hooks under one provider, so the mutation writes the cache the query reads. */
+function renderToggle() {
+  return renderHook(
+    () => ({ value: useNotificationsSetting(), setValue: useSetNotifications() }),
+    { wrapper: wrapper() },
+  );
+}
+
+/** A promise resolved by hand, plus a `settled` flag so a test can prove the
+ *  backend write had NOT completed at the moment it asserted. */
+function defer<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const box = {
+    promise,
+    settled: false,
+    resolve: (v: T) => {
+      box.settled = true;
+      resolve(v);
+    },
+    reject: (e: unknown) => {
+      box.settled = true;
+      reject(e);
+    },
+  };
+  return box;
+}
+
+describe('settings toggles write optimistically', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.getNotifications.mockResolvedValue({ success: true, notifications_enabled: true });
+  });
+
+  test('the toggle flips before the backend write resolves', async () => {
+    const write = defer<{ success: true }>();
+    h.setNotifications.mockReturnValue(write.promise);
+
+    const { result } = renderToggle();
+    await waitFor(() => expect(result.current.value.data).toBe(true));
+
+    await act(async () => {
+      result.current.setValue.mutate(false);
+    });
+
+    // The optimistic write lands one microtask in (onMutate awaits
+    // cancelQueries first, per the TanStack pattern) — not after the backend.
+    await waitFor(() => expect(result.current.value.data).toBe(false));
+    // The decisive part: the value flipped while the write is STILL in flight.
+    expect(result.current.setValue.isPending).toBe(true);
+    expect(write.settled).toBe(false);
+
+    await act(async () => {
+      write.resolve({ success: true });
+      await write.promise;
+    });
+    expect(result.current.value.data).toBe(false);
+  });
+
+  test('a successful write does NOT read the value back', async () => {
+    h.setNotifications.mockResolvedValue({ success: true });
+
+    const { result } = renderToggle();
+    await waitFor(() => expect(result.current.value.data).toBe(true));
+    expect(h.getNotifications).toHaveBeenCalledTimes(1); // the initial read
+
+    await act(async () => {
+      await result.current.setValue.mutateAsync(false);
+    });
+
+    expect(h.setNotifications).toHaveBeenCalledTimes(1);
+    expect(h.setNotifications).toHaveBeenCalledWith(false);
+    // Still 1: no refetch was bolted onto the write. This is the assertion that
+    // fails if `onSuccess: invalidateQueries` ever comes back.
+    expect(h.getNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  test('a failed write rolls the toggle back', async () => {
+    h.setNotifications.mockRejectedValue(new Error('backend unavailable'));
+
+    const { result } = renderToggle();
+    await waitFor(() => expect(result.current.value.data).toBe(true));
+
+    await act(async () => {
+      await result.current.setValue.mutateAsync(false).catch(() => {});
+    });
+
+    // Disk still holds `true`, so the switch must not claim otherwise.
+    await waitFor(() => expect(result.current.value.data).toBe(true));
+  });
+});

--- a/app/renderer/src/hooks/useSettings.ts
+++ b/app/renderer/src/hooks/useSettings.ts
@@ -20,7 +20,47 @@ export const settingsKeys = {
   storagePath: () => [...settingsKeys.all, 'storagePath'] as const,
   appVersion: () => [...settingsKeys.all, 'appVersion'] as const,
   userName: () => [...settingsKeys.all, 'userName'] as const,
+  // Previously spelled inline at both the query and the mutation. The optimistic
+  // write below only works if the two use the identical key, so they get a
+  // factory like every other setting rather than two hand-written arrays.
+  keepRecordings: () => [...settingsKeys.all, 'keepRecordings'] as const,
+  autoSummarize: () => [...settingsKeys.all, 'autoSummarize'] as const,
 };
+
+/**
+ * Shared write path for a settings toggle whose query caches a plain boolean.
+ *
+ * Every `set-*` IPC spawns a backend process (settings-ipc.js -> runPythonScript,
+ * ~315 ms on a packaged build). The old shape here was `onSuccess: invalidate`,
+ * which spawned a SECOND process to read back the value we had just written —
+ * and, because the Switch renders from the query, the toggle only moved once
+ * that round trip finished. Two processes, ~630 ms of visible lag per click.
+ *
+ * So: flip the cache in `onMutate` (the switch responds immediately), let the
+ * write run in the background, and roll back if it rejects. No read-back — a
+ * resolved write means the value on disk IS the value we sent, so re-reading it
+ * only costs a process. The queries still refetch from disk on their own terms;
+ * this only removes the redundant one bolted to each write.
+ */
+function useToggleSetting(queryKey: readonly unknown[], write: (v: boolean) => Promise<unknown>) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: write,
+    onMutate: async (v: boolean) => {
+      // Cancel in-flight reads first: a refetch that started before the write
+      // would otherwise land afterwards and reinstate the pre-toggle value.
+      await qc.cancelQueries({ queryKey });
+      const previous = qc.getQueryData<boolean>(queryKey);
+      qc.setQueryData<boolean>(queryKey, v);
+      return { previous };
+    },
+    // The write failed, so disk still holds the old value — put it back rather
+    // than leaving the switch showing a state that was never persisted.
+    onError: (_err, _v, ctx) => {
+      qc.setQueryData(queryKey, ctx?.previous);
+    },
+  });
+}
 
 export function useNotificationsSetting() {
   return useQuery({
@@ -30,11 +70,9 @@ export function useNotificationsSetting() {
 }
 
 export function useSetNotifications() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setNotifications(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.notifications() }),
-  });
+  return useToggleSetting(settingsKeys.notifications(), async (v) =>
+    unwrap(await ipc().settings.setNotifications(v)),
+  );
 }
 
 export function useTelemetrySetting() {
@@ -44,12 +82,25 @@ export function useTelemetrySetting() {
   });
 }
 
+/** Same optimistic write as `useToggleSetting`, but this query caches an object
+ *  ({ telemetry_enabled, anonymous_id }) — so patch the one field instead of
+ *  replacing the entry, which would drop `anonymous_id`. */
 export function useSetTelemetry() {
   const qc = useQueryClient();
+  const key = settingsKeys.telemetry();
+  type Telemetry = { telemetry_enabled: boolean; anonymous_id?: string };
   return useMutation({
     mutationFn: async ({ enabled, source }: { enabled: boolean; source: TelemetryToggleSource }) =>
       unwrap(await ipc().settings.setTelemetry(enabled, source)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.telemetry() }),
+    onMutate: async ({ enabled }) => {
+      await qc.cancelQueries({ queryKey: key });
+      const previous = qc.getQueryData<Telemetry>(key);
+      if (previous) qc.setQueryData<Telemetry>(key, { ...previous, telemetry_enabled: enabled });
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData<Telemetry>(key, ctx.previous);
+    },
   });
 }
 
@@ -96,11 +147,9 @@ export function useDockIconSetting() {
 }
 
 export function useSetDockIcon() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setDockIcon(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.dockIcon() }),
-  });
+  return useToggleSetting(settingsKeys.dockIcon(), async (v) =>
+    unwrap(await ipc().settings.setDockIcon(v)),
+  );
 }
 
 export function useShowMenuBarIconSetting() {
@@ -111,11 +160,9 @@ export function useShowMenuBarIconSetting() {
 }
 
 export function useSetShowMenuBarIcon() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setMenuBarIcon(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.menuBarIcon() }),
-  });
+  return useToggleSetting(settingsKeys.menuBarIcon(), async (v) =>
+    unwrap(await ipc().settings.setMenuBarIcon(v)),
+  );
 }
 
 export function useSystemAudioSetting() {
@@ -126,11 +173,9 @@ export function useSystemAudioSetting() {
 }
 
 export function useSetSystemAudio() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setSystemAudio(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.systemAudio() }),
-  });
+  return useToggleSetting(settingsKeys.systemAudio(), async (v) =>
+    unwrap(await ipc().settings.setSystemAudio(v)),
+  );
 }
 
 export function useSystemAudioSupport() {
@@ -149,11 +194,9 @@ export function useAutoDetectMeetingsSetting() {
 }
 
 export function useSetAutoDetectMeetings() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setAutoDetectMeetings(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.autoDetectMeetings() }),
-  });
+  return useToggleSetting(settingsKeys.autoDetectMeetings(), async (v) =>
+    unwrap(await ipc().settings.setAutoDetectMeetings(v)),
+  );
 }
 
 export function usePremeetingNotificationsSetting() {
@@ -165,11 +208,9 @@ export function usePremeetingNotificationsSetting() {
 }
 
 export function useSetPremeetingNotifications() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setPremeetingNotifications(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.premeetingNotifications() }),
-  });
+  return useToggleSetting(settingsKeys.premeetingNotifications(), async (v) =>
+    unwrap(await ipc().settings.setPremeetingNotifications(v)),
+  );
 }
 
 export function useLaunchOnLoginSetting() {
@@ -180,11 +221,9 @@ export function useLaunchOnLoginSetting() {
 }
 
 export function useSetLaunchOnLogin() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setLaunchOnLogin(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.launchOnLogin() }),
-  });
+  return useToggleSetting(settingsKeys.launchOnLogin(), async (v) =>
+    unwrap(await ipc().settings.setLaunchOnLogin(v)),
+  );
 }
 
 export function useLanguageSetting() {
@@ -313,32 +352,28 @@ export function useSetUserName() {
 
 export function useKeepRecordingsSetting() {
   return useQuery({
-    queryKey: [...settingsKeys.all, 'keepRecordings'] as const,
+    queryKey: settingsKeys.keepRecordings(),
     queryFn: async () => unwrap(await ipc().settings.getKeepRecordings()).keep_recordings,
   });
 }
 
 export function useSetKeepRecordings() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setKeepRecordings(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: [...settingsKeys.all, 'keepRecordings'] }),
-  });
+  return useToggleSetting(settingsKeys.keepRecordings(), async (v) =>
+    unwrap(await ipc().settings.setKeepRecordings(v)),
+  );
 }
 
 export function useAutoSummarizeSetting() {
   return useQuery({
-    queryKey: [...settingsKeys.all, 'autoSummarize'] as const,
+    queryKey: settingsKeys.autoSummarize(),
     queryFn: async () => unwrap(await ipc().settings.getAutoSummarize()).auto_summarize_enabled,
   });
 }
 
 export function useSetAutoSummarize() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: boolean) => unwrap(await ipc().settings.setAutoSummarize(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: [...settingsKeys.all, 'autoSummarize'] }),
-  });
+  return useToggleSetting(settingsKeys.autoSummarize(), async (v) =>
+    unwrap(await ipc().settings.setAutoSummarize(v)),
+  );
 }
 
 /** Toggle + duration for the renderer-side silence detector. Defaults
@@ -359,20 +394,39 @@ export function useSilenceAutoStopSetting() {
   });
 }
 
-export function useSetSilenceAutoStopEnabled() {
+/** The silence-auto-stop query caches { enabled, minutes, supportedMinutes };
+ *  both setters patch their own field so the other two survive the write.
+ *  `supportedMinutes` is backend-owned and never touched here. */
+type SilenceAutoStop = { enabled: boolean; minutes: number; supportedMinutes: number[] };
+
+function useSilenceAutoStopField<TValue>(
+  field: 'enabled' | 'minutes',
+  write: (v: TValue) => Promise<unknown>,
+) {
   const qc = useQueryClient();
+  const key = settingsKeys.silenceAutoStop();
   return useMutation({
-    mutationFn: async (v: boolean) =>
-      unwrap(await ipc().settings.setSilenceAutoStopEnabled(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.silenceAutoStop() }),
+    mutationFn: write,
+    onMutate: async (v: TValue) => {
+      await qc.cancelQueries({ queryKey: key });
+      const previous = qc.getQueryData<SilenceAutoStop>(key);
+      if (previous) qc.setQueryData<SilenceAutoStop>(key, { ...previous, [field]: v });
+      return { previous };
+    },
+    onError: (_err, _v, ctx) => {
+      if (ctx?.previous) qc.setQueryData<SilenceAutoStop>(key, ctx.previous);
+    },
   });
 }
 
+export function useSetSilenceAutoStopEnabled() {
+  return useSilenceAutoStopField<boolean>('enabled', async (v) =>
+    unwrap(await ipc().settings.setSilenceAutoStopEnabled(v)),
+  );
+}
+
 export function useSetSilenceAutoStopMinutes() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (v: number) =>
-      unwrap(await ipc().settings.setSilenceAutoStopMinutes(v)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: settingsKeys.silenceAutoStop() }),
-  });
+  return useSilenceAutoStopField<number>('minutes', async (v) =>
+    unwrap(await ipc().settings.setSilenceAutoStopMinutes(v)),
+  );
 }


### PR DESCRIPTION
Addresses the "some of the toggle switches are slow" report.

## The cause

Every `set-*` settings IPC spawns a backend process (`settings-ipc.js` →
`runPythonScript`). Each mutation then ran `onSuccess: invalidateQueries`, which
spawned a **second** process to read back the value it had just written. Because
the `Switch` renders from the query, the toggle stayed put until that second
round trip finished.

Measured against the packaged binary from `/Applications` (5 runs each, isolated
data dir so nothing real was touched):

| call | median |
|---|---|
| `set-keep-recordings` | 315 ms |
| `get-keep-recordings` | 311 ms |

So one click cost **~630 ms of visible lag**, almost all of it process startup
rather than work — the write itself is a JSON dump.

## The change

The cache flips in `onMutate` and the write runs in the background, so the
switch responds immediately. A rejected write rolls back to the value still on
disk. The read-back is dropped: a resolved write means disk holds what we sent,
so re-reading it only costs a process. The queries still refetch from disk on
their own terms — this removes only the redundant fetch bolted onto each write.

- Nine plain-boolean toggles go through a shared `useToggleSetting`.
- Telemetry and silence-auto-stop cache objects, so they patch their own field
  rather than replacing the entry (telemetry would otherwise lose
  `anonymous_id`; silence-auto-stop would lose `supportedMinutes`).
- `keepRecordings` / `autoSummarize` gained key factories. The optimistic write
  only works if query and mutation use one identical key, and those two spelled
  theirs inline in both places — a drift waiting to happen.

**Deliberately unchanged:** language, storage path, user name and the privacy
gate keep their invalidate. They are not toggles, and storage path in particular
must re-read the authoritative value after files move.

`useSetRecordHotkey` is not included because it does not exist on `main` yet —
it arrives with #398. It should get the same treatment afterwards, with a small
variant of its own: its `registered` field is only knowable from the backend.

## Testing

New `useSettings.test.tsx` covers the flip-before-resolve, the rollback, and —
the important one — a call-count assertion that the write does **not** trigger a
read.

That last test was verified by re-introducing `onSuccess: invalidateQueries`
temporarily: it fails, and passes again once reverted. A behavioural test cannot
catch this regression, since the toggle would still work, only slowly again.

- Typecheck clean, lint 0 errors
- Unit: 191 node:test + 123 vitest
- T1 suite: 45/45 (macOS, local)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make settings toggles respond instantly by using optimistic updates and dropping the post-write refetch, removing a second backend call and ~630 ms of lag per click. Failed writes roll back to keep the UI consistent with disk.

- **Refactors**
  - Added shared `useToggleSetting` with `onMutate` optimistic update, `cancelQueries`, and rollback on error.
  - Applied to nine boolean toggles; telemetry and silence-auto-stop now patch only their field to preserve other cached data.
  - Removed `onSuccess: invalidateQueries` from toggle writes; normal query refetch behavior remains.
  - Added key factories for `keepRecordings` and `autoSummarize` to align query/mutation keys.
  - Left language, storage path, user name, and privacy gate using invalidate (not simple toggles).
  - Added tests for flip-before-resolve, rollback on failure, and no refetch after successful writes.

<sup>Written for commit 4072f7c71bc82c665906cd7e127b39f64140d27a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

