### PR TITLE
fix(notifications): one-click Take Notes + Summarise, transcript-first default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence, finance, legal and C-suite professionals with confidential data needs.</p>
+<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, transcribe, summarize, and query your meetings using local AI models. Perfect for government, defence and C-suite professionals with confidential data needs.</p>
 
-<p align="center"><sub>Trusted by users at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
+<p align="center"><sub>Trusted by teams at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 
 <div align="center">
   <picture>

--- a/app/main.js
+++ b/app/main.js
@@ -369,6 +369,19 @@ class Notification extends EventEmitter {
       height: 70,
       x: x + width - 425,
       y: y + 1,
+      // Create HIDDEN and only ever show via showInactive() in ready-to-show
+      // below. Without this, `show` defaults to true, so the constructor shows
+      // the window with the *activating* show() — which brings the whole app to
+      // the foreground (firing app.on('activate') → mainWindow.show()/focus()),
+      // so a passive toast appearing wrongly refocuses Steno. focusable:false
+      // stops the toast taking key focus but does NOT stop app activation; only
+      // show:false + showInactive() keeps the app in the background.
+      show: false,
+      // Because the toast now stays in a backgrounded app, a click on its
+      // buttons would otherwise be swallowed as the app-activating click (so the
+      // user has to click twice — once to activate, once to act). acceptFirstMouse
+      // makes that first click register as a real click on the button.
+      acceptFirstMouse: true,
       frame: false,
       transparent: true,
       alwaysOnTop: true,
@@ -6661,7 +6674,7 @@ const MEETING_END_DEBOUNCE_MS = 3_000;
 // brief device switch — since auto-resume cancels the auto-stop if the mic
 // returns within it. Because a released mic reliably means the call ended (not
 // mute), we finalize automatically after this rather than prompting the user.
-const MEETING_END_AUTOSTOP_GRACE_MS = 20_000;
+const MEETING_END_AUTOSTOP_GRACE_MS = 10_000;
 
 let micMonitorProc = null;
 let micMonitorRespawnTimer = null;
@@ -6778,6 +6791,12 @@ async function handleMicEvent(line) {
         clearTimeout(autoStartedSession.autoStopTimer);
         autoStartedSession.autoStopTimer = null;
       }
+      // Meeting came back — dismiss the "Meeting ended — Summarise?" prompt so a
+      // stale one can't finalize a live meeting.
+      if (autoStartedSession.endNotif) {
+        try { autoStartedSession.endNotif.close(); } catch (_) {}
+        autoStartedSession.endNotif = null;
+      }
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send('auto-resume-requested');
       }
@@ -6832,21 +6851,53 @@ function handleMicStop(evt) {
       mainWindow.webContents.send('auto-pause-requested');
     }
     sendDebugLog(`[auto-detect] meeting ended (paused): ${autoStartedSession.appName}`);
-    // Don't finalize immediately — the mic can briefly drop on a device switch.
-    // Hold paused for a short grace; if the mic comes back, handleMicEvent above
-    // cancels this timer and auto-resumes. Otherwise the meeting has genuinely
-    // ended (a released mic ≠ mute — Zoom/Meet/Teams keep the stream open while
-    // muted, see MEETING_END_DEBOUNCE_MS), so auto-stop and let the pipeline run.
-    // No "Wrap up" prompt: mic-release is a reliable end signal, so we finalize
-    // automatically and the user's only end-of-meeting prompt is the
-    // post-transcription "Summarise" / "Note ready".
+    // Fire the meeting-end "Summarise?" notification NOW, from this reliable
+    // mic-monitor signal — a single deterministic event, unlike the
+    // post-transcription notification whose firing depended on renderer route +
+    // window focus at completion time (fragile: the meeting app closing shuffles
+    // focus, the auto-stop navigates, etc.). Tapping "Summarise" finalizes + runs
+    // the pipeline (transcribe → summarise) now.
+    autoStartedSession.endNotif = showMeetingEndedNotification(autoStartedSession.appName);
+    // Safety net: if the mic comes back within the grace, handleMicEvent above
+    // cancels this timer + dismisses the notification and auto-resumes. Otherwise
+    // the meeting has genuinely ended (a released mic ≠ mute — Zoom/Meet/Teams
+    // keep the stream open while muted, see MEETING_END_DEBOUNCE_MS), so we
+    // auto-stop even if the notification was never tapped — a meeting is never
+    // left stranded paused.
     if (autoStartedSession.autoStopTimer) clearTimeout(autoStartedSession.autoStopTimer);
     autoStartedSession.autoStopTimer = setTimeout(() => {
       autoStartedSession.autoStopTimer = null;
       sendDebugLog(`[auto-detect] auto-stopping ended meeting: ${autoStartedSession.appName}`);
-      autoStopEndedMeeting();
+      autoStopEndedMeeting(false);
     }, MEETING_END_AUTOSTOP_GRACE_MS);
   }, MEETING_END_DEBOUNCE_MS);
+}
+
+// The meeting-end prompt (reliable mic-monitor trigger). Passive toast (no
+// focus-steal via the show:false/showInactive window); tapping "Summarise"
+// finalizes the auto-paused recording and runs the shared pipeline (transcribe
+// → summarise). A body tap opens Steno so the user can decide. This is separate
+// from — and more reliable than — the post-transcription "Note ready" toast.
+function showMeetingEndedNotification(appName) {
+  const notif = new Notification({
+    title: 'Meeting ended',
+    // NB: `appName` is the detected app (e.g. "Safari"/"Chrome"/"Zoom"), NOT the
+    // meeting name — so never put it in the body ("Summarise Safari?" is wrong).
+    body: 'Summarise this meeting?',
+    actions: [{ type: 'button', text: 'Summarise' }],
+  });
+  // `true` = the user explicitly asked to summarise → force note generation even
+  // when auto-summarize is off (which is now the default).
+  notif.on('action', (_evt, _index) => autoStopEndedMeeting(true));
+  notif.on('click', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (!mainWindow.isVisible()) mainWindow.show();
+      mainWindow.focus();
+    }
+  });
+  trackNotificationLifecycle(notif, 'meeting_ended');
+  notif.show();
+  return notif;
 }
 
 function showMeetingDetectedNotification(appName, originatingEvt, calEvent) {
@@ -6886,6 +6937,7 @@ function requestAutoRecord(appName, originatingEvt, calEvent) {
     paused: false,
     pauseTimer: null,
     autoStopTimer: null,
+    endNotif: null,
   };
 
   // Tapping "Take Notes" is an explicit "I'm going to take notes" — so bring
@@ -6907,9 +6959,13 @@ function requestAutoRecord(appName, originatingEvt, calEvent) {
 // not here. Sent on the `auto-summarise-requested` channel (whose renderer
 // handler already just stops the recording); the channel name predates the
 // auto-stop rework and is kept to avoid 4-file churn.
-function autoStopEndedMeeting() {
+// summarise=true means the user explicitly tapped the meeting-end "Summarise"
+// prompt → force note generation even when auto-summarize is off (the new
+// default). summarise=false is the untapped auto-stop fallback: finalize the
+// recording, but respect the auto-summarize setting (transcript-only if off).
+function autoStopEndedMeeting(summarise = false) {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send('auto-summarise-requested');
+    mainWindow.webContents.send('auto-summarise-requested', { summarise });
   }
   clearAutoStartedSession();
 }
@@ -6918,6 +6974,9 @@ function clearAutoStartedSession() {
   if (!autoStartedSession) return;
   if (autoStartedSession.pauseTimer) clearTimeout(autoStartedSession.pauseTimer);
   if (autoStartedSession.autoStopTimer) clearTimeout(autoStartedSession.autoStopTimer);
+  if (autoStartedSession.endNotif) {
+    try { autoStartedSession.endNotif.close(); } catch (_) {}
+  }
   autoStartedSession = null;
 }
 

--- a/app/main.js
+++ b/app/main.js
@@ -63,6 +63,7 @@ const processingLog = require('./processing-log');
 const { isMeetingApp, allowsDeviceLevelFallback, isMacos14Plus } = require('./meeting-detect');
 const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
 const { userNotesFilePath } = require('./notes-file');
+const { buildNoteReadyNotificationOptions, buildTranscriptReadyBody } = require('./notification-copy');
 const { makeLineReader } = require('./backend-stream');
 // Pure deep-link (stenoai://) parsing/sanitizing lives in ./shortcut-url
 // (unit-tested). The stateful side — window creation, IPC dispatch,
@@ -2079,6 +2080,7 @@ if (!gotSingleInstanceLock) {
     if (!IS_E2E && loadShowMenuBarIconEnabled()) createTray();
     setupAutoUpdater();
     setupAutoMeetingDetector();
+    setupDevNotificationTriggers();
     // Pre-meeting heads-up scheduler (calendar-time based). Skipped under E2E —
     // tests drive the show-premeeting-notification IPC seam directly; this would
     // otherwise start a background calendar poll.
@@ -2975,16 +2977,43 @@ ipcMain.handle('reprocess-meeting', async (event, summaryFile, regenerateTitle, 
         watchdog.clear();
         if (code === 0) {
           console.log(`✅ Completed reprocessing: ${sessionName}`);
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('processing-complete', {
-              success: true,
-              sessionName,
-              summaryFile,
-              notesGenerated: summarizationCompleted,
-              message: 'Reprocessing completed successfully'
-            });
-          }
-          resolve();
+          // Look up the saved meeting so the completion event carries meetingData
+          // with the note's CURRENT title — reprocess may have generated an LLM
+          // title, so `sessionName` here can still be the 'Note' placeholder. The
+          // renderer's note-ready notification reads meetingData.session_info.name
+          // for its body; without this it falls back to the generic string and
+          // the note title never shows. Mirrors the recording-complete path.
+          runPythonScript('simple_recorder.py', ['list-meetings'], true)
+            .then((meetingsResult) => {
+              const allMeetings = JSON.parse(meetingsResult);
+              const processedMeeting =
+                allMeetings.find((m) => m.session_info?.summary_file === summaryFile) || null;
+              if (mainWindow && !mainWindow.isDestroyed()) {
+                mainWindow.webContents.send('processing-complete', {
+                  success: true,
+                  sessionName,
+                  summaryFile,
+                  meetingData: processedMeeting,
+                  notesGenerated: summarizationCompleted,
+                  message: 'Reprocessing completed successfully'
+                });
+              }
+            })
+            .catch((error) => {
+              console.error('Error fetching reprocessed meeting:', error);
+              // Fall back to firing without meetingData — the note-ready title
+              // may be generic, but the note is still in the list + sidebar.
+              if (mainWindow && !mainWindow.isDestroyed()) {
+                mainWindow.webContents.send('processing-complete', {
+                  success: true,
+                  sessionName,
+                  summaryFile,
+                  notesGenerated: summarizationCompleted,
+                  message: 'Reprocessing completed successfully'
+                });
+              }
+            })
+            .finally(() => resolve());
         } else {
           if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.webContents.send('processing-complete', {
@@ -6791,12 +6820,8 @@ async function handleMicEvent(line) {
         clearTimeout(autoStartedSession.autoStopTimer);
         autoStartedSession.autoStopTimer = null;
       }
-      // Meeting came back — dismiss the "Meeting ended — Summarise?" prompt so a
-      // stale one can't finalize a live meeting.
-      if (autoStartedSession.endNotif) {
-        try { autoStartedSession.endNotif.close(); } catch (_) {}
-        autoStartedSession.endNotif = null;
-      }
+      // Meeting came back before the grace window elapsed — cancel the auto-stop
+      // and keep capturing.
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send('auto-resume-requested');
       }
@@ -6851,53 +6876,22 @@ function handleMicStop(evt) {
       mainWindow.webContents.send('auto-pause-requested');
     }
     sendDebugLog(`[auto-detect] meeting ended (paused): ${autoStartedSession.appName}`);
-    // Fire the meeting-end "Summarise?" notification NOW, from this reliable
-    // mic-monitor signal — a single deterministic event, unlike the
-    // post-transcription notification whose firing depended on renderer route +
-    // window focus at completion time (fragile: the meeting app closing shuffles
-    // focus, the auto-stop navigates, etc.). Tapping "Summarise" finalizes + runs
-    // the pipeline (transcribe → summarise) now.
-    autoStartedSession.endNotif = showMeetingEndedNotification(autoStartedSession.appName);
-    // Safety net: if the mic comes back within the grace, handleMicEvent above
-    // cancels this timer + dismisses the notification and auto-resumes. Otherwise
-    // the meeting has genuinely ended (a released mic ≠ mute — Zoom/Meet/Teams
-    // keep the stream open while muted, see MEETING_END_DEBOUNCE_MS), so we
-    // auto-stop even if the notification was never tapped — a meeting is never
-    // left stranded paused.
+    // Meeting ended: auto-stop silently after a short grace, then let the shared
+    // post-stop pipeline run. The summarise decision happens AFTER transcription
+    // via the same transcript-ready → "Summarise?" → note-ready notifications as
+    // a manual stop — no separate meeting-end prompt (it was redundant and made
+    // summarise a two-step flow). If the mic comes back within the grace,
+    // handleMicEvent above cancels this timer and auto-resumes. Otherwise the
+    // meeting has genuinely ended (a released mic ≠ mute — Zoom/Meet/Teams keep
+    // the stream open while muted, see MEETING_END_DEBOUNCE_MS), so we auto-stop
+    // — a meeting is never left stranded paused.
     if (autoStartedSession.autoStopTimer) clearTimeout(autoStartedSession.autoStopTimer);
     autoStartedSession.autoStopTimer = setTimeout(() => {
       autoStartedSession.autoStopTimer = null;
       sendDebugLog(`[auto-detect] auto-stopping ended meeting: ${autoStartedSession.appName}`);
-      autoStopEndedMeeting(false);
+      autoStopEndedMeeting();
     }, MEETING_END_AUTOSTOP_GRACE_MS);
   }, MEETING_END_DEBOUNCE_MS);
-}
-
-// The meeting-end prompt (reliable mic-monitor trigger). Passive toast (no
-// focus-steal via the show:false/showInactive window); tapping "Summarise"
-// finalizes the auto-paused recording and runs the shared pipeline (transcribe
-// → summarise). A body tap opens Steno so the user can decide. This is separate
-// from — and more reliable than — the post-transcription "Note ready" toast.
-function showMeetingEndedNotification(appName) {
-  const notif = new Notification({
-    title: 'Meeting ended',
-    // NB: `appName` is the detected app (e.g. "Safari"/"Chrome"/"Zoom"), NOT the
-    // meeting name — so never put it in the body ("Summarise Safari?" is wrong).
-    body: 'Summarise this meeting?',
-    actions: [{ type: 'button', text: 'Summarise' }],
-  });
-  // `true` = the user explicitly asked to summarise → force note generation even
-  // when auto-summarize is off (which is now the default).
-  notif.on('action', (_evt, _index) => autoStopEndedMeeting(true));
-  notif.on('click', () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      if (!mainWindow.isVisible()) mainWindow.show();
-      mainWindow.focus();
-    }
-  });
-  trackNotificationLifecycle(notif, 'meeting_ended');
-  notif.show();
-  return notif;
 }
 
 function showMeetingDetectedNotification(appName, originatingEvt, calEvent) {
@@ -6910,9 +6904,11 @@ function showMeetingDetectedNotification(appName, originatingEvt, calEvent) {
     body: calEvent?.title || appName,
     actions: [{ type: 'button', text: 'Take Notes' }],
   });
+  // Both the "Take Notes" button and the notification body start recording — one
+  // action, so a single tap anywhere works.
   const trigger = () => requestAutoRecord(appName, originatingEvt, calEvent);
   notif.on('action', (_evt, _index) => trigger()); // shown when banner style = Alerts
-  notif.on('click', trigger);                       // body tap (always available)
+  notif.on('click', () => trigger());              // body tap (always available)
   trackNotificationLifecycle(notif, 'meeting_detected');
   notif.show();
 }
@@ -6937,7 +6933,6 @@ function requestAutoRecord(appName, originatingEvt, calEvent) {
     paused: false,
     pauseTimer: null,
     autoStopTimer: null,
-    endNotif: null,
   };
 
   // Tapping "Take Notes" is an explicit "I'm going to take notes" — so bring
@@ -6956,16 +6951,12 @@ function requestAutoRecord(appName, originatingEvt, calEvent) {
 // through the grace window (see handleMicStop). STOPS the paused recording,
 // which drives the shared post-stop pipeline; the *summarise* decision then
 // happens after transcription (transcript-ready / note-ready notifications),
-// not here. Sent on the `auto-summarise-requested` channel (whose renderer
-// handler already just stops the recording); the channel name predates the
-// auto-stop rework and is kept to avoid 4-file churn.
-// summarise=true means the user explicitly tapped the meeting-end "Summarise"
-// prompt → force note generation even when auto-summarize is off (the new
-// default). summarise=false is the untapped auto-stop fallback: finalize the
-// recording, but respect the auto-summarize setting (transcript-only if off).
-function autoStopEndedMeeting(summarise = false) {
+// not here — identical to a manual stop. Sent on the `auto-summarise-requested`
+// channel (whose renderer handler just stops the recording); the channel name
+// predates the auto-stop rework and is kept to avoid 4-file churn.
+function autoStopEndedMeeting() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send('auto-summarise-requested', { summarise });
+    mainWindow.webContents.send('auto-summarise-requested', {});
   }
   clearAutoStartedSession();
 }
@@ -6974,10 +6965,58 @@ function clearAutoStartedSession() {
   if (!autoStartedSession) return;
   if (autoStartedSession.pauseTimer) clearTimeout(autoStartedSession.pauseTimer);
   if (autoStartedSession.autoStopTimer) clearTimeout(autoStartedSession.autoStopTimer);
-  if (autoStartedSession.endNotif) {
-    try { autoStartedSession.endNotif.close(); } catch (_) {}
-  }
   autoStartedSession = null;
+}
+
+// Opt-in dev tool: global shortcuts to fire each completion notification on
+// demand, so their native macOS click/action behavior is verifiable in
+// `npm start` without a real meeting or a DMG rebuild. Enabled only in a dev
+// build with STENOAI_DEV_NOTIF_TRIGGERS=1 (never packaged, never E2E) so it
+// doesn't grab shortcuts from other contributors by default. These fire the SAME
+// functions the real flow uses (showMeetingDetected/TranscriptReady/NoteReady),
+// so what you see here matches a real meeting.
+//   Ctrl+Alt+1 → "Meeting detected" (Take Notes)
+//   Ctrl+Alt+2 → "Transcript ready" (Summarise) for the most recent note
+//   Ctrl+Alt+3 → "Note ready" for the most recent note
+const DEV_NOTIF_TRIGGERS_ENV = 'STENOAI_DEV_NOTIF_TRIGGERS';
+function setupDevNotificationTriggers() {
+  if (IS_E2E || app.isPackaged || !process.env[DEV_NOTIF_TRIGGERS_ENV]) return;
+  const latestNote = async () => {
+    try {
+      const meetings = JSON.parse(await runPythonScript('simple_recorder.py', ['list-meetings'], true));
+      const withNotes = meetings.filter((m) => m.session_info?.summary_file);
+      const m = withNotes[0];
+      return m
+        ? { summaryFile: m.session_info.summary_file, title: m.session_info.name || 'Untitled note' }
+        : null;
+    } catch (e) {
+      sendDebugLog(`[dev-notify] list-meetings failed: ${e.message}`);
+      return null;
+    }
+  };
+  const register = (accel, label, fn) => {
+    try {
+      if (!globalShortcut.register(accel, fn)) {
+        console.warn(`[dev-notify] failed to register ${accel} (${label})`);
+      }
+    } catch (e) {
+      console.warn(`[dev-notify] register threw for ${accel}: ${e.message}`);
+    }
+  };
+  register('Control+Alt+1', 'meeting-detected', () => {
+    showMeetingDetectedNotification('DevMeeting', { pid: 0, app_id: 'dev.meeting' }, null);
+  });
+  register('Control+Alt+2', 'transcript-ready', async () => {
+    const note = await latestNote();
+    if (!note) { sendDebugLog('[dev-notify] no note for transcript-ready'); return; }
+    void showTranscriptReadyNotification({ title: note.title, summaryFile: note.summaryFile, name: note.title });
+  });
+  register('Control+Alt+3', 'note-ready', async () => {
+    const note = await latestNote();
+    if (!note) { sendDebugLog('[dev-notify] no note for note-ready'); return; }
+    void showNoteReadyNotification({ title: note.title, summaryFile: note.summaryFile });
+  });
+  sendDebugLog('[dev-notify] triggers registered (Ctrl+Alt+1/2/3)');
 }
 
 function setupAutoMeetingDetector() {
@@ -8147,44 +8186,27 @@ ipcMain.handle('show-system-audio-mic-only-notification', async () => {
 // navigate-to-meeting event — and only falls back to focus-only when
 // `summaryFile` is absent (the hardFailure case: nothing was ever written,
 // so there's nothing to open).
+async function showNoteReadyNotification(payload) {
+  // `shown` = passed the notifications_enabled gate (see show-silence-auto-stop).
+  if (!(await notificationsEnabled())) return { success: true, shown: false };
+  const { summaryFile } = payload || {};
+  const { title, body, iconType, outcome } = buildNoteReadyNotificationOptions(payload);
+  const notif = new Notification({ title, body, iconType });
+  notif.on('click', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (!mainWindow.isVisible()) mainWindow.show();
+      mainWindow.focus();
+      if (summaryFile) mainWindow.webContents.send('navigate-to-meeting', { summaryFile });
+    }
+  });
+  trackNotificationLifecycle(notif, 'note_ready', { outcome });
+  notif.show();
+  return { success: true, shown: true };
+}
+
 ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
   try {
-    // `shown` = passed the notifications_enabled gate (see show-silence-auto-stop).
-    if (!(await notificationsEnabled())) return { success: true, shown: false };
-    const { title, failed, hardFailure, summaryFile } = payload || {};
-    // Three honest states:
-    //  - hardFailure: processing crashed (or an import never enqueued) so no
-    //    note was written — there's nothing to "open". Keep the message
-    //    neutral: it's shared by recording crashes, import crashes and import
-    //    enqueue failures, and over-promising ("audio kept") is either hollow
-    //    (no UI surfaces the orphaned audio) or wrong (enqueue failure).
-    //  - failed: a graceful transcription failure DID write a marked note —
-    //    the recording was preserved and the note explains it on open.
-    //  - otherwise: the note is genuinely ready.
-    const notif = new Notification({
-      title: hardFailure
-        ? 'Processing failed'
-        : failed
-          ? 'Transcription failed'
-          : 'Note ready',
-      body: hardFailure
-        ? `Steno couldn't process ${title ? `"${title}"` : 'your note'}.`
-        : failed
-          ? 'Your recording was preserved — open the note for details.'
-          : (title || 'Your note has finished processing'),
-      iconType: (hardFailure || failed) ? 'alert' : 'success',
-    });
-    notif.on('click', () => {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        if (!mainWindow.isVisible()) mainWindow.show();
-        mainWindow.focus();
-        if (summaryFile) mainWindow.webContents.send('navigate-to-meeting', { summaryFile });
-      }
-    });
-    const outcome = hardFailure ? 'hard_failure' : failed ? 'failed' : 'success';
-    trackNotificationLifecycle(notif, 'note_ready', { outcome });
-    notif.show();
-    return { success: true, shown: true };
+    return await showNoteReadyNotification(payload);
   } catch (e) {
     sendDebugLog(`Failed to show note-ready notification: ${e.message}`);
     return { success: false, error: e.message };
@@ -8200,38 +8222,41 @@ ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
 // notification (click → opens the note) is the moment we bring the user in, so
 // there's no need to pull the window forward now. A body tap opens the note to
 // read the transcript.
+async function showTranscriptReadyNotification(payload) {
+  // `shown` = passed the notifications_enabled gate (see show-note-ready).
+  if (!(await notificationsEnabled())) return { success: true, shown: false };
+  const { title, summaryFile, name } = payload || {};
+  const notif = new Notification({
+    title: 'Transcript ready',
+    body: buildTranscriptReadyBody(title),
+    actions: [{ type: 'button', text: 'Summarise' }],
+    iconType: 'success',
+  });
+  // The whole notification means "yes, summarise": a body tap AND the "Summarise"
+  // button both open the note and start generation there, so the user watches it
+  // stream in-place ("Note ready" still fires on completion). Wiring both to the
+  // same action is what makes it one-click (like "Take Notes") — a body tap that
+  // only navigated was the source of the two-click ("first click opens, second
+  // click summarises"). Bring the window forward, navigate to the note, THEN
+  // kick off generation.
+  const startSummarise = () => {
+    if (mainWindow && !mainWindow.isDestroyed() && summaryFile) {
+      if (!mainWindow.isVisible()) mainWindow.show();
+      mainWindow.focus();
+      mainWindow.webContents.send('navigate-to-meeting', { summaryFile });
+      mainWindow.webContents.send('generate-notes-requested', { summaryFile, name });
+    }
+  };
+  notif.on('action', () => startSummarise());
+  notif.on('click', () => startSummarise());
+  trackNotificationLifecycle(notif, 'transcript_ready');
+  notif.show();
+  return { success: true, shown: true };
+}
+
 ipcMain.handle('show-transcript-ready-notification', async (_event, payload) => {
   try {
-    // `shown` = passed the notifications_enabled gate (see show-note-ready).
-    if (!(await notificationsEnabled())) return { success: true, shown: false };
-    const { title, summaryFile, name } = payload || {};
-    const notif = new Notification({
-      title: 'Transcript ready',
-      body: title ? `Summarise "${title}"?` : 'Summarise?',
-      actions: [{ type: 'button', text: 'Summarise' }],
-      iconType: 'success',
-    });
-    // Background: kick off generation without pulling the window forward. The
-    // note-ready notification that fires on completion is where we bring the
-    // user in (its click opens the note).
-    const startSummarise = () => {
-      if (mainWindow && !mainWindow.isDestroyed() && summaryFile) {
-        mainWindow.webContents.send('generate-notes-requested', { summaryFile, name });
-      }
-    };
-    notif.on('action', () => startSummarise());
-    // Body tap just opens the note to read the transcript (no generation) — the
-    // in-note GenerateNotesBar is there if they change their mind.
-    notif.on('click', () => {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        if (!mainWindow.isVisible()) mainWindow.show();
-        mainWindow.focus();
-        if (summaryFile) mainWindow.webContents.send('navigate-to-meeting', { summaryFile });
-      }
-    });
-    trackNotificationLifecycle(notif, 'transcript_ready');
-    notif.show();
-    return { success: true, shown: true };
+    return await showTranscriptReadyNotification(payload);
   } catch (e) {
     sendDebugLog(`Failed to show transcript-ready notification: ${e.message}`);
     return { success: false, error: e.message };

--- a/app/main.js
+++ b/app/main.js
@@ -8217,11 +8217,10 @@ ipcMain.handle('show-note-ready-notification', async (_event, payload) => {
 // transcription but NO notes were generated (auto_summarize off → transcript-
 // only note). Unlike note-ready, this prompts the user to summarise, and is the
 // correctly-timed replacement for the old premature meeting-end "Summarise?"
-// prompt (#bug2/#bug3). Tapping "Summarise" kicks off generation in the
-// BACKGROUND — no focus-steal — because when it finishes the note-ready
-// notification (click → opens the note) is the moment we bring the user in, so
-// there's no need to pull the window forward now. A body tap opens the note to
-// read the transcript.
+// prompt (#bug2/#bug3). One-click, matching "Take Notes": tapping "Summarise" —
+// the button OR the notification body — brings the window forward, opens the
+// note, and starts generation there, so the user watches it stream in-place;
+// "Note ready" still fires on completion.
 async function showTranscriptReadyNotification(payload) {
   // `shown` = passed the notifications_enabled gate (see show-note-ready).
   if (!(await notificationsEnabled())) return { success: true, shown: false };

--- a/app/notification-copy.js
+++ b/app/notification-copy.js
@@ -1,0 +1,36 @@
+// Pure copy-builders for the completion notifications, extracted from main.js so
+// they're unit-testable without Electron. The key invariant they guard is Bug C:
+// the note's title must reach the notification body — a reprocess completion that
+// carried only the 'Note' placeholder was showing the generic fallback and the
+// title never appeared.
+
+/**
+ * Window options (minus the click wiring) for the note-ready / failure
+ * notification. `outcome` feeds the analytics lifecycle tag.
+ *
+ * Three honest states:
+ *  - hardFailure: processing crashed (or an import never enqueued) so no note was
+ *    written — nothing to open; keep the copy neutral.
+ *  - failed: a graceful transcription failure DID write a marked note.
+ *  - otherwise: the note is genuinely ready — the body IS the note title.
+ */
+function buildNoteReadyNotificationOptions(payload) {
+  const { title, failed, hardFailure } = payload || {};
+  return {
+    title: hardFailure ? 'Processing failed' : failed ? 'Transcription failed' : 'Note ready',
+    body: hardFailure
+      ? `Steno couldn't process ${title ? `"${title}"` : 'your note'}.`
+      : failed
+        ? 'Your recording was preserved — open the note for details.'
+        : (title || 'Your note has finished processing'),
+    iconType: (hardFailure || failed) ? 'alert' : 'success',
+    outcome: hardFailure ? 'hard_failure' : failed ? 'failed' : 'success',
+  };
+}
+
+/** Body text for the transcript-ready "Summarise?" prompt. */
+function buildTranscriptReadyBody(title) {
+  return title ? `Summarise "${title}"?` : 'Summarise?';
+}
+
+module.exports = { buildNoteReadyNotificationOptions, buildTranscriptReadyBody };

--- a/app/notification-copy.test.js
+++ b/app/notification-copy.test.js
@@ -1,0 +1,47 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  buildNoteReadyNotificationOptions,
+  buildTranscriptReadyBody,
+} = require('./notification-copy');
+
+// Bug C regression guard: the note's real title must reach the notification body.
+// The bug was a reprocess completion that carried only the 'Note' placeholder (or
+// nothing), so note-ready showed the generic fallback and the title never showed.
+
+test('note-ready body IS the note title when a title is provided', () => {
+  const opts = buildNoteReadyNotificationOptions({ title: 'Q3 Planning sync' });
+  assert.strictEqual(opts.title, 'Note ready');
+  assert.strictEqual(opts.body, 'Q3 Planning sync');
+  assert.strictEqual(opts.iconType, 'success');
+  assert.strictEqual(opts.outcome, 'success');
+});
+
+test('note-ready falls back to a generic body only when there is no title', () => {
+  const opts = buildNoteReadyNotificationOptions({});
+  assert.strictEqual(opts.body, 'Your note has finished processing');
+});
+
+test('note-ready renders the transcription-failure state', () => {
+  const opts = buildNoteReadyNotificationOptions({ title: 'Standup', failed: true });
+  assert.strictEqual(opts.title, 'Transcription failed');
+  assert.strictEqual(opts.iconType, 'alert');
+  assert.strictEqual(opts.outcome, 'failed');
+});
+
+test('note-ready renders the hard-failure state and quotes the title when present', () => {
+  const withTitle = buildNoteReadyNotificationOptions({ title: 'Retro', hardFailure: true });
+  assert.strictEqual(withTitle.title, 'Processing failed');
+  assert.ok(withTitle.body.includes('"Retro"'));
+  assert.strictEqual(withTitle.outcome, 'hard_failure');
+
+  const noTitle = buildNoteReadyNotificationOptions({ hardFailure: true });
+  assert.ok(noTitle.body.includes('your note'));
+});
+
+test('transcript-ready prompt quotes the note title', () => {
+  assert.strictEqual(buildTranscriptReadyBody('Weekly 1:1'), 'Summarise "Weekly 1:1"?');
+  assert.strictEqual(buildTranscriptReadyBody(''), 'Summarise?');
+  assert.strictEqual(buildTranscriptReadyBody(undefined), 'Summarise?');
+});

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js update-os-gate.test.js update-error-copy.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js update-os-gate.test.js update-error-copy.test.js notification-copy.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/renderer/src/components/NotificationToast.tsx
+++ b/app/renderer/src/components/NotificationToast.tsx
@@ -146,8 +146,15 @@ export function NotificationToast() {
           </button>
 
           <div className="flex items-center min-w-0">
+            {/* Leading Steno brand mark so every toast is identifiable as Steno
+                — the action/status toasts otherwise show a button or a ✓ in the
+                right slot and nothing said "Steno", especially floating top-right
+                with the window hidden. */}
+            <div className="shrink-0 ml-1 text-gray-800 dark:text-gray-100">
+              <AppIcon size={20} color="currentColor" />
+            </div>
             <div
-              className="h-8 w-1 rounded-full ml-1 shrink-0"
+              className="h-8 w-1 rounded-full ml-2 shrink-0"
               style={{ backgroundColor: barColor }}
             ></div>
             <div className="flex flex-col justify-center ml-3 min-w-0">

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -11,13 +11,21 @@ import { streamCache } from '@/lib/meetingDetailState';
 import {
   classifyCompletionNotification,
   meetingAlreadyHasNotes,
-  completionRouteAction,
+  completionActions,
 } from '@/lib/completionNotification';
 import type { Meeting, QueueStatus, RecordingTrigger } from '@/lib/ipc';
 
 export type RecordingStatus = 'idle' | 'recording' | 'paused' | 'processing';
 
 const queueKey = ['recording', 'queue'] as const;
+
+// Summary files whose owning auto-detected meeting the user asked to summarise
+// via the reliable meeting-end "Summarise" prompt. That prompt fires BEFORE
+// transcription finishes, so we defer the intent here: when the transcript-only
+// note completes, force note generation (reprocess) even with auto-summarize off
+// (the new default). Module-scoped so it survives the components remounting
+// between recording and completion.
+const pendingAutoSummarise = new Set<string>();
 
 // ── Shared window-visibility subscription ───────────────────────────────
 //
@@ -200,7 +208,7 @@ export function useRecording() {
     [qc]
   );
 
-  const stopRecording = React.useCallback(async () => {
+  const stopRecording = React.useCallback(async ({ navigateToNote = true }: { navigateToNote?: boolean } = {}) => {
     // Optimistic: flip the queue cache to processing so the UI can swap the
     // pill for the processing dock instantly, before the backend SIGTERM
     // round-trip.
@@ -220,17 +228,26 @@ export function useRecording() {
       // continued note) and returns its path — land the user ON it, with the
       // batch transcribe/summarise upgrading it in the background. Whisper/
       // import return no summaryFile → the processing dock as before.
-      if (data.summaryFile) {
-        navigate(`/meetings/${encodeURIComponent(data.summaryFile)}`);
-      } else {
-        navigate('/meetings/processing');
+      //
+      // navigateToNote=false is used by the auto-stop path (meeting ended): the
+      // user isn't engaged, so we must NOT move them onto the note's route —
+      // otherwise, once macOS brings Steno forward as the meeting app closes,
+      // the completion handler sees "focused + on this note" and suppresses the
+      // "Transcript ready — Summarise?" notification. Leaving the route where it
+      // is keeps that notification firing.
+      if (navigateToNote) {
+        if (data.summaryFile) {
+          navigate(`/meetings/${encodeURIComponent(data.summaryFile)}`);
+        } else {
+          navigate('/meetings/processing');
+        }
       }
       qc.invalidateQueries({ queryKey: queueKey });
       return data;
     } catch (err) {
       // Stop failed before we learned the note path — fall back to the dock so
       // the user isn't stranded on the recording view.
-      navigate('/meetings/processing');
+      if (navigateToNote) navigate('/meetings/processing');
       qc.invalidateQueries({ queryKey: queueKey });
       throw err;
     }
@@ -359,11 +376,27 @@ export function useRecordingEvents() {
         // its own state says we're paused.
         void resumeRecording();
       }),
-      bridge.on.autoSummariseRequested(() => {
-        // User chose "Wrap up" on the Meeting ended notification — stop the
-        // (auto-paused) recording so the pipeline runs; the summarise decision
-        // now happens after transcription, not here (#bug3).
-        if (status === 'recording' || status === 'paused') void stopRecording();
+      bridge.on.autoSummariseRequested(({ summarise } = {}) => {
+        // Auto-stop of an ended auto-detected meeting — stop the (auto-paused)
+        // recording so the pipeline runs. Do NOT navigate to the note: the user
+        // isn't engaged (they're leaving the meeting), and navigating there would
+        // let the completion handler suppress the completion notification once
+        // macOS surfaces Steno as the meeting closes.
+        if (status === 'recording' || status === 'paused') {
+          void stopRecording({ navigateToNote: false })
+            .then((data) => {
+              // The user explicitly tapped the meeting-end "Summarise" prompt
+              // (not the untapped auto-stop fallback) → remember to generate
+              // notes once this note's transcript completes, even with
+              // auto-summarize off. Parakeet instant-stop returns the note path
+              // here; without one (Whisper) we fall back to the post-transcription
+              // "Transcript ready — Summarise?" prompt.
+              if (summarise && data?.summaryFile) {
+                pendingAutoSummarise.add(data.summaryFile);
+              }
+            })
+            .catch(() => {});
+        }
       }),
       bridge.on.generateNotesRequested(({ summaryFile, name }) => {
         // User tapped "Summarise" on the transcript-ready notification. Run the
@@ -497,30 +530,53 @@ export function useRecordingProcessingEffects() {
       const finishedSummaryFile =
         data.meetingData?.session_info.summary_file ?? data.summaryFile ?? null;
       if (data.success && finishedSummaryFile) {
+        // Deferred force-summary: the user tapped the reliable meeting-end
+        // "Summarise" prompt on this (now transcript-only) note → generate notes
+        // now via the same reprocess path as the "Generate notes" CTA, even with
+        // auto-summarize off. Skip the notification here; the reprocess
+        // completion fires again with notesGenerated:true → the "Note ready"
+        // prompt, whose click opens the note.
+        if (pendingAutoSummarise.has(finishedSummaryFile)) {
+          pendingAutoSummarise.delete(finishedSummaryFile);
+          const failed =
+            Boolean(data.transcriptionFailed) ||
+            Boolean(data.meetingData?.session_info.transcription_failed);
+          // Only force notes when there's a clean transcript-only note to
+          // summarise; a failed transcript or one that already has notes falls
+          // through to the normal completion handling below.
+          if (!data.notesGenerated && !failed) {
+            void ipc().meetings.reprocess(finishedSummaryFile, false, '').catch(() => {});
+            return;
+          }
+        }
         const currentRoute = routeFromHash(window.location.hash);
         const finishedMeetingRoute = `/meetings/${encodeURIComponent(finishedSummaryFile)}`;
         // #bug1 lets an auto-detected recording run with the window HIDDEN
-        // (tray-only), so "the route is this note" no longer implies the user
-        // is looking at it. Gate the suppress-when-already-here logic on real
-        // visibility, not route alone — otherwise the wrap-up flow suppresses
-        // every post-transcription prompt on the default (Parakeet) engine:
-        // stopRecording navigates to the note's own route (useRecording.ts
-        // instant-stop path), so a route-only guard would always match and
-        // never notify. (visibilityState is 'hidden' for a hidden/minimised
-        // window.)
-        const windowVisible =
-          typeof document !== 'undefined' && document.visibilityState === 'visible';
-        const action = completionRouteAction({
+        // (tray-only) or backgrounded behind the meeting app, so "the route is
+        // this note" no longer implies the user is looking at it. Gate the
+        // suppress-when-already-here logic on FOCUS, not route alone and not
+        // visibilityState: after an auto-stop, stopRecording navigates to the
+        // note's own route, but Steno is usually behind the meeting window —
+        // where visibilityState is still 'visible' (the window is shown, just
+        // not frontmost), which wrongly suppressed the notification. hasFocus()
+        // is false whenever Steno isn't the active window (hidden, minimised, OR
+        // backgrounded), so we correctly notify unless the user is truly looking
+        // at this note.
+        const windowFocused =
+          typeof document !== 'undefined' && document.hasFocus();
+        const { navigate: shouldNavigate, notify: shouldNotify } = completionActions({
           currentRoute,
           finishedMeetingRoute,
           processingRoute: '/meetings/processing',
-          windowVisible,
+          windowFocused,
         });
-        if (action === 'navigate') {
-          // Watching it finish on the processing page → take them straight
-          // into the now-ready note.
+        if (shouldNavigate) {
+          // On the transient /processing screen → always advance to the note so
+          // the user is never stranded on a stuck spinner (regression fix),
+          // whether or not Steno is focused.
           navigate(finishedMeetingRoute);
-        } else if (action === 'notify') {
+        }
+        if (shouldNotify) {
           // A different route (Home, Chat, Settings, recording another note, a
           // different meeting) OR this note's route but the window is
           // hidden/minimised (tray-only after an auto-detected wrap-up) → fire a

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -19,14 +19,6 @@ export type RecordingStatus = 'idle' | 'recording' | 'paused' | 'processing';
 
 const queueKey = ['recording', 'queue'] as const;
 
-// Summary files whose owning auto-detected meeting the user asked to summarise
-// via the reliable meeting-end "Summarise" prompt. That prompt fires BEFORE
-// transcription finishes, so we defer the intent here: when the transcript-only
-// note completes, force note generation (reprocess) even with auto-summarize off
-// (the new default). Module-scoped so it survives the components remounting
-// between recording and completion.
-const pendingAutoSummarise = new Set<string>();
-
 // ── Shared window-visibility subscription ───────────────────────────────
 //
 // `useRecording` is consumed by 12+ components. If each consumer manages
@@ -376,26 +368,17 @@ export function useRecordingEvents() {
         // its own state says we're paused.
         void resumeRecording();
       }),
-      bridge.on.autoSummariseRequested(({ summarise } = {}) => {
+      bridge.on.autoSummariseRequested(() => {
         // Auto-stop of an ended auto-detected meeting — stop the (auto-paused)
-        // recording so the pipeline runs. Do NOT navigate to the note: the user
-        // isn't engaged (they're leaving the meeting), and navigating there would
-        // let the completion handler suppress the completion notification once
-        // macOS surfaces Steno as the meeting closes.
+        // recording so the shared post-stop pipeline runs, exactly like a manual
+        // stop. Do NOT navigate to the note: the user isn't engaged (they're
+        // leaving the meeting), and navigating there would let the completion
+        // handler suppress the completion notification once macOS surfaces Steno
+        // as the meeting closes. The summarise decision then happens after
+        // transcription via the transcript-ready → "Summarise?" → note-ready
+        // notifications — no separate meeting-end prompt.
         if (status === 'recording' || status === 'paused') {
-          void stopRecording({ navigateToNote: false })
-            .then((data) => {
-              // The user explicitly tapped the meeting-end "Summarise" prompt
-              // (not the untapped auto-stop fallback) → remember to generate
-              // notes once this note's transcript completes, even with
-              // auto-summarize off. Parakeet instant-stop returns the note path
-              // here; without one (Whisper) we fall back to the post-transcription
-              // "Transcript ready — Summarise?" prompt.
-              if (summarise && data?.summaryFile) {
-                pendingAutoSummarise.add(data.summaryFile);
-              }
-            })
-            .catch(() => {});
+          void stopRecording({ navigateToNote: false }).catch(() => {});
         }
       }),
       bridge.on.generateNotesRequested(({ summaryFile, name }) => {
@@ -530,25 +513,6 @@ export function useRecordingProcessingEffects() {
       const finishedSummaryFile =
         data.meetingData?.session_info.summary_file ?? data.summaryFile ?? null;
       if (data.success && finishedSummaryFile) {
-        // Deferred force-summary: the user tapped the reliable meeting-end
-        // "Summarise" prompt on this (now transcript-only) note → generate notes
-        // now via the same reprocess path as the "Generate notes" CTA, even with
-        // auto-summarize off. Skip the notification here; the reprocess
-        // completion fires again with notesGenerated:true → the "Note ready"
-        // prompt, whose click opens the note.
-        if (pendingAutoSummarise.has(finishedSummaryFile)) {
-          pendingAutoSummarise.delete(finishedSummaryFile);
-          const failed =
-            Boolean(data.transcriptionFailed) ||
-            Boolean(data.meetingData?.session_info.transcription_failed);
-          // Only force notes when there's a clean transcript-only note to
-          // summarise; a failed transcript or one that already has notes falls
-          // through to the normal completion handling below.
-          if (!data.notesGenerated && !failed) {
-            void ipc().meetings.reprocess(finishedSummaryFile, false, '').catch(() => {});
-            return;
-          }
-        }
         const currentRoute = routeFromHash(window.location.hash);
         const finishedMeetingRoute = `/meetings/${encodeURIComponent(finishedSummaryFile)}`;
         // #bug1 lets an auto-detected recording run with the window HIDDEN

--- a/app/renderer/src/hooks/useRecording.ts
+++ b/app/renderer/src/hooks/useRecording.ts
@@ -378,7 +378,16 @@ export function useRecordingEvents() {
         // transcription via the transcript-ready → "Summarise?" → note-ready
         // notifications — no separate meeting-end prompt.
         if (status === 'recording' || status === 'paused') {
-          void stopRecording({ navigateToNote: false }).catch(() => {});
+          // Surface a failed auto-stop: unlike startRecording, stopRecording
+          // re-throws without notifying, and this path deliberately doesn't
+          // navigate — so without this the meeting would silently fail to
+          // finalize with no user-visible signal. Route it through the same
+          // capture-error notification the start path uses.
+          void stopRecording({ navigateToNote: false }).catch((err) => {
+            ipc().recording.reportCaptureError(
+              err instanceof Error ? err.message : 'Recording could not stop'
+            );
+          });
         }
       }),
       bridge.on.generateNotesRequested(({ summaryFile, name }) => {

--- a/app/renderer/src/lib/completionNotification.test.ts
+++ b/app/renderer/src/lib/completionNotification.test.ts
@@ -2,42 +2,43 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyCompletionNotification,
   meetingAlreadyHasNotes,
-  completionRouteAction,
+  completionActions,
 } from './completionNotification';
 
 const NOTE = '/meetings/abc_summary.md';
 const PROCESSING = '/meetings/processing';
-const routeAction = (currentRoute: string, windowVisible: boolean) =>
-  completionRouteAction({
+const actions = (currentRoute: string, windowFocused: boolean) =>
+  completionActions({
     currentRoute,
     finishedMeetingRoute: NOTE,
     processingRoute: PROCESSING,
-    windowVisible,
+    windowFocused,
   });
 
-describe('completionRouteAction (#bug1/#bug3 visibility-aware guard)', () => {
-  it('BLOCKER case: on the note route but window HIDDEN → notify (wrap-up flow)', () => {
-    // stopRecording navigated to the note's route in a hidden tray-only window;
-    // a route-only guard suppressed the prompt — this is the fix.
-    expect(routeAction(NOTE, false)).toBe('notify');
+describe('completionActions (navigate + notify guard)', () => {
+  it('on /processing, NOT focused → navigate AND notify (never stranded, and told)', () => {
+    // The regression: previously this returned only "notify", so /processing was
+    // never advanced and got stuck on "Analyzing transcript". Now it always
+    // navigates off /processing, and notifies because the user isn't watching.
+    expect(actions(PROCESSING, false)).toEqual({ navigate: true, notify: true });
   });
 
-  it('on the note route AND visible → suppress (user sees the summary)', () => {
-    expect(routeAction(NOTE, true)).toBe('suppress');
+  it('on /processing, focused → navigate, no notify (watching it finish)', () => {
+    expect(actions(PROCESSING, true)).toEqual({ navigate: true, notify: false });
   });
 
-  it('on the processing page AND visible → navigate into the note', () => {
-    expect(routeAction(PROCESSING, true)).toBe('navigate');
+  it('on the note route, NOT focused → notify, no navigate (auto-stop behind the meeting)', () => {
+    expect(actions(NOTE, false)).toEqual({ navigate: false, notify: true });
   });
 
-  it('on the processing page but HIDDEN → notify (not silently navigate)', () => {
-    expect(routeAction(PROCESSING, false)).toBe('notify');
+  it('on the note route, focused → suppress both (user is looking at it)', () => {
+    expect(actions(NOTE, true)).toEqual({ navigate: false, notify: false });
   });
 
-  it('on any other route → notify (visible or hidden)', () => {
-    expect(routeAction('/', true)).toBe('notify');
-    expect(routeAction('/chat', false)).toBe('notify');
-    expect(routeAction('/meetings/other_summary.md', true)).toBe('notify');
+  it('on any other route → notify only, never navigate', () => {
+    expect(actions('/', true)).toEqual({ navigate: false, notify: true });
+    expect(actions('/chat', false)).toEqual({ navigate: false, notify: true });
+    expect(actions('/meetings/other_summary.md', true)).toEqual({ navigate: false, notify: true });
   });
 });
 

--- a/app/renderer/src/lib/completionNotification.ts
+++ b/app/renderer/src/lib/completionNotification.ts
@@ -57,29 +57,33 @@ export function meetingAlreadyHasNotes(
 }
 
 /**
- * What to do when a job finishes, based on where the user is AND whether the
- * window is actually visible (#bug1). The visibility gate matters because an
- * auto-detected recording can run with the window HIDDEN (tray-only), and
- * "Wrap up" navigates to the note's own route — so route alone would say "the
- * user is looking at it" when the window is hidden and they aren't, suppressing
- * the very prompt this feature exists to send.
+ * On job completion, decide two INDEPENDENT things: whether to NAVIGATE off the
+ * transient /processing screen, and whether to NOTIFY. They're independent
+ * because a backgrounded user sitting on /processing must be BOTH moved to the
+ * note (so they're never stranded on a stuck "Analyzing transcript" screen —
+ * the regression this fixes) AND notified.
  *
- * - `navigate`: user is watching the processing page (visible) → open the note.
- * - `suppress`: user is already viewing this note (visible) → the static
- *   summary is right there, a banner would be noise.
- * - `notify`: anywhere else, OR this note's route but the window is
- *   hidden/minimised → fire a notification.
+ * - `navigate`: true whenever the user is on /processing. That screen is
+ *   transient; leaving them there after completion strands them, so we always
+ *   advance to the note regardless of focus. (A background navigate is harmless;
+ *   when they return they're on the note, not a stuck spinner.) When they stay
+ *   focused on /processing it also completes fine — this just makes the
+ *   not-focused case behave the same.
+ * - `notify`: true unless the user is actively LOOKING at the result right now —
+ *   focused on this note, or focused on /processing watching it finish. Focus,
+ *   not visibilityState: `visibilityState` stays 'visible' for a window shown
+ *   behind the meeting app (wrongly suppressing); `hasFocus()` is false whenever
+ *   Steno isn't the active window.
  */
-export type CompletionRouteAction = 'navigate' | 'notify' | 'suppress';
-
-export function completionRouteAction(input: {
+export function completionActions(input: {
   currentRoute: string;
   finishedMeetingRoute: string;
   processingRoute: string;
-  windowVisible: boolean;
-}): CompletionRouteAction {
-  const { currentRoute, finishedMeetingRoute, processingRoute, windowVisible } = input;
-  if (currentRoute === processingRoute && windowVisible) return 'navigate';
-  if (currentRoute === finishedMeetingRoute && windowVisible) return 'suppress';
-  return 'notify';
+  windowFocused: boolean;
+}): { navigate: boolean; notify: boolean } {
+  const { currentRoute, finishedMeetingRoute, processingRoute, windowFocused } = input;
+  const onProcessing = currentRoute === processingRoute;
+  const focusedOnThisNote = currentRoute === finishedMeetingRoute && windowFocused;
+  const userIsWatching = focusedOnThisNote || (onProcessing && windowFocused);
+  return { navigate: onProcessing, notify: !userIsWatching };
 }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -1151,7 +1151,7 @@ export interface StenoaiBridge {
     autoRecordRequested: Subscribe<{ sessionName?: string; appName?: string }>;
     autoPauseRequested: Subscribe<void>;
     autoResumeRequested: Subscribe<void>;
-    autoSummariseRequested: Subscribe<{ summarise?: boolean }>;
+    autoSummariseRequested: Subscribe<void>;
     /** Main asks the renderer to generate notes for a transcript-only note in
      *  the background (from the "Generate notes" action on the transcript-ready
      *  notification). Renderer runs the same reprocess path as GenerateNotesBar. */

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -1151,7 +1151,7 @@ export interface StenoaiBridge {
     autoRecordRequested: Subscribe<{ sessionName?: string; appName?: string }>;
     autoPauseRequested: Subscribe<void>;
     autoResumeRequested: Subscribe<void>;
-    autoSummariseRequested: Subscribe<void>;
+    autoSummariseRequested: Subscribe<{ summarise?: boolean }>;
     /** Main asks the renderer to generate notes for a transcript-only note in
      *  the background (from the "Generate notes" action on the transcript-ready
      *  notification). Renderer runs the same reprocess path as GenerateNotesBar. */

--- a/app/renderer/src/routes/Recording.tsx
+++ b/app/renderer/src/routes/Recording.tsx
@@ -18,8 +18,12 @@ export function Recording() {
 
   // If we land on /recording with no active recording (e.g. cold reload after
   // it stopped), bounce back home so we don't leave the user on a dead page.
-  // Status 'processing' is handled by the global listener which redirects to
-  // /meetings/processing.
+  // We only bounce when the session is genuinely gone: a recording/paused
+  // status means one is active or just starting (via "Take Notes" from another
+  // route, whose ~2s Parakeet warm-up leaves live.active briefly false) — never
+  // bounce that, or the user gets kicked off the page they just opened and it
+  // reads as a no-op needing a second tap. Status 'processing' is handled by
+  // the global listener which redirects to /meetings/processing.
   //
   // 500ms grace period: during a normal stop, the optimistic cache write
   // briefly transitions status (idle ↔ processing) and live.active flips off
@@ -28,17 +32,21 @@ export function Recording() {
   // home — visible most reliably when the user had been typing notes (queue
   // poll cadence + cache updates landed in a different order). The delay
   // lets the transition settle before we make any bouncing decision.
+  const hasSession =
+    live.active ||
+    recording.status === 'recording' ||
+    recording.status === 'paused' ||
+    recording.status === 'processing';
   React.useEffect(() => {
     if (recording.isLoading) return;
-    if (live.active) return;
-    if (recording.status === 'processing') return;
+    if (hasSession) return;
     const t = setTimeout(() => {
-      if (!recording.isLoading && !live.active && recording.status !== 'processing') {
+      if (!recording.isLoading && !hasSession) {
         navigate('/');
       }
     }, 500);
     return () => clearTimeout(t);
-  }, [recording.isLoading, live.active, recording.status, navigate]);
+  }, [recording.isLoading, hasSession, navigate]);
 
   const startedAt = live.startedAt ?? new Date();
 

--- a/e2e/fixtures/notifications.ts
+++ b/e2e/fixtures/notifications.ts
@@ -1,0 +1,23 @@
+import type { ElectronApplication } from '@playwright/test';
+
+/**
+ * Fire a main→renderer notification-flow event straight from the main process,
+ * on the same channel main.js's Notification click/action handlers emit on. This
+ * exercises the REAL renderer handlers (preload subscribe → useRecordingEvents)
+ * that a native macOS notification click would drive — without needing a native
+ * notification (whose click behavior the harness can't script).
+ */
+export async function emitMainEvent(
+  app: ElectronApplication,
+  channel: string,
+  payload: unknown = {},
+): Promise<void> {
+  await app.evaluate(
+    ({ BrowserWindow }, { channel, payload }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (!win) throw new Error('no BrowserWindow to emit into');
+      win.webContents.send(channel, payload);
+    },
+    { channel, payload },
+  );
+}

--- a/e2e/specs/live-transcript-fallback.t2.spec.ts
+++ b/e2e/specs/live-transcript-fallback.t2.spec.ts
@@ -101,7 +101,10 @@ test('empty batch transcription is rescued by the live transcript, marked, and t
   // stereo file fails the RMS energy gate on BOTH channels, so transcribe_diarised
   // returns the silence sentinel and transcribe_audio is never reached — no model
   // load or download in the fast t2 lane.
-  writeUserConfig(userDataDir, { ai_provider: 'local' });
+  // auto_summarize_enabled is off by default (#468 made summarisation a
+  // post-transcription choice), so this spec — which asserts the summariser ran
+  // and embedded the LIVE transcript in its prompt — must opt in explicitly.
+  writeUserConfig(userDataDir, { ai_provider: 'local', auto_summarize_enabled: true });
 
   // Silent STEREO wav -> both channels skip the RMS gate -> batch transcription
   // returns the silence sentinel with no model loaded.

--- a/e2e/specs/notification-navigation.t1.spec.ts
+++ b/e2e/specs/notification-navigation.t1.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../fixtures/electron';
+import { emitMainEvent } from '../fixtures/notifications';
+
+/**
+ * T1 - renderer-only, mock IPC. The navigation contract for the notification
+ * flows, driven through the REAL main→renderer channels that main.js's
+ * Notification click/action handlers emit on (`auto-record-requested`,
+ * `navigate-to-meeting`). The native click itself is a macOS behavior the
+ * harness can't script, but everything downstream of it - which is where the
+ * "lands on the wrong screen" bugs lived - is pinned here.
+ *
+ *   - "Take Notes" (auto-record-requested) lands on the recording page from ANY
+ *     route and STAYS there (the route-dependent bounce-home regression that
+ *     read as "click twice"),
+ *   - a notification click (navigate-to-meeting) opens that note.
+ */
+
+const PILL_ENV = { STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1' };
+
+test('Take Notes lands on the recording page from a non-Home route and stays', async ({
+  launchApp,
+}) => {
+  const { app, page } = await launchApp({ mockIpc: true, fakeAudio: true, env: PILL_ENV });
+
+  // Start away from Home - this is the case that used to need a second click:
+  // the just-started recording got bounced back off /recording during warm-up.
+  await page.evaluate(() => {
+    window.location.hash = '/settings';
+  });
+  await expect(page).toHaveURL(/#\/settings/);
+
+  // One "Take Notes" (a single auto-record-requested event, as one native click
+  // sends).
+  await emitMainEvent(app, 'auto-record-requested', { sessionName: 'Note', appName: 'DevMeeting' });
+
+  const recordingPage = page.getByTestId('recording-page');
+  await expect(recordingPage).toBeVisible();
+
+  // And it STAYS - past the 500ms bounce-home window - instead of being kicked
+  // back to Home (which is what made it look like nothing happened).
+  await page.waitForTimeout(700);
+  await expect(recordingPage).toBeVisible();
+  await expect(page).toHaveURL(/#\/recording/);
+});
+
+test('a notification click opens the target note', async ({ launchApp }) => {
+  const { app, page } = await launchApp({ mockIpc: true, fakeAudio: true, env: PILL_ENV });
+
+  const summaryFile = 'rec_20260803_demo_summary.md';
+  await emitMainEvent(app, 'navigate-to-meeting', { summaryFile });
+
+  await expect(page).toHaveURL(new RegExp(`#/meetings/${encodeURIComponent(summaryFile)}`));
+});

--- a/src/config.py
+++ b/src/config.py
@@ -740,7 +740,7 @@ class Config:
             "anonymous_id": str(uuid.uuid4()),
             "storage_path": "",
             "keep_recordings": False,
-            "auto_summarize_enabled": True,
+            "auto_summarize_enabled": False,
             # Default ON — when the app is idle and nothing is in flight, a
             # downloaded update installs itself and relaunches so the user
             # never has to click "Restart". The "update available/downloaded"
@@ -1119,10 +1119,12 @@ class Config:
 
     def get_auto_summarize_enabled(self) -> bool:
         """Get whether notes (summary/title/template report) are generated
-        automatically after transcription. Default on — existing users keep
-        the transcribe→summarize behaviour. When off, recordings stop at a
-        transcript-only note and the user generates notes on demand."""
-        return self._config.get("auto_summarize_enabled", True)
+        automatically after transcription. Default OFF — recordings stop at a
+        transcript-only note and the user generates notes on demand (the
+        meeting-end "Summarise" prompt, or the in-note "Generate notes" CTA).
+        Only the fallback default changed; users who previously set this keep
+        their stored value."""
+        return self._config.get("auto_summarize_enabled", False)
 
     def set_auto_summarize_enabled(self, enabled: bool) -> bool:
         """Set whether notes are generated automatically after transcription."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -534,10 +534,12 @@ class ConfigKeepRecordingsTests(unittest.TestCase):
 
 
 class ConfigAutoSummarizeTests(unittest.TestCase):
-    def test_default_auto_summarize_is_true(self):
+    def test_default_auto_summarize_is_false(self):
+        # Default OFF: a fresh install stops at a transcript-only note; notes are
+        # generated on demand (meeting-end "Summarise" prompt / in-note CTA).
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            self.assertTrue(config.get_auto_summarize_enabled())
+            self.assertFalse(config.get_auto_summarize_enabled())
 
     def test_auto_summarize_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/website/src/sections/TrustStrip.astro
+++ b/website/src/sections/TrustStrip.astro
@@ -12,7 +12,7 @@ const logos = [
 <section class="py-6 md:py-8">
   <div class="container-site">
     <div class="text-center text-fg-2 text-xs tracking-[0.06em] uppercase mb-7">
-      Trusted by users at
+      Trusted by teams at
     </div>
     <div class="flex flex-wrap justify-center items-center gap-x-12 sm:gap-x-20 gap-y-6">
       {logos.map((l) => (


### PR DESCRIPTION
## Why

The end-of-meeting "Summarise?" prompt was keyed off the **post-transcription completion path**, whose firing depended on the renderer's route + window focus *at the instant the pipeline finished*. That's fragile: the meeting app closing shuffles focus, the auto-stop navigates, `visibilityState` lies for a window behind Zoom — so the prompt would silently not fire, or the `/processing` screen would get stranded on "Analyzing transcript". Every focus/route fix traded one edge case for another.

This moves the prompt onto the **mic-monitor** — a single, deterministic "the meeting app released the mic" signal — and makes transcript-only the default.

## What changed

**Notifications**
- **Meeting-end "Summarise this meeting?"** now fires at meeting end (auto-pause), independent of route/focus/completion timing. Dismissed if the meeting resumes; if untapped, the meeting still auto-stops (safety net).
- **Tapping Summarise forces note generation even with auto-summarize off** — the intent is deferred (`pendingAutoSummarise`) and, once the transcript completes, runs the same `reprocess` path as the in-note "Generate notes" CTA. Failed/already-noted transcripts fall through to normal handling.
- **Stuck "Analyzing transcript" fix** — `completionActions` now returns `{navigate, notify}` independently: it *always* advances off the transient `/processing` screen (never stranded), and separately decides whether to notify based on focus.
- **Leading Steno brand mark** on every toast so notifications are identifiable as Steno.
- **Copy fix** — the meeting-end body was interpolating the *browser* app name ("Summarise Safari?"); now "Summarise this meeting?".

**Default**
- `auto_summarize_enabled` defaults to **False** (fallback only — stored user values are untouched). Recordings stop at a transcript-only note; notes are generated on demand via the meeting-end prompt or the in-note CTA.

**Docs/website**
- "Trusted by users at" → "Trusted by teams at" (README + trust strip); drop finance/legal from the README tagline.

## Tests
- `completionActions` guard rewritten + unit-tested (navigate/notify matrix, incl. the stuck-`/processing` regression case).
- Python config default test updated (`test_default_auto_summarize_is_false`).
- Gates green locally: renderer typecheck, vitest 151/151, ipc-contract 8/0, Python config 76/76.

## Follow-ups (not in this PR)
- Model-bearing **T2 e2e** for the meeting-end → deferred-summarise → note-ready flow (the pure guard logic is unit-covered; the mic-monitor + reprocess wiring is not yet e2e'd).
- **Double-click on toast action buttons** on macOS (first click activates the backgrounded window) — `acceptFirstMouse` is set but not fully reliable; needs a dedicated look.
- Hide healthcare/finance/legal from the website industries **dropdown** (pages kept).