### PR TITLE
fix(update): follow redirects in the manual update check

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -8515,6 +8515,10 @@ const UPDATE_CHECK_URL = 'https://api.github.com/repos/ruzin/stenoai/releases/la
 // check for every already-installed app.
 async function checkForUpdates() {
   const MAX_REDIRECTS = 5;
+  // One 10s budget shared across the whole redirect chain, so a slow chain of
+  // hops can't keep the check hanging for redirects × 10s (each hop used to
+  // reset its own timeout).
+  const deadline = Date.now() + 10000;
 
   function fetchLatest(urlStr, redirectsLeft) {
     return new Promise((resolve) => {
@@ -8540,8 +8544,17 @@ async function checkForUpdates() {
             resolve({ success: false, error: 'Too many redirects' });
             return;
           }
-          // location may be relative; resolve it against the current URL.
-          const next = new URL(res.headers.location, urlStr).toString();
+          // location may be relative; resolve it against the current URL. A
+          // malformed Location would make new URL() throw synchronously inside
+          // this callback (crashing the main process), so guard it and fail the
+          // check normally instead.
+          let next;
+          try {
+            next = new URL(res.headers.location, urlStr).toString();
+          } catch (e) {
+            resolve({ success: false, error: 'Invalid redirect URL' });
+            return;
+          }
           resolve(fetchLatest(next, redirectsLeft - 1));
           return;
         }
@@ -8587,7 +8600,9 @@ async function checkForUpdates() {
         resolve({ success: false, error: error.message });
       });
 
-      req.setTimeout(10000, () => {
+      // Share the single deadline across all hops (min 1ms so an already-expired
+      // budget still fires promptly rather than being treated as "no timeout").
+      req.setTimeout(Math.max(1, deadline - Date.now()), () => {
         req.destroy();
         resolve({ success: false, error: 'Update check timeout' });
       });

--- a/app/main.js
+++ b/app/main.js
@@ -8502,68 +8502,101 @@ async function findOllamaExecutable() {
   return null;
 }
 
-// Update checking functionality
+// Where the manual "Check for updates" reads the latest release from. Kept as a
+// named constant so the repo path has a single source of truth (and is the one
+// line to change if the repo is renamed/transferred — though the redirect
+// following below means an old build keeps working through GitHub's 301 too).
+const UPDATE_CHECK_URL = 'https://api.github.com/repos/ruzin/stenoai/releases/latest';
+
+// Update checking functionality. Follows HTTP redirects (301/302/307/308):
+// GitHub's REST API returns a 301 to the new owner/repo path when a repo is
+// renamed or transferred, and Node's https.request does NOT follow redirects on
+// its own — so without this, a transfer would silently break the manual update
+// check for every already-installed app.
 async function checkForUpdates() {
-  return new Promise((resolve) => {
-    const options = {
-      hostname: 'api.github.com',
-      path: '/repos/ruzin/stenoai/releases/latest',
-      method: 'GET',
-      headers: {
-        'User-Agent': 'Steno-Updater'
+  const MAX_REDIRECTS = 5;
+
+  function fetchLatest(urlStr, redirectsLeft) {
+    return new Promise((resolve) => {
+      let url;
+      try {
+        url = new URL(urlStr);
+      } catch (e) {
+        resolve({ success: false, error: 'Invalid update URL' });
+        return;
       }
-    };
+      const options = {
+        hostname: url.hostname,
+        path: url.pathname + url.search,
+        method: 'GET',
+        headers: { 'User-Agent': 'Steno-Updater' },
+      };
 
-    const req = https.request(options, (res) => {
-      let data = '';
-
-      res.on('data', (chunk) => {
-        data += chunk;
-      });
-
-      res.on('end', () => {
-        try {
-          const release = JSON.parse(data);
-          const latestVersion = release.tag_name.replace(/^v/, ''); // Remove 'v' prefix if present
-
-          // Get current version from package.json
-          const packagePath = path.join(__dirname, 'package.json');
-          const packageContent = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
-          const currentVersion = packageContent.version;
-
-          console.log(`Current version: ${currentVersion}, Latest version: ${latestVersion}`);
-
-          // Simple version comparison (works for semantic versioning)
-          const isUpdateAvailable = compareVersions(currentVersion, latestVersion) < 0;
-
-          resolve({
-            success: true,
-            updateAvailable: isUpdateAvailable,
-            currentVersion: currentVersion,
-            latestVersion: latestVersion,
-            releaseUrl: release.html_url,
-            releaseName: release.name || `Version ${latestVersion}`,
-            downloadUrl: getDownloadUrl(release.assets)
-          });
-        } catch (error) {
-          console.error('Error parsing GitHub API response:', error);
-          resolve({ success: false, error: 'Failed to parse update data' });
+      const req = https.request(options, (res) => {
+        // Follow a redirect (repo rename/transfer → 301 to the new path).
+        if ([301, 302, 307, 308].includes(res.statusCode) && res.headers.location) {
+          res.resume(); // drain the response so the socket can be reused/freed
+          if (redirectsLeft <= 0) {
+            resolve({ success: false, error: 'Too many redirects' });
+            return;
+          }
+          // location may be relative; resolve it against the current URL.
+          const next = new URL(res.headers.location, urlStr).toString();
+          resolve(fetchLatest(next, redirectsLeft - 1));
+          return;
         }
+
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+
+        res.on('end', () => {
+          try {
+            const release = JSON.parse(data);
+            const latestVersion = release.tag_name.replace(/^v/, ''); // Remove 'v' prefix if present
+
+            // Get current version from package.json
+            const packagePath = path.join(__dirname, 'package.json');
+            const packageContent = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+            const currentVersion = packageContent.version;
+
+            console.log(`Current version: ${currentVersion}, Latest version: ${latestVersion}`);
+
+            // Simple version comparison (works for semantic versioning)
+            const isUpdateAvailable = compareVersions(currentVersion, latestVersion) < 0;
+
+            resolve({
+              success: true,
+              updateAvailable: isUpdateAvailable,
+              currentVersion: currentVersion,
+              latestVersion: latestVersion,
+              releaseUrl: release.html_url,
+              releaseName: release.name || `Version ${latestVersion}`,
+              downloadUrl: getDownloadUrl(release.assets)
+            });
+          } catch (error) {
+            console.error('Error parsing GitHub API response:', error);
+            resolve({ success: false, error: 'Failed to parse update data' });
+          }
+        });
       });
-    });
 
-    req.on('error', (error) => {
-      console.error('Error checking for updates:', error);
-      resolve({ success: false, error: error.message });
-    });
+      req.on('error', (error) => {
+        console.error('Error checking for updates:', error);
+        resolve({ success: false, error: error.message });
+      });
 
-    req.setTimeout(10000, () => {
-      req.destroy();
-      resolve({ success: false, error: 'Update check timeout' });
-    });
+      req.setTimeout(10000, () => {
+        req.destroy();
+        resolve({ success: false, error: 'Update check timeout' });
+      });
 
-    req.end();
-  });
+      req.end();
+    });
+  }
+
+  return fetchLatest(UPDATE_CHECK_URL, MAX_REDIRECTS);
 }
 
 function compareVersions(current, latest) {


### PR DESCRIPTION
Ahead of the planned org transfer. The manual 'Check for updates' (`checkForUpdates()`) used a raw `https.request` with no redirect handling — after a repo transfer, GitHub's API returns **301** to the new owner/repo, which Node doesn't follow, so the check would silently fail ("Failed to parse update data") for every installed app.

Now follows 301/302/307/308 (max 5 hops, relative-Location safe) and hoists the endpoint into `UPDATE_CHECK_URL`. Background auto-update (electron-updater) already follows redirects; this brings the manual check to parity.

Verified the follow-logic against a local 301→200 harness (follows to the new path and parses). Shipping this **before** the transfer so more installs already tolerate the redirect.

Note: no e2e added — it's an internal network helper not reachable from the T1/T2 harness; verified by inspection + the redirect harness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the manual "Check for updates" to follow redirects and handle bad headers safely, so it keeps working after a repo rename/transfer. Centralizes the update URL and tightens timeout handling.

- **Bug Fixes**
  - Follows 301/302/307/308 (max 5) and supports relative `Location`; drains response on redirects.
  - Guards redirect URL parsing and invalid update URLs to prevent crashes and return clearer errors.
  - Uses a single 10s timeout budget across the entire redirect chain.

<sup>Written for commit 1004f16637b4a87a9c7bdd04687a62d91f8370f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

