### PR TITLE
chore(release): v0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
-- **2026-07-24** 🔎 Settings search — press ⌘K on the Settings screen to search every setting and jump straight to the right tab.
-- **2026-07-24** 🔔 Cleaner notifications — meeting and note alerts now show as Steno's own in-app toast instead of native OS notifications.
-- **2026-07-24** ✨ Letter avatars — notes in the Previous list show their initial instead of a generic file icon.
-- **2026-07-24** 📅 Connected calendar — Calendar settings now show the account you've connected.
+- **2026-07-26** 🎙️ System audio without Screen Recording — record both sides of a call with no Screen Recording permission. Now requires macOS 14.4 or later.
+- **2026-07-26** ⬇️ Automatic updates — Steno installs a downloaded update while you're idle and relaunches, never mid-recording. Turn it off in Settings to keep the manual prompt.
+- **2026-07-26** ↩️ Undo delete + re-transcribe — restore a note right after deleting it, and re-transcribe an existing recording from its detail view.
+- **2026-07-26** 🌏 Chinese transcription — pick Simplified or Traditional Chinese when the Whisper engine is selected.
 
 
 ## Features

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
   "homepage": "https://github.com/ruzin/stenoai",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -21,6 +21,7 @@ description: "What's new in Steno -- recent releases and notable changes."
 - Opening Settings from a bare link now lands on General instead of stranding you on a stale tab.
 - The AI's internal reasoning tags no longer leak into your notes in a few remaining cases.
 - Fewer false "meeting detected" prompts.
+- Macs below macOS 14.4 are no longer offered an update they can't install; a manual check explains that a newer macOS is required instead.
 </Update>
 
 <Update label="v0.6.4" description="July 24, 2026">

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,26 @@ title: "Changelog"
 description: "What's new in Steno -- recent releases and notable changes."
 ---
 
+<Update label="v0.6.5" description="July 26, 2026">
+**New**
+- **System audio without the Screen Recording permission** — record both sides of a call without granting Screen Recording. This uses Core Audio Process Taps, so Steno now requires macOS 14.4 or later. (Turn the "Record system audio" toggle off any time to record the microphone only.)
+- **Automatic updates** — Steno now installs a downloaded update while your Mac is idle and relaunches on its own, and never while you're recording or processing. Turn off "Install updates automatically" in Settings → General to keep the manual "Restart to update" prompt.
+- **Re-transcribe a recording** — re-run transcription on an existing recording from its note, useful after switching engines or language.
+- **Undo a deleted note** — deleting a note now shows an Undo, so a note is soft-deleted and recoverable rather than gone immediately.
+- **Chinese transcription** — choose Simplified or Traditional Chinese when the Whisper transcription engine is selected in Settings → AI.
+- **Low-memory warning** — Settings now warns when a local summarization model may exceed your Mac's available memory before you switch to it.
+
+**Improved**
+- Deleting a note no longer asks for confirmation first, since Undo can restore it.
+
+**Fixed**
+- The macOS Keychain "Safe Storage" prompt no longer appears on every launch.
+- The manual check-for-updates now follows redirects, so it keeps working after the download location moves.
+- Opening Settings from a bare link now lands on General instead of stranding you on a stale tab.
+- The AI's internal reasoning tags no longer leak into your notes in a few remaining cases.
+- Fewer false "meeting detected" prompts.
+</Update>
+
 <Update label="v0.6.4" description="July 24, 2026">
 **New**
 - **Settings search** — Press ⌘K on the Settings screen to search every setting and jump straight to the tab it lives on.


### PR DESCRIPTION
Release prep for **v0.6.5**: README "What's New" (rolling 4), `docs/changelog.mdx` Update block, and version bump 0.6.4 → 0.6.5.

Headline changes shipping (since v0.6.4):
- System audio without the Screen Recording permission — **now requires macOS 14.4+** (#416)
- Automatic idle install of downloaded updates (#425)
- Re-transcribe an existing recording (#392); undo / soft-delete for note deletion (#391)
- Chinese Simplified/Traditional transcription on the Whisper engine (#102)
- Low-memory model warning (#389); Keychain prompt fix (#363); redirect-safe update check (#423); nav security hardening (#387)

Docs-and-version-only; no runtime code changes in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release prep for v0.6.5: bump version and update README “What’s New” and `docs/changelog.mdx`. Docs-only; no runtime code changes in this PR.

- **New Features**
  - System audio without Screen Recording; requires macOS 14.4+.
  - Automatic idle install of updates; never during a recording; can be turned off in Settings.
  - Re-transcribe existing recordings; undo/soft-delete note deletions.
  - Chinese transcription (Simplified and Traditional) on the Whisper engine.
  - Low-memory warning for large local models.

- **Bug Fixes**
  - Keychain “Safe Storage” prompt no longer repeats on launch.
  - Auto-update checks: follow redirects and avoid offering updates on macOS <14.4.
  - Settings links land on General.
  - Removed stray AI reasoning tags in notes.
  - Fewer false “meeting detected” prompts.

<sup>Written for commit d45ffcbb84f7d09820fcaa1ed9f4f9d7e7d1b9b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

