### PR TITLE
docs: reflect Windows 10/11 (alpha) support across docs + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu)
 - Live transcription during recording
 - NVIDIA Parakeet as a transcription engine option
 - Editing notes after processing
-- Windows version
+- Windows: GA hardening (alpha already ships on Windows 10/11 x64)
 
 ## Installation
 

--- a/docs/compare/steno-vs-fathom.mdx
+++ b/docs/compare/steno-vs-fathom.mdx
@@ -18,7 +18,7 @@ Fathom is a cloud-based AI meeting notetaker with a generous free tier. Steno is
 | **Price** | Free (personal & team) | Free tier / $20/mo Premium / $19-$34 per user/mo (team) |
 | **Open source** | Yes (MIT) | No |
 | **CRM sync** | No | Yes (Salesforce, HubSpot) |
-| **Platform** | macOS only | macOS, Windows, web |
+| **Platform** | macOS (stable), Windows 10/11 (alpha) | macOS, Windows, web |
 
 *Fathom details as of 2026; check fathom.ai for current pricing and features.*
 

--- a/docs/compare/steno-vs-fireflies.mdx
+++ b/docs/compare/steno-vs-fireflies.mdx
@@ -15,7 +15,7 @@ Fireflies.ai is a cloud-based meeting recording and intelligence platform. Steno
 | **Works offline** | Yes | No |
 | **Meeting bot** | No | Yes (Fred bot) |
 | **Bot visible to participants** | No | Yes |
-| **Supported platforms** | macOS only | Web, Zoom, Meet, Teams, etc. |
+| **Supported platforms** | macOS (stable), Windows 10/11 (alpha) | Web, Zoom, Meet, Teams, etc. |
 | **Transcription** | Parakeet / Whisper (local) | Proprietary cloud |
 | **Languages** | European on the default engine; 99 via Whisper | ~60 |
 | **Speaker labels** | Yes | Yes |

--- a/docs/compare/steno-vs-granola.mdx
+++ b/docs/compare/steno-vs-granola.mdx
@@ -18,7 +18,7 @@ Granola is a popular AI meeting notepad for Mac. Like Steno, it captures your co
 | **Meeting bot** | No | No |
 | **Price** | Free (personal & team) | Free tier (limited history) / $14 / $35 per user/mo |
 | **Open source** | Yes (MIT) | No |
-| **Platform** | macOS only | macOS, Windows, iOS, Android |
+| **Platform** | macOS (stable), Windows 10/11 (alpha) | macOS, Windows, iOS, Android |
 | **Data used for AI training** | No | Yes, unless you opt out |
 
 *Granola details as of 2026; check granola.ai for current pricing and policies.*
@@ -35,7 +35,7 @@ Granola offers a free tier with limited note history, then Business ($14/user/mo
 
 ## Where Granola is stronger
 
-- **Cross-platform and mobile** — Granola runs on Windows, iOS, and Android as well as Mac; Steno is macOS only.
+- **Cross-platform and mobile** — Granola runs on Windows, iOS, and Android as well as Mac; Steno is macOS (stable) with a Windows 10/11 (alpha) build.
 - **Team and CRM workflows** — Granola offers shared folders and paid integrations (Notion, Slack, HubSpot, and others).
 - **Cloud sync** — your notes are available across devices automatically.
 

--- a/docs/compare/steno-vs-macwhisper.mdx
+++ b/docs/compare/steno-vs-macwhisper.mdx
@@ -17,7 +17,7 @@ MacWhisper and Steno are the two closest tools in this comparison: both run on-d
 | **Open source** | Yes (MIT) | No (built on open-source Whisper) |
 | **Focus** | Meeting recorder + summarizer | General transcription (files, meetings, media) |
 | **Works offline** | Yes | Yes (core transcription) |
-| **Platform** | macOS only | macOS only |
+| **Platform** | macOS (stable), Windows 10/11 (alpha) | macOS only |
 
 *MacWhisper details as of 2026; check macwhisper.com for current pricing and features.*
 

--- a/docs/compare/steno-vs-otter.mdx
+++ b/docs/compare/steno-vs-otter.mdx
@@ -19,11 +19,11 @@ Otter.ai is a cloud-based AI meeting transcription service. Steno is a local mac
 | **Supported languages** | 25 European languages, including English, on the default engine; 99 via Whisper | Primarily English |
 | **Speaker labels** | Yes | Yes |
 | **Shared team workspace** | No | Yes |
-| **Mobile app** | No (macOS only) | Yes (iOS, Android) |
+| **Mobile app** | No (desktop only) | Yes (iOS, Android) |
 | **Calendar integration** | Native (Google & Outlook auto-detect), plus Apple Shortcuts | Yes (native) |
 | **Data used for training** | No | Check current policy |
 | **Suitable for confidential audio** | Yes | Requires review |
-| **Platform** | macOS only | Cross-platform |
+| **Platform** | macOS (stable), Windows 10/11 (alpha) | Cross-platform |
 
 ## Privacy
 

--- a/docs/compare/steno-vs-tldv.mdx
+++ b/docs/compare/steno-vs-tldv.mdx
@@ -18,7 +18,7 @@ tl;dv is a cloud-based AI meeting recorder and sales-intelligence platform. Sten
 | **Other participants see the bot** | No | Yes, in bot mode |
 | **Price** | Free (personal & team) | Free tier (10 AI notes lifetime) / paid from ~$18 per user/mo |
 | **Open source** | Yes (MIT) | No |
-| **Platform** | macOS only | Web, Chrome, desktop (Mac/Windows), iOS |
+| **Platform** | macOS (stable), Windows 10/11 (alpha) | Web, Chrome, desktop (Mac/Windows), iOS |
 
 *tl;dv details as of 2026; confirm current pricing on tldv.io — paid-tier prices vary across sources.*
 

--- a/docs/compare/steno-vs-zoom-ai-companion.mdx
+++ b/docs/compare/steno-vs-zoom-ai-companion.mdx
@@ -16,7 +16,7 @@ Zoom AI Companion is the AI assistant built into Zoom Workplace. Steno is a free
 | **Works offline** | Yes | No |
 | **Price** | Free (personal & team) | Included with paid Zoom plans (e.g. Pro ~$15.99/user/mo) |
 | **Open source** | Yes (MIT) | No |
-| **Platform** | macOS only | Zoom Workplace (Mac, Windows, mobile, web) |
+| **Platform** | macOS (stable), Windows 10/11 (alpha) | Zoom Workplace (Mac, Windows, mobile, web) |
 
 *Zoom details as of 2026; check zoom.com for current plans. The separate "My notes" feature claims broader coverage but differs from Meeting Summary.*
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -14,7 +14,7 @@ Yes. After the first-run model download, Steno works fully offline -- transcript
 </Accordion>
 
 <Accordion title="Is there a Windows, iPhone, or web version?">
-Steno runs on macOS (Apple Silicon, M1 and later -- Intel Macs are not supported since v0.4.0) and on Windows 10/11 (x64) in **alpha**, with the full on-device pipeline verified working. There is no iPhone or web version yet.
+Steno runs on macOS (Apple Silicon, M1 and later -- Intel Macs are not supported since v0.4.0) and on Windows 10/11 (x64) in **alpha**, with the full on-device pipeline verified working. There is no iPhone or web version.
 </Accordion>
 
 <Accordion title="Can I export my notes to Notion, Obsidian, or other tools?">

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -14,7 +14,7 @@ Yes. After the first-run model download, Steno works fully offline -- transcript
 </Accordion>
 
 <Accordion title="Is there a Windows, iPhone, or web version?">
-Steno is macOS only today, running on Apple Silicon Macs (M1 and later) -- Intel Macs are not supported since v0.4.0. There is no Windows, iPhone, or web version.
+Steno runs on macOS (Apple Silicon, M1 and later -- Intel Macs are not supported since v0.4.0) and on Windows 10/11 (x64) in **alpha**, with the full on-device pipeline verified working. There is no iPhone or web version yet.
 </Accordion>
 
 <Accordion title="Can I export my notes to Notion, Obsidian, or other tools?">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 ## Key facts
 
-- Platform: macOS only (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0).
+- Platform: macOS (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0) and Windows 10/11 (x64) in alpha.
 - Cost: free and open source (MIT license, no usage restrictions). A paid managed Enterprise deployment tier is a separate, optional offering (details coming soon). Source at https://github.com/ruzin/stenoai
 - No meeting bot: records system audio + microphone locally; no participant is notified by Steno.
 - Transcription: two on-device engines — Parakeet (default, with a live transcript while recording; 25 European languages, including English) and Whisper (optional; 99 languages). No audio is uploaded.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Steno
 
-> Steno is an open-source macOS and Windows (alpha) app that records, transcribes, and summarizes meetings using AI models that run entirely on your device. It captures your Mac's system audio and microphone locally — no meeting bot joins the call — and transcribes and summarizes on-device by default, so audio and transcripts never leave your Mac. Free and open source (MIT, no usage restrictions, including enterprise use); a paid managed Enterprise deployment tier is a separate, optional offering. macOS 14.4+ (Apple Silicon only). MIT licensed.
+> Steno is an open-source macOS and Windows (alpha) app that records, transcribes, and summarizes meetings using AI models that run entirely on your device. It captures your device's system audio and microphone locally — no meeting bot joins the call — and transcribes and summarizes on-device by default, so audio and transcripts never leave your device. Free and open source (MIT, no usage restrictions, including enterprise use); a paid managed Enterprise deployment tier is a separate, optional offering. macOS 14.4+ (Apple Silicon only) or Windows 10/11 (x64). MIT licensed.
 
 ## Key facts
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Steno
 
-> Steno is an open-source macOS app that records, transcribes, and summarizes meetings using AI models that run entirely on your device. It captures your Mac's system audio and microphone locally — no meeting bot joins the call — and transcribes and summarizes on-device by default, so audio and transcripts never leave your Mac. Free and open source (MIT, no usage restrictions, including enterprise use); a paid managed Enterprise deployment tier is a separate, optional offering. macOS 14.4+ (Apple Silicon only). MIT licensed.
+> Steno is an open-source macOS and Windows (alpha) app that records, transcribes, and summarizes meetings using AI models that run entirely on your device. It captures your Mac's system audio and microphone locally — no meeting bot joins the call — and transcribes and summarizes on-device by default, so audio and transcripts never leave your Mac. Free and open source (MIT, no usage restrictions, including enterprise use); a paid managed Enterprise deployment tier is a separate, optional offering. macOS 14.4+ (Apple Silicon only). MIT licensed.
 
 ## Key facts
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -33,7 +33,7 @@ organization-specific features, for teams that want that on top of the free app.
 - Everything works with no cloud provider — the default pipeline is fully local and free.
 
 ## Platform
-- macOS only (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0).
+- macOS (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0) and Windows 10/11 (x64) in alpha.
 
 ## Download
 - https://stenoai.co/#download


### PR DESCRIPTION
## Summary
Closes #433. The docs site still says Steno is "macOS only" / "no Windows version", while the README (`README.md:197`), the website CTA footer, and CI (`build-windows.yml` + a Windows T2 e2e lane) already ship and smoke-test the Windows alpha.

This makes the docs consistent with that reality using the wording suggested in the issue: **macOS (stable) and Windows 10/11 (alpha)**.

## Changes
- `docs/faq.mdx` — accordion answer now states Windows 10/11 (x64) is supported in alpha; no iPhone/web version yet.
- `docs/pricing.md` — Platform line lists macOS + Windows (alpha).
- `docs/llms.txt` — description + Platform line list macOS + Windows (alpha).
- `README.md` — Future Roadmap entry updated: Windows alpha already ships; remaining work is GA hardening.
- `docs/compare/steno-vs-*.mdx` (7 pages) — Steno Platform column updated from "macOS only" to
  "macOS (stable), Windows 10/11 (alpha)"; Otter "Mobile app" row corrected to "No (desktop only)";
  Granola copy updated to "macOS (stable) with a Windows 10/11 (alpha) build". Third-party competitor
  rows that describe another app's own platform (e.g. MacWhisper "macOS only") are left untouched.

## Notes
- Cosmetic doc-only change; no code or build impact.
- The comparison pages were folded into this PR after all: their wording ("macOS (stable), Windows
  10/11 (alpha)") matches the rest of the docs and the issue's intent. MacWhisper's competitor row
  stays "macOS only" because it describes that app's own platform support, not Steno's.
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs across FAQ, pricing, `docs/llms.txt`, README, and all comparison pages to reflect macOS (stable) and Windows 10/11 (x64) alpha support, replacing outdated “macOS only” text. Aligns platform messaging site‑wide with the current release and CI, and updates comparison tables/copy to show Windows (alpha) availability.

<sup>Written for commit cab32c5a5b063dca729dc89a3ba0f6f3128fbe3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

