### PR TITLE
fix(recording): notification timing/focus + duplicate-note fixes

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -429,6 +429,13 @@ function install({ ipcMain }) {
       return { success: true, path: seamPath };
     },
 
+    // Notification handlers — the real ones return { success, shown } after the
+    // notifications_enabled gate; the mock has no OS toast, so it just reports
+    // "shown" so a T1 that drives the transcript-ready branch (#bug2/#bug3) sees
+    // a realistic shape instead of the permissive fallback. (The gate itself is
+    // covered by the T2 spec against the real handler.)
+    'show-transcript-ready-notification': async () => ({ success: true, shown: true }),
+
     // Mirror the real export-note-pdf handler's seam. The mock has no Chromium
     // to rasterise HTML, so instead of a PDF it writes the renderer-built HTML
     // verbatim to STENOAI_E2E_EXPORT_PATH — that lets a T1 spec assert the exact

--- a/app/main.js
+++ b/app/main.js
@@ -4459,14 +4459,25 @@ ipcMain.handle('get-queue-status', async () => {
       (currentRecordingProcess !== null || systemAudioRecordingActive)
         ? (currentRecordingAppendTarget || null)
         : null,
-    // The real note file this recording/processing session produces (the
+    // The real note file the CURRENT recording/processing session produces (the
     // instant-stop placeholder written at stop, then rewritten in place by the
     // pipeline). Lets useMeetings dedupe the synthetic "__live__/…" row against
     // the real note once it exists, so one recording is never shown twice
     // (#bug4). Deterministic from the audio stem, so it's the same key across
-    // the recording → processing phases. Null for Whisper/import (no instant
-    // placeholder) and when idle.
-    liveSummaryFile: currentProcessingJob?.summaryFile || activeSysAudioSummaryFile || null,
+    // this session's recording → processing phases.
+    //
+    // Precedence matters: prefer the ACTIVE recording's key over a PROCESSING
+    // job's. In the supported back-to-back flow (stop meeting A → immediately
+    // start meeting B while A is still processing), `sessionName` reports B (the
+    // recording), so liveSummaryFile must also be B's — otherwise it'd be A's,
+    // A's note is already in the list, and B's live row would be wrongly dropped
+    // (B shows no row at all). At B's own stop, teardown nulls
+    // activeSysAudioSummaryFile before currentProcessingJob is set to B, so the
+    // fallback still yields B and the intended dedup against B's placeholder
+    // fires. Only the Parakeet instant-stop path writes a placeholder, so this
+    // only actually bites there; Whisper/import have no placeholder (dedup is a
+    // no-op) and it's null when idle.
+    liveSummaryFile: activeSysAudioSummaryFile || currentProcessingJob?.summaryFile || null,
   };
 });
 
@@ -6667,6 +6678,13 @@ function showMeetingEndedNotification(appName) {
   // action and a body tap wrap up (low stakes now — it only stops, it doesn't
   // start AI processing), and neither steals focus (background, like
   // requestAutoRecord).
+  //
+  // Gating (deliberate): like the meeting-detected toast, this is an
+  // auto-detect *lifecycle* prompt gated by the auto_detect_meetings toggle,
+  // NOT by notificationsEnabled() — that gate covers the result toasts
+  // (note-ready / transcript-ready / silence). Splitting lifecycle vs result
+  // toasts is intentional so turning off result notifications doesn't strand a
+  // paused auto-detected recording with no way to wrap it up.
   notif.on('action', (_evt, _index) => requestWrapUp());
   notif.on('click', () => requestWrapUp());
   trackNotificationLifecycle(notif, 'meeting_ended');

--- a/app/main.js
+++ b/app/main.js
@@ -1511,15 +1511,11 @@ function createWindow(options = {}) {
       sandbox: true,
       preload: path.join(__dirname, 'preload.js'),
       scrollBounce: true,
-      // Audio capture is fully renderer-owned (getUserMedia + MediaRecorder on a
-      // 1s timeslice + a 1s silence-auto-stop interval, useSystemAudioCapture.ts).
-      // A recording can legitimately run while the window is HIDDEN — the close
-      // handler hides rather than quits, and #bug1 makes auto-detect start
-      // recording without ever showing the window. Chromium background-throttles
-      // timers/rAF in hidden windows by default, which would slow the capture
-      // timeslice and silence-auto-stop cadence. Disable it so capture behaves
-      // the same hidden as visible.
-      backgroundThrottling: false,
+      // backgroundThrottling is left at its default (true) and toggled at
+      // runtime instead — see applyRecordingBackgroundThrottling(). We only
+      // disable throttling WHILE recording (renderer-owned capture timers must
+      // run full-rate even when the window is hidden), and let a
+      // backgrounded-idle app throttle normally so it doesn't burn CPU.
     },
     // Windows/Linux render the Electron application menu as an in-window menu
     // bar (File/Edit/View/…); macOS puts it in the global bar. Hide it off-mac
@@ -4961,6 +4957,21 @@ function loadAutoInstallWhenIdleEnabled() {
 
 // Global recording state management
 let systemAudioRecordingActive = false;  // Track system audio recording for tray/quit
+// Toggle renderer background-throttling to match recording state (#442 review).
+// While recording we must NOT throttle — capture is renderer-owned (MediaRecorder
+// timeslice + silence-auto-stop interval + the live-tap) and can run with the
+// window hidden (auto-detect starts without showing it), where Chromium would
+// otherwise clamp timers. When not recording we allow throttling so a
+// backgrounded-idle app doesn't waste CPU. Reads the flag, so it's correct
+// regardless of which start/stop path called it. Idempotent + fail-safe.
+function applyRecordingBackgroundThrottling() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  try {
+    // setBackgroundThrottling(allowed): true = throttle when hidden (default),
+    // false = never throttle. We disallow throttling while recording.
+    mainWindow.webContents.setBackgroundThrottling(!systemAudioRecordingActive);
+  } catch (_) { /* older Electron / no webContents — harmless */ }
+}
 let currentRecordingProcess = null;
 let currentRecordingSessionName = null;  // Surfaced in get-queue-status so renderer knows which meeting is live
 let processingQueue = [];
@@ -5859,6 +5870,7 @@ ipcMain.handle('start-recording-ui', async (_, sessionName, trigger, appendTo) =
     // hook to fire startCapture. reportSystemAudioState then re-affirms it on
     // success / clears it on failure.
     systemAudioRecordingActive = true;
+    applyRecordingBackgroundThrottling();
     // Reset the live transcript buffer before the sidecar starts emitting.
     // On a resume/continue into the SAME note, preserve the previous session's
     // finalised segments as display-only `priorSegments` so the live bar shows
@@ -6113,6 +6125,7 @@ ipcMain.handle('stop-recording-ui', async () => {
       liveTranscriptState.summaryFile = instantSummaryFile;
     }
     systemAudioRecordingActive = false;
+    applyRecordingBackgroundThrottling();
     stopLiveTranscribe();
     currentRecordingSessionName = null;
     // Captured before resetRecordingRuntimeState() clears startedAtMs.
@@ -6476,23 +6489,30 @@ const ALLOW_DEVICE_LEVEL_FALLBACK = allowsDeviceLevelFallback(
   (() => { try { return process.getSystemVersion(); } catch (_) { return ''; } })(),
 );
 
-// Wait this long after the meeting app releases the mic before triggering
-// auto-pause + "Meeting ended" prompt. Verified empirically that Zoom/Meet/
-// Teams use software-mute (keep the OS-level stream open while muted), so
-// muting in-meeting does NOT emit a stop event and won't trip this debounce
-// — the only remaining false-positive source is a brief device switch.
-// 3s feels near-instant after a real meeting end; auto-resume handles any
-// rare device-switch case if the mic comes back within the window.
+// Wait this long after the meeting app releases the mic before auto-pausing.
+// Verified empirically that Zoom/Meet/Teams use software-mute (keep the
+// OS-level stream open while muted), so muting in-meeting does NOT emit a stop
+// event and won't trip this debounce — the only remaining false-positive source
+// is a brief device switch. 3s feels near-instant after a real meeting end;
+// auto-resume handles any rare device-switch case if the mic comes back within
+// the window.
 const MEETING_END_DEBOUNCE_MS = 3_000;
+
+// After auto-pausing on mic-release, hold the recording paused this long before
+// auto-stopping (finalizing). The grace absorbs the one real false positive — a
+// brief device switch — since auto-resume cancels the auto-stop if the mic
+// returns within it. Because a released mic reliably means the call ended (not
+// mute), we finalize automatically after this rather than prompting the user.
+const MEETING_END_AUTOSTOP_GRACE_MS = 20_000;
 
 let micMonitorProc = null;
 let micMonitorRespawnTimer = null;
 let micMonitorRespawnDelay = MIC_MONITOR_BACKOFF_BASE_MS;
 const lastNotifiedAt = new Map();
 // When the user accepts a "Meeting detected" notification we remember the
-// originating app so we can pair its subsequent mic-stop with the recording
-// and offer a "Summarise" prompt.
-let autoStartedSession = null; // { pid, app_id, appName, paused, pauseTimer, endNotif }
+// originating app so we can pair its subsequent mic-stop with the recording and
+// auto-stop when the meeting ends.
+let autoStartedSession = null; // { pid, app_id, appName, paused, pauseTimer, autoStopTimer }
 
 function humanizeAppName(evt) {
   for (const o of APP_NAME_OVERRIDES) {
@@ -6583,9 +6603,11 @@ async function handleMicEvent(line) {
   }
   if (evt.event !== 'start') return;
 
-  // Meeting briefly went silent then came back — same app resuming. Cancel
-  // any pending pause / dismiss the "Meeting ended" prompt / auto-resume the
-  // recording so the user doesn't have to do anything.
+  // Meeting briefly went silent then came back — same app resuming. Cancel any
+  // pending pause AND any pending auto-stop, and auto-resume the recording so
+  // the user doesn't have to do anything. Cancelling the auto-stop is the whole
+  // point of the grace window: a brief mic drop (device switch) must not
+  // finalize a still-live meeting.
   if (autoStartedSession && evt.app_id === autoStartedSession.app_id) {
     if (autoStartedSession.pauseTimer) {
       clearTimeout(autoStartedSession.pauseTimer);
@@ -6594,9 +6616,9 @@ async function handleMicEvent(line) {
     }
     if (autoStartedSession.paused) {
       autoStartedSession.paused = false;
-      if (autoStartedSession.endNotif) {
-        try { autoStartedSession.endNotif.close(); } catch (_) {}
-        autoStartedSession.endNotif = null;
+      if (autoStartedSession.autoStopTimer) {
+        clearTimeout(autoStartedSession.autoStopTimer);
+        autoStartedSession.autoStopTimer = null;
       }
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send('auto-resume-requested');
@@ -6635,8 +6657,8 @@ function handleMicStop(evt) {
   // Recording may have been stopped manually (Stop button, hotkey, shortcut)
   // since we accepted the auto-start. The autoStartedSession isn't notified
   // of that today, so without this guard the mic-stop event would schedule
-  // a phantom pause + "Meeting ended" notification for a recording that's
-  // already gone. Drop the session here so the next start is clean.
+  // a phantom pause + auto-stop for a recording that's already gone. Drop the
+  // session here so the next start is clean.
   if (!currentRecordingProcess && !systemAudioRecordingActive) {
     clearAutoStartedSession();
     return;
@@ -6652,7 +6674,20 @@ function handleMicStop(evt) {
       mainWindow.webContents.send('auto-pause-requested');
     }
     sendDebugLog(`[auto-detect] meeting ended (paused): ${autoStartedSession.appName}`);
-    autoStartedSession.endNotif = showMeetingEndedNotification(autoStartedSession.appName);
+    // Don't finalize immediately — the mic can briefly drop on a device switch.
+    // Hold paused for a short grace; if the mic comes back, handleMicEvent above
+    // cancels this timer and auto-resumes. Otherwise the meeting has genuinely
+    // ended (a released mic ≠ mute — Zoom/Meet/Teams keep the stream open while
+    // muted, see MEETING_END_DEBOUNCE_MS), so auto-stop and let the pipeline run.
+    // No "Wrap up" prompt: mic-release is a reliable end signal, so we finalize
+    // automatically and the user's only end-of-meeting prompt is the
+    // post-transcription "Summarise" / "Note ready".
+    if (autoStartedSession.autoStopTimer) clearTimeout(autoStartedSession.autoStopTimer);
+    autoStartedSession.autoStopTimer = setTimeout(() => {
+      autoStartedSession.autoStopTimer = null;
+      sendDebugLog(`[auto-detect] auto-stopping ended meeting: ${autoStartedSession.appName}`);
+      autoStopEndedMeeting();
+    }, MEETING_END_AUTOSTOP_GRACE_MS);
   }, MEETING_END_DEBOUNCE_MS);
 }
 
@@ -6673,45 +6708,6 @@ function showMeetingDetectedNotification(appName, originatingEvt, calEvent) {
   notif.show();
 }
 
-function showMeetingEndedNotification(appName) {
-  const notif = new Notification({
-    title: 'Meeting ended',
-    body: appName,
-    actions: [{ type: 'button', text: 'Wrap up' }],
-  });
-  // The explicit "Wrap up" ACTION STOPS the recording (it had been auto-paused
-  // on mic-idle); the shared pipeline then transcribes and — only after that —
-  // prompts to generate notes / fires "Note ready". This notification
-  // deliberately no longer says "Summarise": there are no notes to summarise
-  // yet at meeting end, which is exactly the premature-prompt bug we're fixing.
-  //
-  // A body tap does NOT commit — it just opens Steno so the user can decide
-  // (wrap up / resume / leave paused). Stopping is not low-stakes: it hands the
-  // recording to the pipeline (and, with auto-summarize on, summarises), so if
-  // mic-idle was a false positive and the meeting is still live, a stray body
-  // tap that committed would silently end the recording — and since wrap-up no
-  // longer shows the window, nothing would tell the user. Keeping the split
-  // (action commits, body opens) avoids that.
-  //
-  // Gating (deliberate): like the meeting-detected toast, this is an
-  // auto-detect *lifecycle* prompt gated by the auto_detect_meetings toggle,
-  // NOT by notificationsEnabled() — that gate covers the result toasts
-  // (note-ready / transcript-ready / silence). Splitting lifecycle vs result
-  // toasts is intentional so turning off result notifications doesn't strand a
-  // paused auto-detected recording with no way to wrap it up.
-  notif.on('action', (_evt, _index) => requestWrapUp());
-  notif.on('click', () => {
-    sendDebugLog('[auto-detect] Meeting ended notif body tapped — opening Steno (no commit)');
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      if (!mainWindow.isVisible()) mainWindow.show();
-      mainWindow.focus();
-    }
-  });
-  trackNotificationLifecycle(notif, 'meeting_ended');
-  notif.show();
-  return notif;
-}
-
 function requestAutoRecord(appName, originatingEvt, calEvent) {
   // Prefer the calendar event title when we matched one — it's user-authored
   // and recognisable weeks later. Otherwise fall back to the neutral
@@ -6724,35 +6720,36 @@ function requestAutoRecord(appName, originatingEvt, calEvent) {
   sendDebugLog(`[auto-detect] user requested record (calendar-titled: ${calEvent?.title ? 'yes' : 'no'})`);
 
   // Track the originating app so we can pair its mic-stop with this recording
-  // and offer a "Summarise" prompt when the meeting ends.
+  // and auto-stop when the meeting ends.
   autoStartedSession = {
     pid: originatingEvt?.pid ?? null,
     app_id: originatingEvt?.app_id ?? null,
     appName,
     paused: false,
     pauseTimer: null,
-    endNotif: null,
+    autoStopTimer: null,
   };
 
-  // Start recording in the background pill-dock — do NOT pull the window to
-  // the foreground. Auto-detect recording is a background convenience and the
-  // renderer's auto-record handler works whether or not the window is visible;
-  // stealing focus on "Take Notes" interrupts whatever the user is doing (the
-  // notification is the confirmation). See spec: kick-off taps stay background.
+  // Tapping "Take Notes" is an explicit "I'm going to take notes" — so bring
+  // Steno to the front and open the live note so the user can start typing.
+  // (The notification itself is passive and never steals focus; only this
+  // explicit tap does.) The renderer's auto-record handler then starts the
+  // recording and opens the live-note editor.
   if (mainWindow && !mainWindow.isDestroyed()) {
+    if (!mainWindow.isVisible()) mainWindow.show();
+    mainWindow.focus();
     mainWindow.webContents.send('auto-record-requested', { sessionName, appName });
   }
 }
 
-// The user chose to wrap up an auto-detected meeting (the "Wrap up" action on
-// the meeting-ended notification). This STOPS the paused recording, which then
-// drives the shared post-stop pipeline; the decision to *summarise* now happens
-// after transcription (see the note-ready / transcript-ready notifications),
-// not here. Kept on the `auto-summarise-requested` channel (whose renderer
-// handler already just stops the recording) to avoid churn. Background only —
-// no focus-steal, matching requestAutoRecord.
-function requestWrapUp() {
-  sendDebugLog('[auto-detect] user chose to wrap up the meeting from the end notification');
+// Auto-stop an ended auto-detected meeting once the mic has stayed released
+// through the grace window (see handleMicStop). STOPS the paused recording,
+// which drives the shared post-stop pipeline; the *summarise* decision then
+// happens after transcription (transcript-ready / note-ready notifications),
+// not here. Sent on the `auto-summarise-requested` channel (whose renderer
+// handler already just stops the recording); the channel name predates the
+// auto-stop rework and is kept to avoid 4-file churn.
+function autoStopEndedMeeting() {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send('auto-summarise-requested');
   }
@@ -6762,9 +6759,7 @@ function requestWrapUp() {
 function clearAutoStartedSession() {
   if (!autoStartedSession) return;
   if (autoStartedSession.pauseTimer) clearTimeout(autoStartedSession.pauseTimer);
-  if (autoStartedSession.endNotif) {
-    try { autoStartedSession.endNotif.close(); } catch (_) {}
-  }
+  if (autoStartedSession.autoStopTimer) clearTimeout(autoStartedSession.autoStopTimer);
   autoStartedSession = null;
 }
 
@@ -7981,12 +7976,13 @@ ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
 
 // Fired by the renderer's processing-complete handler when a recording finished
 // transcription but NO notes were generated (auto_summarize off → transcript-
-// only note). Unlike note-ready, this prompts the user to generate notes and is
-// the correctly-timed replacement for the old premature meeting-end "Summarise?"
-// prompt (#bug2/#bug3). The "Generate notes" ACTION starts generation in the
-// BACKGROUND (no focus, matching the kick-off-taps-stay-background rule) by
-// sending `generate-notes-requested`; a body tap opens the note (a result the
-// user asked to see), like note-ready.
+// only note). Unlike note-ready, this prompts the user to summarise, and is the
+// correctly-timed replacement for the old premature meeting-end "Summarise?"
+// prompt (#bug2/#bug3). Tapping "Summarise" kicks off generation in the
+// BACKGROUND — no focus-steal — because when it finishes the note-ready
+// notification (click → opens the note) is the moment we bring the user in, so
+// there's no need to pull the window forward now. A body tap opens the note to
+// read the transcript.
 ipcMain.handle('show-transcript-ready-notification', async (_event, payload) => {
   try {
     // `shown` = passed the notifications_enabled gate (see show-note-ready).
@@ -7994,18 +7990,22 @@ ipcMain.handle('show-transcript-ready-notification', async (_event, payload) => 
     const { title, summaryFile, name } = payload || {};
     const notif = new Notification({
       title: 'Transcript ready',
-      body: title ? `Generate notes for "${title}"?` : 'Generate notes?',
-      actions: [{ type: 'button', text: 'Generate notes' }],
+      body: title ? `Summarise "${title}"?` : 'Summarise?',
+      actions: [{ type: 'button', text: 'Summarise' }],
       iconType: 'success',
     });
-    notif.on('action', () => {
-      // Background: kick off note generation without pulling the window forward.
+    // Background: kick off generation without pulling the window forward. The
+    // note-ready notification that fires on completion is where we bring the
+    // user in (its click opens the note).
+    const startSummarise = () => {
       if (mainWindow && !mainWindow.isDestroyed() && summaryFile) {
         mainWindow.webContents.send('generate-notes-requested', { summaryFile, name });
       }
-    });
+    };
+    notif.on('action', () => startSummarise());
+    // Body tap just opens the note to read the transcript (no generation) — the
+    // in-note GenerateNotesBar is there if they change their mind.
     notif.on('click', () => {
-      // Body tap opens the (transcript-only) note so the user can read it.
       if (mainWindow && !mainWindow.isDestroyed()) {
         if (!mainWindow.isVisible()) mainWindow.show();
         mainWindow.focus();
@@ -9126,6 +9126,7 @@ ipcMain.handle('process-system-audio-recording', async (event, audioFilePath, se
 ipcMain.on('system-audio-recording-state', (event, isRecording) => {
   sendDebugLog(`[sysaudio] state -> ${isRecording ? 'true' : 'false'} (was ${systemAudioRecordingActive})`);
   systemAudioRecordingActive = isRecording;
+  applyRecordingBackgroundThrottling();
   if (!isRecording && !currentRecordingProcess) {
     // Reset the elapsed counter (avoids leaking startedAtMs when startCapture
     // fails), but DON'T blank currentRecordingSessionName here: this is a

--- a/app/main.js
+++ b/app/main.js
@@ -2831,6 +2831,12 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
       });
 
       let stderrBuf = '';
+      // Mirrors the main pipeline: true only if summarization actually ran
+      // (STREAM_COMPLETE). "Generate notes" reprocess always summarises; a
+      // retranscribe with auto_summarize off wouldn't, so track it rather than
+      // assume. Threaded into processing-complete so the renderer fires
+      // "Note ready" only when notes exist (#bug2).
+      let summarizationCompleted = false;
 
       // Liveness watchdog — see makeInactivityWatchdog. Summary CHUNK:
       // lines (and HEARTBEAT: lines if a retranscribe is ever added here)
@@ -2860,6 +2866,7 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
               mainWindow.webContents.send('summary-title', { title, sessionName });
             }
           } else if (line === 'STREAM_COMPLETE') {
+            summarizationCompleted = true;
             if (mainWindow && !mainWindow.isDestroyed()) {
               mainWindow.webContents.send('summary-complete', { success: true, sessionName, summaryFile });
             }
@@ -2898,6 +2905,7 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
               success: true,
               sessionName,
               summaryFile,
+              notesGenerated: summarizationCompleted,
               message: 'Reprocessing completed successfully'
             });
           }
@@ -3074,6 +3082,11 @@ ipcMain.handle('generate-report-meeting', async (event, summaryFile, templateId)
               sessionName,
               summaryFile,
               report: true,
+              // A report is only ever generated for a note that already has
+              // notes, so "notes exist" is true — preserves the pre-existing
+              // note-ready behavior and keeps this off the transcript-only
+              // "generate notes?" branch (#bug2).
+              notesGenerated: true,
               message: 'Report generation completed successfully'
             });
           }
@@ -4446,6 +4459,14 @@ ipcMain.handle('get-queue-status', async () => {
       (currentRecordingProcess !== null || systemAudioRecordingActive)
         ? (currentRecordingAppendTarget || null)
         : null,
+    // The real note file this recording/processing session produces (the
+    // instant-stop placeholder written at stop, then rewritten in place by the
+    // pipeline). Lets useMeetings dedupe the synthetic "__live__/…" row against
+    // the real note once it exists, so one recording is never shown twice
+    // (#bug4). Deterministic from the audio stem, so it's the same key across
+    // the recording → processing phases. Null for Whisper/import (no instant
+    // placeholder) and when idle.
+    liveSummaryFile: currentProcessingJob?.summaryFile || activeSysAudioSummaryFile || null,
   };
 });
 
@@ -5225,6 +5246,12 @@ async function processNextInQueue() {
   // Set when TRANSCRIPTION_COMPLETE arrives, so summarization_completed's
   // processing_bucket measures summarization time alone, not the whole job.
   let transcriptionEndedAtMs = null;
+  // Set true only when STREAM_COMPLETE arrives (summarization actually ran).
+  // Stays false on the transcript-only path (auto_summarize off → the backend
+  // prints SUMMARY_SKIPPED, never STREAM_COMPLETE), so the renderer can fire
+  // "Note ready" only when notes really exist, and a "Transcript ready —
+  // generate notes?" prompt otherwise (#bug2/#bug3).
+  let summarizationCompleted = false;
 
   try {
     const queueAiEnv = getAiEnv();
@@ -5315,6 +5342,7 @@ async function processNextInQueue() {
               mainWindow.webContents.send('summary-title', { title, sessionName: currentProcessingJob.sessionName });
             }
           } else if (line === 'STREAM_COMPLETE') {
+            summarizationCompleted = true;
             const summarizationStartMs = transcriptionEndedAtMs || currentProcessingStartedAtMs;
             trackEvent('summarization_completed', {
               success: true,
@@ -5413,6 +5441,7 @@ async function processNextInQueue() {
                     ? 'Transcription failed; recording preserved (not deleted)'
                     : 'Processing completed successfully',
                   meetingData: processedMeeting,
+                  notesGenerated: summarizationCompleted,
                   transcriptionFailed: Boolean(transcriptionFailedMsg),
                   transcriptionError: transcriptionFailedMsg || undefined
                 });
@@ -5429,6 +5458,7 @@ async function processNextInQueue() {
                   message: transcriptionFailedMsg
                     ? 'Transcription failed; recording preserved (not deleted)'
                     : 'Processing completed successfully',
+                  notesGenerated: summarizationCompleted,
                   transcriptionFailed: Boolean(transcriptionFailedMsg),
                   transcriptionError: transcriptionFailedMsg || undefined
                 });
@@ -6627,20 +6657,18 @@ function showMeetingEndedNotification(appName) {
   const notif = new Notification({
     title: 'Meeting ended',
     body: appName,
-    actions: [{ type: 'button', text: 'Summarise' }],
+    actions: [{ type: 'button', text: 'Wrap up' }],
   });
-  // Only the explicit Summarise button commits — body click just opens
-  // Steno so the user can decide (summarise / resume / leave paused) from
-  // the in-app UI. Once summarised the meeting is finalised and AI
-  // processing has begun, so a stray body tap shouldn't trigger it.
-  notif.on('action', (_evt, _index) => requestAutoSummarise());
-  notif.on('click', () => {
-    sendDebugLog('[auto-detect] Meeting ended notif body clicked — opening Steno (no commit)');
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      if (!mainWindow.isVisible()) mainWindow.show();
-      mainWindow.focus();
-    }
-  });
+  // "Wrap up" STOPS the recording (it had been auto-paused on mic-idle); the
+  // shared pipeline then transcribes and — only after that — prompts to
+  // generate notes / fires "Note ready". This notification deliberately no
+  // longer says "Summarise": there are no notes to summarise yet at meeting
+  // end, which is exactly the premature-prompt bug we're fixing. Both the
+  // action and a body tap wrap up (low stakes now — it only stops, it doesn't
+  // start AI processing), and neither steals focus (background, like
+  // requestAutoRecord).
+  notif.on('action', (_evt, _index) => requestWrapUp());
+  notif.on('click', () => requestWrapUp());
   trackNotificationLifecycle(notif, 'meeting_ended');
   notif.show();
   return notif;
@@ -6668,18 +6696,26 @@ function requestAutoRecord(appName, originatingEvt, calEvent) {
     endNotif: null,
   };
 
+  // Start recording in the background pill-dock — do NOT pull the window to
+  // the foreground. Auto-detect recording is a background convenience and the
+  // renderer's auto-record handler works whether or not the window is visible;
+  // stealing focus on "Take Notes" interrupts whatever the user is doing (the
+  // notification is the confirmation). See spec: kick-off taps stay background.
   if (mainWindow && !mainWindow.isDestroyed()) {
-    if (!mainWindow.isVisible()) mainWindow.show();
-    mainWindow.focus();
     mainWindow.webContents.send('auto-record-requested', { sessionName, appName });
   }
 }
 
-function requestAutoSummarise() {
-  sendDebugLog('[auto-detect] user requested summarise from end notification');
+// The user chose to wrap up an auto-detected meeting (the "Wrap up" action on
+// the meeting-ended notification). This STOPS the paused recording, which then
+// drives the shared post-stop pipeline; the decision to *summarise* now happens
+// after transcription (see the note-ready / transcript-ready notifications),
+// not here. Kept on the `auto-summarise-requested` channel (whose renderer
+// handler already just stops the recording) to avoid churn. Background only —
+// no focus-steal, matching requestAutoRecord.
+function requestWrapUp() {
+  sendDebugLog('[auto-detect] user chose to wrap up the meeting from the end notification');
   if (mainWindow && !mainWindow.isDestroyed()) {
-    if (!mainWindow.isVisible()) mainWindow.show();
-    mainWindow.focus();
     mainWindow.webContents.send('auto-summarise-requested');
   }
   clearAutoStartedSession();
@@ -7901,6 +7937,48 @@ ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
     return { success: true, shown: true };
   } catch (e) {
     sendDebugLog(`Failed to show note-ready notification: ${e.message}`);
+    return { success: false, error: e.message };
+  }
+});
+
+// Fired by the renderer's processing-complete handler when a recording finished
+// transcription but NO notes were generated (auto_summarize off → transcript-
+// only note). Unlike note-ready, this prompts the user to generate notes and is
+// the correctly-timed replacement for the old premature meeting-end "Summarise?"
+// prompt (#bug2/#bug3). The "Generate notes" ACTION starts generation in the
+// BACKGROUND (no focus, matching the kick-off-taps-stay-background rule) by
+// sending `generate-notes-requested`; a body tap opens the note (a result the
+// user asked to see), like note-ready.
+ipcMain.handle('show-transcript-ready-notification', async (_event, payload) => {
+  try {
+    // `shown` = passed the notifications_enabled gate (see show-note-ready).
+    if (!(await notificationsEnabled())) return { success: true, shown: false };
+    const { title, summaryFile, name } = payload || {};
+    const notif = new Notification({
+      title: 'Transcript ready',
+      body: title ? `Generate notes for "${title}"?` : 'Generate notes?',
+      actions: [{ type: 'button', text: 'Generate notes' }],
+      iconType: 'success',
+    });
+    notif.on('action', () => {
+      // Background: kick off note generation without pulling the window forward.
+      if (mainWindow && !mainWindow.isDestroyed() && summaryFile) {
+        mainWindow.webContents.send('generate-notes-requested', { summaryFile, name });
+      }
+    });
+    notif.on('click', () => {
+      // Body tap opens the (transcript-only) note so the user can read it.
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        if (!mainWindow.isVisible()) mainWindow.show();
+        mainWindow.focus();
+        if (summaryFile) mainWindow.webContents.send('navigate-to-meeting', { summaryFile });
+      }
+    });
+    trackNotificationLifecycle(notif, 'transcript_ready');
+    notif.show();
+    return { success: true, shown: true };
+  } catch (e) {
+    sendDebugLog(`Failed to show transcript-ready notification: ${e.message}`);
     return { success: false, error: e.message };
   }
 });

--- a/app/main.js
+++ b/app/main.js
@@ -1511,6 +1511,15 @@ function createWindow(options = {}) {
       sandbox: true,
       preload: path.join(__dirname, 'preload.js'),
       scrollBounce: true,
+      // Audio capture is fully renderer-owned (getUserMedia + MediaRecorder on a
+      // 1s timeslice + a 1s silence-auto-stop interval, useSystemAudioCapture.ts).
+      // A recording can legitimately run while the window is HIDDEN — the close
+      // handler hides rather than quits, and #bug1 makes auto-detect start
+      // recording without ever showing the window. Chromium background-throttles
+      // timers/rAF in hidden windows by default, which would slow the capture
+      // timeslice and silence-auto-stop cadence. Disable it so capture behaves
+      // the same hidden as visible.
+      backgroundThrottling: false,
     },
     // Windows/Linux render the Electron application menu as an in-window menu
     // bar (File/Edit/View/…); macOS puts it in the global bar. Hide it off-mac
@@ -6670,14 +6679,19 @@ function showMeetingEndedNotification(appName) {
     body: appName,
     actions: [{ type: 'button', text: 'Wrap up' }],
   });
-  // "Wrap up" STOPS the recording (it had been auto-paused on mic-idle); the
-  // shared pipeline then transcribes and — only after that — prompts to
-  // generate notes / fires "Note ready". This notification deliberately no
-  // longer says "Summarise": there are no notes to summarise yet at meeting
-  // end, which is exactly the premature-prompt bug we're fixing. Both the
-  // action and a body tap wrap up (low stakes now — it only stops, it doesn't
-  // start AI processing), and neither steals focus (background, like
-  // requestAutoRecord).
+  // The explicit "Wrap up" ACTION STOPS the recording (it had been auto-paused
+  // on mic-idle); the shared pipeline then transcribes and — only after that —
+  // prompts to generate notes / fires "Note ready". This notification
+  // deliberately no longer says "Summarise": there are no notes to summarise
+  // yet at meeting end, which is exactly the premature-prompt bug we're fixing.
+  //
+  // A body tap does NOT commit — it just opens Steno so the user can decide
+  // (wrap up / resume / leave paused). Stopping is not low-stakes: it hands the
+  // recording to the pipeline (and, with auto-summarize on, summarises), so if
+  // mic-idle was a false positive and the meeting is still live, a stray body
+  // tap that committed would silently end the recording — and since wrap-up no
+  // longer shows the window, nothing would tell the user. Keeping the split
+  // (action commits, body opens) avoids that.
   //
   // Gating (deliberate): like the meeting-detected toast, this is an
   // auto-detect *lifecycle* prompt gated by the auto_detect_meetings toggle,
@@ -6686,7 +6700,13 @@ function showMeetingEndedNotification(appName) {
   // toasts is intentional so turning off result notifications doesn't strand a
   // paused auto-detected recording with no way to wrap it up.
   notif.on('action', (_evt, _index) => requestWrapUp());
-  notif.on('click', () => requestWrapUp());
+  notif.on('click', () => {
+    sendDebugLog('[auto-detect] Meeting ended notif body tapped — opening Steno (no commit)');
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (!mainWindow.isVisible()) mainWindow.show();
+      mainWindow.focus();
+    }
+  });
   trackNotificationLifecycle(notif, 'meeting_ended');
   notif.show();
   return notif;

--- a/app/preload.js
+++ b/app/preload.js
@@ -260,6 +260,7 @@ const stenoai = {
     setSilenceAutoStopMinutes: (v) => invoke('set-silence-auto-stop-minutes', v),
     showSilenceAutoStopNotification: (payload) => invoke('show-silence-auto-stop-notification', payload),
     showNoteReadyNotification: (payload) => invoke('show-note-ready-notification', payload),
+    showTranscriptReadyNotification: (payload) => invoke('show-transcript-ready-notification', payload),
     showSystemAudioMicOnlyNotification: () => invoke('show-system-audio-mic-only-notification'),
     // Design-for-test seam: the production fire path is the main-side scheduler
     // timer; this lets e2e drive the gate + suppression deterministically.
@@ -389,6 +390,7 @@ const stenoai = {
     autoPauseRequested: (cb) => subscribe('auto-pause-requested', cb),
     autoResumeRequested: (cb) => subscribe('auto-resume-requested', cb),
     autoSummariseRequested: (cb) => subscribe('auto-summarise-requested', cb),
+    generateNotesRequested: (cb) => subscribe('generate-notes-requested', cb),
     navigateToMeeting: (cb) => subscribe('navigate-to-meeting', cb),
     trayOpenSettings: (cb) => subscribe('tray-open-settings', cb),
     showQuitDialog: (cb) => subscribe('show-quit-dialog', cb),

--- a/app/renderer/src/hooks/useMeetings.dedup.test.ts
+++ b/app/renderer/src/hooks/useMeetings.dedup.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { liveRowRedundant, LIVE_SUMMARY_PREFIX } from '@/lib/liveMeetingRow';
+
+const note = (summary_file: string) => ({ session_info: { summary_file } });
+
+describe('liveRowRedundant (#bug4 — one recording, one row)', () => {
+  it('false while recording before the real note exists (no liveSummaryFile)', () => {
+    expect(liveRowRedundant([note('a_summary.md')], null)).toBe(false);
+    expect(liveRowRedundant([note('a_summary.md')], undefined)).toBe(false);
+  });
+
+  it('false when the real note is not yet in the list (bridges the stop gap)', () => {
+    expect(liveRowRedundant([note('other_summary.md')], 'rec123_summary.md')).toBe(false);
+  });
+
+  it('true once the real note file appears — drop the synthetic live row', () => {
+    const base = [note('rec123_summary.md'), note('older_summary.md')];
+    expect(liveRowRedundant(base, 'rec123_summary.md')).toBe(true);
+  });
+
+  it('never matches the synthetic sentinel key against itself', () => {
+    const base = [note(`${LIVE_SUMMARY_PREFIX}Note`)];
+    // liveSummaryFile is always a real file path, never the sentinel, so a
+    // list that somehow only holds the sentinel row is not "redundant".
+    expect(liveRowRedundant(base, 'rec123_summary.md')).toBe(false);
+  });
+
+  it('empty list → not redundant', () => {
+    expect(liveRowRedundant([], 'rec123_summary.md')).toBe(false);
+  });
+});

--- a/app/renderer/src/hooks/useMeetings.ts
+++ b/app/renderer/src/hooks/useMeetings.ts
@@ -6,12 +6,14 @@ import { useRecording } from '@/hooks/useRecording';
 import { useLiveDraftStore } from '@/hooks/liveDraftStore';
 import { meetingsKeys } from '@/hooks/meetingKeys';
 import { useUndoDeleteStore } from '@/hooks/undoDeleteStore';
+// #bug4 dedup helpers live in a dependency-light module so they're unit-testable
+// without this hook's import graph.
+import { LIVE_SUMMARY_PREFIX, liveRowRedundant } from '@/lib/liveMeetingRow';
 
 export { meetingsKeys };
+// Re-exported for existing consumers that import them from here.
+export { LIVE_SUMMARY_PREFIX, liveRowRedundant };
 
-/** Sentinel summary_file path used by the synthetic in-progress recording row.
- *  Never matches a real meeting file. Consumers detect via `meeting.is_recording`. */
-export const LIVE_SUMMARY_PREFIX = '__live__/';
 
 export function useMeetings() {
   const query = useQuery({
@@ -76,12 +78,20 @@ export function useMeetings() {
         )
       : null;
     if (!live) return base;
+    // #bug4: once the real note file for this session exists in the list, drop
+    // the synthetic live row so one recording is never shown as two entries.
+    // The instant-stop placeholder (Parakeet) is written at stop keyed by its
+    // real summary_file — which main surfaces as `liveSummaryFile` — while the
+    // synthetic row is keyed on the sentinel `__live__/<sessionName>`, so they
+    // never match on their own and would otherwise coexist during processing.
+    if (liveRowRedundant(base, recording.liveSummaryFile)) return base;
     return [live, ...base];
   }, [
     query.data,
     recording.sessionName,
     recording.status,
     recording.reprocessingSummaryFiles,
+    recording.liveSummaryFile,
     liveElapsed,
     draft?.title,
     draft?.startedAtMs,

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -8,7 +8,7 @@ import { useLiveDraftStore } from './liveDraftStore';
 import { navigate, routeFromHash } from '@/lib/router';
 import { composeShareBody, pickTranscriptForShare } from '@/routes/MeetingDetail';
 import { streamCache } from '@/lib/meetingDetailState';
-import { classifyCompletionNotification } from '@/lib/completionNotification';
+import { classifyCompletionNotification, meetingAlreadyHasNotes } from '@/lib/completionNotification';
 import type { Meeting, QueueStatus, RecordingTrigger } from '@/lib/ipc';
 
 export type RecordingStatus = 'idle' | 'recording' | 'paused' | 'processing';
@@ -508,8 +508,9 @@ export function useRecordingProcessingEffects() {
             notesGenerated: data.notesGenerated,
             // Continue-recording (append) skips summarization but the note it
             // appended to already has notes — treat as note-ready, not
-            // "generate notes?" (M2).
-            notesAlreadyExist: data.meetingData?.session_info.notes_generated,
+            // "generate notes?" (M2). meetingAlreadyHasNotes encodes the subtle
+            // notes_generated frontmatter semantics (absent = has notes).
+            notesAlreadyExist: meetingAlreadyHasNotes(data.meetingData),
             transcriptionFailed: data.transcriptionFailed,
             meetingTranscriptionFailed: data.meetingData?.session_info.transcription_failed,
           });

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -325,6 +325,10 @@ export function useRecordingEvents() {
         // user already manually started or is mid-meeting.
         if (status === 'recording' || status === 'paused') return;
         void startRecording(sessionName ?? undefined, 'notification_click');
+        // "Take Notes" is an explicit intent to write notes, so open the
+        // live-note editor (main already brought the window forward). Mirrors
+        // the toolbar New-note button.
+        navigate('/recording');
       }),
       bridge.on.autoPauseRequested(() => {
         // Mic stopped on the meeting app — pause so we don't keep recording
@@ -350,11 +354,12 @@ export function useRecordingEvents() {
         if (status === 'recording' || status === 'paused') void stopRecording();
       }),
       bridge.on.generateNotesRequested(({ summaryFile, name }) => {
-        // User tapped "Generate notes" on the transcript-ready notification.
-        // Run the same reprocess path as GenerateNotesBar, in the background —
-        // main tracks it in activeReprocessJobs so the badge shows, and its
-        // completion fires processing-complete with notesGenerated:true → the
-        // real "Note ready" notification (#bug2/#bug3).
+        // User tapped "Summarise" on the transcript-ready notification. Run the
+        // same reprocess path as GenerateNotesBar in the BACKGROUND (no
+        // navigate/focus) — main tracks it in activeReprocessJobs so the badge
+        // shows, and its completion fires processing-complete with
+        // notesGenerated:true → the "Note ready" notification, whose click opens
+        // the note. That's where the user is brought in. (#bug2/#bug3)
         if (summaryFile) {
           // `name` here is only the processing-badge label (reprocess never
           // passes it to the CLI, so it can't blank the note's title).

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -260,7 +260,8 @@ export function useRecording() {
     recordingSummaryFile: queue.data?.recordingSummaryFile ?? null,
     /** The real note file the live recording/processing session produces.
      *  useMeetings dedupes the synthetic live row against it so one recording
-     *  never shows as two entries (#bug4). Null for Whisper/import and idle. */
+     *  never shows as two entries (#bug4). Only Parakeet writes the placeholder
+     *  it points at, so dedup only bites there; null when idle. */
     liveSummaryFile: queue.data?.liveSummaryFile ?? null,
     /** Set of summary files whose `reprocess-meeting` IPC is currently
      *  in flight. Used by useMeetings to flip the matching existing
@@ -505,6 +506,10 @@ export function useRecordingProcessingEffects() {
             Boolean(data.meetingData?.session_info.transcription_failed);
           const kind = classifyCompletionNotification({
             notesGenerated: data.notesGenerated,
+            // Continue-recording (append) skips summarization but the note it
+            // appended to already has notes — treat as note-ready, not
+            // "generate notes?" (M2).
+            notesAlreadyExist: data.meetingData?.session_info.notes_generated,
             transcriptionFailed: data.transcriptionFailed,
             meetingTranscriptionFailed: data.meetingData?.session_info.transcription_failed,
           });

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -8,6 +8,7 @@ import { useLiveDraftStore } from './liveDraftStore';
 import { navigate, routeFromHash } from '@/lib/router';
 import { composeShareBody, pickTranscriptForShare } from '@/routes/MeetingDetail';
 import { streamCache } from '@/lib/meetingDetailState';
+import { classifyCompletionNotification } from '@/lib/completionNotification';
 import type { Meeting, QueueStatus, RecordingTrigger } from '@/lib/ipc';
 
 export type RecordingStatus = 'idle' | 'recording' | 'paused' | 'processing';
@@ -257,6 +258,10 @@ export function useRecording() {
      *  INTO — lets a detail view match by identity rather than the collidable
      *  display name. Null for a fresh new-note recording or when idle. */
     recordingSummaryFile: queue.data?.recordingSummaryFile ?? null,
+    /** The real note file the live recording/processing session produces.
+     *  useMeetings dedupes the synthetic live row against it so one recording
+     *  never shows as two entries (#bug4). Null for Whisper/import and idle. */
+    liveSummaryFile: queue.data?.liveSummaryFile ?? null,
     /** Set of summary files whose `reprocess-meeting` IPC is currently
      *  in flight. Used by useMeetings to flip the matching existing
      *  meeting rows' `is_processing` flag so Home shows the badge even
@@ -334,8 +339,25 @@ export function useRecordingEvents() {
         void resumeRecording();
       }),
       bridge.on.autoSummariseRequested(() => {
-        // User clicked "Summarise" on the Meeting ended notification.
+        // User chose "Wrap up" on the Meeting ended notification — stop the
+        // (auto-paused) recording so the pipeline runs; the summarise decision
+        // now happens after transcription, not here (#bug3).
         if (status === 'recording' || status === 'paused') void stopRecording();
+      }),
+      bridge.on.generateNotesRequested(({ summaryFile, name }) => {
+        // User tapped "Generate notes" on the transcript-ready notification.
+        // Run the same reprocess path as GenerateNotesBar, in the background —
+        // main tracks it in activeReprocessJobs so the badge shows, and its
+        // completion fires processing-complete with notesGenerated:true → the
+        // real "Note ready" notification (#bug2/#bug3).
+        if (summaryFile) {
+          // `name` here is only the processing-badge label (reprocess never
+          // passes it to the CLI, so it can't blank the note's title).
+          void ipc().meetings.reprocess(summaryFile, false, name ?? '').catch(() => {
+            // Reprocess failure surfaces via its own STREAM_ERROR/processing
+            // path; nothing to recover here.
+          });
+        }
       }),
     ];
     bridge.shortcuts.rendererReady();
@@ -478,25 +500,48 @@ export function useRecordingProcessingEffects() {
             data.meetingData?.session_info.name?.trim() ||
             data.sessionName?.trim() ||
             'Your note has finished processing';
+          const isFailed =
+            Boolean(data.transcriptionFailed) ||
+            Boolean(data.meetingData?.session_info.transcription_failed);
+          const kind = classifyCompletionNotification({
+            notesGenerated: data.notesGenerated,
+            transcriptionFailed: data.transcriptionFailed,
+            meetingTranscriptionFailed: data.meetingData?.session_info.transcription_failed,
+          });
           // Note: no `notifications_enabled` pre-check here — the IPC
-          // handler in main.js gates internally via
-          // `notificationsEnabled()` and short-circuits when the user
-          // has Desktop notifications disabled in Settings. Doing a
-          // round-trip from the renderer to fetch the setting before
-          // firing this IPC would be a wasted poll. The gate stays
-          // single-source-of-truth in main.
-          void ipc()
-            .settings.showNoteReadyNotification({
-              title,
-              summaryFile: finishedSummaryFile,
-              failed:
-                Boolean(data.transcriptionFailed) ||
-                Boolean(data.meetingData?.session_info.transcription_failed),
-            })
-            .catch(() => {
-              // Notification failure isn't fatal — the note is still
-              // visible in Home + sidebar. Don't bubble up.
-            });
+          // handlers in main.js gate internally via `notificationsEnabled()`
+          // and short-circuit when the user has notifications disabled. A
+          // renderer round-trip to fetch the setting first would be a wasted
+          // poll; the gate stays single-source-of-truth in main.
+          if (kind === 'note-ready') {
+            // Notes were generated (auto-summarize on, or the deferred
+            // Generate-notes/reprocess finished) — or a transcription failure
+            // that still wrote a note. Either way it's "ready": open on click.
+            void ipc()
+              .settings.showNoteReadyNotification({
+                title,
+                summaryFile: finishedSummaryFile,
+                failed: isFailed,
+              })
+              .catch(() => {
+                // Notification failure isn't fatal — the note is still
+                // visible in Home + sidebar. Don't bubble up.
+              });
+          } else {
+            // Transcript-only note (auto_summarize off → no notes generated).
+            // Prompt to generate notes rather than claim "Note ready" (#bug2);
+            // this is also the correctly-timed replacement for the old
+            // premature meeting-end "Summarise?" prompt (#bug3).
+            void ipc()
+              .settings.showTranscriptReadyNotification({
+                title,
+                summaryFile: finishedSummaryFile,
+                name: data.sessionName ?? null,
+              })
+              .catch(() => {
+                // Notification failure isn't fatal.
+              });
+          }
         }
         // else: on this note's own detail page → nothing. The streaming
         // UI's own listener swaps to the static view; no extra signal

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -8,7 +8,11 @@ import { useLiveDraftStore } from './liveDraftStore';
 import { navigate, routeFromHash } from '@/lib/router';
 import { composeShareBody, pickTranscriptForShare } from '@/routes/MeetingDetail';
 import { streamCache } from '@/lib/meetingDetailState';
-import { classifyCompletionNotification, meetingAlreadyHasNotes } from '@/lib/completionNotification';
+import {
+  classifyCompletionNotification,
+  meetingAlreadyHasNotes,
+  completionRouteAction,
+} from '@/lib/completionNotification';
 import type { Meeting, QueueStatus, RecordingTrigger } from '@/lib/ipc';
 
 export type RecordingStatus = 'idle' | 'recording' | 'paused' | 'processing';
@@ -478,25 +482,36 @@ export function useRecordingProcessingEffects() {
       if (data.success && finishedSummaryFile) {
         const currentRoute = routeFromHash(window.location.hash);
         const finishedMeetingRoute = `/meetings/${encodeURIComponent(finishedSummaryFile)}`;
-        if (currentRoute === '/meetings/processing') {
+        // #bug1 lets an auto-detected recording run with the window HIDDEN
+        // (tray-only), so "the route is this note" no longer implies the user
+        // is looking at it. Gate the suppress-when-already-here logic on real
+        // visibility, not route alone — otherwise the wrap-up flow suppresses
+        // every post-transcription prompt on the default (Parakeet) engine:
+        // stopRecording navigates to the note's own route (useRecording.ts
+        // instant-stop path), so a route-only guard would always match and
+        // never notify. (visibilityState is 'hidden' for a hidden/minimised
+        // window.)
+        const windowVisible =
+          typeof document !== 'undefined' && document.visibilityState === 'visible';
+        const action = completionRouteAction({
+          currentRoute,
+          finishedMeetingRoute,
+          processingRoute: '/meetings/processing',
+          windowVisible,
+        });
+        if (action === 'navigate') {
           // Watching it finish on the processing page → take them straight
           // into the now-ready note.
           navigate(finishedMeetingRoute);
-        } else if (currentRoute !== finishedMeetingRoute) {
-          // Anywhere else (Home, Chat, Settings, recording another note,
-          // a different meeting's detail page) → fire a native "Note
-          // ready" banner so the user knows their work-in-progress
-          // finished. Route comparison rather than window-focus check on
-          // purpose: it means a minimised Steno / alt-tabbed user who
-          // *was* sitting on this note's detail page still doesn't get a
-          // notification, because the route hasn't changed. They'll see
-          // the static summary the moment they come back.
-          //
-          // Clicking the banner navigates straight to this note (see the
-          // `navigate-to-meeting` listener below) — unlike the idle-route
-          // comparison above, a click is an explicit "take me there" from
-          // the user, so it doesn't have the back-to-back-recording
-          // interruption risk that auto-navigating here would.
+        } else if (action === 'notify') {
+          // A different route (Home, Chat, Settings, recording another note, a
+          // different meeting) OR this note's route but the window is
+          // hidden/minimised (tray-only after an auto-detected wrap-up) → fire a
+          // notification so the user learns their note finished. Clicking it
+          // navigates straight here (navigate-to-meeting listener below) — an
+          // explicit "take me there", so no back-to-back-recording interruption
+          // risk. When the window is visible AND already on this note, we skip
+          // it: the static summary is right there.
           const title =
             data.meetingData?.session_info.name?.trim() ||
             data.sessionName?.trim() ||

--- a/app/renderer/src/lib/completionNotification.test.ts
+++ b/app/renderer/src/lib/completionNotification.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { classifyCompletionNotification } from './completionNotification';
+
+describe('classifyCompletionNotification (#bug2/#bug3)', () => {
+  it('notes generated → note-ready (auto_summarize on / reprocess done)', () => {
+    expect(classifyCompletionNotification({ notesGenerated: true })).toBe('note-ready');
+  });
+
+  it('no notes generated → transcript-ready (auto_summarize off, transcript-only)', () => {
+    expect(classifyCompletionNotification({ notesGenerated: false })).toBe('transcript-ready');
+  });
+
+  it('notesGenerated absent → transcript-ready (defaults to no notes)', () => {
+    expect(classifyCompletionNotification({})).toBe('transcript-ready');
+  });
+
+  it('transcription failure → note-ready even with no notes (never offers "generate notes")', () => {
+    expect(
+      classifyCompletionNotification({ notesGenerated: false, transcriptionFailed: true }),
+    ).toBe('note-ready');
+  });
+
+  it('failure marked on the meeting → note-ready', () => {
+    expect(
+      classifyCompletionNotification({
+        notesGenerated: false,
+        meetingTranscriptionFailed: true,
+      }),
+    ).toBe('note-ready');
+  });
+
+  it('notes generated AND failed → note-ready', () => {
+    expect(
+      classifyCompletionNotification({ notesGenerated: true, transcriptionFailed: true }),
+    ).toBe('note-ready');
+  });
+});

--- a/app/renderer/src/lib/completionNotification.test.ts
+++ b/app/renderer/src/lib/completionNotification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyCompletionNotification } from './completionNotification';
+import { classifyCompletionNotification, meetingAlreadyHasNotes } from './completionNotification';
 
 describe('classifyCompletionNotification (#bug2/#bug3)', () => {
   it('notes generated → note-ready (auto_summarize on / reprocess done)', () => {
@@ -45,5 +45,41 @@ describe('classifyCompletionNotification (#bug2/#bug3)', () => {
     expect(
       classifyCompletionNotification({ notesGenerated: false, notesAlreadyExist: false }),
     ).toBe('transcript-ready');
+  });
+});
+
+describe('meetingAlreadyHasNotes (#M2 — real notes_generated semantics)', () => {
+  // The backend NEVER writes notes_generated:true — it writes false for a
+  // transcript-only note or omits the key when the note has notes. These cases
+  // exercise the real values the call site actually receives (the prior fix's
+  // `Boolean(notes_generated)` was always false because true never occurs).
+  it('note WITH notes: notes_generated absent → true', () => {
+    expect(meetingAlreadyHasNotes({ session_info: {} })).toBe(true);
+  });
+
+  it('transcript-only note: notes_generated explicitly false → false', () => {
+    expect(meetingAlreadyHasNotes({ session_info: { notes_generated: false } })).toBe(false);
+  });
+
+  it('no meetingData on the event → false (fall back to the transient signal)', () => {
+    expect(meetingAlreadyHasNotes(undefined)).toBe(false);
+    expect(meetingAlreadyHasNotes(null)).toBe(false);
+  });
+
+  it('append into a note with notes classifies as note-ready end-to-end', () => {
+    // SUMMARY_SKIPPED (notesGenerated false) + a note that already has notes.
+    const notesAlreadyExist = meetingAlreadyHasNotes({ session_info: {} });
+    expect(classifyCompletionNotification({ notesGenerated: false, notesAlreadyExist })).toBe(
+      'note-ready',
+    );
+  });
+
+  it('fresh transcript-only note classifies as transcript-ready end-to-end', () => {
+    const notesAlreadyExist = meetingAlreadyHasNotes({
+      session_info: { notes_generated: false },
+    });
+    expect(classifyCompletionNotification({ notesGenerated: false, notesAlreadyExist })).toBe(
+      'transcript-ready',
+    );
   });
 });

--- a/app/renderer/src/lib/completionNotification.test.ts
+++ b/app/renderer/src/lib/completionNotification.test.ts
@@ -1,5 +1,45 @@
 import { describe, it, expect } from 'vitest';
-import { classifyCompletionNotification, meetingAlreadyHasNotes } from './completionNotification';
+import {
+  classifyCompletionNotification,
+  meetingAlreadyHasNotes,
+  completionRouteAction,
+} from './completionNotification';
+
+const NOTE = '/meetings/abc_summary.md';
+const PROCESSING = '/meetings/processing';
+const routeAction = (currentRoute: string, windowVisible: boolean) =>
+  completionRouteAction({
+    currentRoute,
+    finishedMeetingRoute: NOTE,
+    processingRoute: PROCESSING,
+    windowVisible,
+  });
+
+describe('completionRouteAction (#bug1/#bug3 visibility-aware guard)', () => {
+  it('BLOCKER case: on the note route but window HIDDEN → notify (wrap-up flow)', () => {
+    // stopRecording navigated to the note's route in a hidden tray-only window;
+    // a route-only guard suppressed the prompt — this is the fix.
+    expect(routeAction(NOTE, false)).toBe('notify');
+  });
+
+  it('on the note route AND visible → suppress (user sees the summary)', () => {
+    expect(routeAction(NOTE, true)).toBe('suppress');
+  });
+
+  it('on the processing page AND visible → navigate into the note', () => {
+    expect(routeAction(PROCESSING, true)).toBe('navigate');
+  });
+
+  it('on the processing page but HIDDEN → notify (not silently navigate)', () => {
+    expect(routeAction(PROCESSING, false)).toBe('notify');
+  });
+
+  it('on any other route → notify (visible or hidden)', () => {
+    expect(routeAction('/', true)).toBe('notify');
+    expect(routeAction('/chat', false)).toBe('notify');
+    expect(routeAction('/meetings/other_summary.md', true)).toBe('notify');
+  });
+});
 
 describe('classifyCompletionNotification (#bug2/#bug3)', () => {
   it('notes generated → note-ready (auto_summarize on / reprocess done)', () => {

--- a/app/renderer/src/lib/completionNotification.test.ts
+++ b/app/renderer/src/lib/completionNotification.test.ts
@@ -34,4 +34,16 @@ describe('classifyCompletionNotification (#bug2/#bug3)', () => {
       classifyCompletionNotification({ notesGenerated: true, transcriptionFailed: true }),
     ).toBe('note-ready');
   });
+
+  it('append/continue: no new notes but the note already has them → note-ready (M2)', () => {
+    expect(
+      classifyCompletionNotification({ notesGenerated: false, notesAlreadyExist: true }),
+    ).toBe('note-ready');
+  });
+
+  it('append into a still-transcript-only note (no notes either way) → transcript-ready', () => {
+    expect(
+      classifyCompletionNotification({ notesGenerated: false, notesAlreadyExist: false }),
+    ).toBe('transcript-ready');
+  });
 });

--- a/app/renderer/src/lib/completionNotification.ts
+++ b/app/renderer/src/lib/completionNotification.ts
@@ -34,3 +34,24 @@ export function classifyCompletionNotification(input: {
   const hasNotes = Boolean(input.notesGenerated) || Boolean(input.notesAlreadyExist);
   return hasNotes || isFailed ? 'note-ready' : 'transcript-ready';
 }
+
+/**
+ * Whether the completed job's note ALREADY had notes (the M2 append case).
+ *
+ * Subtle: the backend only ever writes `notes_generated: false` (a transcript-
+ * only note) or OMITS the key entirely (a note that has notes) — it is never
+ * written `true`. So "has notes" is `notes_generated !== false`, NOT
+ * `notes_generated === true` (which is always false and was the ineffective
+ * first fix). Guard on meetingData presence: when the completion event carries
+ * no meetingData (the rare list-lookup-failed fallback, and the reprocess/report
+ * paths), return false so we fall back to the transient `notesGenerated` signal
+ * rather than defaulting a transcript-only note to "has notes". `notes_stale`
+ * is NOT a substitute — an append sets it unconditionally, including on
+ * transcript-only notes.
+ */
+export function meetingAlreadyHasNotes(
+  meetingData?: { session_info?: { notes_generated?: boolean } } | null,
+): boolean {
+  if (!meetingData) return false;
+  return meetingData.session_info?.notes_generated !== false;
+}

--- a/app/renderer/src/lib/completionNotification.ts
+++ b/app/renderer/src/lib/completionNotification.ts
@@ -55,3 +55,31 @@ export function meetingAlreadyHasNotes(
   if (!meetingData) return false;
   return meetingData.session_info?.notes_generated !== false;
 }
+
+/**
+ * What to do when a job finishes, based on where the user is AND whether the
+ * window is actually visible (#bug1). The visibility gate matters because an
+ * auto-detected recording can run with the window HIDDEN (tray-only), and
+ * "Wrap up" navigates to the note's own route — so route alone would say "the
+ * user is looking at it" when the window is hidden and they aren't, suppressing
+ * the very prompt this feature exists to send.
+ *
+ * - `navigate`: user is watching the processing page (visible) → open the note.
+ * - `suppress`: user is already viewing this note (visible) → the static
+ *   summary is right there, a banner would be noise.
+ * - `notify`: anywhere else, OR this note's route but the window is
+ *   hidden/minimised → fire a notification.
+ */
+export type CompletionRouteAction = 'navigate' | 'notify' | 'suppress';
+
+export function completionRouteAction(input: {
+  currentRoute: string;
+  finishedMeetingRoute: string;
+  processingRoute: string;
+  windowVisible: boolean;
+}): CompletionRouteAction {
+  const { currentRoute, finishedMeetingRoute, processingRoute, windowVisible } = input;
+  if (currentRoute === processingRoute && windowVisible) return 'navigate';
+  if (currentRoute === finishedMeetingRoute && windowVisible) return 'suppress';
+  return 'notify';
+}

--- a/app/renderer/src/lib/completionNotification.ts
+++ b/app/renderer/src/lib/completionNotification.ts
@@ -1,0 +1,28 @@
+/**
+ * Decide which notification a finished recording/processing job should fire
+ * (#bug2/#bug3). Pure so it can be unit-tested without the IPC/route machinery
+ * around it in useRecording.
+ *
+ * - `note-ready`: notes were generated (auto_summarize on, or the deferred
+ *   Generate-notes/reprocess finished), OR a transcription failure that still
+ *   wrote a note — either way there's a note to open.
+ * - `transcript-ready`: transcript-only note (auto_summarize off → no notes
+ *   generated) — prompt the user to generate notes rather than claim it's
+ *   ready. This is the correctly-timed replacement for the old premature
+ *   meeting-end "Summarise?" prompt.
+ *
+ * A failed transcription is deliberately routed to `note-ready` (with the
+ * caller's `failed` flag), NOT `transcript-ready`: there's nothing to summarise
+ * on a failed transcript, so we never offer "generate notes" there.
+ */
+export type CompletionNotificationKind = 'note-ready' | 'transcript-ready';
+
+export function classifyCompletionNotification(input: {
+  notesGenerated?: boolean;
+  transcriptionFailed?: boolean;
+  meetingTranscriptionFailed?: boolean;
+}): CompletionNotificationKind {
+  const isFailed =
+    Boolean(input.transcriptionFailed) || Boolean(input.meetingTranscriptionFailed);
+  return input.notesGenerated || isFailed ? 'note-ready' : 'transcript-ready';
+}

--- a/app/renderer/src/lib/completionNotification.ts
+++ b/app/renderer/src/lib/completionNotification.ts
@@ -14,15 +14,23 @@
  * A failed transcription is deliberately routed to `note-ready` (with the
  * caller's `failed` flag), NOT `transcript-ready`: there's nothing to summarise
  * on a failed transcript, so we never offer "generate notes" there.
+ *
+ * `notesAlreadyExist` covers the continue-recording (append) case: the backend
+ * always prints SUMMARY_SKIPPED for an append (deferring to on-demand
+ * regenerate), so `notesGenerated` is false — but the note it appended to
+ * already has notes (now stale). Prompting "generate notes?" for a note that
+ * already has them is wrong, so a note that already has notes is `note-ready`.
  */
 export type CompletionNotificationKind = 'note-ready' | 'transcript-ready';
 
 export function classifyCompletionNotification(input: {
   notesGenerated?: boolean;
+  notesAlreadyExist?: boolean;
   transcriptionFailed?: boolean;
   meetingTranscriptionFailed?: boolean;
 }): CompletionNotificationKind {
   const isFailed =
     Boolean(input.transcriptionFailed) || Boolean(input.meetingTranscriptionFailed);
-  return input.notesGenerated || isFailed ? 'note-ready' : 'transcript-ready';
+  const hasNotes = Boolean(input.notesGenerated) || Boolean(input.notesAlreadyExist);
+  return hasNotes || isFailed ? 'note-ready' : 'transcript-ready';
 }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -373,7 +373,9 @@ export interface QueueStatus {
    *  instant-stop placeholder, then rewritten by the pipeline). Deterministic
    *  from the audio stem and stable across record→process, so useMeetings can
    *  dedupe the synthetic "__live__/…" row against the real note once it exists
-   *  (one recording, one row — #bug4). Null for Whisper/import and when idle. */
+   *  (one recording, one row — #bug4). Only the Parakeet instant-stop path
+   *  writes that placeholder, so dedup only bites there; Whisper/import have no
+   *  placeholder (dedup is a no-op even when this is set), and it's null idle. */
   liveSummaryFile?: string | null;
 }
 

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -369,6 +369,12 @@ export interface QueueStatus {
    *  different one" by identity rather than the collidable display name. Null
    *  for a fresh new-note recording or when idle. */
   recordingSummaryFile?: string | null;
+  /** The real note file the current recording/processing session produces (the
+   *  instant-stop placeholder, then rewritten by the pipeline). Deterministic
+   *  from the audio stem and stable across record→process, so useMeetings can
+   *  dedupe the synthetic "__live__/…" row against the real note once it exists
+   *  (one recording, one row — #bug4). Null for Whisper/import and when idle. */
+  liveSummaryFile?: string | null;
 }
 
 export type PickAudioFileResponse = Result<{ filePath: string }>;
@@ -648,6 +654,11 @@ export interface ProcessingCompleteEvent {
    *  reprocess banner regardless of whether STREAM_ERROR or a non-zero exit
    *  ended it. */
   report?: boolean;
+  /** True when summarization actually ran (STREAM_COMPLETE), i.e. the note has
+   *  generated notes. False/absent on the transcript-only path (auto_summarize
+   *  off → SUMMARY_SKIPPED). Drives whether the renderer fires "Note ready" vs
+   *  the "Transcript ready — generate notes?" prompt (#bug2/#bug3). */
+  notesGenerated?: boolean;
 }
 export interface QueryChunkEvent {
   queryId: string;
@@ -1019,6 +1030,20 @@ export interface StenoaiBridge {
       ],
       Result<Record<string, never>>
     >;
+    /** Transcript-only note finished transcription with no notes generated
+     *  (auto_summarize off). Prompts "Generate notes?" — the action starts
+     *  generation in the background, a body tap opens the note. Returns `shown`
+     *  for the notifications_enabled gate. (#bug2/#bug3) */
+    showTranscriptReadyNotification: RequestFn<
+      [
+        payload: {
+          title?: string;
+          summaryFile?: string | null;
+          name?: string | null;
+        },
+      ],
+      Result<{ shown?: boolean }>
+    >;
     /** Design-for-test seam for the pre-meeting notification (production fire
      *  path is the main-side scheduler). Returns `shown` for the gate/suppression. */
     showPremeetingNotification: RequestFn<
@@ -1117,6 +1142,10 @@ export interface StenoaiBridge {
     autoPauseRequested: Subscribe<void>;
     autoResumeRequested: Subscribe<void>;
     autoSummariseRequested: Subscribe<void>;
+    /** Main asks the renderer to generate notes for a transcript-only note in
+     *  the background (from the "Generate notes" action on the transcript-ready
+     *  notification). Renderer runs the same reprocess path as GenerateNotesBar. */
+    generateNotesRequested: Subscribe<{ summaryFile: string; name?: string | null }>;
     navigateToMeeting: Subscribe<{ summaryFile: string }>;
     trayOpenSettings: Subscribe<void>;
     showQuitDialog: Subscribe<{ type: 'recording' | 'processing'; jobCount?: number }>;

--- a/app/renderer/src/lib/liveMeetingRow.ts
+++ b/app/renderer/src/lib/liveMeetingRow.ts
@@ -1,0 +1,21 @@
+/**
+ * Live-recording row helpers (#bug4), kept in a dependency-light module so the
+ * dedup logic is unit-testable without pulling in the useMeetings hook graph.
+ */
+
+/** Sentinel summary_file path used by the synthetic in-progress recording row.
+ *  Never matches a real meeting file. Consumers detect via `meeting.is_recording`. */
+export const LIVE_SUMMARY_PREFIX = '__live__/';
+
+/** The synthetic "__live__/…" row is redundant once the session's real note
+ *  file exists in the list — showing both is the duplicate-note bug. main
+ *  surfaces the real note's key as `liveSummaryFile` (deterministic from the
+ *  audio stem, stable across record→process); this returns true when that note
+ *  is already present, so the caller drops the synthetic row. */
+export function liveRowRedundant(
+  base: ReadonlyArray<{ session_info: { summary_file: string } }>,
+  liveSummaryFile: string | null | undefined,
+): boolean {
+  if (!liveSummaryFile) return false;
+  return base.some((m) => m.session_info.summary_file === liveSummaryFile);
+}

--- a/app/renderer/src/routes/MeetingDetail.tsx
+++ b/app/renderer/src/routes/MeetingDetail.tsx
@@ -74,6 +74,7 @@ import { stripReasoning } from '@/lib/markdown';
 import { pendingTitleRegens, streamCache, type StreamPhase } from '@/lib/meetingDetailState';
 import { useReprocessBridge } from '@/hooks/reprocessBridgeStore';
 import { useRecording } from '@/hooks/useRecording';
+import { useAutoSummarizeSetting } from '@/hooks/useSettings';
 
 const LAST_OPENED_KEY = 'steno-last-opened-meeting';
 
@@ -161,6 +162,10 @@ function DetailContent({
   // Re-transcribe (#266) is only offered when the source recording still exists
   // on disk (keep-recordings was on) — otherwise re-running ASR is impossible.
   const recordingAvailable = useRecordingAvailable(summaryFile);
+  // Whether this processing note will get notes generated after transcription.
+  // Defaults to true (config default) while the setting loads, so the copy
+  // doesn't flash the transcript-only wording for the common auto-on case.
+  const willGenerateNotes = useAutoSummarizeSetting().data ?? true;
   const [retranscribeOpen, setRetranscribeOpen] = React.useState(false);
   const generateReport = useGenerateReport();
   const setActiveReport = useSetActiveReport();
@@ -1158,8 +1163,17 @@ function DetailContent({
                     className="text-[14px] leading-[1.6]"
                     style={{ color: 'var(--fg-2)', maxWidth: '64ch' }}
                   >
-                    Your transcript is captured — refining it and generating notes in the
-                    background. You can read and edit <strong>My notes</strong> now.
+                    {willGenerateNotes ? (
+                      <>
+                        Finishing your transcript in the background, then generating notes. You can
+                        read and edit <strong>My notes</strong> now.
+                      </>
+                    ) : (
+                      <>
+                        Finishing your transcript in the background. You can read and edit{' '}
+                        <strong>My notes</strong> now, and generate notes when it's done.
+                      </>
+                    )}
                   </p>
                 </section>
               ) : summary ? (

--- a/e2e/specs/notifications.t2.spec.ts
+++ b/e2e/specs/notifications.t2.spec.ts
@@ -4,7 +4,8 @@ import { readUserConfig } from '../fixtures/user-config';
 
 /**
  * T2 — notifications: get/set toggle persistence + that the toggle GATES the
- * note-ready / silence-auto-stop / system-audio-mic-only notifications. The
+ * note-ready / transcript-ready / silence-auto-stop / system-audio-mic-only
+ * notifications (transcript-ready is the #bug2/#bug3 transcript-only prompt). The
  * handlers now return a `shown` flag (the observable design-for-test signal —
  * a native banner isn't inspectable) reflecting whether the
  * notifications_enabled gate let it through. Deterministic + model-free.
@@ -20,6 +21,7 @@ type StenoWindow = Window & {
       setNotifications: (v: boolean) => Promise<Toggle>;
       showSilenceAutoStopNotification: (payload: unknown) => Promise<ShowResult>;
       showNoteReadyNotification: (payload: unknown) => Promise<ShowResult>;
+      showTranscriptReadyNotification: (payload: unknown) => Promise<ShowResult>;
       showSystemAudioMicOnlyNotification: () => Promise<ShowResult>;
     };
   };
@@ -41,6 +43,14 @@ const showNote = (page: import('@playwright/test').Page) =>
   );
 const showMicOnly = (page: import('@playwright/test').Page) =>
   page.evaluate(() => (window as StenoWindow).stenoai.settings.showSystemAudioMicOnlyNotification());
+const showTranscript = (page: import('@playwright/test').Page) =>
+  page.evaluate(() =>
+    (window as StenoWindow).stenoai.settings.showTranscriptReadyNotification({
+      title: 'E2E note',
+      summaryFile: 'e2e-note.json',
+      name: 'E2E note',
+    }),
+  );
 
 test('notifications toggle persists and gates the note-ready / silence / mic-only notifications; real dir untouched', async ({
   launchApp,
@@ -59,6 +69,7 @@ test('notifications toggle persists and gates the note-ready / silence / mic-onl
 
   expect((await showSilence(page)).shown).toBe(false);
   expect((await showNote(page)).shown).toBe(false);
+  expect((await showTranscript(page)).shown).toBe(false);
   expect((await showMicOnly(page)).shown).toBe(false);
 
   // Enable -> persisted + the gate now lets both through (shown is not false;
@@ -73,6 +84,7 @@ test('notifications toggle persists and gates the note-ready / silence / mic-onl
 
   expect((await showSilence(page)).shown).not.toBe(false);
   expect((await showNote(page)).shown).not.toBe(false);
+  expect((await showTranscript(page)).shown).not.toBe(false);
   expect((await showMicOnly(page)).shown).not.toBe(false);
 
   // Keystone: the real user-data dir is byte-for-byte untouched.


### PR DESCRIPTION
Fixes four related auto-detect/notification UX bugs. Spec: `.specs/2026-07-27-recording-notification-fixes.md` (built via /assemble → ironman → hulk).

## Bugs fixed
1. **Focus-steal** — tapping "Take Notes" no longer yanks the window forward; `requestAutoRecord` drops `mainWindow.show()/focus()` and records in the background pill-dock.
2. **"Note ready" timing** — a `notesGenerated` flag (set only on `STREAM_COMPLETE`) is threaded through `processing-complete` for both the pipeline and reprocess paths; "Note ready" now fires only when notes actually exist.
3. **"Summarise?" too early** — the mic-idle prompt is reframed to "Wrap up" (stops, no summarise wording, no focus); the summarise decision moves to a post-transcription **"Transcript ready — generate notes?"** prompt whose "Generate notes" action runs reprocess in the background → then "Note ready". Engine-agnostic (shared post-stop path).
4. **Duplicate note** — `get-queue-status` surfaces the session's real-note key (`liveSummaryFile`); `useMeetings` drops the synthetic `__live__/…` row once the real note exists → one recording, one entry.

## New IPC (4-file contract synced)
- `show-transcript-ready-notification` (invoke) + `generate-notes-requested` (M→R), across main/preload/ipc.ts/e2e-mock.

## Review (in-context, senior QA + Eng + a confirming pass)
- QA caught a **HIGH** regression (H1: `liveSummaryFile` precedence dropped a fresh recording's row during back-to-back meetings) — fixed (flip precedence).
- A **MEDIUM** (M2: append/continue fired the wrong prompt) — fixed; the confirming pass found the first M2 fix was a no-op (`notes_generated` is never written `true`), re-fixed with the correct `!== false` semantics + a real-value test.
- Engine review: no critical/high; design endorsed.

## Tests
- Pure helpers extracted + unit-tested: `classifyCompletionNotification` + `meetingAlreadyHasNotes` (Bug 2/3), `liveRowRedundant` (Bug 4).
- `notifications.t2` extended to gate the new transcript-ready notification (real backend).
- Gates: typecheck clean, 277 node:test + 138 vitest, IPC contract 8/8, 50/50 T1, notifications.t2 green.

## Verify
Verified at runtime where drivable (T1 app boot + recording/pill-dock flows; notifications.t2 handler+gate). The model-bearing recording→transcription→notification-timing end-to-end isn't drivable in dev (needs mic+model) — noted as the one un-driven slice.

## Follow-ups (non-blocking)
- A T2 exercising get-queue-status during record+process overlap (would regression-guard H1).
- Optional: rename the `auto-summarise-requested` channel (now means "wrap up") — kept for now to avoid 4-file churn, documented in code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-detect recording focus and notification timing (now visibility-aware), and removes duplicate live meeting rows. Recording starts in the background, notifications fire at the right time even when the window is hidden, and each recording shows only one row.

- **Bug Fixes**
  - "Take Notes" no longer steals focus; auto-record runs in the background pill-dock.
  - "Note ready" only fires when notes were generated; threads a `notesGenerated` flag from `STREAM_COMPLETE` through `processing-complete`.
  - Mic-idle prompt is now "Wrap up" (stop only). Body tap just opens the app; the summarization decision moves to a post-transcription "Transcript ready — generate notes?" notification; "Generate notes" runs reprocess in the background.
  - Completion prompts are visibility-aware: they still notify when the window is hidden; disabled window `backgroundThrottling` to keep recorder cadence and silence auto-stop timing consistent.
  - Duplicates removed: `get-queue-status` exposes `liveSummaryFile`, and `useMeetings` drops the synthetic `__live__/…` row once the real note exists.

- **New Features**
  - Added `show-transcript-ready-notification` and `generate-notes-requested` IPC channels to support the new post-transcription flow.

<sup>Written for commit abf92876260766d9a6f7e875b14e742d2ec8f655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

