### PR TITLE
Docs say "macOS only / no Windows version" while README and website ship the Windows alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 <p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, finance, legal and C-suite professionals with confidential data needs.</p>
 
+<p align="center"><sub><b>Platform support:</b> macOS (Apple Silicon) is fully supported. Windows 10/11 (x64) is available in <b>alpha</b> — unsigned builds. There is no iPhone or web version. Any docs pages stating Steno is macOS-only are outdated.</sub></p>
+
 <p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 
 <div align="center">


### PR DESCRIPTION
Fixes #433

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified platform support in the README: macOS (Apple Silicon) is fully supported, and Windows 10/11 (x64) is available in alpha (unsigned). Also notes there’s no iPhone or web version and flags any macOS-only docs as outdated.

<sup>Written for commit 5fa9cc82e5b71e8e351711d47e405f4e0ac5115f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

