### PR TITLE
perf(live): keep the live transcript's render cost flat, and measure it

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: app
         run: npm run build:renderer
 
-      # `@perf` excluded — a measurement harness, not a release gate (see
+      # `@perf` excluded - a measurement harness, not a release gate (see
       # e2e.yml for the same exclusion).
       - name: Run T1 under xvfb
         working-directory: app

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -48,9 +48,11 @@ jobs:
         working-directory: app
         run: npm run build:renderer
 
+      # `@perf` excluded — a measurement harness, not a release gate (see
+      # e2e.yml for the same exclusion).
       - name: Run T1 under xvfb
         working-directory: app
-        run: xvfb-run -a npm run test:e2e -- --project=t1
+        run: xvfb-run -a npm run test:e2e -- --project=t1 --grep-invert @perf
 
   build-macos:
     needs: gate-smoke

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,9 +88,13 @@ jobs:
         run: npm run build:renderer
 
       # Electron is headless-hostile on Linux — run under a virtual framebuffer.
+      # `@perf` is excluded: it is a measurement harness, not a gate, and
+      # wall-clock work on a shared runner is not a number to block a PR on.
+      # Run it by hand before and after a change to the live transcript
+      # rendering (`--project=t1 --grep @perf`).
       - name: Run T1 under xvfb
         working-directory: app
-        run: xvfb-run -a npm run test:e2e -- --project=t1
+        run: xvfb-run -a npm run test:e2e -- --project=t1 --grep-invert @perf
 
       - name: Upload report on failure
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,17 +70,17 @@ overrides luffy's test-level defaults); the QA review lens checks for it.
     `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
     active engine's model **skips** it (loudly) rather than failing.
   - **`@perf` (a T1 spec)**: `live-transcript-perf.t1` is a measurement harness, not a
-    gate — it drives paced synthetic partials into the live transcript panel and reports
+    gate - it drives paced synthetic partials into the live transcript panel and reports
     per-tick script/style/layout cost (CDP `Performance.getMetrics`), retained heap after a
     forced GC, and DOM node count against a growing segment list. CI excludes it
     (`--grep-invert @perf`) because wall-clock work on a shared runner is not something to
     block a PR on. Run it before **and** after any change to live-transcript rendering:
-    `cd app && npm run test:e2e -- --project=t1 --grep @perf`. Pace matters — fired
+    `cd app && npm run test:e2e -- --project=t1 --grep @perf`. Pace matters - fired
     back-to-back the ticks get batched into one React render and the measurement silently
     collapses; the harness paces one per animation frame and counts DOM writes to prove it.
   - **Current specs:** `org-lock.t1`, `shared-notes-policy.t1`, `live-transcript-lanes.t1`
     (the live panel's rendering contract: a partial is replaced in place per speaker, a
-    final retires it, a late final sorts into place, and the Resumed divider — driven
+    final retires it, a late final sorts into place, and the Resumed divider - driven
     through the real `live-transcript-chunk` channel via `e2e/fixtures/live-transcript.ts`),
     `org-lock-lifecycle.t2`,
     `config-corruption.t2`, the core-loop trio `recording-lifecycle.t2` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,20 @@ overrides luffy's test-level defaults); the QA review lens checks for it.
     out: `--grep @pipeline` runs it (CI's `t2-pipeline-macos` job caches a whisper model),
     `--grep-invert @pipeline` keeps the other T2 specs model-free. A dev machine without the
     active engine's model **skips** it (loudly) rather than failing.
-  - **Current specs:** `org-lock.t1`, `shared-notes-policy.t1`, `org-lock-lifecycle.t2`,
+  - **`@perf` (a T1 spec)**: `live-transcript-perf.t1` is a measurement harness, not a
+    gate — it drives paced synthetic partials into the live transcript panel and reports
+    per-tick script/style/layout cost (CDP `Performance.getMetrics`), retained heap after a
+    forced GC, and DOM node count against a growing segment list. CI excludes it
+    (`--grep-invert @perf`) because wall-clock work on a shared runner is not something to
+    block a PR on. Run it before **and** after any change to live-transcript rendering:
+    `cd app && npm run test:e2e -- --project=t1 --grep @perf`. Pace matters — fired
+    back-to-back the ticks get batched into one React render and the measurement silently
+    collapses; the harness paces one per animation frame and counts DOM writes to prove it.
+  - **Current specs:** `org-lock.t1`, `shared-notes-policy.t1`, `live-transcript-lanes.t1`
+    (the live panel's rendering contract: a partial is replaced in place per speaker, a
+    final retires it, a late final sorts into place, and the Resumed divider — driven
+    through the real `live-transcript-chunk` channel via `e2e/fixtures/live-transcript.ts`),
+    `org-lock-lifecycle.t2`,
     `config-corruption.t2`, the core-loop trio `recording-lifecycle.t2` /
     `meetings-crud.t2` / `folders-crud.t2`, the config trio `settings-roundtrip.t2` /
     `ai-provider.t2` / `model-management.t2`, and the chat/org pair `chat-sessions.t2`

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -143,6 +143,28 @@ const seededMeeting = () =>
     ? { ...SEED_MEETING, reports: [SEED_REPORT], active_report: seedActiveReport }
     : SEED_MEETING;
 
+/**
+ * Carried-over segments for the resume/continue case, keyed off
+ * STENOAI_E2E_SEED_PRIOR_SEGMENTS: `1` is one earlier recording, `twice` is a
+ * note continued a second time - two recordings' worth, each numbering its
+ * segments from its own start, which is what produces repeated (start, speaker)
+ * pairs in a single carried-over list.
+ */
+function seedPriorSegments(rec) {
+  const mode = process.env.STENOAI_E2E_SEED_PRIOR_SEGMENTS;
+  if (!mode || !(rec.active || rec.processing)) return [];
+  const first = [
+    { text: 'earlier bit one', start: 3, end: 5, isFinal: true, speaker: 'You' },
+    { text: 'earlier bit two', start: 6, end: 8, isFinal: true, speaker: 'Others' },
+  ];
+  if (mode !== 'twice') return first;
+  return [
+    ...first,
+    { text: 'second session bit one', start: 3, end: 5, isFinal: true, speaker: 'You' },
+    { text: 'second session bit two', start: 6, end: 8, isFinal: true, speaker: 'Others' },
+  ];
+}
+
 function install({ ipcMain }) {
   // In-memory stand-in for the org session + provider config that the real
   // handlers persist to disk. Mutated by the org-login / org-logout / set-ai
@@ -285,18 +307,16 @@ function install({ ipcMain }) {
     // the ASR sidecar (a model) — unreachable in T1 — so we seed it here. With
     // STENOAI_E2E_SEED_PRIOR_SEGMENTS=1 it returns carried-over priorSegments
     // (the resume/continue case) so the generate-notes-bar T1 can assert the
-    // live bar shows earlier speech instead of starting blank.
+    // live bar shows earlier speech instead of starting blank. `=twice` seeds
+    // the note that has been continued a second time: main.js prepends the
+    // existing priors on every continue (main.js, `carryPrior`), and each
+    // recording's `start` counts from zero again, so the carried-over text
+    // legitimately contains repeated offsets for the same speaker.
     'get-live-transcript-state': async () => ({
       success: true,
       sessionName: rec.active || rec.processing ? rec.sessionName : null,
       segments: [],
-      priorSegments:
-        process.env.STENOAI_E2E_SEED_PRIOR_SEGMENTS === '1' && (rec.active || rec.processing)
-          ? [
-              { text: 'earlier bit one', start: 3, end: 5, isFinal: true, speaker: 'You' },
-              { text: 'earlier bit two', start: 6, end: 8, isFinal: true, speaker: 'Others' },
-            ]
-          : [],
+      priorSegments: seedPriorSegments(rec),
       ready: true,
       error: null,
     }),

--- a/app/renderer/src/components/LiveDock.tsx
+++ b/app/renderer/src/components/LiveDock.tsx
@@ -3,7 +3,7 @@ import { ChevronUp, Play, Square } from 'lucide-react';
 import { AudioWave } from '@/components/AudioWave';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { useRecording } from '@/hooks/useRecording';
-import { useLiveTranscript } from '@/hooks/useLiveTranscript';
+import { useLiveTranscriptStatus } from '@/hooks/useLiveTranscript';
 import { useLiveTranscriptOpen } from '@/hooks/liveTranscriptOpenStore';
 import { useLiveTranscriptAvailable } from '@/hooks/useModels';
 
@@ -37,7 +37,11 @@ export function LiveDock() {
   // Gated to Parakeet via `liveAvailable` — Whisper never spawns the live
   // sidecar, so its status would sit at 'loading' forever. Only meaningful
   // while actively recording.
-  const live = useLiveTranscript(liveAvailable ? recording.sessionName : null);
+  //
+  // Status-only subscription on purpose: the pill is mounted for the entire
+  // meeting, and the full hook would keep a second complete copy of every
+  // segment just to decide whether to show one label.
+  const live = useLiveTranscriptStatus(liveAvailable ? recording.sessionName : null);
   const loadingModel = isRecording && live.status === 'loading';
   // Delay the label by ~500ms so a warm-cache load (the common case after
   // the offline-loading fix) goes straight to the timer with no

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -46,7 +46,8 @@ export function LiveTranscriptBar() {
   const isRecording = recording.status === 'recording';
   const stopped = !paused && !isRecording;
 
-  const { status, segments, priorSegments, error, slow } = useLiveTranscript(sessionName);
+  const { status, segments, finals, partials, priorSegments, error, slow } =
+    useLiveTranscript(sessionName);
 
   // On a resume/continue, prior finalised segments render before the live
   // tail so the bar shows earlier speech instead of starting blank. Merge for
@@ -68,6 +69,11 @@ export function LiveTranscriptBar() {
   // trailing text rather than just length so a partial that updates in
   // place (same array length, different last text) still triggers a scroll.
   //
+  // Deferred to the next animation frame: reading scrollHeight in the effect
+  // body forces a synchronous layout of the whole list in the middle of
+  // React's commit, several times a second, and the list can be thousands of
+  // rows deep in a long meeting. At frame time the layout is due anyway.
+  //
   // Skip the auto-scroll while the user has an active search query — they
   // were browsing past matches and a jump to the new tail would yank the
   // viewport away from what they were reading. They get the new segment
@@ -76,9 +82,26 @@ export function LiveTranscriptBar() {
   const filtering = query.trim().length > 0;
   React.useEffect(() => {
     if (filtering) return;
-    const el = bodyRef.current;
-    if (!el || !open) return;
-    el.scrollTop = el.scrollHeight;
+    if (!open) return;
+    let second = 0;
+    const first = requestAnimationFrame(() => {
+      const el = bodyRef.current;
+      if (!el) return;
+      el.scrollTop = el.scrollHeight;
+      // A row rendered for the first time replaces its reserved intrinsic
+      // height with its real one, which can grow the scroller a few pixels
+      // *after* the assignment above clamped to the old maximum — leaving the
+      // newest line a sliver below the fold. Re-assert on the next frame,
+      // once that layout has settled.
+      second = requestAnimationFrame(() => {
+        const node = bodyRef.current;
+        if (node) node.scrollTop = node.scrollHeight;
+      });
+    });
+    return () => {
+      cancelAnimationFrame(first);
+      if (second) cancelAnimationFrame(second);
+    };
   }, [allSegments.length, tailText, open, filtering]);
 
   const filtered = React.useMemo(() => {
@@ -184,10 +207,12 @@ export function LiveTranscriptBar() {
           <LiveTranscriptBodyState
             status={status}
             error={error}
-            segments={filtered}
+            filtered={filtered}
             filtering={filtering}
+            priorSegments={priorSegments}
+            finals={finals}
+            partials={partials}
             slow={slow}
-            dividerAfter={filtering ? -1 : priorSegments.length}
           />
         </div>
 
@@ -240,25 +265,33 @@ export function LiveTranscriptBar() {
 // Body states
 // ---------------------------------------------------------------------------
 
+type Segments = ReturnType<typeof useLiveTranscript>['segments'];
+
 interface BodyStateProps {
   status: 'idle' | 'loading' | 'streaming' | 'error';
   error: { stage: string; message?: string } | null;
-  segments: ReturnType<typeof useLiveTranscript>['segments'];
+  /** The search result, rendered as one flat list while a query is active. */
+  filtered: Segments;
   filtering: boolean;
+  /** Unfiltered rendering runs in three lanes so that a partial tick — up to
+   *  ~5 a second — only invalidates the in-progress rows instead of every
+   *  finalised row above them. Order on screen: prior, divider, finals,
+   *  partials, which is the order the merged list had. */
+  priorSegments: Segments;
+  finals: Segments;
+  partials: Segments;
   slow: boolean;
-  /** Render an "Earlier" divider before this index (the boundary between
-   *  carried-over prior segments and the current session's live tail). -1
-   *  disables it (e.g. while filtering, where the boundary is meaningless). */
-  dividerAfter: number;
 }
 
 function LiveTranscriptBodyState({
   status,
   error,
-  segments,
+  filtered,
   filtering,
+  priorSegments,
+  finals,
+  partials,
   slow,
-  dividerAfter,
 }: BodyStateProps) {
   if (status === 'error' && error) {
     return (
@@ -280,7 +313,8 @@ function LiveTranscriptBodyState({
       />
     );
   }
-  if (segments.length === 0) {
+  const liveCount = finals.length + partials.length;
+  if (filtering ? filtered.length === 0 : priorSegments.length + liveCount === 0) {
     return (
       <EmptyState
         title={filtering ? 'No matches' : 'Listening…'}
@@ -301,54 +335,102 @@ function LiveTranscriptBodyState({
   // forming without confusing them for finalised text.
   return (
     <ul className="flex flex-col gap-0">
-      {segments.map((seg, i) => {
-        const isYou = seg.speaker !== 'Others';
-        const showDivider = i === dividerAfter && dividerAfter > 0;
-        return (
-          <React.Fragment key={i}>
-            {showDivider && (
-              <li
-                className="flex items-center gap-2 px-1 py-1.5"
-                aria-hidden="true"
-                data-testid="live-transcript-resume-divider"
-              >
-                <span className="h-px flex-1" style={{ background: 'var(--border-subtle)' }} />
-                <span
-                  className="text-[10px] font-medium uppercase tracking-wide"
-                  style={{ color: 'var(--fg-2)' }}
-                >
-                  Resumed
-                </span>
-                <span className="h-px flex-1" style={{ background: 'var(--border-subtle)' }} />
-              </li>
-            )}
+      {filtering ? (
+        <SegmentRows segments={filtered} lane="q" />
+      ) : (
+        <>
+          <SegmentRows segments={priorSegments} lane="e" />
+          {priorSegments.length > 0 && liveCount > 0 && (
             <li
-              className={cn(
-                'flex flex-col gap-0.5 px-1 py-0.5',
-                isYou ? 'items-end' : 'items-start'
-              )}
-              style={{ opacity: seg.isFinal ? 1 : 0.55 }}
+              className="flex items-center gap-2 px-1 py-1.5"
+              aria-hidden="true"
+              data-testid="live-transcript-resume-divider"
             >
-              <span className="px-1.5 text-[10.5px] tabular-nums" style={{ color: 'var(--fg-2)' }}>
-                {fmtTimestamp(seg.start)}
-              </span>
-              <div
-                className={cn(
-                  'max-w-[78%] rounded-2xl px-3 py-1.5 text-sm leading-[1.5]',
-                  isYou
-                    ? 'bg-green-100 text-green-950 rounded-br-md dark:bg-green-900/40 dark:text-green-100'
-                    : 'bg-neutral-200/80 text-neutral-900 rounded-bl-md dark:bg-neutral-700/60 dark:text-neutral-100'
-                )}
+              <span className="h-px flex-1" style={{ background: 'var(--border-subtle)' }} />
+              <span
+                className="text-[10px] font-medium uppercase tracking-wide"
+                style={{ color: 'var(--fg-2)' }}
               >
-                {seg.text}
-              </div>
+                Resumed
+              </span>
+              <span className="h-px flex-1" style={{ background: 'var(--border-subtle)' }} />
             </li>
-          </React.Fragment>
-        );
-      })}
+          )}
+          <SegmentRows segments={finals} lane="f" />
+          <SegmentRows segments={partials} lane="p" />
+        </>
+      )}
     </ul>
   );
 }
+
+/**
+ * One lane of bubbles.
+ *
+ * Memoised on the array identity, which is what makes the lane split pay off:
+ * a partial tick produces a new `partials` array but leaves `finals`
+ * untouched, so React skips the finalised rows entirely instead of
+ * re-creating and diffing every one of them.
+ *
+ * Keys are content-derived rather than positional. A final released late by
+ * the bleed-dedup hold is inserted *into* the sorted lane, and index keys made
+ * React re-bind every row below the insert point; start+speaker is unique per
+ * lane (one utterance per speaker can begin at a given instant) and stable.
+ * The partial lane keys on the speaker alone, so a speaker's growing utterance
+ * updates one node in place, tick after tick.
+ */
+const SegmentRows = React.memo(function SegmentRows({
+  segments,
+  lane,
+}: {
+  segments: Segments;
+  lane: 'e' | 'f' | 'p' | 'q';
+}) {
+  // Granola-style bubbles. Speaker attribution is the mic/system channel the
+  // Python sidecar tagged the segment with: 'Others' renders grey/left,
+  // anything else (explicit 'You' or no attribution) renders green/right —
+  // the same charitable default as TranscriptPanel, since the recording
+  // mechanically belongs to the mic owner. Partials stay dimmed at 0.55
+  // opacity so the user can see them forming without confusing them for
+  // finalised text.
+  return (
+    <>
+      {segments.map((seg, i) => {
+        const isYou = seg.speaker !== 'Others';
+        const key =
+          lane === 'p'
+            ? `p:${isYou ? 'You' : 'Others'}`
+            : lane === 'q'
+              ? `q:${i}`
+              : `${lane}:${seg.start}:${isYou ? 'You' : 'Others'}`;
+        return (
+          <li
+            key={key}
+            className={cn(
+              'live-row flex flex-col gap-0.5 px-1 py-0.5',
+              isYou ? 'items-end' : 'items-start'
+            )}
+            style={{ opacity: seg.isFinal ? 1 : 0.55 }}
+          >
+            <span className="px-1.5 text-[10.5px] tabular-nums" style={{ color: 'var(--fg-2)' }}>
+              {fmtTimestamp(seg.start)}
+            </span>
+            <div
+              className={cn(
+                'max-w-[78%] rounded-2xl px-3 py-1.5 text-sm leading-[1.5]',
+                isYou
+                  ? 'bg-green-100 text-green-950 rounded-br-md dark:bg-green-900/40 dark:text-green-100'
+                  : 'bg-neutral-200/80 text-neutral-900 rounded-bl-md dark:bg-neutral-700/60 dark:text-neutral-100'
+              )}
+            >
+              {seg.text}
+            </div>
+          </li>
+        );
+      })}
+    </>
+  );
+});
 
 function EmptyState({ title, subtitle }: { title: string; subtitle: string }) {
   return (

--- a/app/renderer/src/components/LiveTranscriptBar.tsx
+++ b/app/renderer/src/components/LiveTranscriptBar.tsx
@@ -90,7 +90,7 @@ export function LiveTranscriptBar() {
       el.scrollTop = el.scrollHeight;
       // A row rendered for the first time replaces its reserved intrinsic
       // height with its real one, which can grow the scroller a few pixels
-      // *after* the assignment above clamped to the old maximum — leaving the
+      // *after* the assignment above clamped to the old maximum - leaving the
       // newest line a sliver below the fold. Re-assert on the next frame,
       // once that layout has settled.
       second = requestAnimationFrame(() => {
@@ -273,8 +273,8 @@ interface BodyStateProps {
   /** The search result, rendered as one flat list while a query is active. */
   filtered: Segments;
   filtering: boolean;
-  /** Unfiltered rendering runs in three lanes so that a partial tick — up to
-   *  ~5 a second — only invalidates the in-progress rows instead of every
+  /** Unfiltered rendering runs in three lanes so that a partial tick - up to
+   *  ~5 a second - only invalidates the in-progress rows instead of every
    *  finalised row above them. Order on screen: prior, divider, finals,
    *  partials, which is the order the merged list had. */
   priorSegments: Segments;
@@ -372,12 +372,27 @@ function LiveTranscriptBodyState({
  * untouched, so React skips the finalised rows entirely instead of
  * re-creating and diffing every one of them.
  *
- * Keys are content-derived rather than positional. A final released late by
- * the bleed-dedup hold is inserted *into* the sorted lane, and index keys made
- * React re-bind every row below the insert point; start+speaker is unique per
- * lane (one utterance per speaker can begin at a given instant) and stable.
- * The partial lane keys on the speaker alone, so a speaker's growing utterance
- * updates one node in place, tick after tick.
+ * Keys are content-derived in the lanes that get inserted into. A final
+ * released late by the bleed-dedup hold is inserted *into* the sorted finals
+ * lane, and index keys made React re-bind every row below the insert point;
+ * start+speaker is unique there (one utterance per speaker can begin at a given
+ * instant within one recording) and stable. The partial lane keys on the
+ * speaker alone, so a speaker's growing utterance updates one node in place,
+ * tick after tick.
+ *
+ * The prior lane is the exception and keys on position: it carries the
+ * finalised text of EVERY earlier recording into this note (main.js prepends
+ * the existing priors on each continue), and `start` counts from zero within
+ * each recording - so the same speaker at the same offset in two sessions
+ * would collide. That lane is written once and never reordered, which is
+ * exactly the case an index key is right for.
+ *
+ * The filtered lane keys on position too, and there the index genuinely does
+ * point at a different segment after the query changes. It stays because these
+ * rows hold no state of their own - no input, no focus, no animation - so
+ * reusing a node just means React writes new text into it. Only the
+ * reconciliation is less efficient, and only while someone is typing in the
+ * search box.
  */
 const SegmentRows = React.memo(function SegmentRows({
   segments,
@@ -388,7 +403,7 @@ const SegmentRows = React.memo(function SegmentRows({
 }) {
   // Granola-style bubbles. Speaker attribution is the mic/system channel the
   // Python sidecar tagged the segment with: 'Others' renders grey/left,
-  // anything else (explicit 'You' or no attribution) renders green/right —
+  // anything else (explicit 'You' or no attribution) renders green/right -
   // the same charitable default as TranscriptPanel, since the recording
   // mechanically belongs to the mic owner. Partials stay dimmed at 0.55
   // opacity so the user can see them forming without confusing them for
@@ -400,9 +415,9 @@ const SegmentRows = React.memo(function SegmentRows({
         const key =
           lane === 'p'
             ? `p:${isYou ? 'You' : 'Others'}`
-            : lane === 'q'
-              ? `q:${i}`
-              : `${lane}:${seg.start}:${isYou ? 'You' : 'Others'}`;
+            : lane === 'q' || lane === 'e'
+              ? `${lane}:${i}`
+              : `f:${seg.start}:${isYou ? 'You' : 'Others'}`;
         return (
           <li
             key={key}

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -590,7 +590,7 @@
 
   /* One bubble in the live transcript. The panel is a 200px viewport onto a
      list that grows for the whole meeting, so the great majority of rows are
-     scrolled out of sight — content-visibility lets the browser skip their
+     scrolled out of sight - content-visibility lets the browser skip their
      style, layout and paint while a partial arrives up to ~5x a second.
      `contain-intrinsic-size: auto` reserves a plausible height for a row that
      has never been rendered and remembers the real one afterwards, which keeps

--- a/app/renderer/src/globals.css
+++ b/app/renderer/src/globals.css
@@ -588,6 +588,18 @@
     to   { opacity: 1; transform: translateY(0) scale(1); }
   }
 
+  /* One bubble in the live transcript. The panel is a 200px viewport onto a
+     list that grows for the whole meeting, so the great majority of rows are
+     scrolled out of sight — content-visibility lets the browser skip their
+     style, layout and paint while a partial arrives up to ~5x a second.
+     `contain-intrinsic-size: auto` reserves a plausible height for a row that
+     has never been rendered and remembers the real one afterwards, which keeps
+     the scrollbar and the scroll-to-bottom honest. */
+  .live-row {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 44px;
+  }
+
   /* Not itself clickable — only the copy/minimize buttons inside are, via
      .mv-chat-tool's own hover. No cursor/hover here so the row doesn't imply
      the whole header is a click target. */

--- a/app/renderer/src/hooks/useLiveTranscript.ts
+++ b/app/renderer/src/hooks/useLiveTranscript.ts
@@ -6,7 +6,7 @@ export type LiveTranscriptStatus = 'idle' | 'loading' | 'streaming' | 'error';
 export interface UseLiveTranscriptResult {
   status: LiveTranscriptStatus;
   /** Every segment in render order: finalised first, in-progress partials
-   *  trailing. Kept for search, copy and tail-tracking — rendering uses the
+   *  trailing. Kept for search, copy and tail-tracking - rendering uses the
    *  two lanes below so a partial tick doesn't re-render the finals. */
   segments: LiveSegment[];
   /** Finalised segments of the current session, chronologically sorted. */
@@ -77,7 +77,7 @@ function replacePartial(prev: LiveSegment[], segment: LiveSegment): LiveSegment[
  * Only a same-speaker partial that could plausibly BE the utterance this final
  * closes (started before the final's utterance ended) is dropped. A
  * bleed-delayed final can arrive well after the SAME speaker has already
- * started a newer, unrelated utterance — dropping every same-speaker partial
+ * started a newer, unrelated utterance - dropping every same-speaker partial
  * indiscriminately would clobber that unrelated one until its next tick.
  */
 function retirePartials(prev: LiveSegment[], final: LiveSegment): LiveSegment[] {
@@ -113,7 +113,7 @@ function splitLanes(snapshot: LiveSegment[]): { finals: LiveSegment[]; partials:
  * **Why two lanes.** Partials arrive up to ~5x/s (both channels at the
  * sidecar's 400 ms cadence) while finals arrive a couple of times a minute. Held
  * in one array, every partial produced a new array identity for the whole
- * transcript, so React re-rendered every finalised row — a cost that grew with
+ * transcript, so React re-rendered every finalised row - a cost that grew with
  * meeting length. Split, a partial tick only invalidates the (at most two)
  * in-progress rows.
  *
@@ -293,7 +293,7 @@ export function useLiveTranscriptStatus(sessionName: string | null): {
     });
 
     // Same backfill the full hook does, reduced to the booleans this one
-    // exposes — a pill mounted after the recording started must not sit at
+    // exposes - a pill mounted after the recording started must not sit at
     // "Preparing…" until the next event. Carried-over prior segments count as
     // streaming here exactly as they do there, so a resumed recording reads
     // the same in both.

--- a/app/renderer/src/hooks/useLiveTranscript.ts
+++ b/app/renderer/src/hooks/useLiveTranscript.ts
@@ -5,7 +5,15 @@ export type LiveTranscriptStatus = 'idle' | 'loading' | 'streaming' | 'error';
 
 export interface UseLiveTranscriptResult {
   status: LiveTranscriptStatus;
+  /** Every segment in render order: finalised first, in-progress partials
+   *  trailing. Kept for search, copy and tail-tracking — rendering uses the
+   *  two lanes below so a partial tick doesn't re-render the finals. */
   segments: LiveSegment[];
+  /** Finalised segments of the current session, chronologically sorted. */
+  finals: LiveSegment[];
+  /** The in-progress utterances, at most one per speaker. Replaced ~every
+   *  400 ms per channel while someone is talking. */
+  partials: LiveSegment[];
   /** Finalised segments from the previous recording into this same note,
    *  carried across a resume/continue. Display-only — render these before
    *  `segments` so the live bar shows the earlier speech instead of blank.
@@ -27,43 +35,64 @@ function speakerKey(segment: LiveSegment): 'You' | 'Others' {
 }
 
 /**
- * Insert a LIVE_SEG update into the segment list, maintaining the same
- * invariant main.js keeps on `liveTranscriptState.segments`: chronologically
- * sorted finals first, followed by at most one in-progress partial per
- * speaker trailing at the end.
+ * Insert a finalised segment into the chronologically sorted finals lane.
  *
- * Two independent channels (mic + system) emit interleaved streams, so a
- * naive "replace whatever the last array entry is" would clobber one
- * channel's in-progress partial with the other's the moment they overlap,
- * and a final released late by the live path's bleed-dedup hold (up to
- * PER_SEGMENT_BLEED_WINDOW_S) could land out of chronological order
- * relative to a still-ongoing utterance on the other channel. Splitting
- * finals from trailing partials and inserting each in its own lane fixes
- * both.
+ * A final released late by the live path's bleed-dedup hold (up to
+ * PER_SEGMENT_BLEED_WINDOW_S) can land out of chronological order relative to a
+ * still-ongoing utterance on the other channel, so the insert point is searched
+ * from the end rather than assumed to be the tail.
  */
-function insertLiveSegment(prev: LiveSegment[], segment: LiveSegment): LiveSegment[] {
-  let splitIdx = prev.length;
-  while (splitIdx > 0 && !prev[splitIdx - 1].isFinal) splitIdx--;
-  const finals = prev.slice(0, splitIdx);
-  const partials = prev.slice(splitIdx);
+function insertFinal(prev: LiveSegment[], segment: LiveSegment): LiveSegment[] {
+  let insertAt = prev.length;
+  while (insertAt > 0 && prev[insertAt - 1].start > segment.start) insertAt--;
+  if (insertAt === prev.length) return [...prev, segment];
+  return [...prev.slice(0, insertAt), segment, ...prev.slice(insertAt)];
+}
+
+/**
+ * Fold a partial into the partials lane: at most one in-progress utterance per
+ * speaker, the newer one replacing the older **in its existing position**.
+ *
+ * Two independent channels (mic + system) emit interleaved streams, so a naive
+ * "replace whatever is there" would clobber one channel's in-progress partial
+ * with the other's the moment they overlap.
+ *
+ * Position matters because both channels can be mid-utterance at once: filtering
+ * the speaker out and re-appending moved that speaker's bubble to the bottom on
+ * every tick, so two people talking made the two in-progress rows trade places
+ * several times a second.
+ */
+function replacePartial(prev: LiveSegment[], segment: LiveSegment): LiveSegment[] {
   const key = speakerKey(segment);
-  if (segment.isFinal) {
-    let insertAt = finals.length;
-    while (insertAt > 0 && finals[insertAt - 1].start > segment.start) insertAt--;
-    const nextFinals = [...finals.slice(0, insertAt), segment, ...finals.slice(insertAt)];
-    // Only drop a same-speaker partial if it could plausibly BE the
-    // utterance this final supersedes (started before this final's
-    // utterance ended). A bleed-delayed final can arrive well after the
-    // SAME speaker has already started a newer, unrelated utterance —
-    // dropping every same-speaker partial indiscriminately would clobber
-    // that unrelated one until its next partial tick.
-    const remainingPartials = partials.filter(
-      (s) => speakerKey(s) !== key || s.start > segment.end
-    );
-    return [...nextFinals, ...remainingPartials];
-  }
-  const otherPartials = partials.filter((s) => speakerKey(s) !== key);
-  return [...finals, ...otherPartials, segment];
+  const idx = prev.findIndex((s) => speakerKey(s) === key);
+  if (idx === -1) return [...prev, segment];
+  const next = prev.slice();
+  next[idx] = segment;
+  return next;
+}
+
+/**
+ * Drop the partial a final supersedes.
+ *
+ * Only a same-speaker partial that could plausibly BE the utterance this final
+ * closes (started before the final's utterance ended) is dropped. A
+ * bleed-delayed final can arrive well after the SAME speaker has already
+ * started a newer, unrelated utterance — dropping every same-speaker partial
+ * indiscriminately would clobber that unrelated one until its next tick.
+ */
+function retirePartials(prev: LiveSegment[], final: LiveSegment): LiveSegment[] {
+  if (prev.length === 0) return prev;
+  const key = speakerKey(final);
+  const next = prev.filter((s) => speakerKey(s) !== key || s.start > final.end);
+  return next.length === prev.length ? prev : next;
+}
+
+/** Split a backfilled snapshot into the same two lanes main.js keeps it in:
+ *  chronologically sorted finals first, trailing in-progress partials last. */
+function splitLanes(snapshot: LiveSegment[]): { finals: LiveSegment[]; partials: LiveSegment[] } {
+  let splitIdx = snapshot.length;
+  while (splitIdx > 0 && !snapshot[splitIdx - 1].isFinal) splitIdx--;
+  return { finals: snapshot.slice(0, splitIdx), partials: snapshot.slice(splitIdx) };
 }
 
 /**
@@ -73,23 +102,30 @@ function insertLiveSegment(prev: LiveSegment[], segment: LiveSegment): LiveSegme
  *   1. On mount, snapshot the buffer that main.js has been accumulating
  *      since the recording started — this catches a late-mounting panel up
  *      with any segments it missed. main.js maintains the same
- *      finals-then-per-speaker-partials invariant, so the snapshot is used
- *      as-is.
- *   2. Subscribe to `live-transcript-chunk` for the tail and fold each
- *      update in via `insertLiveSegment` (see above for why a naive
- *      replace-the-tail approach doesn't work with two channels).
+ *      finals-then-per-speaker-partials invariant, so the snapshot splits
+ *      cleanly into the two lanes.
+ *   2. Subscribe to `live-transcript-chunk` for the tail and fold each update
+ *      into its lane.
  *   3. Track ready/error state via the dedicated channels so the UI can
  *      distinguish "no speech yet" from "model still loading" from
  *      "model failed to load."
+ *
+ * **Why two lanes.** Partials arrive up to ~5x/s (both channels at the
+ * sidecar's 400 ms cadence) while finals arrive a couple of times a minute. Held
+ * in one array, every partial produced a new array identity for the whole
+ * transcript, so React re-rendered every finalised row — a cost that grew with
+ * meeting length. Split, a partial tick only invalidates the (at most two)
+ * in-progress rows.
  *
  * The hook is safe to mount with no active recording — `getState` returns
  * an empty segments array and the status stays `idle`.
  */
 export function useLiveTranscript(sessionName: string | null): UseLiveTranscriptResult {
-  const [segments, setSegments] = React.useState<LiveSegment[]>([]);
+  const [finals, setFinals] = React.useState<LiveSegment[]>([]);
+  const [partials, setPartials] = React.useState<LiveSegment[]>([]);
   // Carried over from the previous recording into this same note. Static for
   // the session — only the getState backfill populates it (there is no live
-  // event for it), so it's set once and never folded into `segments`.
+  // event for it), so it's set once and never folded into the lanes.
   const [priorSegments, setPriorSegments] = React.useState<LiveSegment[]>([]);
   const [ready, setReady] = React.useState(false);
   const [error, setError] = React.useState<{ stage: string; message?: string } | null>(null);
@@ -104,7 +140,8 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
     // the subscription guarantees the marker resets BEFORE any chunk
     // event can fire for the new session.
     receivedEventRef.current = false;
-    setSegments([]);
+    setFinals([]);
+    setPartials([]);
     setPriorSegments([]);
     setReady(false);
     setError(null);
@@ -126,7 +163,12 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
       // ev.segment.speaker already carries the true mic/system channel
       // tag from the Python sidecar — no client-side attribution needed.
       const segment: LiveSegment = ev.segment;
-      setSegments((prev) => insertLiveSegment(prev, segment));
+      if (segment.isFinal) {
+        setFinals((prev) => insertFinal(prev, segment));
+        setPartials((prev) => retirePartials(prev, segment));
+      } else {
+        setPartials((prev) => replacePartial(prev, segment));
+      }
     });
 
     const offError = ipc().on.liveTranscriptError((ev) => {
@@ -145,12 +187,14 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
         if (res.sessionName !== sessionName) return;
         // priorSegments are independent of the live tail (no live event ever
         // updates them), so apply them even if a chunk raced ahead — the
-        // receivedEventRef guard below only protects the live `segments`.
+        // receivedEventRef guard below only protects the live lanes.
         setPriorSegments(res.priorSegments ?? []);
         if (receivedEventRef.current) return;
         // Backfilled segments already carry their true speaker tag —
         // main.js stores it verbatim in liveTranscriptState.segments.
-        setSegments(res.segments);
+        const lanes = splitLanes(res.segments ?? []);
+        setFinals(lanes.finals);
+        setPartials(lanes.partials);
         setReady(res.ready);
         if (res.error) {
           setError({ stage: res.error.stage, message: res.error.message ?? res.error.error });
@@ -167,6 +211,14 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
       offError();
     };
   }, [sessionName]);
+
+  // Flat view for consumers that need the whole transcript (search, copy,
+  // tail tracking). Concatenating pointers is cheap; what used to be
+  // expensive was making React walk the result every tick.
+  const segments = React.useMemo(
+    () => (partials.length === 0 ? finals : [...finals, ...partials]),
+    [finals, partials],
+  );
 
   const status: LiveTranscriptStatus = error
     ? 'error'
@@ -192,5 +244,102 @@ export function useLiveTranscript(sessionName: string | null): UseLiveTranscript
     };
   }, [status, sessionName]);
 
-  return { status, segments, priorSegments, error, slow };
+  return { status, segments, finals, partials, priorSegments, error, slow };
+}
+
+/**
+ * Status-only view of the same stream, for consumers that render a label rather
+ * than the transcript (the LiveDock pill's "Preparing…").
+ *
+ * The pill is mounted for the whole meeting, so subscribing it to the full hook
+ * meant a second complete copy of every segment was retained and re-inserted on
+ * every tick purely to answer "is the model still loading?". This tracks a
+ * boolean instead, with identical semantics: any segment arriving means the
+ * model is past loading, whether or not LIVE_READY was seen first.
+ */
+export function useLiveTranscriptStatus(sessionName: string | null): {
+  status: LiveTranscriptStatus;
+  slow: boolean;
+} {
+  const [ready, setReady] = React.useState(false);
+  const [sawSegment, setSawSegment] = React.useState(false);
+  const [error, setError] = React.useState<{ stage: string; message?: string } | null>(null);
+  const receivedEventRef = React.useRef(false);
+
+  React.useEffect(() => {
+    receivedEventRef.current = false;
+    setReady(false);
+    setSawSegment(false);
+    setError(null);
+    if (!sessionName) return;
+
+    const offReady = ipc().on.liveTranscriptReady((ev) => {
+      if (ev.sessionName !== sessionName) return;
+      receivedEventRef.current = true;
+      setReady(true);
+      setError(null);
+    });
+    const offChunk = ipc().on.liveTranscriptChunk((ev) => {
+      if (ev.sessionName !== sessionName) return;
+      receivedEventRef.current = true;
+      // setState with the same value is a no-op re-render-wise, so the
+      // remaining per-tick cost here is the IPC hand-off itself.
+      setSawSegment(true);
+    });
+    const offError = ipc().on.liveTranscriptError((ev) => {
+      if (ev.sessionName !== sessionName) return;
+      receivedEventRef.current = true;
+      setError({ stage: ev.stage, message: ev.message ?? ev.error });
+    });
+
+    // Same backfill the full hook does, reduced to the booleans this one
+    // exposes — a pill mounted after the recording started must not sit at
+    // "Preparing…" until the next event. Carried-over prior segments count as
+    // streaming here exactly as they do there, so a resumed recording reads
+    // the same in both.
+    let cancelled = false;
+    ipc()
+      .liveTranscript.getState()
+      .then((res) => {
+        if (cancelled || !res.success) return;
+        if (res.sessionName !== sessionName) return;
+        if ((res.priorSegments ?? []).length > 0) setSawSegment(true);
+        if (receivedEventRef.current) return;
+        if ((res.segments ?? []).length > 0) setSawSegment(true);
+        setReady(res.ready);
+        if (res.error) {
+          setError({ stage: res.error.stage, message: res.error.message ?? res.error.error });
+        }
+      })
+      .catch(() => {
+        /* best-effort backfill; the subscription is the source of truth */
+      });
+
+    return () => {
+      cancelled = true;
+      offReady();
+      offChunk();
+      offError();
+    };
+  }, [sessionName]);
+
+  const status: LiveTranscriptStatus = error
+    ? 'error'
+    : !sessionName
+      ? 'idle'
+      : sawSegment || ready
+        ? 'streaming'
+        : 'loading';
+
+  const [slow, setSlow] = React.useState(false);
+  React.useEffect(() => {
+    if (status !== 'loading') return;
+    const id = window.setTimeout(() => setSlow(true), 2000);
+    return () => {
+      window.clearTimeout(id);
+      setSlow(false);
+    };
+  }, [status, sessionName]);
+
+  return { status, slow };
 }

--- a/e2e/fixtures/electron.ts
+++ b/e2e/fixtures/electron.ts
@@ -17,6 +17,17 @@ const APP_DIR = path.resolve(__dirname, '..', '..', 'app');
 type LaunchOptions = {
   /** Install the deterministic mock IPC layer (T1, no backend). */
   mockIpc?: boolean;
+  /**
+   * Hand Chromium a synthetic capture device so `getUserMedia` resolves on a
+   * machine with no audio hardware. Required by any spec that starts a
+   * recording: a failed renderer-side capture reports
+   * `reportSystemAudioState(false)`, which drops the optimistic recording
+   * state, clears `useRecording().sessionName`, and makes `useLiveTranscript`
+   * discard every `live-transcript-chunk` (it filters strictly on the
+   * session name). That looks like "the panel never renders the segment"
+   * and only happens where there is no device, i.e. CI, never on a dev Mac.
+   */
+  fakeAudio?: boolean;
   /** Extra env vars merged over the e2e defaults. */
   env?: Record<string, string>;
 };
@@ -63,7 +74,16 @@ export const test = base.extend<Fixtures>({
       let lastErr: unknown;
       for (let attempt = 0; attempt < 2; attempt++) {
         try {
-          app = await electron.launch({ args: ['.'], cwd: APP_DIR, env });
+          app = await electron.launch({
+            args: [
+              '.',
+              ...(opts.fakeAudio
+                ? ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream']
+                : []),
+            ],
+            cwd: APP_DIR,
+            env,
+          });
           break;
         } catch (e) {
           lastErr = e;

--- a/e2e/fixtures/live-transcript.ts
+++ b/e2e/fixtures/live-transcript.ts
@@ -1,0 +1,38 @@
+import type { ElectronApplication } from '@playwright/test';
+
+/**
+ * Drive the live transcript from a test.
+ *
+ * Segments are pushed on `live-transcript-chunk` straight from the main
+ * process — the same channel main.js's `handleLiveTranscribeLine` emits on when
+ * the Python sidecar prints a LIVE_SEG. That keeps the renderer path under test
+ * the real one (preload subscribe → useLiveTranscript → LiveTranscriptBar) and
+ * means no test-only seam has to exist in production code.
+ */
+export type LiveSegmentInput = {
+  text: string;
+  start: number;
+  end: number;
+  isFinal: boolean;
+  speaker: 'You' | 'Others';
+};
+
+export async function emitLiveSegments(
+  app: ElectronApplication,
+  sessionName: string,
+  segments: LiveSegmentInput[],
+): Promise<void> {
+  await app.evaluate(
+    ({ BrowserWindow }, payload: { sessionName: string; segments: LiveSegmentInput[] }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (!win) throw new Error('no BrowserWindow to emit into');
+      for (const segment of payload.segments) {
+        win.webContents.send('live-transcript-chunk', {
+          sessionName: payload.sessionName,
+          segment,
+        });
+      }
+    },
+    { sessionName, segments },
+  );
+}

--- a/e2e/fixtures/live-transcript.ts
+++ b/e2e/fixtures/live-transcript.ts
@@ -4,7 +4,7 @@ import type { ElectronApplication } from '@playwright/test';
  * Drive the live transcript from a test.
  *
  * Segments are pushed on `live-transcript-chunk` straight from the main
- * process — the same channel main.js's `handleLiveTranscribeLine` emits on when
+ * process - the same channel main.js's `handleLiveTranscribeLine` emits on when
  * the Python sidecar prints a LIVE_SEG. That keeps the renderer path under test
  * the real one (preload subscribe → useLiveTranscript → LiveTranscriptBar) and
  * means no test-only seam has to exist in production code.

--- a/e2e/specs/live-transcript-lanes.t1.spec.ts
+++ b/e2e/specs/live-transcript-lanes.t1.spec.ts
@@ -38,7 +38,7 @@ async function bubbles(page: import('@playwright/test').Page) {
 }
 
 test('a partial is replaced in place, then retired by its final', async ({ launchApp }) => {
-  const { app, page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+  const { app, page } = await launchApp({ mockIpc: true, fakeAudio: true, env: PILL_ENV });
   await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
   await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
   const panel = page.getByTestId('live-transcript-panel');
@@ -64,7 +64,7 @@ test('a partial is replaced in place, then retired by its final', async ({ launc
 test('both channels can have an in-progress bubble at once, below the finalised text', async ({
   launchApp,
 }) => {
-  const { app, page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+  const { app, page } = await launchApp({ mockIpc: true, fakeAudio: true, env: PILL_ENV });
   await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
   await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
   const panel = page.getByTestId('live-transcript-panel');
@@ -97,7 +97,7 @@ test('a late final sorts into place instead of landing at the end', async ({ lau
   // The live path can release a final well after a later one (the per-segment
   // bleed-dedup hold). It has to sort by start time, or the transcript reads
   // out of order.
-  const { app, page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+  const { app, page } = await launchApp({ mockIpc: true, fakeAudio: true, env: PILL_ENV });
   await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
   await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
   const panel = page.getByTestId('live-transcript-panel');
@@ -132,6 +132,7 @@ test('a note continued twice renders every carried-over line, in order', async (
   // reading main.js's carryPrior, not by this assertion.
   const { app, page } = await launchApp({
     mockIpc: true,
+    fakeAudio: true,
     env: { ...PILL_ENV, STENOAI_E2E_SEED_PRIOR_SEGMENTS: 'twice' },
   });
 
@@ -161,6 +162,7 @@ test('resumed note: the divider sits between the carried-over text and the new t
   // get-live-transcript-state backfill (see pill-dock.t1).
   const { app, page } = await launchApp({
     mockIpc: true,
+    fakeAudio: true,
     env: { ...PILL_ENV, STENOAI_E2E_SEED_PRIOR_SEGMENTS: '1' },
   });
   await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);

--- a/e2e/specs/live-transcript-lanes.t1.spec.ts
+++ b/e2e/specs/live-transcript-lanes.t1.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '../fixtures/electron';
+import { emitLiveSegments, type LiveSegmentInput } from '../fixtures/live-transcript';
+
+/**
+ * T1 — renderer-only, mock IPC. The live transcript panel's rendering contract,
+ * driven through the real `live-transcript-chunk` channel.
+ *
+ * The panel renders in three lanes (carried-over prior segments, finalised
+ * segments, in-progress partials) so a partial tick doesn't invalidate the
+ * finalised rows above it. The lanes are an implementation detail; what a user
+ * sees is not, and that is what this pins down:
+ *
+ *   - a partial is REPLACED in place, never appended, so a long utterance
+ *     doesn't stack up duplicate half-sentences,
+ *   - one in-progress bubble per speaker, both channels at once,
+ *   - partials render dimmed and below the finalised text,
+ *   - a final retires the partial it closes,
+ *   - a final that arrives late (the bleed-dedup hold) still sorts into place.
+ */
+
+const PILL_ENV = { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' };
+const SESSION = 'Lane note';
+
+const seg = (
+  text: string,
+  start: number,
+  isFinal: boolean,
+  speaker: 'You' | 'Others' = 'You',
+): LiveSegmentInput => ({ text, start, end: start + 4, isFinal, speaker });
+
+/** Visible bubble texts, top to bottom. */
+async function bubbles(page: import('@playwright/test').Page) {
+  return page
+    .getByTestId('live-transcript-panel')
+    .locator('li')
+    .allTextContents()
+    .then((rows) => rows.map((r) => r.replace(/^\d+:\d+/, '').trim()));
+}
+
+test('a partial is replaced in place, then retired by its final', async ({ launchApp }) => {
+  const { app, page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+  await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
+  await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
+  const panel = page.getByTestId('live-transcript-panel');
+  await expect(panel).toBeVisible();
+
+  await emitLiveSegments(app, SESSION, [seg('Good morning everyone', 0, true)]);
+  await expect(panel.getByText('Good morning everyone')).toBeVisible();
+
+  // The same utterance growing across three ticks occupies ONE row.
+  await emitLiveSegments(app, SESSION, [seg('so the', 6, false)]);
+  await expect(panel.getByText('so the')).toBeVisible();
+  await emitLiveSegments(app, SESSION, [seg('so the plan for', 6, false)]);
+  await emitLiveSegments(app, SESSION, [seg('so the plan for today', 6, false)]);
+  await expect(panel.getByText('so the plan for today')).toBeVisible();
+  expect(await bubbles(page)).toEqual(['Good morning everyone', 'so the plan for today']);
+
+  // Its final replaces the partial rather than adding a second row.
+  await emitLiveSegments(app, SESSION, [seg('So the plan for today is this.', 6, true)]);
+  await expect(panel.getByText('So the plan for today is this.')).toBeVisible();
+  expect(await bubbles(page)).toEqual(['Good morning everyone', 'So the plan for today is this.']);
+});
+
+test('both channels can have an in-progress bubble at once, below the finalised text', async ({
+  launchApp,
+}) => {
+  const { app, page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+  await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
+  await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
+  const panel = page.getByTestId('live-transcript-panel');
+  await expect(panel).toBeVisible();
+
+  await emitLiveSegments(app, SESSION, [
+    seg('Settled sentence', 0, true, 'You'),
+    seg('mine still going', 10, false, 'You'),
+    seg('and theirs too', 11, false, 'Others'),
+  ]);
+  await expect(panel.getByText('and theirs too')).toBeVisible();
+
+  // Finalised first, both partials trailing — the order the merged list had.
+  expect(await bubbles(page)).toEqual(['Settled sentence', 'mine still going', 'and theirs too']);
+
+  // Partials are dimmed so they don't read as finalised text.
+  const dim = await panel
+    .locator('li')
+    .last()
+    .evaluate((el) => (el as HTMLElement).style.opacity);
+  expect(dim).toBe('0.55');
+
+  // One channel's tick must not clobber the other's in-progress bubble.
+  await emitLiveSegments(app, SESSION, [seg('mine still going on', 10, false, 'You')]);
+  await expect(panel.getByText('mine still going on')).toBeVisible();
+  expect(await bubbles(page)).toEqual(['Settled sentence', 'mine still going on', 'and theirs too']);
+});
+
+test('a late final sorts into place instead of landing at the end', async ({ launchApp }) => {
+  // The live path can release a final well after a later one (the per-segment
+  // bleed-dedup hold). It has to sort by start time, or the transcript reads
+  // out of order.
+  const { app, page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+  await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
+  await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
+  const panel = page.getByTestId('live-transcript-panel');
+  await expect(panel).toBeVisible();
+
+  await emitLiveSegments(app, SESSION, [
+    seg('First thing said', 0, true, 'You'),
+    seg('Third thing said', 20, true, 'You'),
+  ]);
+  await expect(panel.getByText('Third thing said')).toBeVisible();
+
+  await emitLiveSegments(app, SESSION, [seg('Second thing said', 10, true, 'Others')]);
+  await expect(panel.getByText('Second thing said')).toBeVisible();
+  expect(await bubbles(page)).toEqual([
+    'First thing said',
+    'Second thing said',
+    'Third thing said',
+  ]);
+});
+
+test('resumed note: the divider sits between the carried-over text and the new tail', async ({
+  launchApp,
+}) => {
+  // STENOAI_E2E_SEED_PRIOR_SEGMENTS seeds two prior segments through the mock
+  // get-live-transcript-state backfill (see pill-dock.t1).
+  const { app, page } = await launchApp({
+    mockIpc: true,
+    env: { ...PILL_ENV, STENOAI_E2E_SEED_PRIOR_SEGMENTS: '1' },
+  });
+  await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
+  await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
+  const panel = page.getByTestId('live-transcript-panel');
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('earlier bit one')).toBeVisible();
+
+  // Carried-over text alone gets NO divider — there is nothing to divide from.
+  await expect(page.getByTestId('live-transcript-resume-divider')).toHaveCount(0);
+
+  await emitLiveSegments(app, SESSION, [seg('and now the new bit', 0, true)]);
+  await expect(panel.getByText('and now the new bit')).toBeVisible();
+  await expect(page.getByTestId('live-transcript-resume-divider')).toHaveCount(1);
+  expect(await bubbles(page)).toEqual([
+    'earlier bit one',
+    'earlier bit two',
+    'Resumed',
+    'and now the new bit',
+  ]);
+});

--- a/e2e/specs/live-transcript-lanes.t1.spec.ts
+++ b/e2e/specs/live-transcript-lanes.t1.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../fixtures/electron';
 import { emitLiveSegments, type LiveSegmentInput } from '../fixtures/live-transcript';
 
 /**
- * T1 — renderer-only, mock IPC. The live transcript panel's rendering contract,
+ * T1 - renderer-only, mock IPC. The live transcript panel's rendering contract,
  * driven through the real `live-transcript-chunk` channel.
  *
  * The panel renders in three lanes (carried-over prior segments, finalised
@@ -77,7 +77,7 @@ test('both channels can have an in-progress bubble at once, below the finalised 
   ]);
   await expect(panel.getByText('and theirs too')).toBeVisible();
 
-  // Finalised first, both partials trailing — the order the merged list had.
+  // Finalised first, both partials trailing - the order the merged list had.
   expect(await bubbles(page)).toEqual(['Settled sentence', 'mine still going', 'and theirs too']);
 
   // Partials are dimmed so they don't read as finalised text.
@@ -118,6 +118,42 @@ test('a late final sorts into place instead of landing at the end', async ({ lau
   ]);
 });
 
+test('a note continued twice renders every carried-over line, in order', async ({ launchApp }) => {
+  // main.js prepends the existing priors on every continue (`carryPrior`), and
+  // each recording numbers its segments from its own start - so the carried-over
+  // list legitimately repeats (start, speaker) pairs. That is why the prior lane
+  // keys rows by position while the finals lane keys them by content.
+  //
+  // What this test can and cannot show: it pins that all four carried-over lines
+  // render, in order, ahead of the new tail. It does NOT catch a key collision
+  // on its own - the renderer under test is a production React build, which
+  // neither warns about duplicate keys nor misreconciles a list that is written
+  // once and never reordered. The collision is a latent hazard, established by
+  // reading main.js's carryPrior, not by this assertion.
+  const { app, page } = await launchApp({
+    mockIpc: true,
+    env: { ...PILL_ENV, STENOAI_E2E_SEED_PRIOR_SEGMENTS: 'twice' },
+  });
+
+  await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
+  await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
+  const panel = page.getByTestId('live-transcript-panel');
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('second session bit two')).toBeVisible();
+
+  await emitLiveSegments(app, SESSION, [seg('and the third session starts here', 3, true)]);
+  await expect(panel.getByText('and the third session starts here')).toBeVisible();
+
+  expect(await bubbles(page)).toEqual([
+    'earlier bit one',
+    'earlier bit two',
+    'second session bit one',
+    'second session bit two',
+    'Resumed',
+    'and the third session starts here',
+  ]);
+});
+
 test('resumed note: the divider sits between the carried-over text and the new tail', async ({
   launchApp,
 }) => {
@@ -133,7 +169,7 @@ test('resumed note: the divider sits between the carried-over text and the new t
   await expect(panel).toBeVisible();
   await expect(panel.getByText('earlier bit one')).toBeVisible();
 
-  // Carried-over text alone gets NO divider — there is nothing to divide from.
+  // Carried-over text alone gets NO divider - there is nothing to divide from.
   await expect(page.getByTestId('live-transcript-resume-divider')).toHaveCount(0);
 
   await emitLiveSegments(app, SESSION, [seg('and now the new bit', 0, true)]);

--- a/e2e/specs/live-transcript-perf.t1.spec.ts
+++ b/e2e/specs/live-transcript-perf.t1.spec.ts
@@ -1,0 +1,317 @@
+import { test, expect } from '../fixtures/electron';
+import { emitLiveSegments, type LiveSegmentInput } from '../fixtures/live-transcript';
+import type { CDPSession, ElectronApplication, Page } from '@playwright/test';
+
+/**
+ * T1 `@perf` — measurement harness for the live transcript panel's steady-state
+ * cost. NOT a pass/fail regression gate: it asserts only that the harness
+ * actually drove the UI, then prints a table. Wall-clock numbers on a shared
+ * runner are not a threshold anyone should block a PR on, so CI excludes
+ * `@perf`; run it by hand before and after a rendering change.
+ *
+ *   cd app && npm run test:e2e -- --project=t1 --grep @perf
+ *
+ * What it measures. The live path emits a partial roughly every 400 ms per
+ * channel (simple_recorder.py `_LiveVadPipeline.PARTIAL_INTERVAL_S`), i.e. up to
+ * ~5/s with both mic and system speaking, against a segment list that grows for
+ * the whole meeting. So the number that decides whether a two-hour meeting stays
+ * responsive is not the cost of one update — it is how that cost scales with the
+ * list already on screen. The harness seeds N finalised segments, then times a
+ * fixed burst of partial ticks at that size.
+ *
+ * It drives `live-transcript-chunk` straight from the main process (the same
+ * channel main.js's `handleLiveTranscribeLine` uses), so no production code
+ * carries a test-only seam and the renderer path under measurement is the real
+ * one: preload subscribe → useLiveTranscript → LiveTranscriptBar.
+ */
+
+const PERF_ENV = { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' };
+const SESSION = 'Perf note';
+
+/** List sizes to measure the per-tick cost at. ~1400 finalised segments is the
+ *  rough shape of a two-hour two-channel meeting (a real 78-minute single-
+ *  speaker recording transcribes to 230 segments). */
+const LIST_SIZES = [0, 250, 750, 1500];
+/** Partial ticks per measured burst. ~20 s of two-channel speech. */
+const TICKS = 100;
+
+type Segment = LiveSegmentInput;
+
+const emit = (app: ElectronApplication, segments: Segment[]) =>
+  emitLiveSegments(app, SESSION, segments);
+
+function finals(from: number, count: number): Segment[] {
+  return Array.from({ length: count }, (_, i) => {
+    const n = from + i;
+    return {
+      text: `finalised utterance number ${n} with a realistic amount of words in it`,
+      start: n * 6,
+      end: n * 6 + 5,
+      isFinal: true,
+      speaker: n % 2 === 0 ? 'You' : 'Others',
+    };
+  });
+}
+
+/** One in-progress partial per tick — the same speaker's utterance growing,
+ *  which is what the sidecar actually emits between finals. */
+function partials(afterFinals: number, count: number): Segment[] {
+  const base = afterFinals * 6 + 6;
+  return Array.from({ length: count }, (_, i) => ({
+    text: `partial tick ${i} still being spoken`,
+    start: base,
+    end: base + i * 0.4,
+    isFinal: false,
+    speaker: 'You' as const,
+  }));
+}
+
+/** Rendered rows + total DOM nodes. */
+async function snapshot(page: Page) {
+  return page.evaluate(() => {
+    const panel = document.querySelector('[data-testid="live-transcript-panel"]');
+    return {
+      rows: panel ? panel.querySelectorAll('li').length : 0,
+      domNodes: document.getElementsByTagName('*').length,
+    };
+  });
+}
+
+/** Retained heap after a forced collection — `performance.memory` is bucketed
+ *  and lazily updated, so it reports a flat number here and is useless. */
+async function heapMb(cdp: CDPSession) {
+  await cdp.send('HeapProfiler.collectGarbage');
+  const { usedSize } = await cdp.send('Runtime.getHeapUsage');
+  return +(usedSize / 1024 / 1024).toFixed(1);
+}
+
+/**
+ * Time a burst of `TICKS` partial updates, PACED one per animation frame.
+ *
+ * The pacing is the whole point. Fired back-to-back, React 18 coalesces the
+ * whole burst into a single render and the measurement collapses to ~0.5 ms
+ * regardless of list size — an artefact of the harness, not a property of the
+ * app. In production each partial arrives on its own IPC message ~400 ms after
+ * the last, so every tick is its own render. One frame apart is the fastest
+ * faithful model of that.
+ *
+ * Wall-clock would then be dominated by the deliberate idle between frames, so
+ * the reported cost comes from CDP's Performance domain instead: ScriptDuration,
+ * RecalcStyleDuration and LayoutDuration accumulate only real work.
+ */
+async function timeBurst(
+  cdp: CDPSession,
+  app: ElectronApplication,
+  page: Page,
+  afterFinals: number,
+  open: boolean,
+) {
+  const batch = partials(afterFinals, TICKS);
+  // Count DOM writes so a silently batched burst can't masquerade as N renders.
+  // Minimised, near-zero writes is the expected (and interesting) result, so
+  // observe the whole document rather than the absent panel.
+  await page.evaluate((panelOpen) => {
+    const w = window as unknown as { __perfMutations?: number; __perfObserver?: MutationObserver };
+    w.__perfObserver?.disconnect();
+    w.__perfMutations = 0;
+    const target = panelOpen
+      ? document.querySelector('[data-testid="live-transcript-panel"]')
+      : document.body;
+    if (!target) throw new Error('observe target missing');
+    const observer = new MutationObserver((records) => {
+      w.__perfMutations = (w.__perfMutations ?? 0) + records.length;
+    });
+    observer.observe(target, { subtree: true, childList: true, characterData: true });
+    w.__perfObserver = observer;
+  }, open);
+
+  const before = await metrics(cdp);
+  const started = Date.now();
+  for (const segment of batch) {
+    await emit(app, [segment]);
+    await page.evaluate(
+      () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+    );
+  }
+  // Let the last frame's style/layout/paint land before reading the counters.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      ),
+  );
+  const wall = Date.now() - started;
+  const after = await metrics(cdp);
+  const mutations = await page.evaluate(() => {
+    const w = window as unknown as { __perfMutations?: number; __perfObserver?: MutationObserver };
+    w.__perfObserver?.disconnect();
+    return w.__perfMutations ?? 0;
+  });
+
+  return {
+    wall,
+    mutations,
+    script: after.ScriptDuration - before.ScriptDuration,
+    style: after.RecalcStyleDuration - before.RecalcStyleDuration,
+    layout: after.LayoutDuration - before.LayoutDuration,
+  };
+}
+
+/** Chromium's cumulative timing counters, in seconds. */
+async function metrics(cdp: CDPSession): Promise<Record<string, number>> {
+  const { metrics: list } = await cdp.send('Performance.getMetrics');
+  return Object.fromEntries(list.map((m) => [m.name, m.value]));
+}
+
+/**
+ * One sweep over LIST_SIZES in a given panel state.
+ *
+ * Both states matter and they are different code paths. Open, LiveTranscriptBar
+ * owns the hook and renders every segment. Minimised (the usual state during a
+ * meeting — the pill is what users leave on screen) LiveTranscriptBar is
+ * unmounted and LiveDock holds its own `useLiveTranscript`, which keeps
+ * accumulating and re-inserting into the same growing array while rendering no
+ * list at all.
+ *
+ * Each sweep starts from an empty list: toggling the panel unmounts the hook, so
+ * the segment array is rebuilt from the (mock) backfill, not carried over.
+ */
+async function sweep(
+  cdp: CDPSession,
+  app: ElectronApplication,
+  page: Page,
+  open: boolean,
+): Promise<string[]> {
+  const pill = page.getByTestId('transcription-pill');
+  if (open) {
+    await pill.getByRole('button', { name: 'Show transcript' }).click();
+    await expect(page.getByTestId('live-transcript-panel')).toBeVisible();
+  } else {
+    await expect(page.getByTestId('live-transcript-panel')).toHaveCount(0);
+  }
+
+  const out: string[] = [];
+  let seeded = 0;
+
+  for (const size of LIST_SIZES) {
+    for (let sent = seeded; sent < size; sent += 250) {
+      await emit(app, finals(sent, Math.min(250, size - sent)));
+    }
+    if (size > seeded && open) {
+      await page.waitForFunction(
+        (expected) =>
+          (document.querySelector('[data-testid="live-transcript-panel"]')?.querySelectorAll('li')
+            .length ?? 0) >= expected,
+        size,
+        { timeout: 60_000 },
+      );
+    }
+    seeded = size;
+
+    const burst = await timeBurst(cdp, app, page, seeded, open);
+    const after = await snapshot(page);
+    const heap = await heapMb(cdp);
+    const perTick = (ms: number) => (ms / TICKS).toFixed(2).padStart(5);
+    out.push(
+      `  ${(open ? 'open' : 'minimised').padEnd(9)} finals=${String(seeded).padStart(4)}  ` +
+        `rows=${String(after.rows).padStart(4)}  ` +
+        `script=${perTick(burst.script * 1000)}  style=${perTick(burst.style * 1000)}  ` +
+        `layout=${perTick(burst.layout * 1000)} ms/tick  |  ` +
+        `domWrites=${String(burst.mutations).padStart(4)}  ` +
+        `domNodes=${String(after.domNodes).padStart(5)}  heap=${heap} MB`,
+    );
+  }
+
+  if (open) {
+    // The harness has to have actually driven the UI — a measurement of nothing
+    // is worse than no measurement.
+    const final = await snapshot(page);
+    expect(final.rows).toBeGreaterThanOrEqual(LIST_SIZES[LIST_SIZES.length - 1]);
+    await page
+      .getByTestId('live-transcript-panel')
+      .getByRole('button', { name: 'Minimize transcript' })
+      .click();
+    await expect(page.getByTestId('live-transcript-panel')).toHaveCount(0);
+  }
+  return out;
+}
+
+test('@perf live transcript: per-tick cost against a growing segment list', async ({
+  launchApp,
+}) => {
+  test.setTimeout(600_000);
+  const { app, page } = await launchApp({ mockIpc: true, env: PERF_ENV });
+  const cdp = await app.context().newCDPSession(page);
+  await cdp.send('Performance.enable');
+
+  await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
+  await expect(page.getByTestId('transcription-pill')).toBeVisible();
+
+  const minimised = await sweep(cdp, app, page, false);
+  const opened = await sweep(cdp, app, page, true);
+
+  console.log(
+    `\nLive transcript cost per partial tick (${TICKS} paced ticks per row)\n` +
+      `${[...minimised, ...opened].join('\n')}\n`,
+  );
+});
+
+/**
+ * The hypothesis raised on Discord: the live transcript view accumulates memory
+ * over a long meeting until the app dies. Partials are the churn to look at —
+ * they replace rather than append, so at a constant segment count the retained
+ * heap must stay flat. 2000 ticks is ~13 minutes of two-channel speech at the
+ * sidecar's 400 ms partial cadence.
+ */
+test('@perf live transcript: sustained partial churn does not retain memory', async ({
+  launchApp,
+}) => {
+  test.setTimeout(600_000);
+  const CHURN_TICKS = 2000;
+  const { app, page } = await launchApp({ mockIpc: true, env: PERF_ENV });
+  const cdp = await app.context().newCDPSession(page);
+  await cdp.send('Performance.enable');
+
+  await page.evaluate((name) => window.stenoai.recording.start(name), SESSION);
+  await page.getByTestId('transcription-pill').getByRole('button', { name: 'Show transcript' }).click();
+  await expect(page.getByTestId('live-transcript-panel')).toBeVisible();
+
+  // A fixed backlog, so anything the churn adds is growth and not the list.
+  await emit(app, finals(0, 250));
+  await page.waitForFunction(
+    () =>
+      (document.querySelector('[data-testid="live-transcript-panel"]')?.querySelectorAll('li')
+        .length ?? 0) >= 250,
+    undefined,
+    { timeout: 60_000 },
+  );
+
+  const before = await heapMb(cdp);
+  const domBefore = (await snapshot(page)).domNodes;
+  for (let i = 0; i < CHURN_TICKS; i++) {
+    await emit(app, partials(250, 1).map((s) => ({ ...s, text: `partial tick ${i} in progress` })));
+    if (i % 4 === 0) {
+      await page.evaluate(
+        () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+      );
+    }
+  }
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      ),
+  );
+  const after = await heapMb(cdp);
+  const domAfter = (await snapshot(page)).domNodes;
+
+  console.log(
+    `\nSustained churn: ${CHURN_TICKS} partial ticks at 250 finals — ` +
+      `heap ${before} → ${after} MB, DOM nodes ${domBefore} → ${domAfter}\n`,
+  );
+
+  // Retained heap after a forced GC must not track the number of ticks. The
+  // budget is loose on purpose: this catches a leak, not a megabyte of noise.
+  expect(after - before).toBeLessThan(5);
+  expect(domAfter).toBeLessThanOrEqual(domBefore + 20);
+});

--- a/e2e/specs/live-transcript-perf.t1.spec.ts
+++ b/e2e/specs/live-transcript-perf.t1.spec.ts
@@ -3,7 +3,7 @@ import { emitLiveSegments, type LiveSegmentInput } from '../fixtures/live-transc
 import type { CDPSession, ElectronApplication, Page } from '@playwright/test';
 
 /**
- * T1 `@perf` — measurement harness for the live transcript panel's steady-state
+ * T1 `@perf` - measurement harness for the live transcript panel's steady-state
  * cost. NOT a pass/fail regression gate: it asserts only that the harness
  * actually drove the UI, then prints a table. Wall-clock numbers on a shared
  * runner are not a threshold anyone should block a PR on, so CI excludes
@@ -15,7 +15,7 @@ import type { CDPSession, ElectronApplication, Page } from '@playwright/test';
  * channel (simple_recorder.py `_LiveVadPipeline.PARTIAL_INTERVAL_S`), i.e. up to
  * ~5/s with both mic and system speaking, against a segment list that grows for
  * the whole meeting. So the number that decides whether a two-hour meeting stays
- * responsive is not the cost of one update — it is how that cost scales with the
+ * responsive is not the cost of one update - it is how that cost scales with the
  * list already on screen. The harness seeds N finalised segments, then times a
  * fixed burst of partial ticks at that size.
  *
@@ -32,8 +32,18 @@ const SESSION = 'Perf note';
  *  rough shape of a two-hour two-channel meeting (a real 78-minute single-
  *  speaker recording transcribes to 230 segments). */
 const LIST_SIZES = [0, 250, 750, 1500];
-/** Partial ticks per measured burst. ~20 s of two-channel speech. */
-const TICKS = 100;
+/** Partial ticks per measured burst. */
+const TICKS = 60;
+/**
+ * Milliseconds between ticks. Must be comfortably more than two animation
+ * frames, and that is not a detail: work the panel defers to
+ * `requestAnimationFrame` (the auto-scroll) is cancelled by the next update's
+ * effect cleanup, so pacing at one tick per frame would let the deferred work
+ * be skipped almost every time and report a saving that does not exist at the
+ * sidecar's real ~400 ms cadence. Anything past two frames makes the deferred
+ * callbacks run, which is what production does.
+ */
+const TICK_GAP_MS = 80;
 
 type Segment = LiveSegmentInput;
 
@@ -53,7 +63,7 @@ function finals(from: number, count: number): Segment[] {
   });
 }
 
-/** One in-progress partial per tick — the same speaker's utterance growing,
+/** One in-progress partial per tick - the same speaker's utterance growing,
  *  which is what the sidecar actually emits between finals. */
 function partials(afterFinals: number, count: number): Segment[] {
   const base = afterFinals * 6 + 6;
@@ -77,7 +87,7 @@ async function snapshot(page: Page) {
   });
 }
 
-/** Retained heap after a forced collection — `performance.memory` is bucketed
+/** Retained heap after a forced collection - `performance.memory` is bucketed
  *  and lazily updated, so it reports a flat number here and is useless. */
 async function heapMb(cdp: CDPSession) {
   await cdp.send('HeapProfiler.collectGarbage');
@@ -86,17 +96,18 @@ async function heapMb(cdp: CDPSession) {
 }
 
 /**
- * Time a burst of `TICKS` partial updates, PACED one per animation frame.
+ * Time a burst of `TICKS` partial updates, paced `TICK_GAP_MS` apart.
  *
- * The pacing is the whole point. Fired back-to-back, React 18 coalesces the
- * whole burst into a single render and the measurement collapses to ~0.5 ms
- * regardless of list size — an artefact of the harness, not a property of the
- * app. In production each partial arrives on its own IPC message ~400 ms after
- * the last, so every tick is its own render. One frame apart is the fastest
- * faithful model of that.
+ * The pacing is the whole point, in both directions. Fired back-to-back, React
+ * 18 coalesces the burst into a single render and the measurement collapses to
+ * ~0.5 ms regardless of list size. Fired one per animation frame, work the
+ * panel defers to rAF gets cancelled by the following tick and disappears from
+ * the numbers. Neither is what production does: each partial arrives on its own
+ * IPC message ~400 ms after the last, so every tick renders AND every deferred
+ * callback runs. The gap here is the smallest one that reproduces both.
  *
- * Wall-clock would then be dominated by the deliberate idle between frames, so
- * the reported cost comes from CDP's Performance domain instead: ScriptDuration,
+ * Wall-clock would then be dominated by the deliberate idle, so the reported
+ * cost comes from CDP's Performance domain instead: ScriptDuration,
  * RecalcStyleDuration and LayoutDuration accumulate only real work.
  */
 async function timeBurst(
@@ -129,9 +140,10 @@ async function timeBurst(
   const started = Date.now();
   for (const segment of batch) {
     await emit(app, [segment]);
-    await page.evaluate(
-      () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
-    );
+    // Deliberate wall-clock gap, not a poll: the point is to let the frame the
+    // update renders in AND the frames its deferred work runs in complete
+    // before the next tick, the way a 400 ms sidecar cadence would.
+    await page.waitForTimeout(TICK_GAP_MS);
   }
   // Let the last frame's style/layout/paint land before reading the counters.
   await page.evaluate(
@@ -164,11 +176,30 @@ async function metrics(cdp: CDPSession): Promise<Record<string, number>> {
 }
 
 /**
+ * The same wall-clock window with no segments emitted.
+ *
+ * Once the ticks are spaced in real time, the counters also collect whatever
+ * else the app does in that window - the queue poll, the elapsed timer, the
+ * recording wave animation. That baseline is unrelated to the transcript and
+ * would otherwise be attributed to it, so every burst is reported net of it.
+ */
+async function idleBaseline(cdp: CDPSession, page: Page) {
+  const before = await metrics(cdp);
+  await page.waitForTimeout(TICKS * TICK_GAP_MS);
+  const after = await metrics(cdp);
+  return {
+    script: after.ScriptDuration - before.ScriptDuration,
+    style: after.RecalcStyleDuration - before.RecalcStyleDuration,
+    layout: after.LayoutDuration - before.LayoutDuration,
+  };
+}
+
+/**
  * One sweep over LIST_SIZES in a given panel state.
  *
  * Both states matter and they are different code paths. Open, LiveTranscriptBar
  * owns the hook and renders every segment. Minimised (the usual state during a
- * meeting — the pill is what users leave on screen) LiveTranscriptBar is
+ * meeting - the pill is what users leave on screen) LiveTranscriptBar is
  * unmounted and LiveDock holds its own `useLiveTranscript`, which keeps
  * accumulating and re-inserting into the same growing array while rendering no
  * list at all.
@@ -208,22 +239,27 @@ async function sweep(
     }
     seeded = size;
 
+    const idle = await idleBaseline(cdp, page);
     const burst = await timeBurst(cdp, app, page, seeded, open);
     const after = await snapshot(page);
     const heap = await heapMb(cdp);
-    const perTick = (ms: number) => (ms / TICKS).toFixed(2).padStart(5);
+    // Net of the idle baseline, floored at zero - a negative would be noise,
+    // not a negative cost, and printing it as one would be misleading.
+    const perTick = (measured: number, base: number) =>
+      (Math.max(0, measured - base) * 1000 / TICKS).toFixed(2).padStart(5);
     out.push(
       `  ${(open ? 'open' : 'minimised').padEnd(9)} finals=${String(seeded).padStart(4)}  ` +
         `rows=${String(after.rows).padStart(4)}  ` +
-        `script=${perTick(burst.script * 1000)}  style=${perTick(burst.style * 1000)}  ` +
-        `layout=${perTick(burst.layout * 1000)} ms/tick  |  ` +
+        `script=${perTick(burst.script, idle.script)}  ` +
+        `style=${perTick(burst.style, idle.style)}  ` +
+        `layout=${perTick(burst.layout, idle.layout)} ms/tick  |  ` +
         `domWrites=${String(burst.mutations).padStart(4)}  ` +
         `domNodes=${String(after.domNodes).padStart(5)}  heap=${heap} MB`,
     );
   }
 
   if (open) {
-    // The harness has to have actually driven the UI — a measurement of nothing
+    // The harness has to have actually driven the UI - a measurement of nothing
     // is worse than no measurement.
     const final = await snapshot(page);
     expect(final.rows).toBeGreaterThanOrEqual(LIST_SIZES[LIST_SIZES.length - 1]);
@@ -258,7 +294,7 @@ test('@perf live transcript: per-tick cost against a growing segment list', asyn
 
 /**
  * The hypothesis raised on Discord: the live transcript view accumulates memory
- * over a long meeting until the app dies. Partials are the churn to look at —
+ * over a long meeting until the app dies. Partials are the churn to look at -
  * they replace rather than append, so at a constant segment count the retained
  * heap must stay flat. 2000 ticks is ~13 minutes of two-channel speech at the
  * sidecar's 400 ms partial cadence.
@@ -306,7 +342,7 @@ test('@perf live transcript: sustained partial churn does not retain memory', as
   const domAfter = (await snapshot(page)).domNodes;
 
   console.log(
-    `\nSustained churn: ${CHURN_TICKS} partial ticks at 250 finals — ` +
+    `\nSustained churn: ${CHURN_TICKS} partial ticks at 250 finals - ` +
       `heap ${before} → ${after} MB, DOM nodes ${domBefore} → ${domAfter}\n`,
   );
 

--- a/e2e/specs/live-transcript-perf.t1.spec.ts
+++ b/e2e/specs/live-transcript-perf.t1.spec.ts
@@ -276,7 +276,7 @@ test('@perf live transcript: per-tick cost against a growing segment list', asyn
   launchApp,
 }) => {
   test.setTimeout(600_000);
-  const { app, page } = await launchApp({ mockIpc: true, env: PERF_ENV });
+  const { app, page } = await launchApp({ mockIpc: true, fakeAudio: true, env: PERF_ENV });
   const cdp = await app.context().newCDPSession(page);
   await cdp.send('Performance.enable');
 
@@ -304,7 +304,7 @@ test('@perf live transcript: sustained partial churn does not retain memory', as
 }) => {
   test.setTimeout(600_000);
   const CHURN_TICKS = 2000;
-  const { app, page } = await launchApp({ mockIpc: true, env: PERF_ENV });
+  const { app, page } = await launchApp({ mockIpc: true, fakeAudio: true, env: PERF_ENV });
   const cdp = await app.context().newCDPSession(page);
   await cdp.send('Performance.enable');
 


### PR DESCRIPTION
## Description

Valentin reported on Discord that the live transcript accumulates memory over a long meeting, and ruzin reported a crash mid-meeting. This adds a measurement harness for that path and fixes what it actually showed.

**Up front, so nobody reads this as more than it is: there is no leak, and this is not the crash.** 2000 partial ticks against a constant 250 finals move the retained heap (after a forced GC) by ~1 MB and the DOM node count by 3. Every buffer in the path is already bounded: the debug-log ring at 1000 lines, MediaRecorder writing per 1 s timeslice, the stdin queue at 8 MB since #358, and Python at `PARTIAL_WINDOW_S = 15` / `MAX_UTTERANCE_S = 30`. What grows is linear in meeting length (segments and DOM rows), not unbounded.

What the harness *did* show is that per-tick render cost grew with the number of finalised rows, because a partial tick invalidated every finalised row. That is now flat:

| finals | script before/after (ms) | layout before/after (ms) |
|---|---|---|
| 0 | 0.32 / 0.48 | 0.14 / 0.15 |
| 250 | 1.20 / 0.50 | 0.37 / 0.27 |
| 750 | 2.04 / 0.46 | 0.75 / 0.60 |
| 1500 | 2.70 / 0.62 | 1.37 / 0.97 |

4.07 -> 1.59 ms per tick at 1500 rows, and 0.10-0.39 -> 0.00-0.05 while minimised, which is the usual state during a meeting. At five ticks a second that is a few ms of main-thread work reclaimed, so: polish, not a fix for the crash.

Changes:

- `useLiveTranscript` keeps finals and partials in separate lanes, and the panel renders three memoised lanes, so a partial tick no longer re-renders finalised rows.
- `LiveDock` uses a new `useLiveTranscriptStatus` instead of retaining a second full copy of the transcript just to decide whether to show "Preparing...".
- Rows get `content-visibility: auto`. The auto-scroll moved into a rAF and re-asserts on the next frame, because a row rendered for the first time swaps its reserved height for its real one and could leave the newest line a sliver below the fold.
- A partial is now replaced in place rather than re-appended. Pre-existing bug: with both channels mid-utterance, the two bubbles swapped places on every tick.
- Carried-over rows are keyed by position. `main.js` prepends existing priors on every continue and each recording numbers from zero, so start+speaker keys collided across sessions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tested locally with `npm start` (real app, 800-line transcript, scroller verified exactly at the bottom)
- [ ] Verified CLI functionality works (no backend change, zero Python touched)
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

- `typecheck:renderer` clean. `lint:renderer` 37 warnings / 0 errors against 36 on `main`: one added, the same `react-hooks/set-state-in-effect` session-reset pattern the file already used.
- `npm run test:unit`: 120 vitest green.
- T1 e2e: 55 passed excluding `@perf`; `@perf` 2 passed.
- Not run: T2, backend suite (branch touches no Python), packaged DMG, Windows.

## Additional Notes

The new `live-transcript-perf.t1` spec is a **measurement harness, not a gate**, and CI excludes it (`--grep-invert @perf` in both `e2e.yml` and `build-release.yml`) because wall-clock work on a shared runner is not something to block a PR on. Run it by hand before and after any change to live-transcript rendering:

```
cd app && npm run test:e2e -- --project=t1 --grep @perf
```

Two harness traps are worth knowing about, because both flattered the change being measured before they were fixed:

1. Fired back-to-back, React 18 batches the whole burst into **one** render and the numbers collapse to ~0.5 ms at every list size, which reads as "flat, nothing to fix". A MutationObserver now counts DOM writes so a batched burst cannot masquerade as N renders.
2. Paced one tick per animation frame, the auto-scroll's deferred rAF callbacks get cancelled by the next tick. Ticks are now 80 ms apart, and each burst is reported net of an idle baseline over the same wall-clock window, since real time lets the app's own background work into the counters.

`live-transcript-lanes.t1` covers the rendering contract itself: a partial is replaced in place per speaker, a final retires it, a late final sorts into position, and the Resumed divider, driven through the real `live-transcript-chunk` channel.

One thing I'd rather flag than hide: the regression test for the duplicate-key fix does **not** prove that fix. A mutation check put the collision back and the test still passed, because the shipped renderer is a production React build with no key warnings and the lane is written once. That is said in the spec rather than left there looking like a guard.

Also left deliberately unfixed, with the reason recorded in the code: the filtered lane uses index keys. After a query change the index points at a different segment, but those rows hold no state, so it costs reconciliation efficiency only while someone is typing in the search box.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the live transcript’s per-tick render cost flat by splitting finals and partials into lanes, and adds a `@perf` harness to measure it. At ~1500 rows the per-tick work drops from ~4.1 ms to ~1.6 ms (open panel), with near-zero cost when minimised.

- **Refactors**
  - `useLiveTranscript` now returns `finals` and `partials`; the panel renders three memoized lanes (prior, finals, partials). `segments` remains for search/copy.
  - Added `useLiveTranscriptStatus`; `LiveDock` uses it to avoid retaining a second full transcript.
  - Auto-scroll runs in `requestAnimationFrame` and re-asserts next frame; rows use `content-visibility: auto` with intrinsic sizing.
  - Added T1 `@perf` harness (`live-transcript-perf.t1`) and contract tests (`live-transcript-lanes.t1`); CI excludes `@perf` via `--grep-invert @perf`.

- **Bug Fixes**
  - Partials replace in place per speaker; stops bubbles swapping when both channels are mid-utterance.
  - Finals keyed by start+speaker; carried-over rows keyed by position to avoid collisions across continued recordings.
  - E2E: launch with Chromium’s fake media device flags so live-transcript specs run on CI without audio hardware.

<sup>Written for commit 5b263b1a9dd21861886b3dba19a25f42c3aca0a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

