### PR TITLE
docs: add AGENTS.md with Code Review Rules for Codex PR review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+Instructions for coding agents working in this repository.
+
+`CLAUDE.md` at the repo root is the full guide: architecture, development commands, the e2e tiers, the release process, and the cross-platform rules.
+Read it first and treat it as authoritative.
+This file deliberately does not repeat it, so the two cannot drift.
+
+The section below is different in kind.
+Codex's GitHub code review reads `## Code Review Rules` and applies it to pull requests, so it is written for a reviewer rather than for an implementer.
+
+## Code Review Rules
+
+These are the failure modes that are non-obvious and expensive here.
+Each one states the invariant and the safe path.
+Report a finding only when the diff actually violates the invariant, and say which input or state produces the wrong result.
+If a change is clean, say nothing.
+
+### Bundled binaries
+
+Never invoke a bundled binary through `subprocess`/`spawn` for an operation that has an HTTP or library API.
+macOS SIP and the Electron hardened runtime strip `DYLD_LIBRARY_PATH` from child processes, so such a call works in development and fails only in the signed, shipped app.
+Use the `ollama` Python package for model operations.
+Starting the server with `ollama serve` is the one sanctioned exception, covered by the `com.apple.security.cs.allow-dyld-environment-variables` entitlement.
+
+### Platform parity
+
+The app ships on macOS and Windows from shared code, and macOS is the signed, stable build that a Windows fix must never disturb.
+Platform-specific behaviour must be gated on `process.platform` (JS) or `sys.platform` (Python).
+Platform-specific electron-builder options belong in the `mac` or `win` block, never at the top level.
+New additions to `stenoai.spec` must be conditional on the platform so they do not bloat or break the other bundle.
+Flag an ungated change even when it is correct for the platform the author tested on.
+
+### User data paths
+
+Paths into user data must resolve through `get_user_data_dir()` (Python) or `getUserDataDir()` (main.js), and path lists must use `os.pathsep`.
+A literal `~/Library/Application Support/...` or a hardcoded `:` separator breaks Windows silently rather than loudly.
+Bundled binary names need the `.exe` suffix off-darwin.
+
+### Test isolation
+
+Every test that can reach the backend must set `STENOAI_USER_DATA_DIR` to a temporary directory, which both `getUserDataDir()` and `get_user_data_dir()` honour.
+Without it the test reads and can delete the developer's real recordings and transcripts.
+Flag a new or modified test that touches user data without setting it.
+
+### Meeting content in telemetry
+
+Recordings, transcripts, and summaries are the user's private data, and analytics events carry event names and counts only.
+Flag any change that puts transcript text, meeting titles, file names, or model output into a telemetry event, and any new setting that sends data off device while defaulting to on.
+Adding or reclassifying an event name, an error reason, or a counter is fine and needs no comment.
+
+### E2E coverage for behaviour changes
+
+A change to how the app behaves ships with its e2e spec in the same pull request.
+Prefer a model-free T2 spec that drives the `window.stenoai.<group>` preload bridge and asserts backend state on disk; reach for a T1 spec only when the interaction itself is the risk, and keep model or network assertions in the `@pipeline` and nightly lanes.
+When a spec is missing, name the tier that fits rather than only noting the absence.
+This applies to behaviour only.
+Documentation, comments, copy, the website, and release chores need no spec, so do not ask for one there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,43 +16,49 @@ Each one states the invariant and the safe path.
 Report a finding only when the diff actually violates the invariant, and say which input or state produces the wrong result.
 If a change is clean, say nothing.
 
-### Bundled binaries
+### Bundled binaries with an API
 
-Never invoke a bundled binary through `subprocess`/`spawn` for an operation that has an HTTP or library API.
+Never invoke a bundled binary through `subprocess`/`spawn` for an operation that also has an HTTP or library API.
 macOS SIP and the Electron hardened runtime strip `DYLD_LIBRARY_PATH` from child processes, so such a call works in development and fails only in the signed, shipped app.
-Use the `ollama` Python package for model operations.
-Starting the server with `ollama serve` is the one sanctioned exception, covered by the `com.apple.security.cs.allow-dyld-environment-variables` entitlement.
+Model operations go through the `ollama` Python package.
+This rule is narrow: spawning the bundled `stenoai` CLI is the app's architecture, and `ffmpeg` and `ollama serve` have no library alternative, so none of those are findings.
+
+### Bare `exit()` in Python
+
+Use `sys.exit()`, never bare `exit()`.
+`exit` is injected by `site` and is absent from a PyInstaller bundle, so the call raises only in the shipped app and never in development.
+Ruff's default rule set does not catch this.
 
 ### Platform parity
 
 The app ships on macOS and Windows from shared code, and macOS is the signed, stable build that a Windows fix must never disturb.
-Platform-specific behaviour must be gated on `process.platform` (JS) or `sys.platform` (Python).
-Platform-specific electron-builder options belong in the `mac` or `win` block, never at the top level.
-New additions to `stenoai.spec` must be conditional on the platform so they do not bloat or break the other bundle.
+Platform-specific behaviour must be gated on `process.platform` (JS) or `sys.platform` (Python), and platform-specific electron-builder options belong in the `mac` or `win` block rather than at the top level.
+The same applies to `stenoai.spec`: an addition that is platform-specific must be conditional, while a genuinely cross-platform one is correct unconditional.
 Flag an ungated change even when it is correct for the platform the author tested on.
 
 ### User data paths
 
 Paths into user data must resolve through `get_user_data_dir()` (Python) or `getUserDataDir()` (main.js), and path lists must use `os.pathsep`.
 A literal `~/Library/Application Support/...` or a hardcoded `:` separator breaks Windows silently rather than loudly.
-Bundled binary names need the `.exe` suffix off-darwin.
+An executable name needs the `.exe` suffix on Windows only, gated as `".exe" if sys.platform == "win32" else ""`; Linux takes no suffix.
 
 ### Test isolation
 
-Every test that can reach the backend must set `STENOAI_USER_DATA_DIR` to a temporary directory, which both `getUserDataDir()` and `get_user_data_dir()` honour.
+A test that starts the real app or the bundled backend must set `STENOAI_USER_DATA_DIR` to a temporary directory, which both `getUserDataDir()` and `get_user_data_dir()` honour.
 Without it the test reads and can delete the developer's real recordings and transcripts.
-Flag a new or modified test that touches user data without setting it.
+A unit test that isolates paths another way, by a temporary directory plus patching, is equally correct and is not a finding.
 
 ### Meeting content in telemetry
 
-Recordings, transcripts, and summaries are the user's private data, and analytics events carry event names and counts only.
-Flag any change that puts transcript text, meeting titles, file names, or model output into a telemetry event, and any new setting that sends data off device while defaulting to on.
-Adding or reclassifying an event name, an error reason, or a counter is fine and needs no comment.
+Recordings, transcripts, and summaries are the user's private data.
+Analytics events carry no free text and no user content: property keys and their values are allowlisted in `app/analytics-helpers.js`, and exceptions are sanitised before capture.
+Flag a change that puts transcript text, meeting titles, file names, or model output into an event, that forwards a raw error message or response body, or that adds a setting sending data off device while defaulting to on.
+Adding an allowlisted enum property, an event name, or a counter is fine and needs no comment.
 
-### E2E coverage for behaviour changes
+### E2E coverage for user-facing changes
 
-A change to how the app behaves ships with its e2e spec in the same pull request.
+Adding or materially changing a user-facing feature ships its e2e spec in the same pull request.
 Prefer a model-free T2 spec that drives the `window.stenoai.<group>` preload bridge and asserts backend state on disk; reach for a T1 spec only when the interaction itself is the risk, and keep model or network assertions in the `@pipeline` and nightly lanes.
 When a spec is missing, name the tier that fits rather than only noting the absence.
-This applies to behaviour only.
-Documentation, comments, copy, the website, and release chores need no spec, so do not ask for one there.
+This is scoped to user-facing behaviour.
+An internal fix covered by a unit test needs no e2e spec, and documentation, comments, copy, the website, and release chores need none either.


### PR DESCRIPTION
Codex's GitHub code review reads a `## Code Review Rules` section from `AGENTS.md`. There is no such file in the repo, so an automated Codex review would run without any project context.

This adds one. It points at `CLAUDE.md` for architecture, commands and the cross-platform rules instead of copying them, so the two files cannot drift, and adds seven scoped rules for the failure modes that are non-obvious and expensive here: bundled-binary calls under SIP, bare `exit()`, platform gating, user-data paths, test isolation, meeting content in telemetry, and e2e coverage for user-facing changes.

Each rule states the invariant and the safe path, per OpenAI's guidance for custom review rules.

Since a reviewer that comments on correct code gets switched off, I put the rules through two passes looking for false positives: once against the last ten merged PRs, and once with a second model plus a cross-family review. That caught four rules that would have fired on clean code, and one plain error:

- Test isolation demanded `STENOAI_USER_DATA_DIR` from every test, but only 1 of 46 test files uses it; 21 isolate with a temp dir plus patching, which is now named as equally correct.
- The `.exe` claim said "off-darwin", which is wrong for Linux.
- Telemetry said events carry "names and counts only". They carry allowlisted keys and values, so adding an allowlisted enum property would have been flagged.
- E2E said "a change to how the app behaves", which catches every unit-tested backend fix. Scoped back to user-facing, matching CLAUDE.md.

Deliberately left out is anything a linter catches deterministically. `exit()` vs `sys.exit()` looked like that case, but ruff's default rule set passes bare `exit()` clean, so it earns a rule.
