### PR TITLE
build(macos): thin bundled binaries to arm64, drop x86-only Ollama runners (#427)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -106,6 +106,17 @@ jobs:
         file bin/ffmpeg
         file bin/ffmpeg | grep -q "arm64"
 
+    - name: Thin bundled binaries to ${{ matrix.arch }}
+      run: |
+        chmod +x scripts/thin-macos-bin.sh
+        # Idempotent — download-ollama.sh already ran it for the host arch. Run it
+        # again with the explicit target arch so a cached or hand-populated bin/
+        # can't smuggle x86_64 code into the signed bundle (#427). The script
+        # exits non-zero if any non-arm64 Mach-O survives.
+        ./scripts/thin-macos-bin.sh ${{ matrix.arch }}
+        file bin/ollama
+        file bin/ollama | grep -q "arm64"
+
     - name: Build mic-monitor helper (Swift)
       run: |
         chmod +x scripts/build-mic-monitor.sh

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -124,4 +124,11 @@ fi
 rm "$OLLAMA_FILE"
 
 echo "Ollama downloaded to $BIN_DIR"
+
+# Ollama's darwin tarball is universal (x86_64 + arm64) and additionally carries
+# the x86_64-only llama.cpp CPU runners for Intel Macs. The mac build is arm64-only
+# since v0.4.0, so strip both out before bundling (#427) — ~90 MB. No-op on
+# non-darwin hosts and on non-arm64 targets.
+"$(cd "$(dirname "$0")" && pwd)/thin-macos-bin.sh"
+
 ls -la "$BIN_DIR"

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -6,8 +6,9 @@ set -e
 
 OLLAMA_VERSION="v0.31.1"
 # Resolve both paths up front: the script cd's into $BIN_DIR further down, after
-# which a relative $0 no longer resolves.
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# which a relative path no longer resolves. BASH_SOURCE rather than $0 so this
+# still points at the script when it is sourced instead of executed.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/bin"
 
 # --- Download ffmpeg ---

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -5,7 +5,10 @@
 set -e
 
 OLLAMA_VERSION="v0.31.1"
-BIN_DIR="$(cd "$(dirname "$0")/.." && pwd)/bin"
+# Resolve both paths up front: the script cd's into $BIN_DIR further down, after
+# which a relative $0 no longer resolves.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/bin"
 
 # --- Download ffmpeg ---
 echo "=== Downloading ffmpeg ==="
@@ -129,6 +132,6 @@ echo "Ollama downloaded to $BIN_DIR"
 # the x86_64-only llama.cpp CPU runners for Intel Macs. The mac build is arm64-only
 # since v0.4.0, so strip both out before bundling (#427) — ~90 MB. No-op on
 # non-darwin hosts and on non-arm64 targets.
-"$(cd "$(dirname "$0")" && pwd)/thin-macos-bin.sh"
+"$SCRIPT_DIR/thin-macos-bin.sh"
 
 ls -la "$BIN_DIR"

--- a/scripts/thin-macos-bin.sh
+++ b/scripts/thin-macos-bin.sh
@@ -79,6 +79,15 @@ collect() {
     fi
 }
 
+collect_following_symlinks() {
+    # Same, but -L descends into symlinked directories. `-L` has to precede the
+    # path, so this cannot just be another argument to collect().
+    if ! find -L "$BIN_DIR" "$@" -print0 > "$WORK_LIST"; then
+        echo "thin-macos-bin: scanning $BIN_DIR (following symlinks) failed." >&2
+        exit 1
+    fi
+}
+
 echo "=== Thinning $BIN_DIR to arm64 ==="
 
 thinned=0
@@ -105,7 +114,11 @@ while IFS= read -r -d '' file; do
 
         before=$(stat -f%z "$file")
         mode=$(stat -f%Lp "$file")
-        TMP_OUT="$(mktemp -t thin-macos-bin-slice)"
+        # Beside the destination, not in $TMPDIR: mv is only atomic within one
+        # filesystem. Across volumes macOS mv unlinks the destination first and
+        # then copies, so a failure mid-copy would leave neither the original
+        # nor the thinned binary.
+        TMP_OUT="$(mktemp "$(dirname "$file")/.thin-XXXXXXXX")"
         lipo -thin arm64 "$file" -output "$TMP_OUT"
         chmod "$mode" "$TMP_OUT"
         mv -f "$TMP_OUT" "$file"
@@ -141,11 +154,21 @@ echo "Thinned $thinned file(s), removed $removed file(s), saved $((saved / 10485
 # Guard: assert positively that every Mach-O reachable from bin/ is arm64-only.
 # Blacklisting known-bad arches would let an unexpected one (arm64e, x86_64h, a
 # symlink pointing outside bin/) through, so anything that is not exactly
-# "arm64" fails the build. `! -type d` includes symlinks; lipo follows them.
+# "arm64" fails the build.
+#
+# `find -L` follows symlinks, so a symlinked directory (bin/vendor -> /payload)
+# is descended into rather than inspected as one opaque entry. An unreadable
+# file is failed rather than skipped - "lipo could not look at it" must not read
+# as "it is fine".
 leftovers=0
-collect ! -type d
+collect_following_symlinks ! -type d
 while IFS= read -r -d '' entry; do
-    info="$(lipo -info "$entry" 2>/dev/null)" || continue
+    if [[ ! -r "$entry" ]]; then
+        echo "thin-macos-bin: cannot read ${entry#"$REPO_ROOT"/} - refusing to certify it." >&2
+        leftovers=$((leftovers + 1))
+        continue
+    fi
+    info="$(lipo -info "$entry" 2>/dev/null)" || continue  # not a Mach-O file
     if [[ "$info" != *"is architecture: arm64" ]]; then
         echo "thin-macos-bin: non-arm64 binary: ${entry#"$REPO_ROOT"/} ($info)" >&2
         leftovers=$((leftovers + 1))

--- a/scripts/thin-macos-bin.sh
+++ b/scripts/thin-macos-bin.sh
@@ -7,6 +7,8 @@
 #     are universal (x86_64 + arm64)
 #   - the llama.cpp CPU runners (libggml-cpu-*.so, libllama*.dylib, ...) are
 #     x86_64-ONLY - they are the Intel-Mac path and can never load on arm64
+#     (upstream builds arm64 with the MLX backends and takes that payload from
+#     the amd64 tree, universalising only the executables and MLX libs)
 #
 # The macOS release has been arm64-only since v0.4.0 (see the single-entry arch
 # matrix in .github/workflows/build-release.yml), so all of that is dead weight
@@ -16,6 +18,8 @@
 # the app's own identity (the shipped bundle reports TeamIdentifier HSDX294RG4,
 # not Ollama's), so thinning does not strip a signature the build depends on.
 # It must NOT run after signing, which is why it lives next to the download step.
+# Note that thinned files no longer verify against Ollama's upstream signature -
+# only the app's own signature applies from here on.
 #
 # Idempotent: a second run finds nothing to do. No-op on non-darwin hosts and on
 # any target arch other than arm64 (an Intel build needs exactly what this
@@ -49,18 +53,47 @@ if [[ ! -d "$BIN_DIR" || "$(basename "$BIN_DIR")" != "bin" ]]; then
     exit 1
 fi
 
+# Without lipo every file looks like "not a Mach-O" and the guard at the end
+# would pass vacuously. Fail loudly instead.
+if ! command -v lipo >/dev/null 2>&1; then
+    echo "thin-macos-bin: lipo not found - cannot inspect or thin binaries." >&2
+    exit 1
+fi
+
+WORK_LIST="$(mktemp -t thin-macos-bin)"
+TMP_OUT=""
+cleanup() {
+    rm -f "$WORK_LIST"
+    [[ -n "$TMP_OUT" ]] && rm -f "$TMP_OUT"
+    return 0
+}
+trap cleanup EXIT
+
+# Collect into a file first so a find failure is caught - a `while ... done <
+# <(find ...)` loop silently succeeds on a partial scan.
+collect() {
+    # args: the find predicate to apply (e.g. -type f)
+    if ! find "$BIN_DIR" "$@" -print0 > "$WORK_LIST"; then
+        echo "thin-macos-bin: scanning $BIN_DIR failed." >&2
+        exit 1
+    fi
+}
+
 echo "=== Thinning $BIN_DIR to arm64 ==="
 
 thinned=0
 removed=0
 saved=0
 
-# -type f skips symlinks; the dangling ones are cleaned up afterwards.
-while IFS= read -r file; do
+collect -type f   # symlinks are handled in the follow-up pass
+while IFS= read -r -d '' file; do
     info="$(lipo -info "$file" 2>/dev/null)" || continue  # not a Mach-O file
 
     if [[ "$info" == "Architectures in the fat file"* ]]; then
-        if [[ "$info" != *"arm64"* ]]; then
+        # Exact word match on the arch list - a substring test would accept
+        # "arm64e" as "arm64" and then fail the lipo -thin below.
+        archs=" $(lipo -archs "$file" 2>/dev/null) "
+        if [[ "$archs" != *" arm64 "* ]]; then
             # Universal, but no arm64 slice at all (e.g. i386 + x86_64).
             before=$(stat -f%z "$file")
             rm -f "$file"
@@ -72,10 +105,11 @@ while IFS= read -r file; do
 
         before=$(stat -f%z "$file")
         mode=$(stat -f%Lp "$file")
-        tmp="$file.arm64.tmp"
-        lipo -thin arm64 "$file" -output "$tmp"
-        chmod "$mode" "$tmp"
-        mv -f "$tmp" "$file"
+        TMP_OUT="$(mktemp -t thin-macos-bin-slice)"
+        lipo -thin arm64 "$file" -output "$TMP_OUT"
+        chmod "$mode" "$TMP_OUT"
+        mv -f "$TMP_OUT" "$file"
+        TMP_OUT=""
         after=$(stat -f%z "$file")
         thinned=$((thinned + 1))
         saved=$((saved + before - after))
@@ -88,29 +122,35 @@ while IFS= read -r file; do
         saved=$((saved + before))
         echo "  removed (x86-only): ${file#"$REPO_ROOT"/}"
     fi
-done < <(find "$BIN_DIR" -type f)
+    # Any other thin arch (arm64e, x86_64h, ppc, ...) is deliberately left alone
+    # and caught by the guard below rather than deleted on a guess.
+done < "$WORK_LIST"
 
 # Symlinks such as libggml-base.0.dylib -> libggml-base.0.15.3.dylib dangle once
 # their x86-only target is gone.
-while IFS= read -r link; do
+collect -type l
+while IFS= read -r -d '' link; do
     if [[ ! -e "$link" ]]; then
         rm -f "$link"
         echo "  removed (dangling symlink): ${link#"$REPO_ROOT"/}"
     fi
-done < <(find "$BIN_DIR" -type l)
+done < "$WORK_LIST"
 
 echo "Thinned $thinned file(s), removed $removed file(s), saved $((saved / 1048576)) MB."
 
-# Guard: nothing non-arm64 may survive into the bundle.
+# Guard: assert positively that every Mach-O reachable from bin/ is arm64-only.
+# Blacklisting known-bad arches would let an unexpected one (arm64e, x86_64h, a
+# symlink pointing outside bin/) through, so anything that is not exactly
+# "arm64" fails the build. `! -type d` includes symlinks; lipo follows them.
 leftovers=0
-while IFS= read -r file; do
-    info="$(lipo -info "$file" 2>/dev/null)" || continue
-    if [[ "$info" == *"is architecture: x86_64" || "$info" == *"is architecture: i386" ]] \
-       || [[ "$info" == "Architectures in the fat file"* ]]; then
-        echo "thin-macos-bin: non-arm64 binary survived: ${file#"$REPO_ROOT"/} ($info)" >&2
+collect ! -type d
+while IFS= read -r -d '' entry; do
+    info="$(lipo -info "$entry" 2>/dev/null)" || continue
+    if [[ "$info" != *"is architecture: arm64" ]]; then
+        echo "thin-macos-bin: non-arm64 binary: ${entry#"$REPO_ROOT"/} ($info)" >&2
         leftovers=$((leftovers + 1))
     fi
-done < <(find "$BIN_DIR" -type f)
+done < "$WORK_LIST"
 
 if (( leftovers > 0 )); then
     echo "thin-macos-bin: $leftovers non-arm64 binary/binaries left in bin/." >&2

--- a/scripts/thin-macos-bin.sh
+++ b/scripts/thin-macos-bin.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Strip non-native architecture code out of bin/ before it gets bundled (#427).
+#
+# Ollama's darwin tarball is built for both Apple Silicon and Intel Macs:
+#   - `ollama`, `llama-server`, `llama-quantize` and the mlx_metal_v3/ dylibs
+#     are universal (x86_64 + arm64)
+#   - the llama.cpp CPU runners (libggml-cpu-*.so, libllama*.dylib, ...) are
+#     x86_64-ONLY - they are the Intel-Mac path and can never load on arm64
+#
+# The macOS release has been arm64-only since v0.4.0 (see the single-entry arch
+# matrix in .github/workflows/build-release.yml), so all of that is dead weight
+# in the shipped app: ~60 MB of x86_64 slices plus ~32 MB of x86_64-only files.
+#
+# Safe to run before signing: electron-builder re-signs the nested binaries with
+# the app's own identity (the shipped bundle reports TeamIdentifier HSDX294RG4,
+# not Ollama's), so thinning does not strip a signature the build depends on.
+# It must NOT run after signing, which is why it lives next to the download step.
+#
+# Idempotent: a second run finds nothing to do. No-op on non-darwin hosts and on
+# any target arch other than arm64 (an Intel build needs exactly what this
+# removes).
+#
+# Usage:
+#   ./scripts/thin-macos-bin.sh            # target arch = uname -m
+#   ./scripts/thin-macos-bin.sh arm64      # explicit target arch
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_DIR="$REPO_ROOT/bin"
+
+TARGET_ARCH="${1:-$(uname -m)}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "thin-macos-bin: not darwin, nothing to do."
+    exit 0
+fi
+
+if [[ "$TARGET_ARCH" != "arm64" ]]; then
+    echo "thin-macos-bin: target arch '$TARGET_ARCH' is not arm64 - keeping every slice."
+    exit 0
+fi
+
+# Defensive: never let the delete loop below run against an unexpected path.
+if [[ ! -d "$BIN_DIR" || "$(basename "$BIN_DIR")" != "bin" ]]; then
+    echo "thin-macos-bin: '$BIN_DIR' is not a bin/ directory - refusing to touch it." >&2
+    exit 1
+fi
+
+echo "=== Thinning $BIN_DIR to arm64 ==="
+
+thinned=0
+removed=0
+saved=0
+
+# -type f skips symlinks; the dangling ones are cleaned up afterwards.
+while IFS= read -r file; do
+    info="$(lipo -info "$file" 2>/dev/null)" || continue  # not a Mach-O file
+
+    if [[ "$info" == "Architectures in the fat file"* ]]; then
+        if [[ "$info" != *"arm64"* ]]; then
+            # Universal, but no arm64 slice at all (e.g. i386 + x86_64).
+            before=$(stat -f%z "$file")
+            rm -f "$file"
+            removed=$((removed + 1))
+            saved=$((saved + before))
+            echo "  removed (no arm64 slice): ${file#"$REPO_ROOT"/}"
+            continue
+        fi
+
+        before=$(stat -f%z "$file")
+        mode=$(stat -f%Lp "$file")
+        tmp="$file.arm64.tmp"
+        lipo -thin arm64 "$file" -output "$tmp"
+        chmod "$mode" "$tmp"
+        mv -f "$tmp" "$file"
+        after=$(stat -f%z "$file")
+        thinned=$((thinned + 1))
+        saved=$((saved + before - after))
+        echo "  thinned: ${file#"$REPO_ROOT"/} ($((before / 1048576)) MB -> $((after / 1048576)) MB)"
+
+    elif [[ "$info" == *"is architecture: x86_64" || "$info" == *"is architecture: i386" ]]; then
+        before=$(stat -f%z "$file")
+        rm -f "$file"
+        removed=$((removed + 1))
+        saved=$((saved + before))
+        echo "  removed (x86-only): ${file#"$REPO_ROOT"/}"
+    fi
+done < <(find "$BIN_DIR" -type f)
+
+# Symlinks such as libggml-base.0.dylib -> libggml-base.0.15.3.dylib dangle once
+# their x86-only target is gone.
+while IFS= read -r link; do
+    if [[ ! -e "$link" ]]; then
+        rm -f "$link"
+        echo "  removed (dangling symlink): ${link#"$REPO_ROOT"/}"
+    fi
+done < <(find "$BIN_DIR" -type l)
+
+echo "Thinned $thinned file(s), removed $removed file(s), saved $((saved / 1048576)) MB."
+
+# Guard: nothing non-arm64 may survive into the bundle.
+leftovers=0
+while IFS= read -r file; do
+    info="$(lipo -info "$file" 2>/dev/null)" || continue
+    if [[ "$info" == *"is architecture: x86_64" || "$info" == *"is architecture: i386" ]] \
+       || [[ "$info" == "Architectures in the fat file"* ]]; then
+        echo "thin-macos-bin: non-arm64 binary survived: ${file#"$REPO_ROOT"/} ($info)" >&2
+        leftovers=$((leftovers + 1))
+    fi
+done < <(find "$BIN_DIR" -type f)
+
+if (( leftovers > 0 )); then
+    echo "thin-macos-bin: $leftovers non-arm64 binary/binaries left in bin/." >&2
+    exit 1
+fi
+
+echo "Verified: every Mach-O file in bin/ is arm64-only."


### PR DESCRIPTION
Closes the first item of #427.

The macOS release has been arm64-only since v0.4.0, but Ollama's darwin tarball is built for both Apple Silicon and Intel:

- `ollama`, `llama-server`, `llama-quantize` and the `mlx_metal_v3/` dylibs are universal (x86_64 + arm64)
- the llama.cpp CPU runners (`libggml-cpu-*.so`, `libllama*.dylib`, ...) are **x86_64-only** - they are the Intel-Mac path and cannot load in an arm64 process at all

None of that can execute in the shipped app. This strips it before bundling.

**`bin/` 478 MB -> 386 MB, `dist/stenoai` 1.0 GB -> 890 MB.** 59.6 MB of x86_64 slices, 31.9 MB of x86-only files, plus 11 symlinks left dangling behind them.

## What this does

`scripts/thin-macos-bin.sh` walks `bin/`, `lipo -thin arm64`s every fat Mach-O and deletes the x86-only ones. It is idempotent, no-ops on non-darwin hosts and on any target arch other than arm64 (an Intel build needs exactly what it removes), and it ends with a guard that fails the build if anything reachable from `bin/` is not exactly arm64.

It is wired into `scripts/download-ollama.sh` right after extraction, and into `build-release.yml` as an explicit step with the matrix arch, so a cached or hand-populated `bin/` cannot smuggle x86 code into a signed bundle.

**Why before signing:** the nested binaries in the shipped app report `TeamIdentifier HSDX294RG4`, i.e. electron-builder re-signs them with the app's own identity. Thinning therefore does not strip a signature the build depends on. It must not run *after* signing, which is why it sits next to the download step. Thinned files no longer verify against Ollama's upstream signature - only the app's own signature applies from there on.

## What this deliberately does NOT do

It does **not** remove either MLX Metal runner. `mlx_metal_v3` and `mlx_metal_v4` both stay, in full. That is #427 item 4, and it is a supported-hardware compatibility decision, not file pruning - see the note at the end.

## Verification

Measured on an M4 (macOS 26.5) unless stated otherwise.

- Full `./scripts/download-ollama.sh` from a fresh, fat `bin/`: 91 MB saved, guard green, exit 0
- Idempotent: second run thins 0 files
- Intel target (`./scripts/thin-macos-bin.sh x86_64`): no-op, every slice kept
- `scripts/verify_mlx_bundle.py` against the rebuilt bundle: **10/10 PASS**, including the `dlopen` probes on the thinned dylibs and the byte-identity contract between `bin/` and `_internal/ollama/`
- Real MLX generation through the rebuilt bundle with `gemma4:e2b-nvfp4` (the NVFP4 tag the curated Gemma models map to on Apple Silicon): correct output, `mlx runner is ready`
- Guard negative tests, all exit 1 with the offending path named: a symlink to an external x86 binary, a symlinked directory hiding an x86 binary (`bin/vendor -> /payload`), an unreadable Mach-O
- Both scripts pass syntax checking under macOS system bash 3.2
- `ruff` and the backend unittests are unchanged from `main` (this branch contains no Python)

**Byte-identity.** For every thinned file, the arm64 slice extracted from the pre-change binary is byte-identical to the file after thinning. Apple Silicon executes exactly the same code as before; only the x86_64 slice beside it is gone.

**Tested on an M1** (macOS 26.5.2), since that is the hardware class the runner question is about:

- normal operation: loads and generates correctly, every file in the transferred tree arm64
- the M1 selects `mlx_metal_v4`, same as the M4
- so the thinned `mlx_metal_v3` was forced: with `mlx_metal_v4` moved aside, Ollama fell back to v3, `lsof` on the runner process confirms `mlx_metal_v3` is the mapped library, and generation returned a correct answer

## Note for #427 item 4

Both an M1 and an M4 select `mlx_metal_v4`, despite being very different GPU generations, and both run macOS 26. That points at the macOS/Metal version rather than the GPU family driving the selection - which would make `v3` the path for the lower part of the supported range (the minimum is macOS 14.4 since #416). Two machines on the same macOS generation is not proof, but it is an argument against treating `v3` as removable, and pinning the actual threshold needs a machine on macOS 14 or 15.

## Review

Reviewed by Codex across two rounds. Round 1 found a build-breaking path-resolution bug (`download-ollama.sh` cd's into `bin/` before invoking the helper, so a relative `$0` no longer resolved - it would have aborted the macOS release, both e2e backends and the Windows release) plus a fail-open guard. Round 2 found two remaining guard escapes and a non-atomic replace across filesystems. All adopted; the negative tests above cover each of them. Deliberately not implemented: resolving a full symlink chain for the script's own path, which no invocation form in this repo or in CI needs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the macOS bundle arm64-only by thinning fat Mach-O files and removing x86-only Ollama CPU runners. Saves ~90 MB and fails the build if any non-arm64 binary remains. Addresses #427 item 1; keeps both `mlx_metal_v3` and `mlx_metal_v4` (item 4).

- **New Features**
  - Added `scripts/thin-macos-bin.sh` to `lipo -thin arm64` fat binaries, delete x86-only files, and remove dangling symlinks; idempotent and no-op on non-darwin or non-arm64 targets.
  - Wired into `scripts/download-ollama.sh` (post-extract, pre-signing) and `.github/workflows/build-release.yml` (runs with `matrix.arch`) to block cached x86 code from entering signed bundles.
  - Size drop: `bin/` 478→386 MB; `dist/stenoai` 1.0→0.89 GB.

<sup>Written for commit 9b3320c3c5a7d4063397fbfb5ebc9d1cfa81569d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

