### PR TITLE
fix(analytics): classify summarization STREAM_ERROR reasons

### DIFF
--- a/app/analytics-helpers.js
+++ b/app/analytics-helpers.js
@@ -140,13 +140,37 @@ function classifyErrorReason(error) {
 // Bedrock's raw response body), whose text is unpredictable and can echo
 // request content or infra details -- those simply won't match any pattern
 // below and correctly fall through to 'unknown', same as classifyErrorReason.
+//
+// The connection-refused half of ollama_not_running and the
+// insufficient_memory branch match text that ORIGINATES from the Ollama
+// server / the underlying httpx client on a bare re-raise, not a literal
+// authored in summarizer.py -- unlike every other branch here, those two
+// are exempt from the drift-guard test in analytics-helpers.test.js (there
+// is no summarizer.py string for them to grep). "Connection refused"/
+// "ConnectError" mirrors the same detection already used for the
+// remote-Ollama status check in simple_recorder.py.
 function classifySummarizationStreamError(message) {
   const msg = String(message || '');
   if (/Failed to start Ollama service/i.test(msg)) return 'ollama_not_running';
+  // A stream can die mid-generation even after the pre-flight readiness
+  // check in _ensure_ollama_ready already passed (Ollama killed/crashed
+  // during generation) -- functionally the same "Ollama isn't there" case.
+  if (/Connection refused|ConnectError|ECONNREFUSED/i.test(msg)) return 'ollama_not_running';
   if (/Failed to ensure model .* is available|could not find model/i.test(msg)) return 'model_unavailable';
+  // Ollama's own server error when a model doesn't fit in available RAM,
+  // e.g. "model requires more system memory (10.5 GiB) than is available
+  // (8.0 GiB)" -- distinct from model_unavailable (the model IS installed).
+  if (/requires more system memory/i.test(msg)) return 'insufficient_memory';
   if (/too long to summarize even after chunking/i.test(msg)) return 'context_overflow';
-  if (/returned empty result|returned an empty result after retry|returned empty response|returned an empty (summary|report)/i.test(msg)) return 'empty_summary';
-  if (/rejected the (request|api key)/i.test(msg)) return 'auth_expired';
+  // Deliberately matches just "returned (an) empty result/response/summary/
+  // report" with no trailing anchor (e.g. NOT "...after retry") -- anchoring
+  // to what follows would make this brittle to a copy-edit of the rest of
+  // the sentence, same drift risk the guard test below exists to catch.
+  if (/returned (an )?empty result|returned empty response|returned an empty (summary|report)/i.test(msg)) return 'empty_summary';
+  // Neutral name (not auth_expired): the adapter's 401/403 really is a
+  // session expiry, but Bedrock's 403 is a missing IAM permission -- a
+  // rejected credential either way, not necessarily an expired one.
+  if (/rejected the (request|api key)/i.test(msg)) return 'auth_rejected';
   if (/is not configured/i.test(msg)) return 'not_configured';
   if (/is not installed|package is required/i.test(msg)) return 'dependency_missing';
   if (/failed after all retries|HTTP \d+/i.test(msg)) return 'api_error';

--- a/app/analytics-helpers.js
+++ b/app/analytics-helpers.js
@@ -131,6 +131,28 @@ function classifyErrorReason(error) {
   return 'unknown';
 }
 
+// Coarse, PII-free classification of the STREAM_ERROR:<message> line
+// simple_recorder.py's process_streaming() prints on a summarization
+// failure (see src/summarizer.py's raise sites). Fixed enum output only --
+// NEVER forwards the raw message to PostHog. Most raise sites in
+// summarizer.py are static/templated text (safe to pattern-match by name),
+// but several are bare re-raises of third-party SDK/HTTP exceptions (and
+// Bedrock's raw response body), whose text is unpredictable and can echo
+// request content or infra details -- those simply won't match any pattern
+// below and correctly fall through to 'unknown', same as classifyErrorReason.
+function classifySummarizationStreamError(message) {
+  const msg = String(message || '');
+  if (/Failed to start Ollama service/i.test(msg)) return 'ollama_not_running';
+  if (/Failed to ensure model .* is available|could not find model/i.test(msg)) return 'model_unavailable';
+  if (/too long to summarize even after chunking/i.test(msg)) return 'context_overflow';
+  if (/returned empty result|returned an empty result after retry|returned empty response|returned an empty (summary|report)/i.test(msg)) return 'empty_summary';
+  if (/rejected the (request|api key)/i.test(msg)) return 'auth_expired';
+  if (/is not configured/i.test(msg)) return 'not_configured';
+  if (/is not installed|package is required/i.test(msg)) return 'dependency_missing';
+  if (/failed after all retries|HTTP \d+/i.test(msg)) return 'api_error';
+  return 'unknown';
+}
+
 // This module lives in the app/ directory alongside main.js and is always
 // required from there via a relative path, so __dirname here is identical to
 // main.js's own -- the app's install root, whether that's an asar-packaged
@@ -368,6 +390,7 @@ module.exports = {
   sanitizeTrackProperties,
   calendarMeetingProvider,
   classifyErrorReason,
+  classifySummarizationStreamError,
   captureSanitizedException,
   redactLocalPaths,
   sanitizeModelForAnalytics,

--- a/app/analytics-helpers.test.js
+++ b/app/analytics-helpers.test.js
@@ -11,6 +11,7 @@ const {
   sanitizeTrackProperties,
   calendarMeetingProvider,
   classifyErrorReason,
+  classifySummarizationStreamError,
   captureSanitizedException,
   redactLocalPaths,
   sanitizeModelForAnalytics,
@@ -212,6 +213,44 @@ test('classifyErrorReason never leaks the raw message -- fixed enum output only'
   assert.ok(!reason.includes('alice'));
   assert.ok(!reason.includes('jane'));
   assert.strictEqual(reason, 'not_found');
+});
+
+test('classifySummarizationStreamError maps summarizer.py raise-site text to fixed enum values', () => {
+  assert.strictEqual(classifySummarizationStreamError('Failed to start Ollama service'), 'ollama_not_running');
+  assert.strictEqual(classifySummarizationStreamError('Failed to ensure model gemma4:e2b-it-qat is available'), 'model_unavailable');
+  assert.strictEqual(classifySummarizationStreamError("Bedrock could not find model 'foo' in eu-west-2"), 'model_unavailable');
+  assert.strictEqual(
+    classifySummarizationStreamError('Meeting is too long to summarize even after chunking — try a model with a larger context window.'),
+    'context_overflow',
+  );
+  assert.strictEqual(classifySummarizationStreamError('Reduce step returned empty result'), 'empty_summary');
+  assert.strictEqual(
+    classifySummarizationStreamError('Chunk 2/5 returned an empty result after retry — Ollama may have run out of context or memory.'),
+    'empty_summary',
+  );
+  assert.strictEqual(classifySummarizationStreamError('Anthropic returned empty response'), 'empty_summary');
+  assert.strictEqual(
+    classifySummarizationStreamError('Org adapter rejected the request (401). Your session may have expired — re-sign in to your organisation in Settings.'),
+    'auth_expired',
+  );
+  assert.strictEqual(classifySummarizationStreamError('Cloud API key is not configured. Set it in Settings > AI.'), 'not_configured');
+  assert.strictEqual(classifySummarizationStreamError('Remote Ollama URL is not configured. Set it in Settings > AI.'), 'not_configured');
+  assert.strictEqual(classifySummarizationStreamError('Ollama is not installed. Please install ollama-python.'), 'dependency_missing');
+  assert.strictEqual(classifySummarizationStreamError('anthropic package is required for Anthropic cloud mode. pip install anthropic'), 'dependency_missing');
+  assert.strictEqual(classifySummarizationStreamError('OpenAI chat failed after all retries'), 'api_error');
+  assert.strictEqual(classifySummarizationStreamError('Bedrock HTTP 500: Internal Server Error'), 'api_error');
+  assert.strictEqual(classifySummarizationStreamError('something totally unexpected'), 'unknown');
+  assert.strictEqual(classifySummarizationStreamError(), 'unknown');
+});
+
+test('classifySummarizationStreamError never leaks raw third-party/opaque text -- unmatched messages fall to unknown', () => {
+  // A bare re-raise of an underlying SDK/HTTP exception (e.g. OpenAI/Bedrock)
+  // can carry unpredictable, potentially sensitive text -- this must never be
+  // classified into a false-confidence bucket, only the safe 'unknown' default.
+  const opaque = 'RateLimitError: You exceeded your current quota, please check your plan and billing details for account acct_1234567890.';
+  const reason = classifySummarizationStreamError(opaque);
+  assert.strictEqual(reason, 'unknown');
+  assert.ok(!reason.includes('acct_'));
 });
 
 test('sanitizeErrorForCrashReport replaces the message with a fixed enum, never the raw text', () => {

--- a/app/analytics-helpers.test.js
+++ b/app/analytics-helpers.test.js
@@ -2,6 +2,8 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
   textLengthBucket,
   durationBucket,
@@ -231,7 +233,11 @@ test('classifySummarizationStreamError maps summarizer.py raise-site text to fix
   assert.strictEqual(classifySummarizationStreamError('Anthropic returned empty response'), 'empty_summary');
   assert.strictEqual(
     classifySummarizationStreamError('Org adapter rejected the request (401). Your session may have expired — re-sign in to your organisation in Settings.'),
-    'auth_expired',
+    'auth_rejected',
+  );
+  assert.strictEqual(
+    classifySummarizationStreamError("Bedrock rejected the API key (403). Verify the key has bedrock:InvokeModel access in eu-west-2."),
+    'auth_rejected',
   );
   assert.strictEqual(classifySummarizationStreamError('Cloud API key is not configured. Set it in Settings > AI.'), 'not_configured');
   assert.strictEqual(classifySummarizationStreamError('Remote Ollama URL is not configured. Set it in Settings > AI.'), 'not_configured');
@@ -243,6 +249,25 @@ test('classifySummarizationStreamError maps summarizer.py raise-site text to fix
   assert.strictEqual(classifySummarizationStreamError(), 'unknown');
 });
 
+test('classifySummarizationStreamError catches Ollama dying mid-stream and running out of memory, not just the pre-flight check', () => {
+  // These two originate from the Ollama server / a bare-re-raised httpx
+  // exception (see _stream_direct / _chat_no_think's bare `raise original`),
+  // not a literal in summarizer.py -- the 92.5%-of-users-are-local-Ollama
+  // case this classifier most needs to get right.
+  assert.strictEqual(
+    classifySummarizationStreamError("Ollama streaming failed: [Errno 61] Connection refused"),
+    'ollama_not_running',
+  );
+  assert.strictEqual(
+    classifySummarizationStreamError('httpx.ConnectError: All connection attempts failed'),
+    'ollama_not_running',
+  );
+  assert.strictEqual(
+    classifySummarizationStreamError('model requires more system memory (10.5 GiB) than is available (8.0 GiB)'),
+    'insufficient_memory',
+  );
+});
+
 test('classifySummarizationStreamError never leaks raw third-party/opaque text -- unmatched messages fall to unknown', () => {
   // A bare re-raise of an underlying SDK/HTTP exception (e.g. OpenAI/Bedrock)
   // can carry unpredictable, potentially sensitive text -- this must never be
@@ -251,6 +276,42 @@ test('classifySummarizationStreamError never leaks raw third-party/opaque text -
   const reason = classifySummarizationStreamError(opaque);
   assert.strictEqual(reason, 'unknown');
   assert.ok(!reason.includes('acct_'));
+});
+
+test('classifySummarizationStreamError patterns stay in sync with the literal strings in src/summarizer.py (drift guard)', () => {
+  // Every substring below is a literal (or fixed portion of an f-string
+  // template) a classifySummarizationStreamError branch depends on matching.
+  // If a future edit to summarizer.py rewords one of these messages, this
+  // test fails loudly instead of the corresponding bucket silently
+  // degrading to 'unknown' with no signal anywhere. Excludes the
+  // connection-refused half of ollama_not_running and insufficient_memory,
+  // which match text from the Ollama server / httpx client, not a literal
+  // authored in this file (see the comment above classifySummarizationStreamError).
+  const summarizerSrc = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'summarizer.py'),
+    'utf8',
+  );
+  const expectedSubstrings = [
+    'Failed to start Ollama service',
+    'Failed to ensure model',
+    'could not find model',
+    'too long to summarize even after chunking',
+    'returned empty result',
+    'returned an empty result',
+    'returned empty response',
+    'rejected the request',
+    'rejected the API key',
+    'is not configured',
+    'is not installed',
+    'package is required',
+    'failed after all retries',
+  ];
+  for (const substr of expectedSubstrings) {
+    assert.ok(
+      summarizerSrc.includes(substr),
+      `src/summarizer.py no longer contains ${JSON.stringify(substr)} -- update classifySummarizationStreamError's matching pattern to match`,
+    );
+  }
 });
 
 test('sanitizeErrorForCrashReport replaces the message with a fixed enum, never the raw text', () => {

--- a/app/main.js
+++ b/app/main.js
@@ -84,6 +84,7 @@ const {
   sanitizeTrackProperties,
   calendarMeetingProvider,
   classifyErrorReason,
+  classifySummarizationStreamError,
   captureSanitizedException,
   sanitizeModelForAnalytics,
   summarizeCalendarSnapshot,
@@ -5217,6 +5218,10 @@ async function processNextInQueue() {
   // so the catch block below can still read it after the inner Promise
   // executor's scope has closed.
   let processingStage = 'transcription';
+  // Captured from a STREAM_ERROR: line during the summarization stage, so the
+  // catch block below can classify the real failure reason for error_occurred
+  // instead of only seeing "exited with code N" (see classifySummarizationStreamError).
+  let summarizationStreamError = null;
   // Read once per job (not per marker) -- engine/model/language/provider
   // don't change mid-job, and this avoids a repeated config.json read on
   // every stdout line.
@@ -5334,6 +5339,9 @@ async function processNextInQueue() {
               model: transcriptionCtx.model,
               language: transcriptionCtx.language,
             });
+          } else if (line.startsWith('STREAM_ERROR:')) {
+            summarizationStreamError = line.slice('STREAM_ERROR:'.length).trim();
+            forwardDiagnosticStdout(line, 'process-streaming');
           } else if (line.startsWith('PROGRESS:')) {
             if (mainWindow && !mainWindow.isDestroyed()) {
               // Instant stop stamps the (deterministic) summaryFile so the
@@ -5447,6 +5455,13 @@ async function processNextInQueue() {
       error_type: 'processing_queue',
       stage: processingStage,
       reason: classifyErrorReason(error),
+      // A STREAM_ERROR: line during the summarization stage carries the real
+      // failure reason (Ollama down, model missing, empty reduce result, ...)
+      // that classifyErrorReason can't see -- it only looked at stderr, which
+      // otherwise collapses every summarization crash into subprocess_exit_1.
+      ...(processingStage === 'summarization' && summarizationStreamError
+        ? { summarization_reason: classifySummarizationStreamError(summarizationStreamError) }
+        : {}),
     });
 
     // A processing crash (e.g. a metal::malloc OOM that SIGABRTs the

--- a/app/main.js
+++ b/app/main.js
@@ -5340,7 +5340,15 @@ async function processNextInQueue() {
               language: transcriptionCtx.language,
             });
           } else if (line.startsWith('STREAM_ERROR:')) {
-            summarizationStreamError = line.slice('STREAM_ERROR:'.length).trim();
+            // Guarded on the WRITE (not just read at trackEvent time): today
+            // process_streaming only ever prints STREAM_ERROR during the
+            // summarization stage, but if that ever changed, an unguarded
+            // capture here would let a transcription-stage STREAM_ERROR
+            // masquerade as (or be overwritten by) a later summarization
+            // failure that dies without its own message.
+            if (processingStage === 'summarization') {
+              summarizationStreamError = line.slice('STREAM_ERROR:'.length).trim();
+            }
             forwardDiagnosticStdout(line, 'process-streaming');
           } else if (line.startsWith('PROGRESS:')) {
             if (mainWindow && !mainWindow.isDestroyed()) {


### PR DESCRIPTION
## Description

Summarization failures accounted for 86% of tracked `error_occurred` events, but all collapsed into an uninformative `subprocess_exit_1` -- the real failure reason (Ollama not running, model missing, empty map-reduce result, etc.), printed by the Python backend as `STREAM_ERROR:<message>` on stdout, was captured for the local debug log but never reached analytics. This adds `classifySummarizationStreamError()` to bucket that message into a small, fixed, PII-free enum and attaches it as a new `summarization_reason` property on `error_occurred` when the failure happens during the summarization stage. No user-facing behavior changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Unit tests added/passing (`node --test app/analytics-helpers.test.js`, `node --test app/*.test.js` -- 279/279 pass)
- [ ] Tested locally with `npm start`
- [ ] Verified CLI functionality works
- [ ] Tested on macOS
- [x] No breaking changes to existing functionality (analytics-only change)

## Additional Notes

Fixes https://github.com/ruzin/stenoai/issues/450. Only wires up the `processing_queue`/summarization path, which drives the cited 86% figure -- `reprocess`/`generate-report`/chat streaming don't fire `error_occurred` at all today, which is a separate, unrelated instrumentation gap left out of scope here. Root-causing which bucket actually dominates is the issue's own stated follow-up, pending real PostHog data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies summarization `STREAM_ERROR` messages into a small PII-safe enum and adds `summarization_reason` to `error_occurred` so analytics show real failure causes instead of an opaque `subprocess_exit_1`. No user-facing changes.

- **Bug Fixes**
  - Capture `STREAM_ERROR:` during summarization and map via `classifySummarizationStreamError()`; guard the write so only the summarization stage is recorded.
  - Extend classification to mid-stream Ollama failures (`Connection refused`/`ConnectError`) and out-of-memory model loads (`insufficient_memory`).
  - Add `summarization_reason` to `error_occurred` only for the summarization stage.
  - Buckets: `ollama_not_running`, `model_unavailable`, `insufficient_memory`, `context_overflow`, `empty_summary`, `auth_rejected`, `not_configured`, `dependency_missing`, `api_error`, `unknown` (never forwards raw text).

- **Tests**
  - Added unit tests plus a drift-guard that asserts classifier patterns match `src/summarizer.py` strings.

<sup>Written for commit f8b0cd661c351c4893e3348cb4457f0014ec08ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

