### PR TITLE
docs: align stated macOS requirement to the 14.4 floor

### DIFF
--- a/docs/features/recording.mdx
+++ b/docs/features/recording.mdx
@@ -24,7 +24,7 @@ macOS requires explicit permission for apps to record system audio. On first use
 3. Enable Steno
 4. Relaunch Steno if macOS asks you to
 
-After this one-time setup, the toggle stays on for future recordings until you turn it off. System audio capture requires macOS 14.4 or later; on older macOS versions the toggle is hidden and Steno records the microphone only.
+After this one-time setup, the toggle stays on for future recordings until you turn it off. Turn it off to record the microphone only -- useful for in-person meetings or dictation.
 
 ## Speaker labels
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: "Download and install Steno on macOS. The setup takes about five mi
 
 ## Requirements
 
-- macOS 12 (Monterey) or later, on Apple Silicon (M1 or newer) -- Intel Macs are not supported since v0.4.0; the last release with Intel support is [v0.3.8](https://github.com/ruzin/stenoai/releases/tag/v0.3.8)
+- macOS 14.4 (Sonoma) or later, on Apple Silicon (M1 or newer) -- Intel Macs are not supported since v0.4.0; the last release with Intel support is [v0.3.8](https://github.com/ruzin/stenoai/releases/tag/v0.3.8)
 - 8GB RAM minimum (16GB recommended for larger models)
 - ~8GB free disk space for the default models
 

--- a/docs/getting-started/what-is-steno.mdx
+++ b/docs/getting-started/what-is-steno.mdx
@@ -33,7 +33,7 @@ Steno is not a meeting bot. It does not join your video calls as a participant, 
 
 ## Supported platforms
 
-macOS 12 (Monterey) or later, on Apple Silicon (M1 and newer). Intel Macs are not supported since v0.4.0.
+macOS 14.4 (Sonoma) or later, on Apple Silicon (M1 and newer). Intel Macs are not supported since v0.4.0.
 
 ---
 

--- a/docs/guides/record-google-meet-on-mac.mdx
+++ b/docs/guides/record-google-meet-on-mac.mdx
@@ -7,7 +7,7 @@ To record a Google Meet call on a Mac, use Steno: it captures your Mac's system 
 
 ## Steps
 
-1. Install Steno and grant microphone and system-audio permission, and turn on the **Record system audio** toggle (requires macOS 14.4+; see [Installation](/getting-started/installation) and [Recording](/features/recording)). On older macOS versions the toggle is hidden and Steno records the microphone only.
+1. Install Steno and grant microphone and system-audio permission, and turn on the **Record system audio** toggle (see [Installation](/getting-started/installation) and [Recording](/features/recording)).
 2. Join your Google Meet call in your browser as usual.
 3. In Steno, click **New note** to start recording. It captures your microphone and system audio together.
 4. When the call ends, click **Stop**. Steno transcribes the recording and generates notes automatically.

--- a/docs/guides/record-system-audio-on-mac.mdx
+++ b/docs/guides/record-system-audio-on-mac.mdx
@@ -16,7 +16,7 @@ See [Recording](/features/recording) for the full recording options.
 
 ## What system audio captures
 
-System audio is everything your Mac plays through its output — the remote participants on a call, a video you are watching, or audio from any app. Combined with your microphone, it lets Steno record both sides of a conversation. There is no per-app filtering; Steno captures the system output as a whole. System audio capture requires macOS 14.4 or later; on older macOS versions the toggle is hidden.
+System audio is everything your Mac plays through its output — the remote participants on a call, a video you are watching, or audio from any app. Combined with your microphone, it lets Steno record both sides of a conversation. There is no per-app filtering; Steno captures the system output as a whole. Turn the toggle off to record the microphone only.
 
 ## Speaker labels
 

--- a/docs/guides/record-teams-on-mac.mdx
+++ b/docs/guides/record-teams-on-mac.mdx
@@ -7,7 +7,7 @@ To record a Microsoft Teams meeting on a Mac, use Steno: it captures your Mac's 
 
 ## Steps
 
-1. Install Steno and grant microphone and system-audio permission, and turn on the **Record system audio** toggle (requires macOS 14.4+; see [Installation](/getting-started/installation) and [Recording](/features/recording)). On older macOS versions the toggle is hidden and Steno records the microphone only.
+1. Install Steno and grant microphone and system-audio permission, and turn on the **Record system audio** toggle (see [Installation](/getting-started/installation) and [Recording](/features/recording)).
 2. Join your Teams call as usual.
 3. In Steno, click **New note** to start recording. It captures your microphone and system audio together.
 4. When the call ends, click **Stop**. Steno transcribes the recording and generates notes automatically.

--- a/docs/guides/record-zoom-on-mac.mdx
+++ b/docs/guides/record-zoom-on-mac.mdx
@@ -7,7 +7,7 @@ To record a Zoom meeting on a Mac, use Steno: it captures your Mac's system audi
 
 ## Steps
 
-1. Install Steno and grant microphone and system-audio permission, and turn on the **Record system audio** toggle (requires macOS 14.4+; see [Installation](/getting-started/installation) and [Recording](/features/recording)). On older macOS versions the toggle is hidden and Steno records the microphone only.
+1. Install Steno and grant microphone and system-audio permission, and turn on the **Record system audio** toggle (see [Installation](/getting-started/installation) and [Recording](/features/recording)).
 2. Join your Zoom call as usual.
 3. In Steno, click **New note** to start recording. It captures your microphone and system audio together.
 4. When the call ends, click **Stop**. Steno transcribes the recording and generates notes automatically.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,10 +1,10 @@
 # Steno
 
-> Steno is an open-source macOS app that records, transcribes, and summarizes meetings using AI models that run entirely on your device. It captures your Mac's system audio and microphone locally — no meeting bot joins the call — and transcribes and summarizes on-device by default, so audio and transcripts never leave your Mac. Free and open source (MIT, no usage restrictions, including enterprise use); a paid managed Enterprise deployment tier is a separate, optional offering. macOS 12+ (Apple Silicon only). MIT licensed.
+> Steno is an open-source macOS app that records, transcribes, and summarizes meetings using AI models that run entirely on your device. It captures your Mac's system audio and microphone locally — no meeting bot joins the call — and transcribes and summarizes on-device by default, so audio and transcripts never leave your Mac. Free and open source (MIT, no usage restrictions, including enterprise use); a paid managed Enterprise deployment tier is a separate, optional offering. macOS 14.4+ (Apple Silicon only). MIT licensed.
 
 ## Key facts
 
-- Platform: macOS only (macOS 12 Monterey or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0).
+- Platform: macOS only (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0).
 - Cost: free and open source (MIT license, no usage restrictions). A paid managed Enterprise deployment tier is a separate, optional offering (details coming soon). Source at https://github.com/ruzin/stenoai
 - No meeting bot: records system audio + microphone locally; no participant is notified by Steno.
 - Transcription: two on-device engines — Parakeet (default, with a live transcript while recording; 25 European languages, including English) and Whisper (optional; 99 languages). No audio is uploaded.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -33,7 +33,7 @@ organization-specific features, for teams that want that on top of the free app.
 - Everything works with no cloud provider — the default pipeline is fully local and free.
 
 ## Platform
-- macOS only (macOS 12 Monterey or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0).
+- macOS only (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0).
 
 ## Download
 - https://stenoai.co/#download

--- a/website/src/sections/CTAFooter.astro
+++ b/website/src/sections/CTAFooter.astro
@@ -47,7 +47,7 @@ import { WINDOWS_EXE_URL } from "../lib/downloads";
         </div>
 
         <p class="mt-5 text-[13px]" style={{ color: "var(--primary-fg)", opacity: 0.5 }}>
-          macOS 12+ (Apple Silicon) · Windows 10/11 (x64, alpha — unsigned) · ~4 GB for the default model
+          macOS 14.4+ (Apple Silicon) · Windows 10/11 (x64, alpha — unsigned) · ~4 GB for the default model
         </p>
       </div>
     </div>


### PR DESCRIPTION
## What

`#416` raised the app-wide `LSMinimumSystemVersion` to **14.4.0** (dropping the Screen Recording requirement for system audio), but the stated requirement was left inconsistent:

- README's download section was updated to "macOS 14.4 or later" ✓
- but `docs/pricing.md`, `docs/llms.txt`, `docs/getting-started/{what-is-steno,installation}.mdx`, and `website/.../CTAFooter.astro` still said **"macOS 12 Monterey or later"**
- and `docs/features/recording.mdx` + the four record-on-mac guides still described a **mic-only fallback for older macOS versions** — a path that can no longer run, since the app won't launch below 14.4.

## Change

- Bump every stated requirement (docs + website + `llms.txt`) from macOS 12 → **14.4**.
- Drop the now-moot "on older macOS the toggle is hidden / records mic-only" caveats. System audio is available to everyone who can run the app; **mic-only stays** as the deliberate toggle-off choice (in-person meetings, dictation) — that behavior is unchanged.

## Not changed

- No code changes. The `LSMinimumSystemVersion` floor stays at 14.4.0 (intentional). The mic-only recording path and the `isSystemAudioSupported()` plumbing (still load-bearing for Windows) are untouched.

Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align docs and website with the app’s macOS 14.4 minimum by updating all stated requirements and download copy. Remove outdated mic-only fallback notes for older macOS; system audio is available on all supported Macs (docs-only).

<sup>Written for commit 1cf2800cf4f290b79766ce8ae77396af2e61e32a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

