### PR TITLE
fix(release): write the macOS floor into latest-mac.yml, in Darwin form (#432)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -156,6 +156,67 @@ jobs:
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+    # Write the macOS floor into the update manifest (#432). The runtime gate in
+    # app/update-os-gate.js cannot protect the installs that are actually at
+    # risk: it only runs inside a build that already meets the floor, while the
+    # machines that would be bricked are running the PREVIOUS release. Only
+    # latest-mac.yml reaches them — electron-updater checks its
+    # `minimumSystemVersion` before it reports an update or downloads one.
+    #
+    # electron-builder does NOT write that field. `mac.minimumSystemVersion`
+    # only reaches Info.plist (app-builder-lib macPackager.js) and `ReleaseInfo`
+    # in its schema is additionalProperties:false. Verified against 26.8.1: a
+    # build with mac.minimumSystemVersion set emits the plist key and a
+    # latest-mac.yml with zero occurrences of minimumSystemVersion.
+    #
+    # The value MUST be the DARWIN version — electron-updater compares against
+    # os.release(), which on macOS is the kernel version. The product floor
+    # 14.4.0 would be a silent no-op, since macOS 12 reports Darwin 21.6.0.
+    # darwinFloorForMacos() does the translation from the same constant the
+    # runtime gate uses, so the two can never disagree.
+    #
+    # Runs here rather than in the release job because `npm ci` has run, so the
+    # patched manifest can be re-parsed with a real YAML parser instead of being
+    # eyeballed. A missing js-yaml (electron-builder's, hoisted) fails the step —
+    # the right direction: never publish an ungated manifest.
+    - name: Write the macOS floor into the update manifest
+      working-directory: app
+      run: |
+        node -e "
+          const fs = require('fs');
+          const yaml = require('js-yaml');
+          const { darwinFloorForMacos, MIN_MACOS_FOR_AUTOUPDATE } = require('./update-os-gate');
+          const file = 'dist/latest-mac.yml';
+
+          const floor = darwinFloorForMacos(MIN_MACOS_FOR_AUTOUPDATE);
+          const before = fs.readFileSync(file, 'utf8');
+          const parsed = yaml.load(before);
+          if (!parsed || typeof parsed !== 'object') {
+            throw new Error('latest-mac.yml did not parse as a mapping');
+          }
+          if (parsed.minimumSystemVersion !== undefined) {
+            throw new Error('latest-mac.yml already carries minimumSystemVersion — electron-builder gained native support, so check the value is the DARWIN one before removing this step');
+          }
+
+          const patched = before.replace(/\n*\$/, '\n') + 'minimumSystemVersion: ' + floor + '\n';
+          // Re-parse: proves the append produced ONE valid document with the key
+          // at the root, whatever shape the serializer emitted (a document
+          // marker or a flow-style root would throw or land the key elsewhere).
+          const after = yaml.load(patched);
+          if (after.minimumSystemVersion !== floor) {
+            throw new Error('patched manifest reads back as ' + JSON.stringify(after.minimumSystemVersion));
+          }
+          for (const key of ['version', 'files', 'path', 'sha512', 'releaseDate']) {
+            if (JSON.stringify(after[key]) !== JSON.stringify(parsed[key])) {
+              throw new Error('patching altered ' + key);
+            }
+          }
+
+          fs.writeFileSync(file, patched);
+          console.log('Gated latest-mac.yml (minimumSystemVersion: ' + floor + ', i.e. macOS ' + MIN_MACOS_FOR_AUTOUPDATE + '):');
+          console.log(patched);
+        "
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -231,8 +292,21 @@ jobs:
         find artifacts -name "*.zip" -exec cp {} release/ \;
         # Single-arch release (arm64) as of v0.4.0 — the per-arch
         # latest-mac.yml from the build job is the published auto-update
-        # manifest as-is.
+        # manifest.
         cp artifacts/build-arm64/latest-mac.yml release/latest-mac.yml
+        # The build job writes the macOS floor into this manifest (#432).
+        # Re-derive it here and require an exact match, so a removed, reordered
+        # or half-applied step cannot publish a feed that offers the build to
+        # Macs which cannot launch it. update-os-gate.js is dependency-free, so
+        # this needs no node_modules in the release job.
+        MIN_DARWIN=$(node -e "
+          const m = require('./app/update-os-gate');
+          process.stdout.write(m.darwinFloorForMacos(m.MIN_MACOS_FOR_AUTOUPDATE));
+        ")
+        if ! grep -qx "minimumSystemVersion: ${MIN_DARWIN}" release/latest-mac.yml; then
+          echo "::error::latest-mac.yml does not carry 'minimumSystemVersion: ${MIN_DARWIN}' — refusing to publish an ungated update manifest (see #432)."
+          exit 1
+        fi
         echo "Published latest-mac.yml:"
         cat release/latest-mac.yml
         ls -la release/

--- a/app/update-os-gate.js
+++ b/app/update-os-gate.js
@@ -23,6 +23,14 @@
  * floor blocks. Non-darwin is always eligible — this floor is macOS-only
  * (Windows has its own update semantics), so the gate must not touch it.
  *
+ * WHICH LAYER PROTECTS WHOM. This gate only ever runs inside a build that
+ * already meets the floor — Launch Services would not have started it
+ * otherwise — so it cannot protect the installs that are actually at risk:
+ * those run the PREVIOUS release, which we cannot ship code to. Only the
+ * manifest reaches them, and it is what makes the fail-open above safe. See
+ * `darwinFloorForMacos` for how that value is produced, and why
+ * `build.mac.minimumSystemVersion` alone does not produce it.
+ *
  * NOTE: this deliberately does a full major.minor.patch compare, unlike
  * meeting-detect.js's `isMacos14Plus` which only checks the major version —
  * the floor is 14.**4**, so 14.0–14.3 must be blocked too.
@@ -79,4 +87,69 @@ function compareVersion(a, b) {
   return 0;
 }
 
-module.exports = { isOSUpdateEligible, MIN_MACOS_FOR_AUTOUPDATE };
+// macOS product major -> Darwin kernel major. Deliberately a table and not
+// `major + 9`: that arithmetic holds from macOS 11 to 15 and then breaks, since
+// macOS 26 (Tahoe) is Darwin 25. An unmapped major must fail loudly at release
+// time rather than silently produce a floor that gates the wrong OS versions.
+const MACOS_TO_DARWIN_MAJOR = {
+  11: 20, // Big Sur
+  12: 21, // Monterey
+  13: 22, // Ventura
+  14: 23, // Sonoma
+  15: 24, // Sequoia
+  26: 25, // Tahoe
+};
+
+/**
+ * Translate the macOS product floor into the value that belongs in
+ * `latest-mac.yml` as `minimumSystemVersion`.
+ *
+ * Two things make this necessary, and both are invisible from the outside:
+ *
+ * 1. electron-builder never writes the field. `mac.minimumSystemVersion` only
+ *    reaches Info.plist as LSMinimumSystemVersion (app-builder-lib
+ *    `macPackager.js`), and `ReleaseInfo` in its schema is
+ *    `additionalProperties: false`, so no config path produces it. Verified
+ *    empirically against electron-builder 26.8.1: a build with
+ *    `mac.minimumSystemVersion: 14.4.0` set emits the plist key and a
+ *    latest-mac.yml with zero occurrences of `minimumSystemVersion`. The
+ *    release workflow therefore writes it in.
+ *
+ * 2. electron-updater compares the field against `os.release()`, which on
+ *    macOS is the DARWIN kernel version, not the product version
+ *    (`AppUpdater.checkIfUpdateSupported`). So the product floor `14.4.0` is a
+ *    silent no-op: macOS 12 reports Darwin `21.6.0`, which is not lower. The
+ *    manifest needs `23.4.0`.
+ *
+ * The macOS minor tracks the Darwin minor within a major (macOS 14.4 is Darwin
+ * 23.4.0), so only the major needs mapping. A patch level in the floor is
+ * deliberately dropped rather than carried over: Darwin's third component does
+ * not track the macOS patch release, so mapping it would invent a boundary that
+ * does not exist. A floor of 14.4.1 therefore gates at 23.4.0, i.e. one macOS
+ * patch release more permissive than stated — pick minor-level floors.
+ *
+ * @param {string} macosVersion a macOS product version, e.g. MIN_MACOS_FOR_AUTOUPDATE
+ * @returns {string} Darwin semver for the update manifest, e.g. '23.4.0'
+ * @throws {Error} on an unparseable version or an unmapped major
+ */
+function darwinFloorForMacos(macosVersion) {
+  const parsed = parseVersion(macosVersion);
+  if (!parsed) {
+    throw new Error(`Unparseable macOS version: ${macosVersion}`);
+  }
+  const [major, minor] = parsed;
+  const darwinMajor = MACOS_TO_DARWIN_MAJOR[major];
+  if (darwinMajor === undefined) {
+    throw new Error(
+      `No Darwin mapping for macOS ${major}. Add it to MACOS_TO_DARWIN_MAJOR in app/update-os-gate.js.`
+    );
+  }
+  return `${darwinMajor}.${minor}.0`;
+}
+
+module.exports = {
+  isOSUpdateEligible,
+  MIN_MACOS_FOR_AUTOUPDATE,
+  MACOS_TO_DARWIN_MAJOR,
+  darwinFloorForMacos,
+};

--- a/app/update-os-gate.test.js
+++ b/app/update-os-gate.test.js
@@ -5,7 +5,11 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { isOSUpdateEligible, MIN_MACOS_FOR_AUTOUPDATE } = require('./update-os-gate');
+const {
+  isOSUpdateEligible,
+  MIN_MACOS_FOR_AUTOUPDATE,
+  darwinFloorForMacos,
+} = require('./update-os-gate');
 
 const FLOOR = '14.4.0';
 const eligible = (platform, osVersion) =>
@@ -101,8 +105,39 @@ test('package.json mac floor matches the runtime gate floor (single-source #432)
   assert.ok(mac, 'build.mac block present');
   // The runtime gate constant is the single source; the config floors must both
   // equal it, or a user could be offered / installed a build their OS can't run.
-  // Layer 1: electron-builder writes minimumSystemVersion into latest-mac.yml.
+  // NOTE: mac.minimumSystemVersion only sets the Info.plist launch floor — it
+  // does NOT reach latest-mac.yml (verified against electron-builder 26.8.1).
+  // The manifest floor is written by the release workflow from
+  // darwinFloorForMacos(MIN_MACOS_FOR_AUTOUPDATE); see below.
   assert.strictEqual(mac.minimumSystemVersion, MIN_MACOS_FOR_AUTOUPDATE, 'mac.minimumSystemVersion == runtime floor');
   // The Info.plist launch floor must agree too.
   assert.strictEqual(mac.extendInfo.LSMinimumSystemVersion, MIN_MACOS_FOR_AUTOUPDATE, 'LSMinimumSystemVersion == runtime floor');
+});
+
+// --- the manifest floor: Darwin, not the product version (#432) ---
+// This is the layer that protects installs already in the field, so a wrong
+// value here is a SILENT no-op rather than a visible failure.
+
+test('the release manifest floor derives to the Darwin value that blocks macOS 12/13', () => {
+  assert.strictEqual(MIN_MACOS_FOR_AUTOUPDATE, '14.4.0');
+  assert.strictEqual(darwinFloorForMacos(MIN_MACOS_FOR_AUTOUPDATE), '23.4.0');
+});
+
+test('maps macOS product versions to their Darwin equivalents', () => {
+  assert.strictEqual(darwinFloorForMacos('14.4'), '23.4.0');
+  assert.strictEqual(darwinFloorForMacos('14.0'), '23.0.0');
+  assert.strictEqual(darwinFloorForMacos('12'), '21.0.0');
+  assert.strictEqual(darwinFloorForMacos('15.2'), '24.2.0');
+  // macOS 26 is Darwin 25 — the version jump that rules out `major + 9`.
+  assert.strictEqual(darwinFloorForMacos('26.1'), '25.1.0');
+});
+
+test('raising the floor to an unmapped major fails the release loudly', () => {
+  assert.throws(() => darwinFloorForMacos('27.0'), /No Darwin mapping for macOS 27/);
+});
+
+test('a malformed floor throws instead of deriving a plausible-looking value', () => {
+  for (const bad of ['sonoma', '14x.4y', '14.', '', '14.4-beta']) {
+    assert.throws(() => darwinFloorForMacos(bad), /Unparseable macOS version/, `accepted: ${bad}`);
+  }
 });


### PR DESCRIPTION
## What

Completes #432. #435 landed the runtime gate and set
`build.mac.minimumSystemVersion`, but the manifest half of it does not take
effect, so the installs #432 is about are still unprotected and tagging v0.6.5
would still push the 14.4-only build onto macOS 12/13.

Rebased onto `main`, and folded into #435's module rather than sitting beside
it: `darwinFloorForMacos()` now lives in `app/update-os-gate.js` and derives
from `MIN_MACOS_FOR_AUTOUPDATE`, so the runtime floor and the manifest floor
cannot drift.

## Why the manifest half doesn't work today

**1. electron-builder never writes the field.** `mac.minimumSystemVersion` only
reaches Info.plist (`app-builder-lib/out/macPackager.js:462-464`); the manifest
is built from `releaseInfo` (`out/publish/updateInfoBuilder.js:132-152`) and
`ReleaseInfo` in `scheme.json` is `additionalProperties: false`. Verified by
building it — electron-builder 26.8.1, `mac.minimumSystemVersion: 14.4.0` set,
`zip` target:

```
Info.plist  → LSMinimumSystemVersion = 14.4.0
latest-mac.yml → grep -c minimumSystemVersion = 0
```

**2. The value has to be the Darwin version.** electron-updater compares
`minimumSystemVersion` against `os.release()`, which on macOS is the kernel
version (`AppUpdater.js:364-378`). So `14.4.0` is inert even once written —
macOS 12 reports Darwin `21.6.0`, which is not lower. Driving the real 6.8.3
function with a stubbed `os.release()` against the patched manifest this PR
produces:

| Darwin (macOS) | `14.4.0` | `23.4.0` (this PR) |
|---|---|---|
| 21.6.0 (macOS 12) | update offered | **blocked** |
| 22.6.0 (macOS 13) | update offered | **blocked** |
| 23.3.0 (macOS 14.3) | update offered | **blocked** |
| 23.4.0 (macOS 14.4) | update offered | update offered |
| 25.5.0 (macOS 26.5) | update offered | update offered |

**3. The runtime gate cannot cover for it.** `isOSUpdateEligible` only ever runs
inside a build that already meets the floor — Launch Services would not have
started it otherwise. The machines that get bricked are running v0.6.4, which
has no gate. That is also why the gate's documented fail-open needs the manifest
to exist: the comments in `update-os-gate.js` are corrected here to say which
layer protects whom.

## Changes

- **`app/update-os-gate.js`** — adds `darwinFloorForMacos()` (a table, not
  `major + 9`: that breaks at macOS 26 = Darwin 25; an unmapped major throws so
  a floor bump fails the release rather than shipping a floor that gates
  nobody), reusing the existing strict `parseVersion`. Corrects the header
  comments about the manifest layer.
- **`.github/workflows/build-release.yml`**
  - `build-macos`: writes `minimumSystemVersion` into `dist/latest-mac.yml`
    after the DMG build, where `npm ci` has run — so the patched manifest is
    **re-parsed with js-yaml** to prove the key landed at the root with the
    right value and that `version` / `files` / `path` / `sha512` /
    `releaseDate` are untouched. Anything unexpected throws.
  - `release`: re-derives the expected value and refuses to publish unless the
    manifest carries exactly `minimumSystemVersion: 23.4.0`, so a removed or
    half-applied step cannot ship an ungated feed.
- **`app/update-os-gate.test.js`** — 4 tests on top of #435's 18, pinning
  `MIN_MACOS_FOR_AUTOUPDATE` → `23.4.0` end to end.

## Verification

- `npm run test:unit`: 277 node:test + 120 vitest, all passing. Typecheck clean.
- Both workflow steps extracted from the YAML and executed against the manifest
  a real `electron-builder` run had just produced, plus the published v0.6.4
  one. Failure branches exercised: key already present, YAML document marker,
  unmapped macOS major, manifest without a trailing newline, ungated manifest
  reaching the release job, and a manifest carrying the *product* floor instead
  of the Darwin one — each fails the job instead of publishing.
- Reviewed by Codex (read-only, cross-family) over four rounds, the last one
  adversarial on the two load-bearing claims above. Adopted from review: strict
  version parsing, replacing textual validation with a real parse/re-parse, and
  the release backstop asserting the value rather than only its presence.

## Not in scope

- **Windows** (`latest.yml`) is deliberately untouched — the same field is
  compared against the NT version there, so a macOS floor would wrongly block
  Windows updates.
- The release body template still says "macOS 12 (Monterey) or later"; that is
  #434.
