### PR TITLE
chore(transfer): repoint all references to github.com/stenolabs/stenoai

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,6 +1,6 @@
 {
   "contributors": [],
-  "message": "Thank you for your pull request! Before we can merge it, we need you to sign our [Contributor License Agreement (CLA)](https://github.com/ruzin/stenoai/blob/main/CLA.md).\n\n**To sign the CLA, please comment on this PR with:**\n\n> I have read the CLA Document and I hereby sign the CLA\n\nThis is a one-time process. Once you've signed, all your future contributions to Steno will be covered.",
+  "message": "Thank you for your pull request! Before we can merge it, we need you to sign our [Contributor License Agreement (CLA)](https://github.com/stenolabs/stenoai/blob/main/CLA.md).\n\n**To sign the CLA, please comment on this PR with:**\n\n> I have read the CLA Document and I hereby sign the CLA\n\nThis is a one-time process. Once you've signed, all your future contributions to Steno will be covered.",
   "label": "cla-signed",
   "recheckComment": "I have read the CLA Document and I hereby sign the CLA"
 }

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -348,7 +348,7 @@ jobs:
           - Microphone access permissions
 
           ### Intel Mac users
-          Steno is **Apple Silicon only** (since v0.4.0). Intel users should stay on [v0.3.8](https://github.com/ruzin/stenoai/releases/tag/v0.3.8), the last release supporting Intel Macs. Auto-update on existing Intel installs is gated and will not offer newer versions to those machines.
+          Steno is **Apple Silicon only** (since v0.4.0). Intel users should stay on [v0.3.8](https://github.com/stenolabs/stenoai/releases/tag/v0.3.8), the last release supporting Intel Macs. Auto-update on existing Intel installs is gated and will not offer newer versions to those machines.
         files: |
           release/*.dmg
           release/*.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ stenoai/
 
 ## Getting Help
 
-- Check existing [issues](https://github.com/ruzin/stenoai/issues)
+- Check existing [issues](https://github.com/stenolabs/stenoai/issues)
 - Create a new issue for bugs or feature requests
 - Join discussions in the repository
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/ruzin/stenoai/actions/workflows/build-release.yml"><img src="https://img.shields.io/github/actions/workflow/status/ruzin/stenoai/build-release.yml?style=for-the-badge" alt="Build"></a>
-  <a href="https://github.com/ruzin/stenoai/releases"><img src="https://img.shields.io/github/v/release/ruzin/stenoai?style=for-the-badge" alt="Release"></a>
+  <a href="https://github.com/stenolabs/stenoai/actions/workflows/build-release.yml"><img src="https://img.shields.io/github/actions/workflow/status/stenolabs/stenoai/build-release.yml?style=for-the-badge" alt="Build"></a>
+  <a href="https://github.com/stenolabs/stenoai/releases"><img src="https://img.shields.io/github/v/release/stenolabs/stenoai?style=for-the-badge" alt="Release"></a>
   <a href="https://discord.gg/DZ6vcQnxxu"><img src="https://img.shields.io/badge/Discord-Join%20Server-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge" alt="License"></a>
   <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS">
@@ -175,9 +175,9 @@ Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu)
 
 Download the latest release (**Apple Silicon Mac, macOS 14.4 or later**):
 
-- [Apple Silicon (M1-M5)](https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg)
+- [Apple Silicon (M1-M5)](https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg)
 
-> **Intel Mac users**: v0.4.0 is Apple Silicon only. Stay on [v0.3.8](https://github.com/ruzin/stenoai/releases/tag/v0.3.8) — the last release supporting Intel Macs. Auto-update on existing Intel installs will not push v0.4.0 to those machines.
+> **Intel Mac users**: v0.4.0 is Apple Silicon only. Stay on [v0.3.8](https://github.com/stenolabs/stenoai/releases/tag/v0.3.8) — the last release supporting Intel Macs. Auto-update on existing Intel installs will not push v0.4.0 to those machines.
 
 ### Installing on macOS
 
@@ -198,9 +198,9 @@ You can run it locally as well (see below) if you don't want to install a DMG.
 
 Windows 10/11 (x64) is supported in **alpha**, with the full pipeline verified working: record → live Parakeet transcription → batch transcript → Ollama summary, **including system-audio loopback capture with `[You]`/`[Others]` diarisation**.
 
-**Install:** download **`stenoAI-windows-x64.exe`** from the [latest release](https://github.com/ruzin/stenoai/releases/latest) and run it — it installs per-user (no admin needed) and creates Start-menu/desktop shortcuts. On first launch, Windows SmartScreen warns because the alpha is unsigned — click **More info → Run anyway**. The first-run setup wizard then downloads the transcription model (~670 MB) and the default summarisation model, Gemma 4 E2B (~4.3 GB).
+**Install:** download **`stenoAI-windows-x64.exe`** from the [latest release](https://github.com/stenolabs/stenoai/releases/latest) and run it — it installs per-user (no admin needed) and creates Start-menu/desktop shortcuts. On first launch, Windows SmartScreen warns because the alpha is unsigned — click **More info → Run anyway**. The first-run setup wizard then downloads the transcription model (~670 MB) and the default summarisation model, Gemma 4 E2B (~4.3 GB).
 
-> Before the first tagged Windows release lands, grab the installer from the [Windows build workflow](https://github.com/ruzin/stenoai/actions/workflows/build-windows.yml): sign in to GitHub, open the latest green run, download the `stenoai-windows` artifact, and run the `.exe` inside.
+> Before the first tagged Windows release lands, grab the installer from the [Windows build workflow](https://github.com/stenolabs/stenoai/actions/workflows/build-windows.yml): sign in to GitHub, open the latest green run, download the `stenoai-windows` artifact, and run the `.exe` inside.
 
 Known alpha limitations:
 
@@ -219,7 +219,7 @@ Issues + feedback welcome on the GitHub issues tracker.
 
 ### Setup
 ```bash
-git clone https://github.com/ruzin/stenoai.git
+git clone https://github.com/stenolabs/stenoai.git
 cd stenoai
 
 # Backend setup

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -599,7 +599,7 @@ function install({ ipcMain }) {
           updateAvailable: true,
           currentVersion: '0.0.0-e2e',
           latestVersion: '9.9.9',
-          releaseUrl: 'https://github.com/ruzin/stenoai/releases/latest',
+          releaseUrl: 'https://github.com/stenolabs/stenoai/releases/latest',
           releaseName: 'Version 9.9.9',
           downloadUrl: null,
           osUpdateEligible: false,

--- a/app/main.js
+++ b/app/main.js
@@ -1910,7 +1910,7 @@ if (!gotSingleInstanceLock) {
     const helpSubmenu = {
       role: 'help',
       submenu: [
-        { label: 'Learn More', click: () => shell.openExternal('https://github.com/ruzin/stenoai') },
+        { label: 'Learn More', click: () => shell.openExternal('https://github.com/stenolabs/stenoai') },
         { label: 'Report a Bug', click: () => shell.openExternal('https://discord.gg/DZ6vcQnxxu') }
       ]
     };
@@ -9301,7 +9301,7 @@ async function findOllamaExecutable() {
 // named constant so the repo path has a single source of truth (and is the one
 // line to change if the repo is renamed/transferred — though the redirect
 // following below means an old build keeps working through GitHub's 301 too).
-const UPDATE_CHECK_URL = 'https://api.github.com/repos/ruzin/stenoai/releases/latest';
+const UPDATE_CHECK_URL = 'https://api.github.com/repos/stenolabs/stenoai/releases/latest';
 
 // Update checking functionality. Follows HTTP redirects (301/302/307/308):
 // GitHub's REST API returns a 301 to the new owner/repo path when a repo is

--- a/app/package.json
+++ b/app/package.json
@@ -3,10 +3,10 @@
   "version": "0.6.5",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
-  "homepage": "https://github.com/ruzin/stenoai",
+  "homepage": "https://github.com/stenolabs/stenoai",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ruzin/stenoai.git"
+    "url": "https://github.com/stenolabs/stenoai.git"
   },
   "scripts": {
     "postinstall": "node scripts/patch-electron-dev.js",
@@ -228,7 +228,7 @@
     },
     "publish": {
       "provider": "github",
-      "owner": "ruzin",
+      "owner": "stenolabs",
       "repo": "stenoai"
     }
   }

--- a/app/renderer/src/routes/Setup.tsx
+++ b/app/renderer/src/routes/Setup.tsx
@@ -766,7 +766,7 @@ export function Setup() {
 
         <div className="mt-8 text-center text-xs text-muted-foreground">
           <a
-            href="https://github.com/ruzin/stenoai/issues"
+            href="https://github.com/stenolabs/stenoai/issues"
             target="_blank"
             rel="noreferrer"
             className="hover:text-foreground"

--- a/app/renderer/src/routes/settings/AboutTab.tsx
+++ b/app/renderer/src/routes/settings/AboutTab.tsx
@@ -29,7 +29,7 @@ function ExternalLinkAction({ label, onClick }: { label: string; onClick: () => 
 // handler) for the contextual "View release" button below.
 const CHANGELOG_URL = 'https://docs.stenoai.co/changelog';
 const DISCORD_URL = 'https://discord.gg/DZ6vcQnxxu';
-const GITHUB_URL = 'https://github.com/ruzin/stenoai';
+const GITHUB_URL = 'https://github.com/stenolabs/stenoai';
 const TERMS_URL = 'https://stenoai.co/terms.html';
 const PRIVACY_URL = 'https://stenoai.co/privacy.html';
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,7 +93,7 @@
         },
         {
           "anchor": "GitHub",
-          "href": "https://github.com/ruzin/stenoai",
+          "href": "https://github.com/stenolabs/stenoai",
           "icon": "github"
         },
         {
@@ -119,7 +119,7 @@
     "links": [
       {
         "label": "GitHub",
-        "href": "https://github.com/ruzin/stenoai"
+        "href": "https://github.com/stenolabs/stenoai"
       }
     ],
     "primary": {
@@ -130,7 +130,7 @@
   },
   "footer": {
     "socials": {
-      "github": "https://github.com/ruzin/stenoai",
+      "github": "https://github.com/stenolabs/stenoai",
       "discord": "https://discord.gg/DZ6vcQnxxu",
       "x": "https://x.com/ruzin_saleem"
     }

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: "Download and install Steno on macOS. The setup takes about five mi
 
 ## Requirements
 
-- macOS 14.4 (Sonoma) or later, on Apple Silicon (M1 or newer) -- Intel Macs are not supported since v0.4.0; the last release with Intel support is [v0.3.8](https://github.com/ruzin/stenoai/releases/tag/v0.3.8)
+- macOS 14.4 (Sonoma) or later, on Apple Silicon (M1 or newer) -- Intel Macs are not supported since v0.4.0; the last release with Intel support is [v0.3.8](https://github.com/stenolabs/stenoai/releases/tag/v0.3.8)
 - 8GB RAM minimum (16GB recommended for larger models)
 - ~8GB free disk space for the default models
 

--- a/docs/getting-started/what-is-steno.mdx
+++ b/docs/getting-started/what-is-steno.mdx
@@ -46,7 +46,7 @@ All data is stored in `~/Library/Application Support/stenoai/`. This includes re
 </Accordion>
 
 <Accordion title="Is Steno open source?">
-Yes. The source code is available at [github.com/ruzin/stenoai](https://github.com/ruzin/stenoai) under the MIT license.
+Yes. The source code is available at [github.com/stenolabs/stenoai](https://github.com/stenolabs/stenoai) under the MIT license.
 </Accordion>
 
 <Accordion title="What hardware does Steno need?">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -46,4 +46,4 @@ Your audio, transcripts, and summaries are stored locally in `~/Library/Applicat
 
 ## Trusted by users at AWS, Deliveroo, Tesco, HashiCorp, Rutgers, and the European Union.
 
-Open source under the MIT license -- [github.com/ruzin/stenoai](https://github.com/ruzin/stenoai).
+Open source under the MIT license -- [github.com/stenolabs/stenoai](https://github.com/stenolabs/stenoai).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,7 @@
 ## Key facts
 
 - Platform: macOS (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0) and Windows 10/11 (x64) in alpha.
-- Cost: free and open source (MIT license, no usage restrictions). A paid managed Enterprise deployment tier is a separate, optional offering (details coming soon). Source at https://github.com/ruzin/stenoai
+- Cost: free and open source (MIT license, no usage restrictions). A paid managed Enterprise deployment tier is a separate, optional offering (details coming soon). Source at https://github.com/stenolabs/stenoai
 - No meeting bot: records system audio + microphone locally; no participant is notified by Steno.
 - Transcription: two on-device engines — Parakeet (default, with a live transcript while recording; 25 European languages, including English) and Whisper (optional; 99 languages). No audio is uploaded.
 - Summarization: local models via Ollama by default (default model Gemma 4 E2B). Optional off-device alternatives -- a cloud model (OpenAI, Anthropic, AWS Bedrock, or a custom endpoint), a self-hosted "Private Server" remote Ollama instance, or an organization adapter -- receive the transcript and any typed notes only, never audio.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -14,7 +14,7 @@ organization-specific features, for teams that want that on top of the free app.
 ## Free — for everyone, including enterprise use
 - Price: $0
 - License: MIT (open source) -- no usage restrictions, including for commercial or enterprise deployments
-- Source code: https://github.com/ruzin/stenoai
+- Source code: https://github.com/stenolabs/stenoai
 - Account required: no
 - Includes: recording (system audio + microphone), on-device transcription (Parakeet and
   Whisper engines), on-device summarization (local models via Ollama), live transcription,

--- a/docs/privacy/how-on-device-works.mdx
+++ b/docs/privacy/how-on-device-works.mdx
@@ -34,7 +34,7 @@ Steno bundles [Ollama](https://ollama.com), which manages and runs small languag
 | Request | When | Why |
 |---------|------|-----|
 | Model download | First launch / setup only | Downloads transcription and Ollama model weights |
-| Update check | On app launch, then periodically | Checks `github.com/ruzin/stenoai` for new releases |
+| Update check | On app launch, then periodically | Checks `github.com/stenolabs/stenoai` for new releases |
 | Anonymous usage analytics | On events like recording start/stop, transcription/summarization completion, and errors | Anonymous product-usage telemetry (event names and counts only -- never meeting content); on by default, can be turned off in **Settings → Advanced** |
 
 None of these requests include your audio, transcript, or summary content. To verify this yourself, you can monitor network traffic with [Little Snitch](https://www.obdev.at/products/littlesnitch/) or macOS's built-in `nettop` while Steno is processing a recording.

--- a/docs/superpowers/plans/2026-07-15-post-download-experience.md
+++ b/docs/superpowers/plans/2026-07-15-post-download-experience.md
@@ -42,9 +42,9 @@ Expected: install completes, `astro build` completes with no errors, output list
 
 ```js
 export const MAC_DMG_URL =
-  "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+  "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
 export const WINDOWS_EXE_URL =
-  "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
+  "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
 ```
 
 - [ ] **Step 2: Commit**
@@ -68,8 +68,8 @@ Find:
 import AppleIcon from "../components/icons/AppleIcon.astro";
 import WindowsIcon from "../components/icons/WindowsIcon.astro";
 
-const DOWNLOAD_ARM = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
-const DOWNLOAD_WIN = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
+const DOWNLOAD_ARM = "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+const DOWNLOAD_WIN = "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
 ---
 ```
 
@@ -164,8 +164,8 @@ Find:
 import AppleIcon from "../components/icons/AppleIcon.astro";
 import WindowsIcon from "../components/icons/WindowsIcon.astro";
 
-const DOWNLOAD_ARM = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
-const DOWNLOAD_WIN = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
+const DOWNLOAD_ARM = "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+const DOWNLOAD_WIN = "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
 ---
 ```
 

--- a/skills/granola-to-steno/README.md
+++ b/skills/granola-to-steno/README.md
@@ -1,6 +1,6 @@
 # granola-to-steno
 
-Originally contributed by @SylvainRamousse in ruzin/stenoai#265, polished for
+Originally contributed by @SylvainRamousse in stenolabs/stenoai#265, polished for
 inclusion in the repo.
 
 A Cowork / Claude **skill** that syncs Granola meeting notes into Steno's

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Steno marketing website
 
-Part of the [Steno](https://github.com/ruzin/stenoai) project, licensed under [MIT](../LICENSE).
+Part of the [Steno](https://github.com/stenolabs/stenoai) project, licensed under [MIT](../LICENSE).
 
 Built with [Astro](https://astro.build) — static output, React islands for
 interactive pieces (nav, FAQ accordion, animated hero demo), Tailwind v4.

--- a/website/src/components/ComparisonPage.astro
+++ b/website/src/components/ComparisonPage.astro
@@ -10,8 +10,8 @@ import { ALL, VERIFIED } from "../content/comparisons.data.js";
 const { data } = Astro.props;
 const others = ALL.filter((c) => c.slug !== data.slug);
 
-const DOWNLOAD_ARM = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
-const DOWNLOAD_WIN = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
+const DOWNLOAD_ARM = "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+const DOWNLOAD_WIN = "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
 
 const H2_STYLE = {
   fontFamily: "var(--font-serif)",

--- a/website/src/components/IndustryPage.astro
+++ b/website/src/components/IndustryPage.astro
@@ -9,7 +9,7 @@ import { ALL, COMPLIANCE_BODY, CTA_MAILTO } from "../content/industries.data.js"
 const { data } = Astro.props;
 const others = ALL.filter((c) => c.slug !== data.slug);
 
-const DOWNLOAD_ARM = "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+const DOWNLOAD_ARM = "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
 
 const H2_STYLE = {
   fontFamily: "var(--font-serif)",

--- a/website/src/lib/downloads.js
+++ b/website/src/lib/downloads.js
@@ -1,4 +1,4 @@
 export const MAC_DMG_URL =
-  "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
+  "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-macos-arm64.dmg";
 export const WINDOWS_EXE_URL =
-  "https://github.com/ruzin/stenoai/releases/latest/download/stenoAI-windows-x64.exe";
+  "https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-windows-x64.exe";

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -178,7 +178,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
       <section>
         <h2>Contact</h2>
-        <p>For privacy-related questions, open an issue on <a href="https://github.com/ruzin/stenoai">GitHub</a> or reach out on <a href="https://discord.gg/DZ6vcQnxxu">Discord</a>.</p>
+        <p>For privacy-related questions, open an issue on <a href="https://github.com/stenolabs/stenoai">GitHub</a> or reach out on <a href="https://discord.gg/DZ6vcQnxxu">Discord</a>.</p>
       </section>
     </div>
   </main>

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -74,7 +74,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <div class="content">
       <section>
         <h2>Acceptance of terms</h2>
-        <p>By downloading and using Steno, you agree to these terms. Steno is open-source software provided under the terms of its <a href="https://github.com/ruzin/stenoai/blob/main/LICENSE">license</a>.</p>
+        <p>By downloading and using Steno, you agree to these terms. Steno is open-source software provided under the terms of its <a href="https://github.com/stenolabs/stenoai/blob/main/LICENSE">license</a>.</p>
       </section>
 
       <section>

--- a/website/src/sections/Footer.astro
+++ b/website/src/sections/Footer.astro
@@ -1,7 +1,7 @@
 ---
 import { StenoMark, Wordmark } from "../components/Brand";
 
-const GITHUB_URL = "https://github.com/ruzin/stenoai";
+const GITHUB_URL = "https://github.com/stenolabs/stenoai";
 const DISCORD_URL = "https://discord.gg/DZ6vcQnxxu";
 const DOCS_URL = "https://docs.stenoai.co";
 

--- a/website/src/sections/Nav.jsx
+++ b/website/src/sections/Nav.jsx
@@ -5,7 +5,7 @@ import { StenoMark, Wordmark } from "../components/Brand";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { trackDownload, trackGitHub } from "../analytics";
 
-const GITHUB_URL = "https://github.com/ruzin/stenoai";
+const GITHUB_URL = "https://github.com/stenolabs/stenoai";
 
 // Plain in-page hash links. Product + Enterprise are dropdowns (below), so the
 // only flat top-level link left is FAQ. Compare lives in the footer only.
@@ -185,7 +185,7 @@ export function Nav({ subpage = false }) {
   }, []);
 
   useEffect(() => {
-    fetch("https://api.github.com/repos/ruzin/stenoai")
+    fetch("https://api.github.com/repos/stenolabs/stenoai")
       .then(r => r.json())
       .then(d => { if (d.stargazers_count != null) setStars(d.stargazers_count); })
       .catch(() => {});


### PR DESCRIPTION
**Draft — do not merge until the repo is transferred to the org** (these paths 404 until the move happens). Stacks on #423, so its diff will clean up to just the reference sweep once #423 lands.

Repoints everything from `ruzin/stenoai` → `stenoai/stenoai`:
- **Functional:** `build.publish.owner` (`ruzin`→`stenoai`) so new builds' auto-update feed points at the org directly (not via redirect); `UPDATE_CHECK_URL` for the manual check.
- **Links:** README badges + download links, `AboutTab.tsx`, `Setup.tsx`, `.clabot`, the whole `website/` (download URLs, nav/footer/legal), `docs/`, and the release-notes text in `build-release.yml`.

⚠️ **Assumes the new path is `stenoai/stenoai`.** If the org or repo slug ends up different, it's a one-command re-run: `grep -rl 'stenoai/stenoai' | xargs perl -pi -e 's{stenoai/stenoai}{NEWORG/NEWREPO}g'`.

⚠️ Touches `.github/workflows/build-release.yml`, so it needs merging from the GitHub UI (workflow-scope), same as #393/#395.

Recommended: merge #423 first (pre-transfer), do the transfer + secrets/domains/integrations, then merge this, then run a dry-run release to confirm the signed build + auto-update feed end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repointed all GitHub references from `ruzin/stenoai` to `stenoai/stenoai` across the app, docs, and website. Also updated `build.publish.owner` and the manual update check so existing installs keep working after the org transfer.

- **Bug Fixes**
  - Manual “Check for updates” now follows GitHub redirects (301/302/307/308, max 5 hops) and resolves relative locations.
  - Centralized endpoint in `UPDATE_CHECK_URL` with a 10s timeout and basic error handling.

- **Migration**
  - Merge only after the repo is transferred to `stenoai/stenoai` (links 404 until then).
  - This touches `.github/workflows/build-release.yml`; merge via the GitHub UI.
  - After merging, run a dry-run release to verify the signed build and update feed.

<sup>Written for commit c8d07648ef36c6b85eff867a8d4fd6713c25745b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

