### PR TITLE
docs: add the Windows data path and unsigned-alpha note to llms.txt and pricing

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,13 +4,13 @@
 
 ## Key facts
 
-- Platform: macOS (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0) and Windows 10/11 (x64) in alpha.
+- Platform: macOS (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0) and Windows 10/11 (x64) in alpha (unsigned; Windows SmartScreen warns on first launch).
 - Cost: free and open source (MIT license, no usage restrictions). A paid managed Enterprise deployment tier is a separate, optional offering (details coming soon). Source at https://github.com/stenolabs/stenoai
 - No meeting bot: records system audio + microphone locally; no participant is notified by Steno.
 - Transcription: two on-device engines — Parakeet (default, with a live transcript while recording; 25 European languages, including English) and Whisper (optional; 99 languages). No audio is uploaded.
 - Summarization: local models via Ollama by default (default model Gemma 4 E2B). Optional off-device alternatives -- a cloud model (OpenAI, Anthropic, AWS Bedrock, or a custom endpoint), a self-hosted "Private Server" remote Ollama instance, or an organization adapter -- receive the transcript and any typed notes only, never audio.
 - Privacy: recording, transcription, and summarization are on-device by default. The app has anonymous usage analytics (no meeting content, on by default) that can be turned off during setup or later in Settings.
-- Data location: ~/Library/Application Support/stenoai/ (recordings, transcripts, output).
+- Data location: ~/Library/Application Support/stenoai/ on macOS, %APPDATA%\stenoai\ on Windows (recordings, transcripts, output).
 
 ## Getting started
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -33,7 +33,7 @@ organization-specific features, for teams that want that on top of the free app.
 - Everything works with no cloud provider — the default pipeline is fully local and free.
 
 ## Platform
-- macOS (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0) and Windows 10/11 (x64) in alpha.
+- macOS (macOS 14.4 Sonoma or later; Apple Silicon, M1 or later -- Intel Macs are not supported since v0.4.0) and Windows 10/11 (x64) in alpha (unsigned; Windows SmartScreen warns on first launch).
 
 ## Download
 - https://stenoai.co/#download


### PR DESCRIPTION
#453 and #457 made `faq.mdx`, the eight comparison tables and the README consistent about the
Windows alpha. Two statements were missed, both still macOS-only on `main`:

**1. `llms.txt` gave the data location with no Windows equivalent.** `faq.mdx` now names
`%APPDATA%\stenoai\` in five places, so the two files contradicted each other. This is the
file that language models and crawlers read as the summary of the project, so it is the worst
place to leave a macOS-only path.

Verified against the source rather than copied from the FAQ: `get_user_data_dir()` in
`src/config.py:97` resolves to `%APPDATA%/stenoai` (Roaming) on Windows.

**2. Neither `llms.txt` nor `pricing.md` said the Windows build is unsigned.** The README has
documented that since the alpha landed in June, and `faq.mdx` documents it since #457. Someone
reading either of these two files still has no way to know a SmartScreen warning is coming.

Three lines, no code. Closes the last of the #433 inconsistencies.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated llms.txt to include the Windows data path (%APPDATA%\stenoai\) and note that the Windows alpha is unsigned. Updated pricing.md with the same unsigned note to match README/FAQ and warn about Windows SmartScreen on first launch.

<sup>Written for commit fd1a1d800e11a43b5489dd07b234e3bd2d866b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruzin/stenoai/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

