### PR TITLE
fix(persistence): write the summary Markdown and folders.json durably

### DIFF
--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -189,12 +189,13 @@ def _normalize_markdown_for_parsing(md_text: str) -> str:
     """Ensure headers immediately following a reasoning tag start on a new line."""
     return _REASONING_TAG_HEADER_PATTERN.sub(r'\1\n\2', md_text)
 
-# Shared atomic JSON writer (tempfile + os.replace + Windows PermissionError
+# Shared atomic writers (tempfile + os.replace + Windows PermissionError
 # retry). One implementation for the summary JSON and config.json (recorder_state.json
-# is no longer written — see MeetingPipeline.state_file) — re-exported here so
-# existing imports keep working. The canonical copy lives in src.config because
-# this module already imports from src (the reverse import would be circular).
-from src.config import _atomic_write_json  # noqa: E402
+# is no longer written — see MeetingPipeline.state_file) and one for the summary
+# Markdown — re-exported here so existing imports keep working. The canonical
+# copies live in src.config because this module already imports from src (the
+# reverse import would be circular).
+from src.config import _atomic_write_json, _atomic_write_text  # noqa: E402
 
 
 def _start_summary_heartbeat(label: str = "summarize", interval_s: int = 60, max_beats: int = 30):
@@ -623,7 +624,7 @@ Summary output language: {config.get_language_name(output_language)}
             md_lines.append('## User Notes')
             md_lines.append('')
             md_lines.append(notes_text)
-        summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
+        _atomic_write_text(summary_path, '\n'.join(md_lines))
 
         print(f"⚠️ Transcription failed; preserved audio: {audio_path}")
         print(f"TRANSCRIPTION_FAILED:{short_error}", flush=True)
@@ -717,7 +718,7 @@ Summary output language: {config.get_language_name(output_language)}
                 md_lines.append('## User Notes')
                 md_lines.append('')
                 md_lines.append(notes_text)
-            summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
+            _atomic_write_text(summary_path, '\n'.join(md_lines))
             if not gate_config.get_keep_recordings():
                 try:
                     audio_path.unlink()
@@ -811,7 +812,7 @@ Summary output language: {config.get_language_name(output_language)}
             md_lines.append('## User Notes')
             md_lines.append('')
             md_lines.append(notes_text)
-        summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
+        _atomic_write_text(summary_path, '\n'.join(md_lines))
 
         # Clean up
         from src.config import get_config
@@ -950,7 +951,7 @@ def _append_segment_to_note(target: Path, new_text: str, duration_seconds):
             content = content[:notes_idx] + segment + '\n' + content[notes_idx:]
         else:
             content = content.rstrip('\n') + segment + '\n'
-        target.write_text(content, encoding='utf-8')
+        _atomic_write_text(target, content)
     else:
         with open(target, 'r', encoding='utf-8') as f:
             data = json.load(f)
@@ -1256,7 +1257,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
                 md_lines.append('## User Notes')
                 md_lines.append('')
                 md_lines.append(notes_text)
-            summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
+            _atomic_write_text(summary_path, '\n'.join(md_lines))
 
             if not is_live_transcript and not gate_config.get_keep_recordings():
                 try:
@@ -1370,7 +1371,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
             md_lines.append('## User Notes')
             md_lines.append('')
             md_lines.append(notes_text)
-        summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
+        _atomic_write_text(summary_path, '\n'.join(md_lines))
 
         # Clean up audio. When we fell back to the live transcript the batch
         # transcription was empty/failed, so KEEP the audio regardless of the
@@ -3099,7 +3100,7 @@ def reprocess(summary_file, regenerate_title, retranscribe):
                 md_lines.append('## User Notes')
                 md_lines.append('')
                 md_lines.append(notes_text)
-            summary_path.write_text('\n'.join(md_lines), encoding='utf-8')
+            _atomic_write_text(summary_path, '\n'.join(md_lines))
         else:
             # JSON format: parse streamed markdown into structured fields
             parsed = recorder._parse_streamed_markdown(streamed_md)
@@ -3330,7 +3331,7 @@ def regen_title(summary_file):
             import re
             escaped = generated_title.replace('\\', '\\\\').replace('"', '\\"')
             text = re.sub(r'^title:.*$', f'title: "{escaped}"', text, flags=re.MULTILINE)
-            summary_path.write_text(text, encoding='utf-8')
+            _atomic_write_text(summary_path, text)
         else:
             with open(summary_path, 'w') as f:
                 json.dump(existing_data, f, indent=2)

--- a/src/config.py
+++ b/src/config.py
@@ -39,18 +39,21 @@ logger = logging.getLogger(__name__)
 BEDROCK_REGION_RE = re.compile(r"[a-z]{2}(-gov)?-[a-z]+-[0-9]{1,2}")
 
 
-def _atomic_write_json(path: Path, payload) -> None:
-    """Write `payload` as JSON to `path` atomically.
+def _atomic_write(path: Path, render, encoding: str = 'utf-8') -> None:
+    """Durably replace `path` with whatever `render(fh)` writes.
 
-    The shared atomic writer for every JSON file the CLI persists —
-    config.json here, recorder_state.json and the final summary JSON via
-    the re-export in simple_recorder. tempfile + os.replace in the same
-    directory keeps the rename a single filesystem operation on POSIX and
-    Windows, so a crash mid-write leaves the prior file intact rather
-    than a half-written one. config.json in particular is read by many
-    concurrent CLI subprocesses; a plain truncate-and-rewrite lets a
-    reader see a torn file, fall back to defaults, and (pre-fix) persist
-    those defaults over the user's real settings.
+    The shared core behind _atomic_write_json and _atomic_write_text: a
+    tempfile in the SAME directory (so the rename can't cross a filesystem
+    boundary), flush + fsync so the bytes are on the platter before the
+    rename, then os.replace — a single filesystem operation on POSIX and
+    Windows. A crash, a full disk, or a killed process mid-write therefore
+    leaves the previous file intact rather than a half-written one, and a
+    concurrent reader sees either the old file or the new one, never a torn
+    mix. The temp file is removed on any failure so a failed write leaves
+    no debris next to the real file.
+
+    `render` takes the open text handle and writes the payload; anything it
+    raises propagates to the caller after cleanup.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -60,10 +63,10 @@ def _atomic_write_json(path: Path, payload) -> None:
         prefix=f'.{path.name}.',
         suffix='.tmp',
         delete=False,
-        encoding='utf-8',
+        encoding=encoding,
     )
     try:
-        json.dump(payload, tmp, indent=2)
+        render(tmp)
         tmp.flush()
         os.fsync(tmp.fileno())
         tmp.close()
@@ -88,6 +91,36 @@ def _atomic_write_json(path: Path, payload) -> None:
         except OSError:
             pass
         raise
+
+
+def _atomic_write_json(path: Path, payload) -> None:
+    """Write `payload` as JSON to `path` atomically.
+
+    The shared atomic writer for every JSON file the CLI persists —
+    config.json and folders.json here, recorder_state.json and the final
+    summary JSON via the re-export in simple_recorder. config.json in
+    particular is read by many concurrent CLI subprocesses; a plain
+    truncate-and-rewrite lets a reader see a torn file, fall back to
+    defaults, and (pre-fix) persist those defaults over the user's real
+    settings. See _atomic_write for the durability mechanics.
+    """
+    _atomic_write(path, lambda fh: json.dump(payload, fh, indent=2))
+
+
+def _atomic_write_text(path: Path, text: str, encoding: str = 'utf-8') -> None:
+    """Write `text` to `path` atomically — the Path.write_text replacement.
+
+    The summary Markdown is the app's primary user artifact and is rewritten
+    in place on every reprocess, retranscribe, title regeneration and live
+    append. Plain write_text truncates first, so a crash (or a full disk)
+    between truncate and write leaves the user with an empty or half-written
+    note and no previous version to fall back to. See _atomic_write.
+
+    Note: the .md and its sidecar .json are each written atomically but are
+    NOT written as one transaction — a crash between the two can still leave
+    them disagreeing. Out of scope here; the individual files stay readable.
+    """
+    _atomic_write(path, lambda fh: fh.write(text), encoding=encoding)
 
 
 def get_user_data_dir() -> Path:

--- a/src/folders.py
+++ b/src/folders.py
@@ -7,10 +7,15 @@ Meeting-to-folder assignment is stored in each meeting's summary JSON.
 
 import json
 import logging
+import shutil
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
+
+import filelock
+
+from src.config import _atomic_write_json, _atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -18,81 +23,197 @@ logger = logging.getLogger(__name__)
 class FoldersManager:
     """Manages folders for organizing meetings."""
 
+    # Seconds to wait for the cross-process folders lock before giving up and
+    # falling back to an unlocked read-modify-write. Mirrors
+    # Config._SAVE_LOCK_TIMEOUT: generous enough for a normal save on a busy
+    # disk, short enough that a stuck lock never blocks the CLI for long.
+    _SAVE_LOCK_TIMEOUT = 10
+
     def __init__(self, data_dir: Path):
         self.folders_file = data_dir / "folders.json"
         self._data = self._load()
 
     def _load(self) -> Dict:
-        if self.folders_file.exists():
-            try:
-                with open(self.folders_file, "r") as f:
-                    return json.load(f)
-            except Exception as e:
-                logger.error(f"Error loading folders: {e}")
+        """Read folders.json, or return an empty folder list.
+
+        Failure kinds are deliberately NOT treated alike — conflating them is
+        what made this a data-loss path. A blanket ``except Exception`` turned
+        *any* hiccup (a permission problem, an exhausted file-descriptor
+        limit, an I/O error) into an empty in-memory folder list, which the
+        next create_folder() then persisted over the user's real folders.
+
+        - Provably invalid content (unparseable JSON, or valid JSON of the
+          wrong shape) can't be fixed by retrying: quarantine it to
+          folders.json.corrupt and start from empty, the same recovery
+          config.json gets. Folder *assignments* live in each meeting's own
+          summary file, so the folders can be recreated; the quarantined copy
+          keeps the original recoverable. If that copy itself fails the
+          recovery is abandoned and the error propagates — see
+          _quarantine_corrupt.
+        - Everything else (PermissionError, OSError, ...) is a transient or
+          environmental failure where the file on disk is presumed fine.
+          Propagate it so the caller fails loudly instead of silently
+          presenting — and then persisting — an empty list.
+        """
+        if not self.folders_file.exists():
+            return self._empty()
+        try:
+            with open(self.folders_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as e:
+            self._quarantine_corrupt(e)
+            return self._empty()
+        if not isinstance(data, dict) or not isinstance(data.get("folders"), list):
+            # `null`, `[]` or a hand-edited file parses fine but breaks every
+            # accessor below; route it through the corrupt path.
+            self._quarantine_corrupt(
+                ValueError("folders.json root is not an object with a folders list")
+            )
+            return self._empty()
+        return data
+
+    @staticmethod
+    def _empty() -> Dict:
         return {"folders": []}
 
-    def _save(self) -> bool:
+    def _quarantine_corrupt(self, error: Exception) -> None:
+        """Back the unparseable file up to folders.json.corrupt.
+
+        Unlike config.json we go on to write a fresh file over the original,
+        so this copy is the only surviving version of the user's folder list.
+        A backup that didn't happen would therefore turn recovery into
+        deletion — so a failed copy is re-raised and _load() never reaches
+        its empty list. Refusing to proceed leaves the corrupt file where the
+        user can still salvage or move it by hand; recovering on top of it
+        would be the same silent data loss this module exists to remove.
+        """
+        backup_path = self.folders_file.with_name(self.folders_file.name + ".corrupt")
         try:
-            self.folders_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.folders_file, "w") as f:
-                json.dump(self._data, f, indent=2)
-            return True
+            shutil.copy2(self.folders_file, backup_path)
+        except Exception as backup_error:
+            logger.error(
+                f"Error loading folders: {error}. Refusing to start from an "
+                f"empty list because the backup to {backup_path} failed too: "
+                f"{backup_error}. The corrupt file is left untouched."
+            )
+            raise
+        logger.error(
+            f"Error loading folders: {error}. Starting from an empty list; "
+            f"corrupt file backed up to {backup_path}"
+        )
+
+    def _update(self, mutate: Callable[[Dict], Any]) -> Any:
+        """Re-read folders.json under the cross-process lock, apply `mutate`
+        to that fresh data, and persist the result atomically.
+
+        The app spawns a fresh CLI subprocess per operation (no daemon), so
+        two near-simultaneous folder edits would each build a whole file from
+        their own stale read and silently drop the other's change — the same
+        lost update config.json fixes. Reading inside the lock, immediately
+        before mutating, is what makes the read-modify-write one critical
+        section.
+
+        `mutate` returns None to mean "nothing changed, don't write". Returns
+        that value, or None when nothing changed or the write failed. Read
+        failures propagate (see _load) — a folder edit that can't see the
+        current file must not proceed as if there were none.
+        """
+        lock_path = str(self.folders_file) + ".lock"
+        try:
+            with filelock.FileLock(lock_path, timeout=self._SAVE_LOCK_TIMEOUT):
+                return self._apply(mutate)
+        except filelock.Timeout:
+            # Deliberate tradeoff: mutual exclusion is given up so a stuck
+            # lock can never block folder edits outright. The write stays
+            # atomic and stays built on a fresh read, so the file can't tear;
+            # what we accept is that two editors racing past this point can
+            # still lose one of the two updates.
+            logger.warning(
+                f"Timed out acquiring folders lock at {lock_path}; "
+                f"proceeding without it"
+            )
+            return self._apply(mutate)
+
+    def _apply(self, mutate: Callable[[Dict], Any]) -> Any:
+        data = self._load()
+        result = mutate(data)
+        if result is None:
+            self._data = data
+            return None
+        try:
+            _atomic_write_json(self.folders_file, data)
         except Exception as e:
             logger.error(f"Error saving folders: {e}")
-            return False
+            # The atomic replace never ran, so the previous file is intact.
+            return None
+        self._data = data
+        return result
 
     def list_folders(self) -> List[Dict]:
         return self._data.get("folders", [])
 
     def create_folder(self, name: str, color: str = "#6366f1") -> Optional[Dict]:
-        folder = {
-            "id": str(uuid.uuid4())[:8],
-            "name": name,
-            "color": color,
-            "icon": "folder",
-            "created_at": datetime.now().isoformat(),
-            "order": len(self._data["folders"]),
-        }
-        self._data["folders"].append(folder)
-        if self._save():
+        def _mutate(data: Dict) -> Dict:
+            folder = {
+                "id": str(uuid.uuid4())[:8],
+                "name": name,
+                "color": color,
+                "icon": "folder",
+                "created_at": datetime.now().isoformat(),
+                "order": len(data["folders"]),
+            }
+            data["folders"].append(folder)
             return folder
-        return None
+
+        return self._update(_mutate)
 
     def update_icon(self, folder_id: str, icon: str) -> bool:
-        for folder in self._data["folders"]:
-            if folder["id"] == folder_id:
-                folder["icon"] = icon
-                return self._save()
-        return False
+        def _mutate(data: Dict) -> Optional[bool]:
+            for folder in data["folders"]:
+                if folder["id"] == folder_id:
+                    folder["icon"] = icon
+                    return True
+            return None  # unknown id: nothing to write
+
+        return self._update(_mutate) is True
 
     def rename_folder(self, folder_id: str, name: str) -> bool:
-        for folder in self._data["folders"]:
-            if folder["id"] == folder_id:
-                folder["name"] = name
-                return self._save()
-        return False
+        def _mutate(data: Dict) -> Optional[bool]:
+            for folder in data["folders"]:
+                if folder["id"] == folder_id:
+                    folder["name"] = name
+                    return True
+            return None  # unknown id: nothing to write
+
+        return self._update(_mutate) is True
 
     def delete_folder(self, folder_id: str) -> bool:
-        self._data["folders"] = [
-            f for f in self._data["folders"] if f["id"] != folder_id
-        ]
-        return self._save()
+        def _mutate(data: Dict) -> bool:
+            data["folders"] = [
+                f for f in data["folders"] if f["id"] != folder_id
+            ]
+            return True
+
+        return self._update(_mutate) is True
 
     def reorder_folders(self, folder_ids: List[str]) -> bool:
         """Reorder folders to match the given ID order, updating each folder's order field."""
-        existing = {f["id"]: f for f in self._data["folders"]}
-        reordered = []
-        for i, fid in enumerate(folder_ids):
-            if fid in existing:
-                folder = existing.pop(fid)
-                folder["order"] = i
+        def _mutate(data: Dict) -> bool:
+            existing = {f["id"]: f for f in data["folders"]}
+            reordered = []
+            for i, fid in enumerate(folder_ids):
+                if fid in existing:
+                    folder = existing.pop(fid)
+                    folder["order"] = i
+                    reordered.append(folder)
+            # Append any folders not in the provided list (shouldn't happen, but safe)
+            for folder in existing.values():
+                folder["order"] = len(reordered)
                 reordered.append(folder)
-        # Append any folders not in the provided list (shouldn't happen, but safe)
-        for folder in existing.values():
-            folder["order"] = len(reordered)
-            reordered.append(folder)
-        self._data["folders"] = reordered
-        return self._save()
+            data["folders"] = reordered
+            return True
+
+        return self._update(_mutate) is True
 
     def _update_md_folders(self, summary_path: Path, update_fn) -> bool:
         """Update the folders list in a .md file's YAML frontmatter."""
@@ -123,7 +244,9 @@ class FoldersManager:
             else:
                 frontmatter = frontmatter.rstrip('\n') + f'\n{folders_line}\n'
 
-            summary_path.write_text(f'---{frontmatter}---{body}', encoding='utf-8')
+            # Same atomic writer the summary Markdown gets everywhere else:
+            # this rewrites the user's whole note to change one frontmatter line.
+            _atomic_write_text(summary_path, f'---{frontmatter}---{body}')
             return True
         except Exception as e:
             logger.error(f"Error updating md folders: {e}")

--- a/tests/test_atomic_write_text.py
+++ b/tests/test_atomic_write_text.py
@@ -1,0 +1,53 @@
+"""Persistence safety for the summary Markdown.
+
+The .md note is the app's primary user artifact, and it is rewritten in
+place on every reprocess, retranscribe, title regeneration and live
+append. Path.write_text truncates the file first, so a crash or a full
+disk between truncate and write left the user with an empty or
+half-written note and nothing to fall back to.
+
+These tests pin the guarantee _atomic_write_text provides: the previous
+file survives a failed write untouched, and no temp debris is left behind.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.config import _atomic_write_text
+
+
+class AtomicWriteTextTests(unittest.TestCase):
+    def test_write_replaces_previous_content_and_leaves_no_tmp_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "meeting.md"
+            _atomic_write_text(path, "---\ntitle: \"First\"\n---\n")
+            _atomic_write_text(path, "---\ntitle: \"Zweite Fassung\"\n---\n")
+
+            self.assertEqual(path.read_text(encoding="utf-8"),
+                             "---\ntitle: \"Zweite Fassung\"\n---\n")
+            leftovers = [p for p in Path(tmp_dir).iterdir() if p.suffix == ".tmp"]
+            self.assertEqual(leftovers, [])
+
+    def test_failed_write_preserves_previous_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "meeting.md"
+            _atomic_write_text(path, "## Summary\n\nThe original note.\n")
+            before = path.read_text(encoding="utf-8")
+
+            # Fail after the payload has been written to the temp file but
+            # before the replace — the "disk fills up mid-write" case.
+            with patch("src.config.os.fsync", side_effect=OSError("disk full")):
+                with self.assertRaises(OSError):
+                    _atomic_write_text(path, "## Summary\n\nThe replacement.\n")
+
+            # The note on disk is the previous, complete version — not empty,
+            # not truncated.
+            self.assertEqual(path.read_text(encoding="utf-8"), before)
+            leftovers = [p for p in Path(tmp_dir).iterdir() if p.suffix == ".tmp"]
+            self.assertEqual(leftovers, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_folders_persistence.py
+++ b/tests/test_folders_persistence.py
@@ -1,0 +1,169 @@
+"""Persistence safety for folders.json.
+
+The old _load() caught *every* exception and returned an empty folder
+list; the next create_folder() then wrote that list back, so a single
+transient read failure permanently destroyed the user's folders. These
+tests pin the distinction the fix draws:
+
+- provably invalid content is quarantined and recovery starts from empty;
+- any other read failure propagates instead of silently emptying the list;
+- a failed save leaves the previous file intact;
+- two concurrent editors don't clobber each other (read under the lock).
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.folders import FoldersManager
+
+
+def _seed(tmp_dir: str) -> Path:
+    """Write a folders.json with two real folders and return its path."""
+    path = Path(tmp_dir) / "folders.json"
+    path.write_text(json.dumps({"folders": [
+        {"id": "aaa", "name": "Kunden", "color": "#6366f1",
+         "icon": "folder", "created_at": "2026-01-01T00:00:00", "order": 0},
+        {"id": "bbb", "name": "Intern", "color": "#6366f1",
+         "icon": "folder", "created_at": "2026-01-01T00:00:00", "order": 1},
+    ]}, indent=2), encoding="utf-8")
+    return path
+
+
+class CorruptFoldersTests(unittest.TestCase):
+    def test_corrupt_folders_json_is_quarantined_not_silently_emptied(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "folders.json"
+            path.write_text('{"folders": [{"id": "aaa", "name": "Kun')  # torn write
+            corrupt_bytes = path.read_bytes()
+
+            mgr = FoldersManager(Path(tmp_dir))
+
+            # Unparseable content can't be recovered by retrying, so we start
+            # from empty — but the original is preserved next to it.
+            self.assertEqual(mgr.list_folders(), [])
+            backup = Path(tmp_dir) / "folders.json.corrupt"
+            self.assertTrue(backup.exists())
+            self.assertEqual(backup.read_bytes(), corrupt_bytes)
+
+            # Recovery works: a new folder lands in a valid file, and the
+            # quarantined copy is still there for manual rescue.
+            created = mgr.create_folder("Neu")
+            self.assertIsNotNone(created)
+            on_disk = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual([f["name"] for f in on_disk["folders"]], ["Neu"])
+            self.assertEqual(backup.read_bytes(), corrupt_bytes)
+
+    def test_failed_quarantine_refuses_to_recover(self):
+        """The .corrupt copy is the only surviving version of the folder list,
+        so recovery must not be reachable when the backup didn't happen — the
+        next mutation would write the empty list straight over the original."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "folders.json"
+            path.write_text('{"folders": [{"id": "aaa", "name": "Kun')  # torn write
+            corrupt_bytes = path.read_bytes()
+
+            with patch("src.folders.shutil.copy2", side_effect=OSError("disk full")):
+                with self.assertRaises(OSError):
+                    FoldersManager(Path(tmp_dir))
+
+            # The corrupt-but-hand-recoverable original is still there, and no
+            # empty list was persisted over it.
+            self.assertTrue(path.exists())
+            self.assertEqual(path.read_bytes(), corrupt_bytes)
+
+    def test_wrong_shape_json_takes_the_corrupt_path(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "folders.json"
+            path.write_text("null", encoding="utf-8")  # parses, but unusable
+
+            mgr = FoldersManager(Path(tmp_dir))
+
+            self.assertEqual(mgr.list_folders(), [])
+            self.assertTrue((Path(tmp_dir) / "folders.json.corrupt").exists())
+
+
+class UnreadableFoldersTests(unittest.TestCase):
+    """A read failure that is NOT invalid content must never degrade to an
+    empty list that a later save persists — the actual data-loss bug."""
+
+    def test_unreadable_file_raises_instead_of_emptying(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _seed(tmp_dir)
+            before = path.read_bytes()
+
+            with patch("src.folders.open", side_effect=PermissionError("denied")):
+                with self.assertRaises(PermissionError):
+                    FoldersManager(Path(tmp_dir))
+
+            # Nothing was written, nothing was quarantined: the user's real
+            # folders are still on disk, and the failure was loud.
+            self.assertEqual(path.read_bytes(), before)
+            self.assertFalse((Path(tmp_dir) / "folders.json.corrupt").exists())
+
+    def test_read_failure_during_a_mutation_does_not_persist_an_empty_list(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _seed(tmp_dir)
+            mgr = FoldersManager(Path(tmp_dir))
+            before = path.read_bytes()
+
+            # The re-read inside create_folder fails. The old code would have
+            # appended to an empty list and written it over the two folders.
+            with patch("src.folders.open", side_effect=OSError("I/O error")):
+                with self.assertRaises(OSError):
+                    mgr.create_folder("Neu")
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(
+                [f["name"] for f in json.loads(path.read_text())["folders"]],
+                ["Kunden", "Intern"],
+            )
+
+
+class FoldersSaveTests(unittest.TestCase):
+    def test_failed_save_preserves_previous_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _seed(tmp_dir)
+            mgr = FoldersManager(Path(tmp_dir))
+            before = path.read_text(encoding="utf-8")
+
+            with patch("src.config.os.fsync", side_effect=OSError("disk full")):
+                self.assertIsNone(mgr.create_folder("Neu"))
+
+            self.assertEqual(path.read_text(encoding="utf-8"), before)
+            leftovers = [p for p in Path(tmp_dir).iterdir() if p.suffix == ".tmp"]
+            self.assertEqual(leftovers, [])
+
+    def test_concurrent_editors_both_survive(self):
+        """Each CLI operation is its own subprocess, so two managers can hold
+        the same baseline. Re-reading under the lock is what keeps the second
+        write from dropping the first one's folder."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "folders.json"
+            first = FoldersManager(Path(tmp_dir))
+            second = FoldersManager(Path(tmp_dir))  # loaded the same baseline
+
+            self.assertIsNotNone(first.create_folder("Alpha"))
+            self.assertIsNotNone(second.create_folder("Beta"))
+
+            names = [f["name"] for f in json.loads(path.read_text())["folders"]]
+            self.assertEqual(sorted(names), ["Alpha", "Beta"])
+
+    def test_rename_of_unknown_id_reports_failure_without_writing(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _seed(tmp_dir)
+            mgr = FoldersManager(Path(tmp_dir))
+            before = path.read_text(encoding="utf-8")
+
+            self.assertFalse(mgr.rename_folder("nope", "Neuer Name"))
+            self.assertEqual(path.read_text(encoding="utf-8"), before)
+
+            self.assertTrue(mgr.rename_folder("aaa", "Neuer Name"))
+            on_disk = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(on_disk["folders"][0]["name"], "Neuer Name")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`config.json` has had a proper durability story for a while: an atomic writer (tempfile + `fsync` + `os.replace`, with a Windows retry), a cross-process filelock, a re-read-before-mutate merge, and quarantine-on-corrupt. The two other files a user owns never got any of it.

## What was wrong

**1. The summary Markdown - the primary user artifact - was not crash-safe.**
`simple_recorder.py` imports `_atomic_write_json` and uses it for the `.json`, while writing the `.md` with a plain `Path.write_text()`. In one function the two sit nine lines apart: the `.json` is protected, the `.md` beside it is not. A crash or a full disk mid-write leaves a truncated note.

**2. A corrupt `folders.json` silently destroyed the user's folders.**
`_load()` caught *any* exception and returned `{"folders": []}`; `_save()` was a plain `open(...,"w")` + `json.dump` with no atomic replace and no lock. The next `create_folder()` then wrote that empty list over the original.

Reproduced end-to-end through the real CLI with an isolated `STENOAI_USER_DATA_DIR`, using an unreadable-but-writable file (`chmod 222`) - read fails, write succeeds:

```
BEFORE  create_folder -> {"success": true, ...}   exit=0
        on disk: ['Neu']                # 'Kunden', 'Intern' gone, reported as success
AFTER   PermissionError                  exit=1
        on disk: ['Kunden', 'Intern']    # preserved, failure is loud
```

## What changed

- **`src/config.py`** - the durable-replace core is factored out as `_atomic_write`; `_atomic_write_json` and a new `_atomic_write_text` are thin wrappers, so there is one copy of the tempfile/fsync/replace/Windows-retry mechanics.
- **`simple_recorder.py`** - all eight `.md` write sites go through `_atomic_write_text`.
- **`src/folders.py`** - writes are atomic and run under the same filelock `config.json` uses, re-reading inside the lock. `_load()` now distinguishes failure kinds: provably invalid content (`JSONDecodeError`, or a root that isn't a dict with a `folders` list) is quarantined to `folders.json.corrupt` and starts empty; **every other error propagates** instead of degrading into an empty list that the next mutation persists.

## Three things worth a reviewer's attention

1. **Note file mode changes 0644 -> 0600.** `NamedTemporaryFile` creates at 0600, so a note becomes owner-only the first time it is rewritten (existing notes keep 0644 until touched). `config.json` already behaves this way and this seems right for a local-first app, but it is an observable change. Say the word and I will preserve 0644 for the `.md` path specifically.
2. **Missing parent directories are now created** by the shared writer, where a plain `write_text` would have raised. More robust, but it can mask a misconfigured storage path.
3. **The `filelock.Timeout` fallback deliberately drops mutual exclusion** so a stuck lock can never block folder edits outright, matching `Config._save()`. The write stays atomic and stays built on a fresh read, so the file cannot tear; the accepted cost is that two editors racing past that point can lose one update. Stated plainly in the code comment rather than glossed.

## Verification

- `OLLAMA_HOST=http://127.0.0.1:1 python -m unittest discover tests` -> **507 tests, OK (skipped=8)**
- `ruff check` on the touched files -> 16 findings, all pre-existing (identical count measured against the `origin/main` versions of the same files; the two new test files add none)
- New tests verified red-green: they fail against the pre-fix code (5 failures, 1 error) and pass after
- The end-to-end CLI repro above, re-run after the fix

## Deliberately out of scope

`.md` and `.json` are still not *jointly* transactional (noted in the docstring). Three further non-atomic writes of the same class are left alone and flagged rather than fixed: `add_meeting_to_folder`, `remove_meeting_from_folder`, and the JSON branch in `regen_title`. No dead-code cleanup rode along.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make summary Markdown and `folders.json` crash-safe with atomic writes, safe reads, and a file lock to prevent truncated notes and silent folder loss.

- **Bug Fixes**
  - All `.md` writes now use `_atomic_write_text` (temp file + `fsync` + `os.replace` with Windows retry).
  - `folders.json` load: invalid content is quarantined to `folders.json.corrupt`; other read errors propagate.
  - `folders.json` save: atomic replace under a cross-process lock with a fresh re-read; timeout falls back without the lock.
  - Added tests for Markdown durability and folder persistence.

- **Refactors**
  - Centralized durable write logic in `_atomic_write`, shared by `_atomic_write_json` and `_atomic_write_text`.
  - Missing parent directories are auto-created; rewritten notes may adopt 0600 permissions.

<sup>Written for commit 59d7cb775eb25e442d9bf21dcc1f494d1ad4fee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

