### PR TITLE
docs: add Windows data location and unsigned installer documentation

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -18,7 +18,7 @@ Steno runs on macOS (Apple Silicon, M1 and later -- Intel Macs are not supported
 </Accordion>
 
 <Accordion title="Can I export my notes to Notion, Obsidian, or other tools?">
-Steno saves your notes as plain Markdown files under `~/Library/Application Support/stenoai/output/`. Because they are ordinary files, you can move them into Notion, Obsidian, or any other tool by hand or through your own automation.
+Steno saves your notes as plain Markdown files under `~/Library/Application Support/stenoai/output/` (macOS) or `%APPDATA%\stenoai\output\` (Windows). Because they are ordinary files, you can move them into Notion, Obsidian, or any other tool by hand or through your own automation.
 </Accordion>
 
 <Accordion title="How do I back up or delete my data?">
@@ -64,7 +64,7 @@ Steno's Windows alpha builds are not digitally signed yet. Windows SmartScreen f
 </Accordion>
 
 <Accordion title="How much disk space does Steno need?">
-The default setup uses roughly 7GB: the Parakeet transcription model (~572MB) plus the default Gemma summarization model. Plan for around 8GB free during install. Larger summarization models take more space. Recordings accumulate over time in `~/Library/Application Support/stenoai/recordings/`.
+The default setup uses roughly 7GB: the Parakeet transcription model (~572MB) plus the default Gemma summarization model. Plan for around 8GB free during install. Larger summarization models take more space. Recordings accumulate over time in `~/Library/Application Support/stenoai/recordings/` (macOS) or `%APPDATA%\stenoai\recordings\` (Windows).
 </Accordion>
 
 <Accordion title="How do I update Steno?">

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -22,7 +22,7 @@ Steno saves your notes as plain Markdown files under `~/Library/Application Supp
 </Accordion>
 
 <Accordion title="How do I back up or delete my data?">
-Everything Steno stores lives under `~/Library/Application Support/stenoai/` -- recordings, transcripts, and summaries. To back up your data, copy that folder. To delete it, remove that folder. Nothing is stored remotely, so there is no cloud copy to clear.
+Everything Steno stores lives under `~/Library/Application Support/stenoai/` (macOS) or `%APPDATA%\stenoai\` (Windows) -- recordings, transcripts, and summaries. To back up your data, copy that folder. To delete it, remove that folder. Nothing is stored remotely, so there is no cloud copy to clear.
 </Accordion>
 
 ## Privacy and data
@@ -32,7 +32,11 @@ No. Steno processes all recordings using AI models that run locally on your Mac.
 </Accordion>
 
 <Accordion title="Where does Steno store my data?">
-All data is stored in `~/Library/Application Support/stenoai/`:
+All data is stored locally:
+
+**macOS**: `~/Library/Application Support/stenoai/`
+
+**Windows**: `%APPDATA%\stenoai\` (e.g. `C:\Users\<your-name>\AppData\Roaming\stenoai\`)
 
 - `recordings/` -- raw `.webm` audio files
 - `transcripts/` -- verbatim transcript text
@@ -55,6 +59,10 @@ Steno is designed for professionals handling confidential audio. Because process
 Steno is signed but distributed outside the Mac App Store. On first launch, macOS Gatekeeper may block it. Go to **System Settings → Privacy & Security** and click **Open Anyway** next to Steno. This is a one-time step.
 </Accordion>
 
+<Accordion title="Why does Windows SmartScreen say Steno is an unrecognized app?">
+Steno's Windows alpha builds are not digitally signed yet. Windows SmartScreen flags unsigned executables with a warning. To proceed, click **More info** and then **Run anyway**. The app is safe to run — we will sign the installer before the general availability release.
+</Accordion>
+
 <Accordion title="How much disk space does Steno need?">
 The default setup uses roughly 7GB: the Parakeet transcription model (~572MB) plus the default Gemma summarization model. Plan for around 8GB free during install. Larger summarization models take more space. Recordings accumulate over time in `~/Library/Application Support/stenoai/recordings/`.
 </Accordion>
@@ -64,7 +72,7 @@ Steno updates automatically in the background. When an update is ready, you will
 </Accordion>
 
 <Accordion title="How do I uninstall Steno?">
-Delete Steno from your Applications folder. To also remove all recordings, transcripts, and model files, delete `~/Library/Application Support/stenoai/` and `~/.ollama/` (if you want to remove the Ollama models too).
+Delete Steno from your Applications folder (macOS) or uninstall via **Settings → Apps** (Windows). To also remove all recordings, transcripts, and model files, delete `~/Library/Application Support/stenoai/` (macOS) or `%APPDATA%\stenoai\` (Windows), and `~/.ollama/` (if you want to remove the Ollama models too).
 </Accordion>
 
 ## Recording


### PR DESCRIPTION
## Summary

Follow-up to #453. Adds the two documentation items @Optic00 mentioned, all in `docs/faq.mdx`:

1. **Windows data location**: `%APPDATA%\stenoai\` is now documented in five FAQ entries — data storage, backup, and uninstall (first commit), plus the export-notes and disk-space answers (latest commit). Every path mention in the FAQ is now dual-platform.

2. **Unsigned installer note**: a new FAQ entry ("Why does Windows SmartScreen say Steno is an unrecognized app?") explains that the alpha is unsigned and how to bypass SmartScreen. (The README already covered this; the gap was the FAQ.)

## Files changed

- `docs/faq.mdx` — five accordions now include the Windows `%APPDATA%\stenoai\` path alongside the macOS path; added a new SmartScreen accordion.

## Notes

- No code changes, documentation only.
- As @Optic00 said: "yours if you fancy, otherwise I'll pick them up." Picking them up 🙂
- Per review: the intended README change was a no-op against what was already there (SmartScreen is documented in the README since the Windows alpha landed), so this PR is FAQ-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Windows-specific docs: data lives in `%APPDATA%\stenoai\`, now noted in storage, backup, and uninstall FAQs. Add a new FAQ explaining Windows SmartScreen warnings for the unsigned alpha and how to proceed.

<sup>Written for commit bba6b29ab5ffb97fce475aae61b49f8e50287873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
