### PR TITLE
fix(parakeet): bound MLX's Metal buffer cache in the live path

### DIFF
--- a/src/_parakeet_mlx.py
+++ b/src/_parakeet_mlx.py
@@ -52,8 +52,64 @@ SUPPORTS_PARTIALS = True
 PARAKEET_CHUNK_DURATION_S = 60.0
 PARAKEET_CHUNK_OVERLAP_S = 15.0
 
+# Ceiling on MLX's Metal buffer cache — freed-but-retained GPU buffers, not
+# live tensors. MLX defaults this to ~95% of system memory (22.8 GB of 24 GB on
+# the machine this was measured on), which is a sane default for a one-shot
+# script and a bad one for a long-lived recorder.
+#
+# The live consumer re-transcribes a GROWING speech buffer every 400 ms, so
+# nearly every generate() asks for a buffer size MLX has not seen before, and
+# each freed one is retained. Nothing releases them: parakeet-mlx's only
+# mx.clear_cache() lives in its streaming context manager's __exit__, and the
+# live path deliberately bypasses that API for the plain batch loop (see
+# transcribe_samples below).
+#
+# Measured by hand (CI cannot — see tests/test_parakeet_mlx_memory.py), driving
+# `transcribe-stream` with synthetic two-channel speech at real time.
+#
+# Growth run, 12 min of audio:
+#   without a limit   0.3 GB -> 10.7 GB after 1 audio-minute -> 12.6 GB at 1.6
+#   with this limit   flat at 1.9-2.6 GB across 3 audio-minutes
+#   throughput 242 vs 247 segments per audio-minute
+# An in-process probe over 730 inferences put mx.get_active_memory() at a
+# CONSTANT 1237 MB, so the memory the computation actually needs never grows —
+# everything above it was cache.
+#
+# Separate A/B on identical 60 s audio, the two trees differing only by this
+# limit:
+#   generate() p50 389 -> 359 ms, p95 582 -> 466 ms, max 2476 -> 1327 ms
+#   238 vs 252 segments, footprint 10.7 GB vs 1.9 GB
+# So bounding the cache does not cost latency; it wins some. The mechanism is
+# not pinned down — system swap grew by ~5.7 GB during the unbounded arm, but
+# page-zeroing an endless supply of never-seen buffer sizes would explain the
+# tail as well. Only the numbers are claimed, not the cause.
+#
+# 512 MB is empirical, not derived. Under this cap the cache rides 475-512 MB,
+# i.e. the cap BINDS — that is the point, and it is not evidence the value is
+# right. What makes it defensible is the A/B above: the pool still recycles at
+# this size rather than thrashing. Deliberately NOT a fraction of system
+# memory: what the cache needs follows from the model and the window length,
+# both fixed here, not from how much RAM the Mac has. Raising it trades memory
+# for nothing measurable; lowering it toward the observed 475 MB floor would
+# start costing the 400 ms partial path.
+MLX_CACHE_LIMIT_BYTES = 512 * 2**20
+
 _MODEL_CACHE: dict[str, object] = {}
 _MODEL_LOCK = threading.Lock()
+
+
+def _configure_mlx_memory(limit_bytes: int = MLX_CACHE_LIMIT_BYTES) -> int:
+    """Bound MLX's Metal buffer cache. Returns the previous limit in bytes.
+
+    Caps only retained-free buffers — never active allocations or peak usage —
+    so it cannot make an inference fail for want of memory the way
+    ``mx.set_memory_limit`` could. Applies to every caller of ``_load_model``,
+    which is why the batch file path (``transcribe_file``, used by
+    ``process-streaming``) is covered by the same call: parakeet-mlx's batch
+    ``transcribe()`` never clears the cache either.
+    """
+    import mlx.core as mx
+    return mx.set_cache_limit(limit_bytes)
 
 
 def _load_model(model_id: str):
@@ -95,8 +151,16 @@ def _load_model(model_id: str):
             ) from e
         logger.info("Loading Parakeet model: %s", model_id)
         model = from_pretrained(model_id)
+        # After the load, not before. The limit governs only retained-free
+        # buffers, so it could not constrain the load either way; putting it
+        # here just keeps from_pretrained's one-off transients out of the
+        # capped pool instead of having them evicted from it.
+        previous = _configure_mlx_memory()
+        logger.info(
+            "Parakeet model loaded (MLX cache limit %.0f MB, was %.0f MB)",
+            MLX_CACHE_LIMIT_BYTES / 2**20, previous / 2**20,
+        )
         _MODEL_CACHE[model_id] = model
-        logger.info("Parakeet model loaded")
         return model
 
 

--- a/tests/test_parakeet_mlx_memory.py
+++ b/tests/test_parakeet_mlx_memory.py
@@ -1,0 +1,131 @@
+"""Guard the MLX Metal cache bound applied at Parakeet model load.
+
+What this can and cannot cover, stated plainly so nobody reads more into a
+green run than is there: the BEHAVIOUR being fixed - live transcription no
+longer growing into swap - cannot be tested in CI at all. GitHub-hosted macOS
+runners have no Metal GPU, so parakeet-mlx cannot load there (the same reason
+the @pipeline e2e lane runs whisper in CI, see CLAUDE.md). The regression was
+therefore measured by hand; see the PR and the comment on
+MLX_CACHE_LIMIT_BYTES.
+
+What IS testable, and is what these cases do: that the helper applies the
+limit we think it does, against real mlx on real Apple Silicon, without
+downloading or loading a model. Hardware-gated with a loud skip, matching the
+convention in test_bundle_mlx.py - it never fails just for running elsewhere.
+"""
+
+import platform
+import sys
+import unittest
+from unittest.mock import patch
+
+from src import _parakeet_mlx
+from src._parakeet_mlx import MLX_CACHE_LIMIT_BYTES, _configure_mlx_memory
+
+
+# MLX's own default ceiling, captured at import - before any test in this
+# process has had a chance to change it. Read here rather than inside a test
+# because the limit is global mutable state shared by the whole discover run:
+# a test that reads it late would be comparing against whatever ran first.
+_MLX_DEFAULT_CACHE_LIMIT = None
+if sys.platform == 'darwin' and platform.machine() == 'arm64':
+    try:
+        import mlx.core as _mx_probe
+
+        _MLX_DEFAULT_CACHE_LIMIT = _mx_probe.set_cache_limit(1)
+        _mx_probe.set_cache_limit(_MLX_DEFAULT_CACHE_LIMIT)
+    except Exception:  # noqa: BLE001 - absence is a skip, never a failure
+        _MLX_DEFAULT_CACHE_LIMIT = None
+
+
+def _requires_mlx(test):
+    if sys.platform != 'darwin' or platform.machine() != 'arm64':
+        test.skipTest(f"darwin-arm64 only (host: {sys.platform}/{platform.machine()})")
+    try:
+        import mlx.core as mx
+    except ImportError:
+        test.skipTest("mlx not installed - run `pip install -r requirements.txt` in the venv")
+    try:
+        # _load_model imports this one; without it the wiring case would ERROR
+        # on a machine that simply hasn't installed the ASR extra, which is a
+        # skip condition, not a failure.
+        import parakeet_mlx  # noqa: F401
+    except ImportError:
+        test.skipTest("parakeet-mlx not installed - run `pip install parakeet-mlx` in the venv")
+    return mx
+
+
+class MLXCacheLimitTests(unittest.TestCase):
+    def test_configure_applies_the_limit_and_reports_the_previous_one(self):
+        mx = _requires_mlx(self)
+        original = mx.set_cache_limit(MLX_CACHE_LIMIT_BYTES)
+        try:
+            # Park the limit somewhere else first, so a passing assertion can't
+            # be an accident of the limit already happening to be right.
+            sentinel = 7 * 2**20
+            mx.set_cache_limit(sentinel)
+
+            previous = _configure_mlx_memory()
+            self.assertEqual(previous, sentinel,
+                             "should report the limit it replaced")
+            self.assertEqual(mx.set_cache_limit(MLX_CACHE_LIMIT_BYTES),
+                             MLX_CACHE_LIMIT_BYTES,
+                             "the configured limit should be in effect afterwards")
+        finally:
+            mx.set_cache_limit(original)
+
+    def test_limit_is_well_under_the_default(self):
+        _requires_mlx(self)
+        if _MLX_DEFAULT_CACHE_LIMIT is None:
+            self.skipTest("could not read mlx's default cache limit at import")
+        # MLX's default is ~95% of system memory - the thing this constant
+        # exists to override. A "fix" that RAISED the ceiling would satisfy
+        # every other case in this file. Compared against the value captured
+        # at import, not the ambient one: by the time this runs, another test
+        # may legitimately have left the configured limit in place, and then
+        # the ambient value would be our own 512 MB and this would compare a
+        # number against itself.
+        self.assertLess(
+            MLX_CACHE_LIMIT_BYTES, _MLX_DEFAULT_CACHE_LIMIT,
+            f"cache limit {MLX_CACHE_LIMIT_BYTES} must be BELOW mlx's default "
+            f"{_MLX_DEFAULT_CACHE_LIMIT}, otherwise it bounds nothing",
+        )
+
+    def test_loading_a_model_applies_the_limit(self):
+        """The wiring, not just the helper.
+
+        Without this, deleting the _configure_mlx_memory() call from
+        _load_model leaves every other case in this file green while the bug
+        is fully restored. from_pretrained is stubbed, so no model is
+        downloaded and no GPU work happens - the assertion is only that the
+        load path bounds the cache on its way through.
+        """
+        mx = _requires_mlx(self)
+        original = mx.set_cache_limit(MLX_CACHE_LIMIT_BYTES)
+        fake_id = 'test/not-a-real-model'
+        try:
+            mx.set_cache_limit(9 * 2**20)
+            with patch('parakeet_mlx.from_pretrained', return_value=object()) as loader:
+                _parakeet_mlx._load_model(fake_id)
+            loader.assert_called_once_with(fake_id)
+            self.assertEqual(
+                mx.set_cache_limit(MLX_CACHE_LIMIT_BYTES), MLX_CACHE_LIMIT_BYTES,
+                "_load_model must bound the MLX cache; it did not",
+            )
+        finally:
+            _parakeet_mlx._MODEL_CACHE.pop(fake_id, None)
+            mx.set_cache_limit(original)
+
+    def test_bound_leaves_room_for_the_measured_working_set(self):
+        # No mlx needed: a pure statement about the constant, so it also runs
+        # in CI. The live path's measured steady-state cache cycles 475-512 MB;
+        # dropping the ceiling near or below that would trade the memory bug
+        # for cache thrashing on the 400 ms partial path.
+        self.assertGreaterEqual(
+            MLX_CACHE_LIMIT_BYTES, 256 * 2**20,
+            "a ceiling this low would thrash the live partial path",
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Live transcription grew to **12.6 GB of GPU memory inside 1.6 minutes of audio** and kept climbing, driving 24 GB Macs deep into swap during an ordinary meeting. This has reached us as user feedback.

One line fixes it. The rest of this description is the evidence, because the behaviour cannot be regression-tested in CI (see the last section).

## Cause

MLX defaults its Metal buffer cache to **~95% of system memory** — 22.8 GB of 24 GB on the machine this was measured on. That is a reasonable default for a one-shot script and the wrong one for a process that lives as long as a recording.

The live consumer re-transcribes a *growing* speech buffer every 400 ms, so nearly every `generate()` asks for a buffer size MLX has not seen before, and each freed one is retained. Nothing ever releases them: `parakeet-mlx`'s only `mx.clear_cache()` sits in its streaming context manager's `__exit__`, and `transcribe_samples` deliberately bypasses that API in favour of the plain VAD-gated batch loop.

So this was never a working set. An in-process probe over 730 inferences put `mx.get_active_memory()` at a **constant 1237 MB** — everything above that was cache.

### Not a recent regression

Worth knowing before anyone bisects: this has been present since live transcription first landed (#145, shipped in v0.4.0), so every release from v0.4.0 to v0.6.5 has it. Nothing in the recent merges caused it.

That PR started out wrapping `parakeet-mlx`'s streaming API in a `StreamingSession` context manager, and then replaced it with the VAD-gated batch loop we have today — for reasons that still read as correct and are documented at the top of the module: streaming produced unstable partials and a worse live feel. What went with it, invisibly, was the `mx.clear_cache()` in that API's `__exit__`. It only becomes apparent if you go looking inside the library for who was doing the cleanup.

Strictly speaking this is not a leak: nothing becomes unreachable, and the memory is returned when the sidecar exits at stop. It is a cache with no ceiling below "almost all of RAM", which is why it presents to the user as one.

## Measurements

Measured by hand against this PR's base, driving `transcribe-stream` with synthetic two-channel speech (two `say` voices, verified distinct) at real time, isolated via `STENOAI_USER_DATA_DIR`.

**Growth run**, 12 minutes of audio:

| | without a limit | with the limit |
|---|---|---|
| start | 0.3 GB | 0.3 GB |
| after 1 audio-minute | **10.7 GB** | 2.0 GB |
| after 1.6 audio-minutes | **12.6 GB** | 2.0 GB |
| after 3.0 audio-minutes | — | **2.3 GB** |
| segments / audio-minute | 242 | 247 |

**Latency A/B**, a separate run on identical 60 s audio, the two trees differing only by this limit:

| | without a limit | with the limit |
|---|---|---|
| `generate()` p50 | 388.6 ms | **359.3 ms** |
| p95 | 582.0 ms | **466.3 ms** |
| max | 2476.4 ms | **1327.4 ms** |
| segments | 238 | 252 |
| footprint | 10.70 GB | **1.90 GB** |

Bounding the cache does not cost latency; it wins some. The mechanism behind the tail is **not** pinned down — system swap grew ~5.7 GB during the unbounded arm, but page-zeroing an endless supply of never-seen buffer sizes would explain it just as well. Only the numbers are claimed here, not the cause.

## Why 512 MB

Empirical, not derived. Under the cap the cache rides 475–512 MB, so the cap binds — that is the intent, not evidence that the value is right. What makes it defensible is the A/B above: the pool still recycles at this size rather than thrashing.

Deliberately **not** a fraction of system memory. What the cache needs follows from the model and the window length, both fixed here, not from how much RAM the Mac has.

`set_cache_limit` caps only retained-free buffers, never active allocations, so unlike `set_memory_limit` it cannot make an inference fail for want of memory.

## Scope

- **The batch file path is covered by the same call**, not a second one: the limit is applied in `_load_model`, which `transcribe_file` shares, and `parakeet-mlx`'s batch `transcribe()` never clears the cache either. That path was observed at 4.4 GB after 32 seconds and is **not separately measured here**.
- **One deliberate gap:** `scripts/spike_parakeet.py` (CLI `spike-parakeet`) calls `from_pretrained()` directly and so never gets the limit. Left alone on purpose — it is a manual ~10 s diagnostic whose whole job is to prove the *raw* loader works under PyInstaller, and routing it through `_load_model` would change what it diagnoses.
- **Windows/Linux are untouched.** `_parakeet_onnx.py` is a different runtime with no MLX in it.

## Tests, and what they honestly cover

Four cases in `tests/test_parakeet_mlx_memory.py`, darwin-arm64 gated with a loud skip per the convention in `test_bundle_mlx.py`. One of them stubs `from_pretrained` and asserts the **load path** applies the limit, so deleting the call from `_load_model` fails the suite (verified) rather than silently restoring the bug.

Full Python suite green: 514 tests, `ruff` clean on the changed files.

**What these tests do not cover: the behaviour itself.** CI's macOS runners have no Metal, so `parakeet-mlx` cannot load there — the same reason the `@pipeline` lane runs whisper in CI. The memory numbers above were measured by hand and cannot be regression-gated in CI today. I would rather say that plainly than ship a test that looks like a guard and is not one.
