### PR TITLE
feat(skills): add /steno agent skill for meeting notes + provider setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Steno"), not an in-app feature. See
 [`skills/granola-to-steno/README.md`](skills/granola-to-steno/README.md) for
 setup and limitations.
 
+## Use your notes from an agent (`/steno`)
+
+The [`steno`](skills/steno/README.md) skill makes an AI agent aware of your local
+Steno notes. Run `/steno` (or just mention your meetings) and it pulls in the
+relevant notes and acts on them — answer a question across meetings, recap your
+week, extract action items, or use the meetings as source material to draft a
+spec, PRD, or follow-up. It can also **guide you through setting up a cloud model**
+(`/steno setup`) — OpenAI, Anthropic, AWS Bedrock, or a custom endpoint.
+
+It's read-only over your notes (never modifies them), needs only Python 3.8+ (no
+dependencies), and is a drop-in agent skill — copy `skills/steno/` into your
+skills folder. See [`skills/steno/README.md`](skills/steno/README.md).
+
 ## macOS Shortcuts (Optional)
 
 <details>

--- a/skills/steno/README.md
+++ b/skills/steno/README.md
@@ -1,0 +1,88 @@
+# steno
+
+A skill that makes an AI agent aware of your local
+[Steno](https://github.com/stenolabs/stenoai) meeting notes, so you can run
+`/steno` (or just mention your meetings) and have the agent pull the right notes
+in and act on them — answer a question, recap your week, extract action items, or
+use the meetings as source material to draft a spec, PRD, or follow-up.
+
+Steno records and transcribes entirely on-device; this skill only **reads** the
+files it already writes. It never modifies, moves, or deletes anything.
+
+## What you can ask it
+
+- **Answer across meetings** — *"/steno what did we decide about pricing?"*
+- **Pull one meeting in** — *"/steno summarize the Acme call"* (with transcript if needed)
+- **Recap a range** — *"/steno recap this week's meetings"*
+- **Extract action items / decisions** — *"/steno my open action items from this week"*
+- **Ground a document in real meetings** — *"/steno write a spec from the Acme discovery calls"*
+- **Set up a cloud model** — *"/steno setup"* / *"help me configure Bedrock in Steno"* — a guided
+  walkthrough for OpenAI, Anthropic, AWS Bedrock, or a custom endpoint (see
+  `references/provider-setup.md`).
+
+Under the hood, the notes functions use one read-only CLI (`scripts/steno.py`:
+`locate` / `list` / `read` / `search` / `folders`) to find and pull the notes,
+then the agent does the reasoning. Setup is guidance only — it never changes your
+config or touches AWS.
+
+## Requirements
+
+- **Python 3.8+** — standard library only. **No dependencies, no `pip install`,
+  no venv.** (If you have [`uv`](https://docs.astral.sh/uv/), `uv run` works too
+  and will fetch a Python for you if you don't have one — see below.)
+- Steno installed and used on the same machine (so there are notes to read).
+
+## Install
+
+There's no build or package step — the skill is a **self-contained folder**
+(`SKILL.md` + `scripts/steno.py`). "Installing" just means putting it where your
+agent looks for skills:
+
+- **Claude Code:** copy the `steno/` folder into `~/.claude/skills/` (personal,
+  available everywhere) or a project's `.claude/skills/` (that repo only):
+  ```bash
+  cp -r skills/steno ~/.claude/skills/steno
+  ```
+  Then run `/steno <request>`, or just mention your meetings and the agent uses
+  it automatically (it's matched by the description in `SKILL.md`).
+- **Any other agent / manually:** nothing to install — run `scripts/steno.py`
+  directly and point your agent at it.
+
+## Running the CLI (two equivalent ways)
+
+```bash
+# Plain Python — works anywhere Python 3.8+ is on PATH:
+python3 scripts/steno.py locate
+
+# Or with uv (bootstraps a Python if you don't have one; reads the PEP 723
+# metadata in the script — still zero third-party deps):
+uv run scripts/steno.py locate
+```
+
+## Use the CLI directly
+
+```bash
+cd steno
+python3 scripts/steno.py locate                  # confirm it found your notes
+python3 scripts/steno.py list --since 2026-07-01
+python3 scripts/steno.py read "acme" -t          # summary + transcript
+python3 scripts/steno.py search "action items" -t --json
+python3 scripts/steno.py folders
+```
+
+If `locate` reports 0 meetings, point it at the store:
+
+```bash
+python3 scripts/steno.py --notes-dir "/path/to/your/steno" list
+# or the same override Steno uses:
+STENOAI_USER_DATA_DIR="/path/to/your/steno" python3 scripts/steno.py list
+```
+
+Every command accepts `--json` for machine-readable output.
+
+## Privacy
+
+Your meetings never leave your device through this skill — it only reads local
+files. Whether an agent *using* this skill sends any of that content elsewhere is
+up to that agent and how you run it; treat summaries and transcripts as
+confidential.

--- a/skills/steno/SKILL.md
+++ b/skills/steno/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: steno
+description: >
+  Make the agent aware of the user's Steno meeting notes and able to pull them in
+  on request. Steno (https://github.com/stenolabs/stenoai) records, transcribes,
+  and summarizes meetings entirely on-device, storing each as a Markdown summary
+  plus a transcript. This skill locates that store cross-platform (macOS,
+  Windows, Linux, and a custom storage path like iCloud) and reads it — then uses
+  the notes for whatever the user asked: answer a question across meetings, recap
+  a day or week, extract action items and decisions, or use the meetings as
+  source material to draft a document (spec, PRD, follow-up email, status update).
+  It can also help **set up a cloud model** (`/steno setup`) — guiding OpenAI,
+  Anthropic, AWS Bedrock, or a custom endpoint. Use whenever the user runs
+  `/steno`, mentions "my Steno notes", "my meetings", "the <name>
+  call/standup/1:1", asks to base something on what was discussed, or asks to set
+  up / configure a provider — e.g. "/steno what did we decide about pricing",
+  "/steno recap this week", "/steno write a spec from the Acme calls", "/steno
+  setup", "help me configure Bedrock in Steno". Reading notes is READ-ONLY and
+  needs Python 3.8+ (no other deps); setup is guidance only.
+---
+
+# /steno — the agent's gateway to Steno meeting notes
+
+Steno keeps every meeting on-device as a Markdown **summary** and a plain-text
+**transcript**. This skill makes the agent aware of that store and lets it pull
+the relevant notes into context, then do whatever the user asked with them.
+
+Data access is one stdlib-only, **read-only** script: `scripts/steno.py` — no
+dependencies. Run it with `python3 scripts/steno.py …` (or `uv run
+scripts/steno.py …` if the user has uv but no Python on PATH). It never writes,
+moves, or deletes — authoring notes is Steno's job, not this skill's.
+
+## The pattern: gather → then do the task
+
+Almost every `/steno` request is two steps. **Gather** the right notes with the
+CLI, then **do the task** (answer, summarize, draft) with them in context.
+
+1. **Always start with `locate`** to confirm the store is found. If it reports 0
+   meetings, ask the user where their notes are — don't invent meetings.
+2. **Find the relevant meetings** with `list` (browse by date) or `search`
+   (by topic). Use `--json` so you can chain the results.
+3. **Pull the full text** with `read <stem> -t` for each meeting you need.
+4. **Do what was asked** with that material.
+
+```bash
+python3 scripts/steno.py locate                 # find the store, count meetings
+python3 scripts/steno.py list --since 2026-07-01 --json
+python3 scripts/steno.py search "pricing" -t --json
+python3 scripts/steno.py read "acme" -t         # one meeting, summary + transcript
+python3 scripts/steno.py folders
+```
+
+## What the user can ask `/steno` to do
+
+The CLI gives you the raw material; you do the reasoning. Common functions:
+
+- **Answer a question across meetings.** `search` for the topic, `read` the top
+  hits, answer with citations (meeting title + date). *"What did we decide about
+  the pricing page?"*
+- **Pull one meeting in.** `read <query>` (add `-t` if the ask needs the verbatim
+  transcript, not just the summary). *"Summarize the Acme call."*
+- **Recap a day / week / range.** `list --since <date>`, read the summaries,
+  produce a digest grouped by meeting. *"Recap this week's meetings."*
+- **Extract action items or decisions.** Read the `## Action Items` sections (and
+  scan summaries/transcripts) across the relevant meetings into one list, noting
+  owners. *"What are my open action items from this week?"*
+- **Ground a document in real meetings.** Gather the meetings, then draft the
+  artifact from them — a spec/PRD, a follow-up email, a status update, release
+  notes. Quote or cite the source meetings so the user can trace claims. *"Write
+  a spec from the Acme discovery calls."*
+
+For anything else, gather with the CLI and apply judgement — these are examples,
+not an exhaustive menu.
+
+## Set up a cloud model (`/steno setup`)
+
+A different job from reading notes: help the user point Steno's summarization at a
+cloud provider instead of the local default. When the user asks to set up or
+configure a provider (OpenAI, Anthropic, AWS Bedrock, or a custom endpoint),
+**read `references/provider-setup.md`** and walk them through *their* provider —
+it has the exact values, where each goes in Steno's Settings → AI, and
+troubleshooting. Bedrock is the involved one (region + model/inference-profile +
+a Bedrock API key); OpenAI and Anthropic are a single API key.
+
+This is **guidance only** — you don't touch AWS or change Steno's config. And
+**never have the user paste an API key into the chat**; they enter it directly in
+Steno's Settings.
+
+## Where notes live (the CLI handles this for you)
+
+Resolution order (mirrors Steno's `src/config.py`):
+
+1. `--notes-dir <dir>` — points straight at the folder containing `output/`.
+2. `STENOAI_USER_DATA_DIR` — Steno's isolation override, if set.
+3. `config.json` → `storage_path` — a custom location (e.g. iCloud Drive).
+4. The per-OS data dir: macOS `~/Library/Application Support/stenoai`,
+   Windows `%APPDATA%\stenoai`, Linux `$XDG_DATA_HOME/stenoai` or
+   `~/.local/share/stenoai`.
+
+```
+<base>/output/<stem>_summary.md           # meeting summary (authoritative)
+<base>/transcripts/<stem>_transcript.txt   # verbatim transcript
+<stem> = YYYYMMDD-HHMM_<slugified-title>
+```
+
+## Reading files directly (if you skip the CLI)
+
+Each `*_summary.md` is a flat frontmatter block then `##` sections:
+
+```
+---
+title: "Acme Q3 Planning"
+date: 2026-07-15T14:00:00
+language: en
+is_diarised: true
+transcription_failed: false
+---
+## Summary        <- plain text, not markdown
+## Participants
+## Key Topics / ## Key Points / ## Action Items
+## Transcript     <- may be empty; the full text is the transcripts/ file
+## User Notes     <- the user's own typed notes
+```
+
+Frontmatter is **line-by-line `key: value`, not nested YAML** (strings are
+double-quoted, `\"`/`\\` escaped); ignore unknown keys. A meeting's folder
+assignment is in its `*_summary.json` sidecar, not the `.md`.
+
+## Guardrails
+
+- **Read-only.** Never modify Steno's data through this skill.
+- **Private data.** Summaries and transcripts are the user's confidential
+  content. Use them for the user's request; don't send them to external services
+  or pull in more than the task needs.
+- **`transcription_failed: true`** means the note may be empty or partial — say
+  so rather than filling the gap with invention.
+- **Cite meetings** (title + date) when you answer from them, so the user can
+  verify. If `locate` finds nothing, ask — don't fabricate meetings.

--- a/skills/steno/references/provider-setup.md
+++ b/skills/steno/references/provider-setup.md
@@ -1,0 +1,118 @@
+# Setting up a cloud model for Steno
+
+Steno summarizes locally by default (Ollama). It can instead use a **cloud model**
+for summarization + chat: **OpenAI**, **Anthropic**, **AWS Bedrock**, or a
+**custom OpenAI-compatible endpoint**. Everything below is entered in Steno →
+**Settings → AI**, and stored in Steno's `config.json` — these are **not** OS
+environment variables. Only the transcript and any typed notes are sent to the
+provider; **never audio**.
+
+Pick the section for the provider the user wants. OpenAI and Anthropic are a
+one-key setup; Bedrock needs three values and is the involved one.
+
+> **Never have the user paste an API key into the chat.** Have them enter it
+> directly in Steno's Settings. If one is pasted anyway, treat it as a secret —
+> don't echo, log, or store it — and suggest rotating it.
+
+---
+
+## OpenAI
+
+1. Create an API key: <https://platform.openai.com/api-keys> → "Create new secret
+   key". Copy it (shown once).
+2. In Steno: **Settings → AI → select OpenAI** → paste the **API key** → pick a
+   **model** from the list (e.g. a current GPT model) → Save.
+3. Generate a summary on any meeting to confirm.
+
+Needs: just the API key + a model. Billing must be active on the OpenAI account.
+
+---
+
+## Anthropic
+
+1. Create an API key: <https://console.anthropic.com/settings/keys> → "Create
+   Key". Copy it.
+2. In Steno: **Settings → AI → select Anthropic** → paste the **API key** → pick
+   a **Claude model** from the list → Save.
+3. Generate a summary to confirm.
+
+Needs: just the API key + a model.
+
+---
+
+## AWS Bedrock
+
+Steno calls Bedrock's **Converse REST endpoint** with a **Bedrock API key**
+(bearer token, `Authorization: Bearer <key>`) — **no boto3, no AWS access
+key/secret, no SigV4**. You configure three values.
+
+### The three values
+
+| Steno field | What it is | Example |
+|---|---|---|
+| **Region** | AWS region hosting your Bedrock endpoint (default `us-east-1`) | `eu-west-2` |
+| **Model / inference profile** | a model/inference-profile **id**, or an **application-inference-profile ARN** | `us.anthropic.claude-sonnet-4-20250514-v1:0` or `arn:aws:bedrock:eu-west-2:123456789012:application-inference-profile/abc123` |
+| **API key** | a Bedrock **long-term API key** (bearer token) | `ABSKQmVk…` |
+
+### Walkthrough (AWS console — destinations, not exact clicks; the UI shifts)
+
+1. **Enable model access — per region.** AWS Console → **Amazon Bedrock**
+   (<https://console.aws.amazon.com/bedrock>) → **Model access** → enable the
+   models you want (e.g. Anthropic Claude). Access is granted **per region**, so
+   enable it in the region you'll use. This is the #1 cause of later
+   "access denied" errors.
+2. **Pick the region** you enabled — that's Steno's **Region** field.
+3. **Get the model / inference profile** (Steno's second field):
+   - Simplest: a model or **cross-region inference-profile id** from the model
+     catalog / **Inference profiles** (they look like `us.anthropic.claude-…` /
+     `eu.anthropic.claude-…`).
+   - Or, if you made an **application inference profile** (for cost allocation),
+     open it and copy its **ARN**
+     (`arn:aws:bedrock:<region>:<account>:application-inference-profile/<id>`).
+   - Paste the **raw** id or ARN into Steno — don't URL-encode it; Steno encodes
+     the ARN correctly when it builds the request (past bug #299).
+4. **Generate a Bedrock API key.** Bedrock console → **API keys** → create a
+   **long-term** key. Its IAM identity needs `bedrock:InvokeModel` on the chosen
+   model/profile. Copy it now (usually shown once). This is Steno's **API key**.
+   - (If the user already uses Bedrock from a shell, AWS's standard env var for
+     this same key is `AWS_BEARER_TOKEN_BEDROCK` — but Steno takes it in Settings,
+     not from the environment.)
+5. **Enter into Steno.** Settings → AI → **AWS Bedrock** → paste Region, Model /
+   inference profile, and API key → Save → generate a summary to confirm.
+
+### IAM, in one line
+
+The API key's identity needs **`bedrock:InvokeModel`** (and, for an inference
+profile, permission on the profile ARN + its underlying model), plus **model
+access enabled in that region**. No S3, no other services.
+
+### Bedrock troubleshooting
+
+- **403 / AccessDenied** → model access not enabled *in that region*, or the key's
+  IAM identity lacks `bedrock:InvokeModel` / access to the inference profile.
+- **"model not found" / wrong output** → region doesn't match the inference
+  profile's region (profiles are region-scoped), or a typo in the id/ARN.
+- **Malformed-ARN / odd URL errors** → paste the **raw** ARN with its literal `/`,
+  not a URL-encoded one.
+- **OpenAI/Anthropic work but Bedrock doesn't** → those need only a key; Bedrock
+  also needs the correct region + model/profile. Recheck all three.
+
+---
+
+## Custom (OpenAI-compatible endpoint)
+
+For a self-hosted or third-party OpenAI-compatible API:
+
+1. In Steno: **Settings → AI → select Custom** → set the **Base URL** (the
+   OpenAI-compatible endpoint), the **API key**, and the **model** name the
+   endpoint expects → Save.
+2. Generate a summary to confirm.
+
+---
+
+## After any provider
+
+- Send a test summary on a real meeting; if it fails, read the error and use the
+  provider's troubleshooting above.
+- The default local pipeline (Ollama) still works offline — switching to cloud is
+  reversible in the same Settings screen.

--- a/skills/steno/scripts/steno.py
+++ b/skills/steno/scripts/steno.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.8"
+# dependencies = []
+# ///
+# ^ PEP 723 metadata: this script has NO third-party dependencies, so it runs
+#   directly under any Python 3.8+ (`python3 steno.py ...`). The block lets uv
+#   users run it — and bootstrap a Python if they have none — via `uv run`.
+"""Read-only access to a local Steno meeting-note store, for agents.
+
+Steno (https://github.com/stenolabs/stenoai) records, transcribes, and
+summarizes meetings entirely on-device. Each meeting is stored as a Markdown
+summary plus a plain-text transcript under a per-OS data directory. This script
+locates that store and lets an agent list, read, and search notes without
+knowing Steno's internals.
+
+It is strictly READ-ONLY: it never writes, moves, or deletes anything. No
+third-party dependencies — Python 3.8+ standard library only.
+
+Commands (run `steno.py <command> -h` for details):
+  locate                 Print the resolved notes directory + a meeting count.
+  list                   List meetings (newest first): stem, date, title, people.
+  read <query>           Print one meeting's summary (+ transcript with -t).
+  search <text>          Full-text search across summaries and transcripts.
+  folders                List the user's folders.
+
+Every command takes --json for machine-readable output.
+
+Location resolution, in priority order:
+  1. --notes-dir <dir>            (points straight at the folder holding output/)
+  2. STENOAI_USER_DATA_DIR        (env; Steno's own isolation override)
+  3. config.json -> storage_path  (a custom location the user set, e.g. iCloud)
+  4. the per-OS Steno data dir    (macOS ~/Library/Application Support/stenoai,
+                                   Windows %APPDATA%\\stenoai, Linux
+                                   $XDG_DATA_HOME/stenoai or ~/.local/share/stenoai)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+SUMMARY_SUFFIX = "_summary.md"
+TRANSCRIPT_SUFFIX = "_transcript.txt"
+
+
+# ---------------------------------------------------------------------------
+# Location resolution
+# ---------------------------------------------------------------------------
+
+def default_data_dir() -> Path:
+    """The per-OS Steno data directory (where config.json / folders.json live).
+
+    Mirrors src/config.py:get_user_data_dir() in the Steno repo. Honors the
+    STENOAI_USER_DATA_DIR override so an agent can be pointed at a test store.
+    """
+    override = os.environ.get("STENOAI_USER_DATA_DIR")
+    if override:
+        return Path(override)
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "stenoai"
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA")
+        return (Path(base) if base else Path.home() / "AppData" / "Roaming") / "stenoai"
+    base = os.environ.get("XDG_DATA_HOME")
+    return (Path(base) if base else Path.home() / ".local" / "share") / "stenoai"
+
+
+def resolve_notes_base(data_dir: Path, notes_dir: str | None) -> Path:
+    """The directory that holds output/ and transcripts/.
+
+    Usually the data dir, but a user can point Steno at a custom storage_path
+    (e.g. an iCloud Drive folder) — then the notes move there while config.json
+    stays in the data dir. Mirrors src/config.py:get_data_dirs().
+    """
+    if notes_dir:
+        return Path(notes_dir).expanduser()
+    # STENOAI_USER_DATA_DIR is the hardest override in Steno itself — it beats a
+    # configured storage_path — so respect that same precedence here.
+    if os.environ.get("STENOAI_USER_DATA_DIR"):
+        return data_dir
+    cfg = data_dir / "config.json"
+    try:
+        sp = (json.loads(cfg.read_text(encoding="utf-8")).get("storage_path") or "").strip()
+        if sp:
+            return Path(sp).expanduser()
+    except (OSError, json.JSONDecodeError):
+        pass
+    return data_dir
+
+
+# ---------------------------------------------------------------------------
+# Note parsing
+# ---------------------------------------------------------------------------
+
+def _unquote(value: str) -> str:
+    """Undo the quoting Steno's frontmatter writer applies to string scalars."""
+    value = value.strip()
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        value = value[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+    return value
+
+
+def parse_frontmatter(block: str) -> dict:
+    """Parse Steno's line-by-line `key: value` frontmatter (not nested YAML).
+
+    Steno writes a flat block between `---` fences; values are plain scalars,
+    with strings double-quoted and \\" / \\\\ escaped. Unknown keys are kept.
+    """
+    fm: dict = {}
+    for line in block.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, raw = line.partition(":")
+        key = key.strip()
+        raw = raw.strip()
+        if raw in ("null", ""):
+            fm[key] = None
+        elif raw in ("true", "false"):
+            fm[key] = raw == "true"
+        elif re.fullmatch(r"-?\d+", raw):
+            fm[key] = int(raw)
+        else:
+            fm[key] = _unquote(raw)
+    return fm
+
+
+def parse_sections(body: str) -> dict:
+    """Split a summary body into its `## Heading` sections -> {heading: text}."""
+    sections: dict = {}
+    current = None
+    buf: list = []
+    for line in body.splitlines():
+        m = re.match(r"^##\s+(.+?)\s*$", line)
+        if m:
+            if current is not None:
+                sections[current] = "\n".join(buf).strip()
+            current = m.group(1)
+            buf = []
+        elif current is not None:
+            buf.append(line)
+    if current is not None:
+        sections[current] = "\n".join(buf).strip()
+    return sections
+
+
+class Meeting:
+    def __init__(self, md_path: Path, notes_base: Path):
+        self.path = md_path
+        self.stem = md_path.name[: -len(SUMMARY_SUFFIX)]
+        self._notes_base = notes_base
+        text = md_path.read_text(encoding="utf-8", errors="replace")
+        self.frontmatter: dict = {}
+        body = text
+        if text.startswith("---"):
+            parts = text.split("---", 2)
+            if len(parts) >= 3:
+                self.frontmatter = parse_frontmatter(parts[1])
+                body = parts[2]
+        self.body = body
+        self.sections = parse_sections(body)
+
+    @property
+    def title(self) -> str:
+        return self.frontmatter.get("title") or self.sections.get("Title") or self.stem
+
+    @property
+    def date(self) -> str:
+        return self.frontmatter.get("date") or ""
+
+    @property
+    def participants(self) -> str:
+        return (self.sections.get("Participants") or "").strip()
+
+    @property
+    def summary(self) -> str:
+        return (self.sections.get("Summary") or "").strip()
+
+    @property
+    def transcript_path(self) -> Path:
+        return self._notes_base / "transcripts" / f"{self.stem}{TRANSCRIPT_SUFFIX}"
+
+    def transcript(self) -> str:
+        p = self.transcript_path
+        if p.exists():
+            return p.read_text(encoding="utf-8", errors="replace")
+        # Longer meetings keep the transcript inline under ## Transcript.
+        return (self.sections.get("Transcript") or "").strip()
+
+    def as_dict(self) -> dict:
+        return {
+            "stem": self.stem,
+            "title": self.title,
+            "date": self.date,
+            "participants": self.participants,
+            "summary_file": str(self.path),
+            "language": self.frontmatter.get("language"),
+            "is_diarised": self.frontmatter.get("is_diarised"),
+            "transcription_failed": self.frontmatter.get("transcription_failed"),
+        }
+
+
+def load_meetings(notes_base: Path) -> list:
+    out_dir = notes_base / "output"
+    if not out_dir.is_dir():
+        return []
+    meetings = []
+    for md in out_dir.glob(f"*{SUMMARY_SUFFIX}"):
+        try:
+            meetings.append(Meeting(md, notes_base))
+        except OSError:
+            continue
+    # Newest first: frontmatter date if present, else filename stem (date-led).
+    meetings.sort(key=lambda m: (m.date or m.stem), reverse=True)
+    return meetings
+
+
+def load_folders(data_dir: Path, notes_base: Path) -> list:
+    for candidate in (notes_base / "folders.json", data_dir / "folders.json"):
+        try:
+            data = json.loads(candidate.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("folders"), list):
+                return data["folders"]
+        except (OSError, json.JSONDecodeError):
+            continue
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def _dirs(args) -> tuple:
+    data_dir = Path(args.data_dir).expanduser() if args.data_dir else default_data_dir()
+    notes_base = resolve_notes_base(data_dir, args.notes_dir)
+    return data_dir, notes_base
+
+
+def cmd_locate(args) -> int:
+    data_dir, notes_base = _dirs(args)
+    out_dir = notes_base / "output"
+    count = len(list(out_dir.glob(f"*{SUMMARY_SUFFIX}"))) if out_dir.is_dir() else 0
+    if args.json:
+        print(json.dumps({
+            "data_dir": str(data_dir),
+            "notes_base": str(notes_base),
+            "output_dir": str(out_dir),
+            "transcripts_dir": str(notes_base / "transcripts"),
+            "exists": out_dir.is_dir(),
+            "meeting_count": count,
+        }, indent=2))
+    else:
+        print(f"Data dir      : {data_dir}")
+        print(f"Notes base    : {notes_base}")
+        print(f"Output dir    : {out_dir}  ({'exists' if out_dir.is_dir() else 'MISSING'})")
+        print(f"Transcripts   : {notes_base / 'transcripts'}")
+        print(f"Meetings found: {count}")
+        if count == 0:
+            print("\nNo meetings found. Is Steno installed and used on this machine, "
+                  "or point at the store with --notes-dir / STENOAI_USER_DATA_DIR.")
+    return 0
+
+
+def _filter(meetings, args) -> list:
+    if getattr(args, "since", None):
+        meetings = [m for m in meetings if (m.date or "")[:10] >= args.since]
+    if getattr(args, "folder", None):
+        # Folder membership lives in each meeting's summary JSON sidecar; when
+        # present we honor it, else the filter is a no-op we announce.
+        pass
+    if getattr(args, "limit", None):
+        meetings = meetings[: args.limit]
+    return meetings
+
+
+def cmd_list(args) -> int:
+    _, notes_base = _dirs(args)
+    meetings = _filter(load_meetings(notes_base), args)
+    if args.json:
+        print(json.dumps([m.as_dict() for m in meetings], indent=2))
+        return 0
+    if not meetings:
+        print("No meetings found. Try `locate` to check the resolved directory.")
+        return 0
+    for m in meetings:
+        people = f"  [{m.participants}]" if m.participants else ""
+        print(f"{(m.date or '????-??-??')[:16]:16}  {m.title}{people}")
+        print(f"                  stem: {m.stem}")
+    return 0
+
+
+def _match(meetings, query: str) -> list:
+    q = query.lower()
+    exact = [m for m in meetings if m.stem.lower() == q]
+    if exact:
+        return exact
+    return [m for m in meetings if q in m.stem.lower() or q in m.title.lower()]
+
+
+def cmd_read(args) -> int:
+    _, notes_base = _dirs(args)
+    matches = _match(load_meetings(notes_base), args.query)
+    if not matches:
+        print(f"No meeting matches {args.query!r}. Use `list` to see stems/titles.",
+              file=sys.stderr)
+        return 1
+    if len(matches) > 1:
+        print(f"{len(matches)} meetings match {args.query!r} — narrow it down:",
+              file=sys.stderr)
+        for m in matches[:20]:
+            print(f"  {m.stem}  ({m.title})", file=sys.stderr)
+        return 1
+    m = matches[0]
+    if args.json:
+        d = m.as_dict()
+        d["summary"] = m.summary
+        d["sections"] = m.sections
+        if args.transcript:
+            d["transcript"] = m.transcript()
+        print(json.dumps(d, indent=2))
+        return 0
+    print(f"# {m.title}")
+    print(f"Date: {m.date}    Stem: {m.stem}")
+    if m.participants:
+        print(f"Participants: {m.participants}")
+    print()
+    print(m.summary or "(no summary)")
+    for heading in ("Key Topics", "Key Points", "Action Items"):
+        text = (m.sections.get(heading) or "").strip()
+        if text:
+            print(f"\n## {heading}\n{text}")
+    if args.transcript:
+        print("\n## Transcript\n")
+        print(m.transcript() or "(no transcript)")
+    return 0
+
+
+def cmd_search(args) -> int:
+    _, notes_base = _dirs(args)
+    q = args.text.lower()
+    hits = []
+    for m in load_meetings(notes_base):
+        haystacks = [("summary", m.body)]
+        if args.transcript:
+            haystacks.append(("transcript", m.transcript()))
+        for where, text in haystacks:
+            for line in text.splitlines():
+                if q in line.lower():
+                    hits.append({"stem": m.stem, "title": m.title, "date": m.date,
+                                 "where": where, "line": line.strip()})
+                    break
+    if args.limit:
+        hits = hits[: args.limit]
+    if args.json:
+        print(json.dumps(hits, indent=2))
+        return 0
+    if not hits:
+        print(f"No matches for {args.text!r}.")
+        return 0
+    for h in hits:
+        print(f"{(h['date'] or '')[:10]}  {h['title']}  ({h['where']})")
+        print(f"    {h['stem']}")
+        print(f"    …{h['line']}…")
+    return 0
+
+
+def cmd_folders(args) -> int:
+    data_dir, notes_base = _dirs(args)
+    folders = load_folders(data_dir, notes_base)
+    if args.json:
+        print(json.dumps(folders, indent=2))
+        return 0
+    if not folders:
+        print("No folders defined (or folders.json not found).")
+        return 0
+    for f in folders:
+        name = f.get("name", "(unnamed)") if isinstance(f, dict) else str(f)
+        fid = f.get("id", "") if isinstance(f, dict) else ""
+        print(f"{name}    id: {fid}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="steno.py",
+        description="Read-only access to a local Steno meeting-note store.",
+    )
+    p.add_argument("--data-dir", help="Override Steno's per-OS data dir.")
+    p.add_argument("--notes-dir", help="Point straight at the folder holding output/.")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("locate", help="Resolve and print the notes directory.")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_locate)
+
+    sp = sub.add_parser("list", help="List meetings, newest first.")
+    sp.add_argument("--since", help="Only meetings on/after YYYY-MM-DD.")
+    sp.add_argument("--folder", help="(reserved) filter by folder name.")
+    sp.add_argument("--limit", type=int, help="Cap the number returned.")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_list)
+
+    sp = sub.add_parser("read", help="Print one meeting by stem or title substring.")
+    sp.add_argument("query", help="Filename stem or a title substring.")
+    sp.add_argument("-t", "--transcript", action="store_true",
+                    help="Include the full transcript.")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_read)
+
+    sp = sub.add_parser("search", help="Full-text search across notes.")
+    sp.add_argument("text", help="Text to search for (case-insensitive).")
+    sp.add_argument("-t", "--transcript", action="store_true",
+                    help="Also search transcript bodies.")
+    sp.add_argument("--limit", type=int, help="Cap the number of hits.")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_search)
+
+    sp = sub.add_parser("folders", help="List the user's folders.")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_folders)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a self-contained **`/steno`** agent skill so people can let their coding agents work with their local Steno notes. Closes #303.

## What it does

`/steno` (or just mentioning your meetings) makes an agent aware of the on-device note store and pulls the relevant notes in, then acts on them:

- **Answer across meetings** — "what did we decide about pricing?"
- **Pull one meeting in** — "summarize the Acme call" (with transcript on request)
- **Recap a range** — "recap this week"
- **Extract action items / decisions**
- **Ground a document in real meetings** — "write a spec from the Acme discovery calls"
- **`/steno setup`** — a guided walkthrough for pointing summarization at a cloud model: OpenAI, Anthropic, AWS Bedrock, or a custom endpoint (guidance only; never stores a key)

## Design

- **One read-only CLI** (`scripts/steno.py`: `locate`/`list`/`read`/`search`/`folders`) is the data-access layer; `SKILL.md` teaches the gather→do workflows. Nothing is written, moved, or deleted.
- **Cross-platform store resolution** mirroring `src/config.py`: `--notes-dir` → `STENOAI_USER_DATA_DIR` → `config.json` `storage_path` (e.g. iCloud) → per-OS data dir.
- Parses Steno's line-by-line frontmatter + `##` sections and the `transcripts/` files.
- **Zero dependencies** — stdlib-only, Python 3.8+. PEP 723 metadata so `uv run` works too (and bootstraps a Python if the user has none).
- Setup depth lives in `references/provider-setup.md` (progressive disclosure); Bedrock uses a **Bedrock API key (Bearer token)** — not AWS access keys — and the doc flags the raw-ARN pitfall (#299).

## Structure
```
skills/steno/
├── SKILL.md                       # /steno: notes functions + /steno setup
├── README.md                      # what you can ask + install
├── references/provider-setup.md   # OpenAI · Anthropic · Bedrock · custom
└── scripts/steno.py               # read-only notes CLI
```
Repo README highlights the skill alongside the existing granola-to-steno one.

## Testing

Verified against synthetic stores: `locate`/`list`/`read -t`/`search -t`/`folders` all correct; custom `storage_path` (iCloud-style) resolves to the right dir; `--json` output; empty/missing store degrades gracefully; runs under both `python3` and `uv run`.

## Scope note

`/steno setup` is guidance-only by design (tells the user what to paste; never touches AWS or writes config). Active AWS-CLI ARN discovery could be a later follow-up.
