### PR TITLE
fix(update): don't auto-update onto macOS below the 14.4 launch floor (#432)

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -588,14 +588,33 @@ function install({ ipcMain }) {
     // Read-only display poll for the About tab's "Check for Updates" button
     // (settings-about.t1). Fully hermetic — no real GitHub call under mock
     // IPC, so this is the only source of truth for that flow in T1.
-    'check-for-updates': {
-      success: true,
-      updateAvailable: false,
-      currentVersion: '0.0.0-e2e',
-      latestVersion: '0.0.0-e2e',
-      releaseUrl: '',
-      releaseName: '',
-      downloadUrl: null,
+    'check-for-updates': () => {
+      // STENOAI_E2E_SEED_UPDATE_BLOCKED_OS=1 simulates an under-floor Mac: an
+      // update exists on GitHub but this OS is below the 14.4 launch floor, so
+      // osUpdateEligible is false and the About tab must explain that instead of
+      // offering a broken install/download nudge (#432, settings-about.t1).
+      if (process.env.STENOAI_E2E_SEED_UPDATE_BLOCKED_OS === '1') {
+        return {
+          success: true,
+          updateAvailable: true,
+          currentVersion: '0.0.0-e2e',
+          latestVersion: '9.9.9',
+          releaseUrl: 'https://github.com/ruzin/stenoai/releases/latest',
+          releaseName: 'Version 9.9.9',
+          downloadUrl: null,
+          osUpdateEligible: false,
+        };
+      }
+      return {
+        success: true,
+        updateAvailable: false,
+        currentVersion: '0.0.0-e2e',
+        latestVersion: '0.0.0-e2e',
+        releaseUrl: '',
+        releaseName: '',
+        downloadUrl: null,
+        osUpdateEligible: true,
+      };
     },
     // AboutTab's mount-time re-seed effect. Without an explicit stub, both
     // fields fall through to the permissive default (undefined, not null),

--- a/app/main.js
+++ b/app/main.js
@@ -57,7 +57,7 @@ const { createTeardownRegistry } = require('./teardown');
 const { registerFoldersIpc } = require('./folders-ipc');
 const { registerSettingsIpc } = require('./settings-ipc');
 const { isSafeToAutoInstall } = require('./update-idle-gate');
-const { isOSUpdateEligible } = require('./update-os-gate');
+const { isOSUpdateEligible, MIN_MACOS_FOR_AUTOUPDATE } = require('./update-os-gate');
 const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback, isMacos14Plus } = require('./meeting-detect');
 const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
@@ -6237,22 +6237,20 @@ function startIdleAutoInstallChecker() {
   if (idleAutoInstallInterval.unref) idleAutoInstallInterval.unref();
 }
 
-// Auto-update OS floor. MUST stay in lockstep with the Info.plist floor
-// (`build.mac.minimumSystemVersion` / `extendInfo.LSMinimumSystemVersion` in
-// app/package.json). The DMG won't LAUNCH below this, so we must never
-// download or install it onto an under-floor Mac (#432).
-const MIN_MACOS_FOR_AUTOUPDATE = '14.4.0';
+// Current OS version for the update gate, '' if it can't be read (→ fail open).
+function currentSystemVersionSafe() {
+  try { return process.getSystemVersion(); } catch (_) { return ''; }
+}
 
 // Whether electron-updater may run on this OS. See update-os-gate.js — darwin
-// below the floor is blocked (so nothing downloads and the idle installer has
-// nothing to apply); non-darwin and unparseable versions are eligible, with the
-// manifest `minimumSystemVersion` in latest-mac.yml as the authoritative backstop.
+// below the 14.4 floor (MIN_MACOS_FOR_AUTOUPDATE) is blocked (so nothing
+// downloads and the idle installer has nothing to apply); non-darwin and
+// unparseable versions are eligible, with the manifest `minimumSystemVersion`
+// in latest-mac.yml as the authoritative backstop.
 function autoUpdateOSEligible() {
-  let osVersion = '';
-  try { osVersion = process.getSystemVersion(); } catch (_) {}
   return isOSUpdateEligible({
     platform: process.platform,
-    osVersion,
+    osVersion: currentSystemVersionSafe(),
     minVersion: MIN_MACOS_FOR_AUTOUPDATE,
   });
 }
@@ -6273,9 +6271,7 @@ function setupAutoUpdater() {
   // ever fires, so `update-downloaded` never fires and the idle checker never
   // arms. (latest-mac.yml's minimumSystemVersion is the second layer.)
   if (!autoUpdateOSEligible()) {
-    let v = '';
-    try { v = process.getSystemVersion(); } catch (_) {}
-    sendDebugLog(`Auto-updater: skipped — macOS ${v} is below the ${MIN_MACOS_FOR_AUTOUPDATE} floor; this build won't launch here (#432).`);
+    sendDebugLog(`Auto-updater: skipped — macOS ${currentSystemVersionSafe()} is below the ${MIN_MACOS_FOR_AUTOUPDATE} floor; this build won't launch here (#432).`);
     return;
   }
 
@@ -6368,6 +6364,15 @@ function setupAutoUpdater() {
 }
 
 ipcMain.on('install-update', () => {
+  // Defense in depth for #432: today the renderer only shows "Restart to
+  // Update" once a real 'update-downloaded' fired (impossible under the floor,
+  // since setupAutoUpdater is skipped), so this is unreachable on an under-floor
+  // Mac. Gate it here too so a future renderer change can't reintroduce an
+  // ungated quitAndInstall onto a build this OS can't launch.
+  if (!autoUpdateOSEligible()) {
+    sendDebugLog('install-update: ignored — OS below the auto-update floor (#432).');
+    return;
+  }
   // Bypass the mainWindow 'close' handler's preventDefault+hide so that
   // quitAndInstall's window-close step actually quits the app. Without this
   // the app just minimises and Squirrel never gets to apply the update.

--- a/app/main.js
+++ b/app/main.js
@@ -57,6 +57,7 @@ const { createTeardownRegistry } = require('./teardown');
 const { registerFoldersIpc } = require('./folders-ipc');
 const { registerSettingsIpc } = require('./settings-ipc');
 const { isSafeToAutoInstall } = require('./update-idle-gate');
+const { isOSUpdateEligible } = require('./update-os-gate');
 const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback, isMacos14Plus } = require('./meeting-detect');
 const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
@@ -6236,6 +6237,26 @@ function startIdleAutoInstallChecker() {
   if (idleAutoInstallInterval.unref) idleAutoInstallInterval.unref();
 }
 
+// Auto-update OS floor. MUST stay in lockstep with the Info.plist floor
+// (`build.mac.minimumSystemVersion` / `extendInfo.LSMinimumSystemVersion` in
+// app/package.json). The DMG won't LAUNCH below this, so we must never
+// download or install it onto an under-floor Mac (#432).
+const MIN_MACOS_FOR_AUTOUPDATE = '14.4.0';
+
+// Whether electron-updater may run on this OS. See update-os-gate.js — darwin
+// below the floor is blocked (so nothing downloads and the idle installer has
+// nothing to apply); non-darwin and unparseable versions are eligible, with the
+// manifest `minimumSystemVersion` in latest-mac.yml as the authoritative backstop.
+function autoUpdateOSEligible() {
+  let osVersion = '';
+  try { osVersion = process.getSystemVersion(); } catch (_) {}
+  return isOSUpdateEligible({
+    platform: process.platform,
+    osVersion,
+    minVersion: MIN_MACOS_FOR_AUTOUPDATE,
+  });
+}
+
 function setupAutoUpdater() {
   if (IS_E2E) {
     sendDebugLog('Auto-updater: skipped (E2E mode)');
@@ -6244,6 +6265,17 @@ function setupAutoUpdater() {
   // Don't check for updates in dev mode
   if (!app.isPackaged) {
     sendDebugLog('Auto-updater: skipped (dev mode)');
+    return;
+  }
+  // Never auto-download/install onto a Mac below the launch floor — the build
+  // wouldn't start, and with idle auto-install (#425) it would replace a
+  // working install unattended. Skipping the whole setup means no download
+  // ever fires, so `update-downloaded` never fires and the idle checker never
+  // arms. (latest-mac.yml's minimumSystemVersion is the second layer.)
+  if (!autoUpdateOSEligible()) {
+    let v = '';
+    try { v = process.getSystemVersion(); } catch (_) {}
+    sendDebugLog(`Auto-updater: skipped — macOS ${v} is below the ${MIN_MACOS_FOR_AUTOUPDATE} floor; this build won't launch here (#432).`);
     return;
   }
 
@@ -9390,16 +9422,21 @@ function getDownloadUrl(assets) {
 
 ipcMain.handle('check-for-updates', async () => {
   const result = await checkForUpdates();
+  const osEligible = autoUpdateOSEligible();
   // The GitHub comparison above is a read-only display poll — it never
   // itself starts a download. Kick the real autoUpdater check alongside it
   // so a manual "Check for Updates" click actually starts a background
   // download when one's available, instead of only reporting the latest
-  // tag and waiting for the next scheduled interval. Same guard as
-  // setupAutoUpdater() so this stays a no-op (and network-free) in e2e/dev.
-  if (!IS_E2E && app.isPackaged) {
+  // tag and waiting for the next scheduled interval. Same guards as
+  // setupAutoUpdater(): no-op (and network-free) in e2e/dev, and never on a
+  // Mac below the launch floor, which must not download a build it can't run (#432).
+  if (!IS_E2E && app.isPackaged && osEligible) {
     autoUpdater.checkForUpdates().catch(() => {});
   }
-  return result;
+  // Surface eligibility so the About tab can explain why an "update available"
+  // won't auto-install on an under-floor Mac, rather than offering a broken
+  // Restart. (Display-only; the safety is the gated kick above.)
+  return { ...result, osUpdateEligible: osEligible };
 });
 
 // Lets a freshly-(re)mounted About tab recover "an update already

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js update-os-gate.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",
@@ -146,6 +146,7 @@
     "mac": {
       "icon": "build/icon-dragonfly.icns",
       "category": "public.app-category.productivity",
+      "minimumSystemVersion": "14.4.0",
       "target": [
         "dmg",
         "zip"

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -574,6 +574,10 @@ export type CheckForUpdatesResponse = Result<{
   releaseUrl: string;
   releaseName: string;
   downloadUrl: string | null;
+  // macOS only: false when this OS is below the app's launch floor (14.4), so
+  // an available update can't be auto-installed and the About tab explains that
+  // instead of offering a broken Restart (#432). Absent/true elsewhere.
+  osUpdateEligible?: boolean;
 }>;
 
 // downloadedVersion is null until a download finishes (or after one already

--- a/app/renderer/src/routes/settings/AboutTab.tsx
+++ b/app/renderer/src/routes/settings/AboutTab.tsx
@@ -38,7 +38,11 @@ type CheckState =
   | { kind: 'checking' }
   | { kind: 'error'; message: string }
   | { kind: 'up-to-date' }
-  | { kind: 'update-available'; version: string; releaseUrl: string };
+  | { kind: 'update-available'; version: string; releaseUrl: string }
+  // An update exists on GitHub but this Mac is below the 14.4 launch floor, so
+  // it can't be installed here (#432). We explain it rather than offer a broken
+  // "View release" download nudge.
+  | { kind: 'update-blocked-os'; version: string };
 
 export function AboutTab() {
   const version = useAppVersion();
@@ -125,7 +129,11 @@ export function AboutTab() {
         setCheckState({ kind: 'error', message: result.error });
         return;
       }
-      if (result.updateAvailable) {
+      if (result.updateAvailable && result.osUpdateEligible === false) {
+        // Update exists but this macOS is below the launch floor (#432) — don't
+        // point the user at a DMG that won't run.
+        setCheckState({ kind: 'update-blocked-os', version: result.latestVersion });
+      } else if (result.updateAvailable) {
         setCheckState({
           kind: 'update-available',
           version: result.latestVersion,
@@ -161,7 +169,9 @@ export function AboutTab() {
   const checkDescription =
     checkState.kind === 'update-available'
       ? `${versionLabel} — Update available (v${checkState.version})`
-      : versionLabel;
+      : checkState.kind === 'update-blocked-os'
+        ? `${versionLabel} — v${checkState.version} requires a newer version of macOS`
+        : versionLabel;
 
   return (
     <section data-settings-tab="about">

--- a/app/update-os-gate.js
+++ b/app/update-os-gate.js
@@ -33,6 +33,13 @@
  * @param {string} o.minVersion the floor, e.g. "14.4.0"
  * @returns {boolean} true when an auto-update may proceed on this OS
  */
+// The macOS auto-update floor — single source of truth. MUST equal the
+// Info.plist / update-manifest floor (`build.mac.minimumSystemVersion` and
+// `extendInfo.LSMinimumSystemVersion` in app/package.json); the unit test pins
+// all three together so they can't drift. main.js imports this rather than
+// redeclaring it.
+const MIN_MACOS_FOR_AUTOUPDATE = '14.4.0';
+
 function isOSUpdateEligible({ platform, osVersion, minVersion } = {}) {
   if (platform !== 'darwin') return true; // macOS-only floor; leave other platforms alone
   const cur = parseVersion(osVersion);
@@ -72,4 +79,4 @@ function compareVersion(a, b) {
   return 0;
 }
 
-module.exports = { isOSUpdateEligible };
+module.exports = { isOSUpdateEligible, MIN_MACOS_FOR_AUTOUPDATE };

--- a/app/update-os-gate.js
+++ b/app/update-os-gate.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * macOS auto-update OS-eligibility gate (#432).
+ *
+ * The app's Info.plist floor (LSMinimumSystemVersion) is 14.4.0, and macOS
+ * Launch Services refuses to LAUNCH the app below that. So an auto-update must
+ * never be downloaded or installed onto a Mac under the floor — combined with
+ * idle auto-install (#425), doing so would silently replace a working install
+ * with one that then won't start (an active brick; see #432). This gate lets
+ * main.js skip the whole electron-updater path on an under-floor Mac, so
+ * nothing downloads and the idle installer has nothing to apply.
+ *
+ * Pure and unit-tested, mirroring update-idle-gate.js: main.js supplies the
+ * live platform/version, this only decides.
+ *
+ * FAIL OPEN: the manifest `minimumSystemVersion` in latest-mac.yml is the
+ * authoritative second layer — electron-updater's own `isUpdateSupported`
+ * honours it before downloading. So if we can't confidently PARSE the version
+ * here, we return true (eligible) rather than silently disabling updates for a
+ * real, up-to-date user on a parse hiccup; the manifest gate still catches a
+ * genuinely old OS. Only a confidently-parsed darwin version strictly BELOW the
+ * floor blocks. Non-darwin is always eligible — this floor is macOS-only
+ * (Windows has its own update semantics), so the gate must not touch it.
+ *
+ * NOTE: this deliberately does a full major.minor.patch compare, unlike
+ * meeting-detect.js's `isMacos14Plus` which only checks the major version —
+ * the floor is 14.**4**, so 14.0–14.3 must be blocked too.
+ *
+ * @param {Object} o
+ * @param {string} o.platform   process.platform
+ * @param {string} o.osVersion  process.getSystemVersion() (e.g. "14.4.1")
+ * @param {string} o.minVersion the floor, e.g. "14.4.0"
+ * @returns {boolean} true when an auto-update may proceed on this OS
+ */
+function isOSUpdateEligible({ platform, osVersion, minVersion } = {}) {
+  if (platform !== 'darwin') return true; // macOS-only floor; leave other platforms alone
+  const cur = parseVersion(osVersion);
+  const min = parseVersion(minVersion);
+  if (!cur || !min) return true; // fail open on a parse hiccup — see doc above
+  return compareVersion(cur, min) >= 0;
+}
+
+// Parse "major.minor.patch" into a [major, minor, patch] number triple. A
+// MISSING trailing component ("14.4" has no patch) defaults to 0; a PRESENT but
+// empty or non-numeric component ("", "14.", "14.x.0") is malformed and returns
+// null (→ fail open), so a garbled version never silently reads as "0.0.0" and
+// gets blocked as below-floor.
+function parseVersion(v) {
+  if (typeof v !== 'string') return null;
+  const parts = v.trim().split('.');
+  const out = [];
+  for (let i = 0; i < 3; i++) {
+    const raw = parts[i];
+    if (raw === undefined) {
+      out.push(0); // fewer than 3 components — pad the missing trailing ones
+      continue;
+    }
+    const trimmed = raw.trim();
+    const n = parseInt(trimmed, 10);
+    if (trimmed === '' || !Number.isInteger(n) || String(n) !== trimmed) return null;
+    out.push(n);
+  }
+  return out;
+}
+
+function compareVersion(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] < b[i]) return -1;
+    if (a[i] > b[i]) return 1;
+  }
+  return 0;
+}
+
+module.exports = { isOSUpdateEligible };

--- a/app/update-os-gate.test.js
+++ b/app/update-os-gate.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { isOSUpdateEligible } = require('./update-os-gate');
+
+const FLOOR = '14.4.0';
+const eligible = (platform, osVersion) =>
+  isOSUpdateEligible({ platform, osVersion, minVersion: FLOOR });
+
+// --- darwin below the floor: BLOCKED (the whole point of #432) ---
+
+test('darwin macOS 12 blocked', () => {
+  assert.strictEqual(eligible('darwin', '12.7.6'), false);
+});
+
+test('darwin macOS 13 blocked', () => {
+  assert.strictEqual(eligible('darwin', '13.6.9'), false);
+});
+
+test('darwin 14.0 blocked (below 14.4, not just below 14)', () => {
+  assert.strictEqual(eligible('darwin', '14.0'), false);
+});
+
+test('darwin 14.3.1 blocked (minor-version aware)', () => {
+  assert.strictEqual(eligible('darwin', '14.3.1'), false);
+});
+
+// --- darwin at/above the floor: ALLOWED ---
+
+test('darwin 14.4.0 boundary allowed', () => {
+  assert.strictEqual(eligible('darwin', '14.4.0'), true);
+});
+
+test('darwin 14.4 (no patch) allowed', () => {
+  assert.strictEqual(eligible('darwin', '14.4'), true);
+});
+
+test('darwin 14.4.1 allowed', () => {
+  assert.strictEqual(eligible('darwin', '14.4.1'), true);
+});
+
+test('darwin 14.5 allowed', () => {
+  assert.strictEqual(eligible('darwin', '14.5'), true);
+});
+
+test('darwin 15.x allowed', () => {
+  assert.strictEqual(eligible('darwin', '15.1.1'), true);
+});
+
+test('darwin 26.x allowed (future naming)', () => {
+  assert.strictEqual(eligible('darwin', '26.0'), true);
+});
+
+// --- non-darwin: always eligible (macOS-only floor, Windows untouched) ---
+
+test('win32 always eligible regardless of version', () => {
+  assert.strictEqual(eligible('win32', '10.0.19045'), true);
+  assert.strictEqual(eligible('win32', '6.1.7601'), true);
+});
+
+test('linux always eligible', () => {
+  assert.strictEqual(eligible('linux', '0.0.0'), true);
+});
+
+// --- fail-open on a parse hiccup (manifest gate is the backstop) ---
+
+test('darwin empty version fails open (eligible)', () => {
+  assert.strictEqual(eligible('darwin', ''), true);
+});
+
+test('darwin garbled version fails open (eligible)', () => {
+  assert.strictEqual(eligible('darwin', 'not-a-version'), true);
+  assert.strictEqual(eligible('darwin', '14.x.0'), true);
+  assert.strictEqual(eligible('darwin', '14a'), true);
+});
+
+test('darwin non-string version fails open (eligible)', () => {
+  assert.strictEqual(eligible('darwin', undefined), true);
+  assert.strictEqual(eligible('darwin', null), true);
+  assert.strictEqual(eligible('darwin', 14.4), true);
+});
+
+test('unparseable minVersion fails open (eligible)', () => {
+  assert.strictEqual(isOSUpdateEligible({ platform: 'darwin', osVersion: '12.0.0', minVersion: 'oops' }), true);
+});
+
+test('no args does not throw and is eligible', () => {
+  assert.strictEqual(isOSUpdateEligible(), true);
+  assert.strictEqual(isOSUpdateEligible({}), true);
+});
+
+// --- config assertion: the runtime floor MUST match the Info.plist/manifest floor ---
+
+test('package.json mac floor matches the runtime gate floor (single-source #432)', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+  const mac = pkg.build && pkg.build.mac;
+  assert.ok(mac, 'build.mac block present');
+  // Layer 1: electron-builder writes this into latest-mac.yml for electron-updater.
+  assert.strictEqual(mac.minimumSystemVersion, '14.4.0', 'mac.minimumSystemVersion set for the update manifest');
+  // And it must agree with the Info.plist launch floor, or a user could still
+  // be offered a build their OS refuses to launch.
+  assert.strictEqual(mac.extendInfo.LSMinimumSystemVersion, '14.4.0', 'LSMinimumSystemVersion agrees with the manifest floor');
+});

--- a/app/update-os-gate.test.js
+++ b/app/update-os-gate.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { isOSUpdateEligible } = require('./update-os-gate');
+const { isOSUpdateEligible, MIN_MACOS_FOR_AUTOUPDATE } = require('./update-os-gate');
 
 const FLOOR = '14.4.0';
 const eligible = (platform, osVersion) =>
@@ -99,9 +99,10 @@ test('package.json mac floor matches the runtime gate floor (single-source #432)
   const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
   const mac = pkg.build && pkg.build.mac;
   assert.ok(mac, 'build.mac block present');
-  // Layer 1: electron-builder writes this into latest-mac.yml for electron-updater.
-  assert.strictEqual(mac.minimumSystemVersion, '14.4.0', 'mac.minimumSystemVersion set for the update manifest');
-  // And it must agree with the Info.plist launch floor, or a user could still
-  // be offered a build their OS refuses to launch.
-  assert.strictEqual(mac.extendInfo.LSMinimumSystemVersion, '14.4.0', 'LSMinimumSystemVersion agrees with the manifest floor');
+  // The runtime gate constant is the single source; the config floors must both
+  // equal it, or a user could be offered / installed a build their OS can't run.
+  // Layer 1: electron-builder writes minimumSystemVersion into latest-mac.yml.
+  assert.strictEqual(mac.minimumSystemVersion, MIN_MACOS_FOR_AUTOUPDATE, 'mac.minimumSystemVersion == runtime floor');
+  // The Info.plist launch floor must agree too.
+  assert.strictEqual(mac.extendInfo.LSMinimumSystemVersion, MIN_MACOS_FOR_AUTOUPDATE, 'LSMinimumSystemVersion == runtime floor');
 });

--- a/e2e/specs/settings-about.t1.spec.ts
+++ b/e2e/specs/settings-about.t1.spec.ts
@@ -28,6 +28,32 @@ test('About tab shows the version and resolves a Check for Updates click', async
   ).toBeVisible();
 });
 
+test('About tab explains an update that this macOS is too old to install', async ({
+  launchApp,
+}) => {
+  // Under-floor Mac (#432): the check reports an update, but osUpdateEligible
+  // is false, so the tab must say it needs a newer macOS and must NOT offer the
+  // "View release" download nudge (which would point at a DMG that won't run).
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_UPDATE_BLOCKED_OS: '1' },
+  });
+
+  await page.evaluate(() => {
+    window.location.hash = '#/settings?tab=about';
+  });
+
+  const aboutSection = page.locator('[data-settings-tab="about"]');
+  await expect(aboutSection).toBeVisible();
+
+  await aboutSection.getByRole('button', { name: 'Check for Updates' }).click();
+  await expect(
+    aboutSection.getByText(/v9\.9\.9 requires a newer version of macOS/),
+  ).toBeVisible();
+  // No download nudge on an OS that can't run the build.
+  await expect(aboutSection.getByRole('button', { name: 'View release' })).toHaveCount(0);
+});
+
 test('About tab rehydrates a persisted failed background update on mount', async ({
   launchApp,
 }) => {


### PR DESCRIPTION
Closes #432.

## Problem
#416 raised the app-wide floor to macOS 14.4 (`Info.plist` `LSMinimumSystemVersion`), but the update path had **no OS gate**. An existing install on macOS 12/13 would auto-download and — with idle auto-install (#425) — **auto-install a build that Launch Services then refuses to start**. An active brick, not passive abandonment.

## Fix — two layers
1. **Manifest** — `build.mac.minimumSystemVersion` so electron-builder writes `minimumSystemVersion` into `latest-mac.yml`, which electron-updater 6.8.3's `isUpdateSupported` already honours before downloading (verified in `node_modules/electron-updater/out/AppUpdater.js:348,365-375`).
2. **Runtime guard** — new pure `app/update-os-gate.js` (`isOSUpdateEligible`) gates `setupAutoUpdater()` (early return → nothing downloads → `update-downloaded` never fires → the #425 idle checker never arms) and the manual `check-for-updates` kick. Minor-version aware (blocks 14.0–14.3, not just <14), **fail-open** on a parse hiccup (manifest is the backstop). Darwin-only — Windows untouched.

Under-floor Macs also get an honest **manual-check** experience: the About tab now says "vX requires a newer version of macOS" and suppresses the "View release" download nudge (`osUpdateEligible` threaded through IPC).

## Invariants preserved
`process.arch` Intel/arm64 gate, #423 redirect logic, and the #425 idle gate are all untouched; the new guard sits upstream. The floor is single-sourced (`MIN_MACOS_FOR_AUTOUPDATE`) and a unit test pins `minimumSystemVersion` + `LSMinimumSystemVersion` to it so they can't drift.

## Tests
- `app/update-os-gate.test.js` — 18 cases (boundary/garbled/non-string/fail-open + the config-floor consistency assertion).
- `settings-about.t1` — new spec: under-floor Mac shows the "requires a newer macOS" notice and no "View release".
- Gates green locally: 273 node:test, 120 vitest, renderer typecheck.

## Verification honesty
The pure gate is runtime-exercised + unit-tested, and the About-tab notice is driven by a real-Electron T1. The full end-to-end — a signed build on a **macOS 13 VM** confirming electron-updater reports no-update from `latest-mac.yml` — can't run in CI/here; the runtime guard is the correct-by-inspection second layer. Flagging that manual VM check as a follow-up.

Reviewed in-context (senior QA + senior Eng lenses): no critical/high; medium/low folded in (single-source floor, wired the notice, hardened install-update).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents auto-update from downloading or installing on macOS versions below 14.4, avoiding installs that won’t launch. Adds a manifest floor and a runtime gate, and clarifies the About tab when an update requires a newer macOS.

- **Bug Fixes**
  - Set `build.mac.minimumSystemVersion: "14.4.0"` so `electron-builder` writes the floor into `latest-mac.yml` and `electron-updater` blocks before download.
  - Added `app/update-os-gate.js` with `isOSUpdateEligible` and `MIN_MACOS_FOR_AUTOUPDATE`; gates `setupAutoUpdater`, `install-update`, and manual `check-for-updates` on macOS, fail-open on parse; other platforms unchanged.
  - Threaded `osUpdateEligible` through IPC; About tab shows “vX requires a newer version of macOS” and hides “View release” when blocked.
  - Single-sourced the floor and added tests (unit coverage for the gate + an About-tab e2e).

<sup>Written for commit 163fc386c0bd62d27418289fc48948540eaf743a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

