### PR TITLE
fix(export): save the note that's on screen as PDF, not always the Standard one

### DIFF
--- a/app/renderer/src/lib/notesPdf.test.ts
+++ b/app/renderer/src/lib/notesPdf.test.ts
@@ -125,3 +125,61 @@ describe('escapeHtml', () => {
     expect(escapeHtml(`&<>"'`)).toBe('&amp;&lt;&gt;&quot;&#39;');
   });
 });
+
+/**
+ * A generated template report is free-form markdown, not the Standard note's
+ * structured fields — so when one is on screen the PDF must carry THAT, the way
+ * "Copy notes" already does (#318). The caller serialises the markdown with the
+ * same renderer the detail view uses and hands the HTML in; this builder only
+ * places it inside the branded shell.
+ */
+describe('buildNotesHtml with an open template report', () => {
+  const report = {
+    templateName: 'Shareable summary',
+    contentHtml: '<h2>Outcome</h2>\n<p>We ship on <strong>Friday</strong>.</p>',
+  };
+
+  test('renders the report instead of the Standard sections', () => {
+    const html = buildNotesHtml(full, report);
+    // The report's content is present…
+    expect(html).toContain('<p>We ship on <strong>Friday</strong>.</p>');
+    // …labelled with the template it came from…
+    expect(html).toContain('>Shareable summary</h2>');
+    // …and the Standard note's sections are NOT along for the ride.
+    expect(html).not.toContain('>Key Topics</h2>');
+    expect(html).not.toContain('Ship v2 in July');
+    expect(html).not.toContain('Ben: draft the announcement');
+  });
+
+  test('keeps the brand chrome, title and meta line', () => {
+    const html = buildNotesHtml(full, report);
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('<h1>Weekly sync</h1>');
+    expect(html).toContain('Mon, Jun 23, 2026 · 45m');
+    expect(html).toContain('@font-face');
+  });
+
+  test('renders a report even when the Standard note is empty', () => {
+    // A transcript-only note (auto-summarise off) can still have a generated
+    // report — the export must not be gated on the Standard sections.
+    const empty: NotesPdfInput = {
+      name: 'Transcript only',
+      discussionAreas: [],
+      keyPoints: [],
+      actionItems: [],
+      participants: [],
+    };
+    const html = buildNotesHtml(empty, report);
+    expect(html).toContain('<p>We ship on <strong>Friday</strong>.</p>');
+    expect(html).toContain('<h1>Transcript only</h1>');
+  });
+
+  test('escapes the template name but passes the pre-rendered content through', () => {
+    const html = buildNotesHtml(full, {
+      templateName: 'Q3 <Review> & Notes',
+      contentHtml: '<p>kept &amp; intact</p>',
+    });
+    expect(html).toContain('Q3 &lt;Review&gt; &amp; Notes');
+    expect(html).toContain('<p>kept &amp; intact</p>');
+  });
+});

--- a/app/renderer/src/lib/notesPdf.ts
+++ b/app/renderer/src/lib/notesPdf.ts
@@ -20,6 +20,26 @@ import type { StructuredNoteSections } from '@/lib/notesCopy';
 // pre-formatted "date · duration"-style line, omitted when empty.
 export type NotesPdfInput = StructuredNoteSections;
 
+/**
+ * A generated template report, ready to drop into the branded shell.
+ *
+ * `contentHtml` is PRE-RENDERED by the caller, deliberately: a report is
+ * free-form markdown, and the only way to guarantee the PDF matches what the
+ * detail view shows is to serialise the very same renderer (react-markdown)
+ * rather than grow a second markdown implementation here that would drift.
+ * Keeping the markdown out of this module also keeps it pure and React-free.
+ *
+ * That means this one value is injected WITHOUT escaping, so its provenance
+ * matters: react-markdown does not emit raw HTML from its input unless
+ * rehype-raw is enabled (it is not), so note content cannot inject markup
+ * through it. The document's CSP (`default-src 'none'`) is the second line of
+ * defence. Never pass a hand-built or otherwise untrusted string here.
+ */
+export interface NotesPdfReport {
+  templateName: string;
+  contentHtml: string;
+}
+
 // Escape the five characters that are unsafe in HTML text/attribute context, so
 // note content (a title with "&", an action item with "<", etc.) can never
 // inject markup into the rendered document. Every dynamic value routes through
@@ -50,13 +70,30 @@ function listItems(items: string[]): string {
   return items.map((i) => `      <li>${escapeHtml(i)}</li>`).join('\n');
 }
 
-export function buildNotesHtml(input: NotesPdfInput): string {
-  if (!hasNotesContent(input)) return '';
+export function buildNotesHtml(input: NotesPdfInput, activeReport?: NotesPdfReport | null): string {
+  // A report carries its own content, so it is exportable even when the
+  // Standard note is empty (a transcript-only note can still have one).
+  const reportHtml = activeReport?.contentHtml?.trim();
+  if (!reportHtml && !hasNotesContent(input)) return '';
 
   const title = (input.name ?? '').trim() || 'Untitled note';
   const summary = input.summary?.trim();
 
   const sections: string[] = [];
+
+  // When a report is open it REPLACES the Standard sections — the PDF must show
+  // what's on screen, not both (matches buildNotesCopyText's short-circuit).
+  if (reportHtml) {
+    const label = escapeHtml((activeReport?.templateName || 'Report').trim());
+    return renderDocument(title, input.meta, [
+      `  <section>
+    <h2>${label}</h2>
+    <div class="report">
+${reportHtml}
+    </div>
+  </section>`,
+    ]);
+  }
 
   if (summary) {
     sections.push(`  <section>
@@ -108,8 +145,17 @@ ${listItems(input.actionItems)}
   </section>`);
   }
 
-  const metaLine = input.meta?.trim()
-    ? `  <div class="meta">${escapeHtml(input.meta.trim())}</div>`
+  return renderDocument(title, input.meta, sections);
+}
+
+/**
+ * The branded shell: masthead, title block, whatever sections it is handed, and
+ * the footer. Shared by both paths (Standard note and open report) so the two
+ * can never drift apart on chrome, fonts or layout.
+ */
+function renderDocument(title: string, meta: string | undefined, sections: string[]): string {
+  const metaLine = meta?.trim()
+    ? `  <div class="meta">${escapeHtml(meta.trim())}</div>`
     : '';
 
   return `<!doctype html>
@@ -192,6 +238,50 @@ ${listItems(input.actionItems)}
     border-radius: 1px; top: 0.55em; width: 5px; height: 5px;
     background: none; border: 1.2px solid var(--ink-900);
   }
+  /* An open template report is free-form markdown (react-markdown output), so
+     it brings element types the structured note never emits — headings inside
+     the body, ordered lists, emphasis, code, quotes, tables. Style them here;
+     without this they would inherit the structured note's list rules and lose
+     their numbering and hierarchy. */
+  .report { padding: 0 var(--inset); }
+  .report > :first-child { margin-top: 0; }
+  .report h1, .report h2, .report h3, .report h4 {
+    font-family: 'Ovo', Georgia, serif; font-weight: 400; color: var(--ink-900);
+    letter-spacing: 0; text-transform: none; border-bottom: none;
+    margin: 16px 0 7px; padding: 0; break-after: avoid;
+  }
+  .report h1 { font-size: 15pt; }
+  .report h2 { font-size: 13pt; }
+  .report h3 { font-size: 11.5pt; }
+  .report h4 { font-size: 10.5pt; font-weight: 600; }
+  .report p { margin: 0 0 9px; }
+  .report ul, .report ol { margin: 0 0 10px; padding-left: 18px; }
+  .report ul { list-style: disc; }
+  .report ol { list-style: decimal; }
+  .report li { padding-left: 0; margin-bottom: 5px; }
+  .report li::before { content: none; }
+  .report li::marker { color: var(--ink-900); }
+  .report strong { font-weight: 600; }
+  .report blockquote {
+    margin: 0 0 10px; padding-left: 12px;
+    border-left: 2px solid var(--rule); color: var(--ink-500);
+  }
+  .report code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 9pt;
+    background: var(--paper-1); padding: 1px 4px; border-radius: 3px;
+  }
+  .report pre {
+    margin: 0 0 10px; padding: 10px; background: var(--paper-1);
+    border: 1px solid var(--rule); border-radius: 6px; overflow-wrap: break-word;
+    white-space: pre-wrap; break-inside: avoid;
+  }
+  .report pre code { background: none; padding: 0; }
+  .report table { width: 100%; border-collapse: collapse; margin: 0 0 10px; font-size: 9.5pt; }
+  .report th, .report td {
+    border: 1px solid var(--rule); padding: 5px 7px; text-align: left; vertical-align: top;
+  }
+  .report th { background: var(--paper-1); font-weight: 600; }
+  .report hr { border: none; border-top: 1px solid var(--rule); margin: 14px 0; }
   footer {
     margin-top: 30px; padding: 10px var(--inset) 0; border-top: 1px solid var(--rule);
     font-size: 8pt; color: var(--ink-500); letter-spacing: 0.02em;

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+// Serialises the report markdown to an HTML string for the branded PDF, using
+// the same react-markdown renderer the detail view renders on screen.
+import { renderToStaticMarkup } from 'react-dom/server';
 import ReactMarkdown from 'react-markdown';
 import {
   Calendar as CalendarIcon,
@@ -576,21 +579,35 @@ function DetailContent({
     };
   }, [info, meeting]);
 
-  // Whether the note has structured content worth exporting to PDF — the
-  // disabled state only needs this boolean, so the ~45KB branded HTML (base64
-  // font included) is built lazily on click in saveNotesPdf, not on every render.
-  const canExportNotesPdf = hasNotesContent(noteSections);
+  // Whether there is anything worth exporting to PDF — the disabled state only
+  // needs this boolean, so the ~45KB branded HTML (base64 font included) is
+  // built lazily on click in saveNotesPdf, not on every render. An open report
+  // counts on its own: a transcript-only note (auto-summarise off) has no
+  // structured sections but can still have a generated report on screen.
+  const canExportNotesPdf = activeReport
+    ? Boolean(stripReasoning(activeReport.content).trim())
+    : hasNotesContent(noteSections);
 
-  // Branded-PDF export of the Standard structured note (not an open template
-  // report — the branded template is structured-note shaped). Hands finished
-  // HTML to the export-note-pdf IPC, which rasterises + writes it.
+  // Branded-PDF export of whichever note is on screen — the open template
+  // report when one is selected, otherwise the Standard structured note. The
+  // report's markdown is serialised with the SAME renderer the view above uses
+  // (react-markdown), so the PDF can't drift from what the user is looking at.
+  // Hands finished HTML to the export-note-pdf IPC, which rasterises + writes it.
   const saveNotesPdf = async () => {
     if (!canExportNotesPdf) return;
     setExportError(null);
     try {
+      const reportForPdf = activeReport
+        ? {
+            templateName: activeReport.template_name,
+            contentHtml: renderToStaticMarkup(
+              <ReactMarkdown>{stripReasoning(activeReport.content)}</ReactMarkdown>,
+            ),
+          }
+        : null;
       const res = await ipc().meetings.exportNotePdf(
         defaultExportFilename(meeting, 'pdf'),
-        buildNotesHtml(noteSections)
+        buildNotesHtml(noteSections, reportForPdf)
       );
       if (!res.success && res.error !== EXPORT_CANCELED_ERROR) {
         setExportError(`Couldn't save notes: ${res.error || 'unknown error'}`);

--- a/e2e/specs/notes-pdf-export.t1.spec.ts
+++ b/e2e/specs/notes-pdf-export.t1.spec.ts
@@ -89,3 +89,70 @@ test('Save notes as PDF is disabled for a transcript-only note (no structured co
   await expect(page.getByRole('button', { name: /Save notes as PDF/ })).toBeDisabled();
   await expect(page.getByRole('button', { name: /Save transcript as \.md/ })).toBeEnabled();
 });
+
+/**
+ * The PDF must carry whichever note is on screen, exactly like "Copy notes"
+ * (#318). Before this, Save-as-PDF always exported the Standard structured
+ * note — with a generated report open, the file silently disagreed with the
+ * screen.
+ */
+test('Save notes as PDF exports the open template report, not the Standard note', async ({
+  launchApp,
+}) => {
+  const outDir = mkdtempSync(path.join(tmpdir(), 'steno-pdf-report-t1-'));
+  const outFile = path.join(outDir, 'notes.html');
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: {
+      STENOAI_E2E_SEED_MEETING: '1',
+      STENOAI_E2E_SEED_REPORT: '1',
+      STENOAI_E2E_EXPORT_PATH: outFile,
+    },
+  });
+
+  try {
+    await openDetail(page);
+
+    // Open the seeded report from the view-toggle's template dropdown.
+    const menu = page.getByTestId('note-view-menu');
+    await page.getByTestId('note-view-menu-trigger').click();
+    await menu.getByRole('button', { name: /^Status Report/ }).click();
+    await expect(page.getByText('Pipeline healthy')).toBeVisible();
+
+    await page.getByRole('button', { name: 'More options' }).click();
+    await page.getByRole('button', { name: /Save notes as PDF/ }).click();
+
+    await expect
+      .poll(
+        () => {
+          try {
+            return readFileSync(outFile, 'utf8');
+          } catch {
+            return '';
+          }
+        },
+        { timeout: 10_000, intervals: [200] },
+      )
+      .toContain('<!doctype html>');
+
+    const html = readFileSync(outFile, 'utf8');
+
+    // The report's markdown arrives RENDERED, not as raw markdown — the same
+    // react-markdown output the detail view shows.
+    expect(html).toContain('<li>Pipeline healthy</li>');
+    expect(html).toContain('<li>Next: open the reqs</li>');
+    expect(html).not.toContain('- Pipeline healthy');
+    // Labelled with the template it came from.
+    expect(html).toContain('>Status Report</h2>');
+    // The Standard note's sections did NOT ride along.
+    expect(html).not.toContain('>Key Topics</h2>');
+    expect(html).not.toContain('Alice, Bob');
+    // Reasoning is stripped, exactly as in the rendered view and the clipboard.
+    expect(html).not.toContain('secret chain of thought');
+    // Brand chrome is unchanged.
+    expect(html).toContain('<h1>Epsilon Planning</h1>');
+    expect(html).toContain('@font-face');
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Found while testing a build: with a generated template report open, **"Save
notes as PDF…" exported the Standard structured note** instead of the report on
screen.

## Root cause

`saveNotesPdf` called `buildNotesHtml(noteSections)` and never passed
`activeReport` — the builder's input type had no slot for one. That was a
deliberate scoping decision (*"the branded template is structured-note
shaped"*), but it left the two adjacent menu actions disagreeing: #318 taught
**Copy notes** to follow the screen, and the PDF path was never given the same
treatment.

## Fix

A report is free-form markdown, so it is serialised with the **same renderer the
detail view uses** (`react-markdown` via `renderToStaticMarkup`) and dropped into
the branded shell. Reusing the view's renderer is the point: a second markdown
implementation inside `notesPdf.ts` would drift from what the user is looking at.

- `buildNotesHtml` takes an optional pre-rendered report; when present it
  **replaces** the Standard sections, mirroring `buildNotesCopyText`'s
  short-circuit.
- The branded shell moved into `renderDocument()` so both paths share chrome,
  fonts and layout and cannot drift.
- CSS for the element types markdown brings that the structured note never
  emits: body headings, ordered lists, emphasis, code, quotes, tables. Without
  it they inherited the structured note's list rules and lost their numbering.
- **Also fixed:** `canExportNotesPdf` now counts an open report on its own. A
  transcript-only note (auto-summarise off) with a generated report had the
  action disabled outright — the report could not be exported at all.

The report HTML is injected unescaped by necessity. `notesPdf.ts` documents why
that is safe: `react-markdown` emits no raw HTML from its input unless
`rehype-raw` is enabled (it is not), and the document's CSP
(`default-src 'none'`) remains the second line of defence.

## Testing

- Four unit cases in `notesPdf.test.ts` — **three failed before the fix**, so the
  bug was pinned by tests before any code changed.
- A `notes-pdf-export.t1` case driving the real UI: open the seeded report,
  export, then assert the written file carries the **rendered** report, the
  template name, no Standard sections, and no leaked `<think>` reasoning.
- That e2e case was verified to fail without the fix.

Typecheck clean, lint 0 errors, unit 255 node:test + 124 vitest, T1 suite 50/50.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Save notes as PDF…” exporting the Standard note when a template report is open. The PDF now matches what’s on screen and can export generated reports even when the structured note is empty.

- **Bug Fixes**
  - Report markdown is serialized with the same renderer as the detail view (`react-markdown` via `renderToStaticMarkup`) so the PDF matches the UI.
  - `buildNotesHtml` accepts an optional pre-rendered report and replaces the Standard sections when present.
  - Moved the branded shell to shared `renderDocument()` and added CSS for markdown elements (headings, ordered lists, code, tables) to keep numbering and layout correct.
  - `canExportNotesPdf` now treats an open report as exportable on its own, enabling export for transcript-only notes.

<sup>Written for commit 6ce64dee8feb413aa43afa1617e7a254d76a1466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

