### PR TITLE
feat(speakers): review a cluster's excerpts and mark it as more than one person

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -272,10 +272,15 @@ function install({ ipcMain }) {
               // transcript text (a real, common case -- a diarized segment
               // no transcript line covers); it stays in the list because
               // dropping it would shift every later play button's index.
+              // The fourth is a turn the backend could not place in the
+              // audio: extract_segment_samples collapses those to
+              // start === end and extract_speaker_sample_audio refuses to
+              // cut them, so the row must not offer a play button for it.
               samples: [
                 { start: 130.0, end: 138.0, text: 'I think we should ship this on Friday' },
                 { start: 400.0, end: 406.0, text: 'the migration is the risky part' },
                 { start: 900.0, end: 904.0, text: null },
+                { start: 1200.0, end: 1200.0, text: 'a line with no audio to match it' },
               ],
               contains_multiple_speakers: false,
               is_likely_artifact: false,

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -165,6 +165,35 @@ function seedPriorSegments(rec) {
   ];
 }
 
+// Two notes differing ONLY in whether their original recording still exists,
+// for the overview's audio indicator (STENOAI_E2E_SEED_AUDIO_MEETINGS=1).
+// keep_recordings defaults off, so "no audio" is the normal case -- the pair
+// is what proves the icon tracks the flag rather than always rendering.
+const AUDIO_SEED_MEETINGS = [
+  {
+    session_info: {
+      name: 'With audio',
+      summary_file: 'with-audio_summary.md',
+      processed_at: '2026-08-02T12:00:00Z',
+      duration_seconds: 600,
+    },
+    summary: 'A note whose recording was kept.',
+    has_audio: true,
+    key_points: [], action_items: [], discussion_areas: [], participants: [],
+  },
+  {
+    session_info: {
+      name: 'Without audio',
+      summary_file: 'without-audio_summary.md',
+      processed_at: '2026-08-02T11:00:00Z',
+      duration_seconds: 900,
+    },
+    summary: 'A note whose recording was discarded after processing.',
+    has_audio: false,
+    key_points: [], action_items: [], discussion_areas: [], participants: [],
+  },
+];
+
 function install({ ipcMain }) {
   // In-memory stand-in for the org session + provider config that the real
   // handlers persist to disk. Mutated by the org-login / org-logout / set-ai
@@ -377,6 +406,9 @@ function install({ ipcMain }) {
     // lives in MOCKS, which shadows DEFAULTS, so it is the single source for the
     // channel.
     'list-meetings': async () => {
+      if (process.env.STENOAI_E2E_SEED_AUDIO_MEETINGS === '1') {
+        return { success: true, meetings: AUDIO_SEED_MEETINGS };
+      }
       if (process.env.STENOAI_E2E_SEED_PENDING_NOTE === '1') {
         return { success: true, meetings: [PENDING_MEETING] };
       }

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -796,7 +796,10 @@ function install({ ipcMain }) {
       cluster.contains_multiple_speakers = Boolean(containsMultipleSpeakers);
       const clearedFrom = [];
       if (cluster.contains_multiple_speakers) {
-        cluster.prevSuggestion = {
+        // Only on the FIRST mark. Marking an already-marked cluster would
+        // otherwise snapshot the already-cleared state over the real one,
+        // and the undo would restore nothing.
+        cluster.prevSuggestion = cluster.prevSuggestion ?? {
           status: cluster.status,
           suggested_person_id: cluster.suggested_person_id,
           suggested_name: cluster.suggested_name,

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -789,17 +789,27 @@ function install({ ipcMain }) {
         return { success: false, error: `No cluster ${diarizationSpeakerId} in ${channel}` };
       }
       cluster.contains_multiple_speakers = Boolean(containsMultipleSpeakers);
+      const clearedFrom = [];
       if (cluster.contains_multiple_speakers) {
         cluster.prevSuggestion = {
           status: cluster.status,
           suggested_person_id: cluster.suggested_person_id,
           suggested_name: cluster.suggested_name,
           candidates: cluster.candidates,
+          confirmed_by_user: cluster.confirmed_by_user,
         };
         cluster.status = 'none';
         cluster.suggested_person_id = null;
         cluster.suggested_name = null;
         cluster.candidates = [];
+        // The real CLI also WITHDRAWS a confirmation already made on this
+        // cluster -- someone typically confirms first and only later, on a
+        // second excerpt, hears the second voice. Leaving it would keep a
+        // blended embedding enrolled as that person.
+        if (cluster.confirmed_by_user) {
+          clearedFrom.push(cluster.confirmed_by_user);
+          cluster.confirmed_by_user = null;
+        }
       } else if (cluster.prevSuggestion) {
         Object.assign(cluster, cluster.prevSuggestion);
         delete cluster.prevSuggestion;
@@ -808,6 +818,7 @@ function install({ ipcMain }) {
         success: true,
         resolved_diarization_speaker_id: diarizationSpeakerId,
         contains_multiple_speakers: cluster.contains_multiple_speakers,
+        cleared_confirmation_from: clearedFrom,
         minimum_speaker_count: 0,
       };
     },

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -268,6 +268,16 @@ function install({ ipcMain }) {
               reasons: [],
               speech_duration_seconds: 245, segment_count: 60, first_timestamp: '02:10',
               sample_text: 'I think we should ship this on Friday',
+              // Several excerpts so the row can expand. The third has no
+              // transcript text (a real, common case -- a diarized segment
+              // no transcript line covers); it stays in the list because
+              // dropping it would shift every later play button's index.
+              samples: [
+                { start: 130.0, end: 138.0, text: 'I think we should ship this on Friday' },
+                { start: 400.0, end: 406.0, text: 'the migration is the risky part' },
+                { start: 900.0, end: 904.0, text: null },
+              ],
+              contains_multiple_speakers: false,
               is_likely_artifact: false,
               confirmed_by_user: null,
             },
@@ -281,6 +291,8 @@ function install({ ipcMain }) {
               reasons: [],
               speech_duration_seconds: 80, segment_count: 20, first_timestamp: '05:45',
               sample_text: 'let me check the numbers again',
+              samples: [{ start: 345.0, end: 351.0, text: 'let me check the numbers again' }],
+              contains_multiple_speakers: false,
               is_likely_artifact: false,
               confirmed_by_user: null,
             },
@@ -294,6 +306,8 @@ function install({ ipcMain }) {
               reasons: [],
               speech_duration_seconds: 30, segment_count: 8, first_timestamp: '00:42',
               sample_text: null,
+              samples: [{ start: 42.0, end: 46.0, text: null }],
+              contains_multiple_speakers: false,
               is_likely_artifact: false,
               confirmed_by_user: null,
             },
@@ -302,6 +316,8 @@ function install({ ipcMain }) {
               merged_from: [], candidates: [], reasons: [],
               speech_duration_seconds: 5, segment_count: 1, first_timestamp: '10:02',
               sample_text: null,
+              samples: [],
+              contains_multiple_speakers: false,
               is_likely_artifact: false,
               confirmed_by_user: null,
             },
@@ -314,6 +330,8 @@ function install({ ipcMain }) {
               reasons: [],
               speech_duration_seconds: 12, segment_count: 20, first_timestamp: '08:03',
               sample_text: null,
+              samples: [],
+              contains_multiple_speakers: false,
               is_likely_artifact: true,
               confirmed_by_user: null,
             },
@@ -747,13 +765,76 @@ function install({ ipcMain }) {
       success: true,
       meeting_id: meetingStem,
       recording_available: seedSpeakers,
+      // Same derivation as the real minimum_speaker_count: every cluster is
+      // at least one person, every cluster marked as mixed is at least two.
+      minimum_speaker_count: Object.values(speakerState.suggestions).reduce(
+        (sum, clusters) =>
+          sum
+          + Object.keys(clusters).length
+          + Object.values(clusters).filter((c) => c.contains_multiple_speakers).length,
+        0,
+      ),
       channels: speakerState.suggestions,
     }),
+
+    // Marks/clears "this cluster holds more than one person". Mirrors the
+    // real CLI's effect on a later suggest-speakers refetch, which is what
+    // the panel actually re-renders from: a marked cluster loses its
+    // suggestion AND its candidates, so the T1 spec sees the same row shape
+    // a real backend would produce rather than just a flag flipping.
+    'mark-speaker-cluster': async (_event, params) => {
+      const { channel, diarizationSpeakerId, containsMultipleSpeakers } = params || {};
+      const cluster = (speakerState.suggestions[channel] || {})[diarizationSpeakerId];
+      if (!cluster) {
+        return { success: false, error: `No cluster ${diarizationSpeakerId} in ${channel}` };
+      }
+      cluster.contains_multiple_speakers = Boolean(containsMultipleSpeakers);
+      if (cluster.contains_multiple_speakers) {
+        cluster.prevSuggestion = {
+          status: cluster.status,
+          suggested_person_id: cluster.suggested_person_id,
+          suggested_name: cluster.suggested_name,
+          candidates: cluster.candidates,
+        };
+        cluster.status = 'none';
+        cluster.suggested_person_id = null;
+        cluster.suggested_name = null;
+        cluster.candidates = [];
+      } else if (cluster.prevSuggestion) {
+        Object.assign(cluster, cluster.prevSuggestion);
+        delete cluster.prevSuggestion;
+      }
+      return {
+        success: true,
+        resolved_diarization_speaker_id: diarizationSpeakerId,
+        contains_multiple_speakers: cluster.contains_multiple_speakers,
+        minimum_speaker_count: 0,
+      };
+    },
+
+    'speaker-naming-status': async (_event, meetingStem) => {
+      const clusters = Object.values(speakerState.suggestions).flatMap((c) => Object.values(c));
+      const countable = clusters.filter((c) => !c.contains_multiple_speakers);
+      return {
+        success: true,
+        meeting_id: meetingStem,
+        has_sidecar: seedSpeakers,
+        total_clusters: countable.length,
+        named_clusters: countable.filter((c) => c.confirmed_by_user).length,
+        unnamed_clusters: countable.filter((c) => !c.confirmed_by_user).length,
+      };
+    },
 
     // Deterministic fake clip -- no real ffmpeg/audio decode in T1. Always
     // "succeeds" when speaker suggestions are seeded, mirroring
     // recording_available: true above.
-    'get-speaker-sample-audio': async (_event, _meetingStem, _channel, _diarizationSpeakerId) => {
+    // `segmentIndex` (which excerpt to play) is accepted and ignored: T1 has
+    // no real audio to slice, so which moment comes back is not something
+    // this tier can be honest about. That the index selects the right
+    // segment is proven where the selection actually happens -- see
+    // tests/test_speaker_multi_marking.py's sample_segments/segment_index
+    // cases and the T2 samples-ordering spec.
+    'get-speaker-sample-audio': async (_event, _meetingStem, _channel, _diarizationSpeakerId, _segmentIndex) => {
       if (!seedSpeakers) return { success: false, error: 'no source audio available' };
       // A real (if silent/empty) minimal 16-bit mono WAV -- so the renderer's
       // blob: URL construction + <audio> playback path is exercised with

--- a/app/main.js
+++ b/app/main.js
@@ -4305,6 +4305,23 @@ ipcMain.handle('delete-meeting', async (event, meetingData) => {
       }
       ancillaryCandidates.push(path.join(outputDir, sidecarBase));
     }
+    // Speakers sidecar: <stem>_speakers.json. Same class of miss as the
+    // reports sidecar was -- a per-meeting file added later that the delete
+    // enumeration never learned about. Reproduced end to end: the note,
+    // transcript and audio went, and an 84 KB file of VOICE EMBEDDINGS
+    // stayed behind, which is the worst thing in the set to leave on disk
+    // after someone deletes a meeting. It is stem-bound like the others, so
+    // it inherits the same containment checks and the same undo window.
+    //
+    // Note this removes only the meeting's per-cluster embeddings. A person
+    // CONFIRMED from this meeting keeps their voice profile in config.json,
+    // deliberately: those are bound to the person, not the meeting, and are
+    // what makes recognition work across recordings (verified against a real
+    // library, where working prototypes came from meetings deleted long ago).
+    // Deleting a person is its own explicit action in the Speakers panel.
+    if (stem) {
+      ancillaryCandidates.push(path.join(outputDir, `${stem}_speakers.json`));
+    }
     // Derive the transcript + recording from the summary stem (FACT A). A normal
     // .md note carries ONLY summary_file, so without this the transcript and the
     // RECORDING would be orphaned, defeating the whole point of #234 (protect the
@@ -7941,13 +7958,44 @@ ipcMain.handle('delete-person-profile', async (_e, id) => {
   }
 });
 
-ipcMain.handle('get-speaker-sample-audio', async (_e, meetingStem, channel, diarizationSpeakerId) => {
+ipcMain.handle('get-speaker-sample-audio', async (_e, meetingStem, channel, diarizationSpeakerId, segmentIndex) => {
+  try {
+    const args = ['get-speaker-sample-audio', meetingStem, channel, diarizationSpeakerId];
+    // Only forwarded when the caller actually asked for a specific excerpt.
+    // Number.isInteger (not a truthiness check) because index 0 is the
+    // first excerpt and must not be dropped as falsy.
+    if (Number.isInteger(segmentIndex)) args.push('--segment-index', String(segmentIndex));
+    const out = await runPythonScript('simple_recorder.py', args);
+    return JSON.parse(out);
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('mark-speaker-cluster', async (_e, params) => {
   try {
     const out = await runPythonScript('simple_recorder.py', [
-      'get-speaker-sample-audio', meetingStem, channel, diarizationSpeakerId,
+      'mark-speaker-cluster',
+      params.meetingStem,
+      params.channel,
+      params.diarizationSpeakerId,
+      params.containsMultipleSpeakers ? '--multiple' : '--single',
     ]);
     return JSON.parse(out);
   } catch (error) {
+    return parsePythonFailureJson(error);
+  }
+});
+
+ipcMain.handle('speaker-naming-status', async (_e, meetingStem) => {
+  try {
+    const out = await runPythonScript('simple_recorder.py', ['speaker-naming-status', meetingStem]);
+    return JSON.parse(out);
+  } catch (error) {
+    // Never surfaced to the user and never allowed to matter: this only
+    // decides whether one extra sentence appears in a delete confirmation.
+    // A failure here must not stand between someone and deleting their own
+    // recording, so it degrades to "nothing to warn about".
     return { success: false, error: error.message };
   }
 });

--- a/app/preload.js
+++ b/app/preload.js
@@ -206,8 +206,10 @@ const stenoai = {
     createProfile: (displayName) => invoke('create-person-profile', displayName),
     renameProfile: (id, displayName) => invoke('rename-person-profile', id, displayName),
     deleteProfile: (id) => invoke('delete-person-profile', id),
-    getSampleAudio: (meetingStem, channel, diarizationSpeakerId) =>
-      invoke('get-speaker-sample-audio', meetingStem, channel, diarizationSpeakerId),
+    getSampleAudio: (meetingStem, channel, diarizationSpeakerId, segmentIndex) =>
+      invoke('get-speaker-sample-audio', meetingStem, channel, diarizationSpeakerId, segmentIndex),
+    markCluster: (params) => invoke('mark-speaker-cluster', params),
+    namingStatus: (meetingStem) => invoke('speaker-naming-status', meetingStem),
   },
 
   models: {

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -199,7 +199,11 @@ function PlaySampleButton({
  * dropped, since a human might legitimately want to review one (e.g. a
  * real quiet third participant).
  */
-type ConfirmFeedback = { message: string };
+/** `action` names what the person actually clicked. Without it every
+ * failure on this row read "Couldn't confirm", including a failed
+ * more-than-one-person marking, which describes an operation the user did
+ * not attempt. */
+type ConfirmFeedback = { message: string; action?: 'confirm' | 'mark' | 'unmark' };
 
 export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPanelProps) {
   const meetingStem = meetingStemFromSummaryFile(summaryFile);
@@ -311,10 +315,14 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
         channel: row.channel,
         diarizationSpeakerId: row.diarizationSpeakerId,
         containsMultipleSpeakers,
+        summaryFile,
       },
       {
         onError: (error) => {
-          setFeedback((prev) => new Map(prev).set(key, { message: error.message }));
+          setFeedback((prev) => new Map(prev).set(key, {
+            message: error.message,
+            action: containsMultipleSpeakers ? 'mark' : 'unmark',
+          }));
         },
       },
     );
@@ -425,7 +433,13 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                     style={{ color: 'var(--danger)' }}
                     data-testid={`speaker-feedback-${key}`}
                   >
-                    {`Couldn't confirm: ${feedback.get(key)!.message}`}
+                    {`${
+                      feedback.get(key)!.action === 'mark'
+                        ? "Couldn't mark this as more than one person"
+                        : feedback.get(key)!.action === 'unmark'
+                          ? "Couldn't undo the marking"
+                          : "Couldn't confirm"
+                    }: ${feedback.get(key)!.message}`}
                   </span>
                 )}
               </div>

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -556,20 +556,26 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                   variant={isMarked ? 'outline' : 'ghost'}
                   aria-label={
                     isMarked
-                      ? 'Undo: this is one person after all'
+                      ? 'This is one person after all - reopens the row for naming, does not restore the earlier name'
                       : 'This is more than one person'
                   }
                   title={
                     isMarked
-                      ? 'Undo: this is one person after all'
+                      ? 'This is one person after all - reopens the row for naming, does not restore the earlier name'
                       : 'This is more than one person'
                   }
                   disabled={anyConfirmPending}
                   onClick={() => setMultiSpeaker(row, !isMarked)}
                   data-testid={`speaker-mark-multi-${key}`}
                 >
+                  {/* Not labelled "Undo": clearing the marking reopens the
+                      row for naming, it does not put back a name that was
+                      withdrawn when the cluster was marked. The prototype,
+                      the participants entry and the transcript labels are
+                      all gone by then, and calling that an undo would
+                      promise a recovery the backend cannot perform. */}
                   {isMarked ? <Undo2 className="size-[13px]" /> : <Users className="size-[13px]" />}
-                  {isMarked ? 'Undo' : null}
+                  {isMarked ? 'One person' : null}
                 </Button>
                 <Button
                   size="sm"

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -605,14 +605,27 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                       className="flex items-center gap-1.5"
                       data-testid={`speaker-sample-${key}-${index}`}
                     >
+                      {/* A collapsed range is the backend saying it could
+                          not place this turn in the audio, and
+                          extract_speaker_sample_audio refuses to cut one --
+                          padding it into a clip would play whoever WAS
+                          speaking at that second under this name. The row
+                          keeps its place (its text is still this speaker's,
+                          and every later play button is addressed by index),
+                          the button is shown inert rather than firing a
+                          request that can only fail. */}
                       {recordingAvailable && (
                         <PlaySampleButton
                           meetingStem={meetingStem}
                           channel={row.channel}
                           diarizationSpeakerId={row.diarizationSpeakerId}
                           segmentIndex={index}
-                          disabled={anyConfirmPending}
-                          label={`Play excerpt at ${formatOffset(sample.start)}`}
+                          disabled={anyConfirmPending || sample.end <= sample.start}
+                          label={
+                            sample.end <= sample.start
+                              ? 'No audio could be matched to this moment'
+                              : `Play excerpt at ${formatOffset(sample.start)}`
+                          }
                         />
                       )}
                       <span

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { Check, ChevronDown, Loader2, Play, Square, Trash2, UserPlus, X } from 'lucide-react';
+import {
+  Check, ChevronDown, ChevronRight, Loader2, Play, Square, Trash2, Undo2, Users, UserPlus, X,
+} from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from '@/components/ui/dialog';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -11,6 +13,7 @@ import {
   useConfirmSpeaker,
   useGetSpeakerSampleAudio,
   useDeletePersonProfile,
+  useMarkSpeakerCluster,
   meetingStemFromSummaryFile,
 } from '@/hooks/useSpeakerSuggestions';
 import type { PersonProfile, SpeakerSuggestion } from '@/lib/ipc';
@@ -37,6 +40,12 @@ function rowKey(row: Pick<Row, 'channel' | 'diarizationSpeakerId'>): string {
  * human already confirmed who this is; the ranking that produced the
  * original suggestion is no longer the interesting fact about this row. */
 function suggestionLabel(suggestion: SpeakerSuggestion): string {
+  // Ahead of confirmed_by_user, because a marked cluster cannot BE
+  // confirmed (confirm-speaker refuses it) -- if both were ever somehow
+  // set, the marking is the newer and more specific fact.
+  if (suggestion.contains_multiple_speakers) {
+    return 'More than one person';
+  }
   if (suggestion.confirmed_by_user) {
     return `✓ Confirmed as ${suggestion.confirmed_by_user}`;
   }
@@ -85,11 +94,26 @@ function base64ToBlobUrl(base64: string, mimeType = 'audio/wav'): string {
   return URL.createObjectURL(new Blob([bytes], { type: mimeType }));
 }
 
+/** Seconds -> "MM:SS" / "H:MM:SS", matching the [MM:SS] markers in the
+ * saved transcript (src.transcriber._format_timestamp) so an excerpt's
+ * timestamp can be found by eye in the transcript above. */
+function formatOffset(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  const s = String(total % 60).padStart(2, '0');
+  const m = Math.floor(total / 60) % 60;
+  const h = Math.floor(total / 3600);
+  return h > 0 ? `${h}:${String(m).padStart(2, '0')}:${s}` : `${String(m).padStart(2, '0')}:${s}`;
+}
+
 interface PlaySampleButtonProps {
   meetingStem: string;
   channel: string;
   diarizationSpeakerId: string;
+  /** Which of the row's `samples` to play. Omitted plays the cluster's
+   * longest turn -- the collapsed row's single button. */
+  segmentIndex?: number;
   disabled?: boolean;
+  label?: string;
 }
 
 /** Play/stop toggle for a cluster's longest-segment audio sample -- mirrors
@@ -97,7 +121,9 @@ interface PlaySampleButtonProps {
  * (fetch-on-click, toggle icon, auto-reset when playback ends). Fetched via
  * a mutation (not cached) since nothing needs to stay fresh in the
  * background for a clip a human explicitly triggers. */
-function PlaySampleButton({ meetingStem, channel, diarizationSpeakerId, disabled }: PlaySampleButtonProps) {
+function PlaySampleButton({
+  meetingStem, channel, diarizationSpeakerId, segmentIndex, disabled, label,
+}: PlaySampleButtonProps) {
   const getSample = useGetSpeakerSampleAudio();
   const audioRef = React.useRef<HTMLAudioElement | null>(null);
   const [playing, setPlaying] = React.useState(false);
@@ -115,7 +141,9 @@ function PlaySampleButton({ meetingStem, channel, diarizationSpeakerId, disabled
       stop();
       return;
     }
-    const result = await getSample.mutateAsync({ meetingStem, channel, diarizationSpeakerId });
+    const result = await getSample.mutateAsync({
+      meetingStem, channel, diarizationSpeakerId, segmentIndex,
+    });
     const url = base64ToBlobUrl(result.audio_base64);
     const audio = new Audio(url);
     audio.onended = () => {
@@ -127,15 +155,23 @@ function PlaySampleButton({ meetingStem, channel, diarizationSpeakerId, disabled
     void audio.play();
   };
 
+  const title = label ?? (playing ? 'Stop sample' : 'Play sample');
+  // Distinct testid per excerpt: the whole point of the expanded list is
+  // that each row plays a DIFFERENT moment, so a spec has to be able to
+  // address them individually.
+  const testId = segmentIndex === undefined
+    ? `speaker-play-${channel}:${diarizationSpeakerId}`
+    : `speaker-play-${channel}:${diarizationSpeakerId}-${segmentIndex}`;
+
   return (
     <Button
       size="sm"
       variant="ghost"
-      aria-label={playing ? 'Stop sample' : 'Play sample'}
-      title={playing ? 'Stop sample' : 'Play sample'}
+      aria-label={playing ? 'Stop sample' : title}
+      title={playing ? 'Stop sample' : title}
       disabled={disabled || getSample.isPending}
       onClick={() => void toggle()}
-      data-testid={`speaker-play-${channel}:${diarizationSpeakerId}`}
+      data-testid={testId}
     >
       {getSample.isPending ? (
         <Loader2 className="size-[13px] animate-spin" />
@@ -171,8 +207,10 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
   const profilesQuery = usePersonProfiles();
   const confirmSpeaker = useConfirmSpeaker();
   const deleteProfile = useDeletePersonProfile();
+  const markCluster = useMarkSpeakerCluster();
 
   const [dismissed, setDismissed] = React.useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
   const [changeOpenFor, setChangeOpenFor] = React.useState<string | null>(null);
   const [newPersonRow, setNewPersonRow] = React.useState<Row | null>(null);
   const [newPersonName, setNewPersonName] = React.useState('');
@@ -202,7 +240,15 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
   for (const channel of Object.keys(channels)) {
     for (const [diarizationSpeakerId, suggestion] of Object.entries(channels[channel])) {
       const key = rowKey({ channel, diarizationSpeakerId });
-      const nothingActionable = suggestion.status === 'none' && suggestion.candidates.length === 0;
+      // A MARKED cluster is deliberately status "none" with zero
+      // candidates, which is exactly the "nothing actionable" shape hidden
+      // below -- so without this it would disappear the moment it was
+      // marked, taking the only way to undo a misclick with it. Marking is
+      // a statement about the recording, not a dismissal.
+      const nothingActionable =
+        suggestion.status === 'none'
+        && suggestion.candidates.length === 0
+        && !suggestion.contains_multiple_speakers;
       if (nothingActionable && !keepVisible.has(key)) continue;
       rows.push({ channel, diarizationSpeakerId, suggestion });
     }
@@ -211,8 +257,14 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
     (a, b) => a.channel.localeCompare(b.channel) || a.diarizationSpeakerId.localeCompare(b.diarizationSpeakerId),
   );
   const notDismissed = rows.filter((row) => !dismissed.has(rowKey(row)));
-  const artifactRows = notDismissed.filter((row) => row.suggestion.is_likely_artifact);
-  const primaryRows = notDismissed.filter((row) => !row.suggestion.is_likely_artifact);
+  // A row a human has explicitly marked stays in the main list even if its
+  // turn shape also matches the artifact heuristic -- hiding it behind
+  // "Show N filtered rows" would bury the undo for a deliberate action
+  // behind a toggle the user has no reason to open.
+  const isFiltered = (row: Row) =>
+    row.suggestion.is_likely_artifact && !row.suggestion.contains_multiple_speakers;
+  const artifactRows = notDismissed.filter(isFiltered);
+  const primaryRows = notDismissed.filter((row) => !isFiltered(row));
   const visibleRows = showFiltered ? notDismissed : primaryRows;
   const recordingAvailable = suggestionsQuery.data?.recording_available ?? false;
 
@@ -246,6 +298,33 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
     );
   };
 
+  const setMultiSpeaker = (row: Row, containsMultipleSpeakers: boolean) => {
+    const key = rowKey(row);
+    setFeedback((prev) => {
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    });
+    markCluster.mutate(
+      {
+        meetingStem,
+        channel: row.channel,
+        diarizationSpeakerId: row.diarizationSpeakerId,
+        containsMultipleSpeakers,
+      },
+      {
+        onError: (error) => {
+          setFeedback((prev) => new Map(prev).set(key, { message: error.message }));
+        },
+      },
+    );
+  };
+
+  const totalClusters = Object.values(channels).reduce(
+    (sum, clusters) => sum + Object.keys(clusters).length, 0,
+  );
+  const minimumSpeakers = suggestionsQuery.data?.minimum_speaker_count ?? 0;
+
   return (
     <section className="flex flex-col gap-3" data-testid="speaker-review-panel">
       <h2
@@ -254,6 +333,16 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
       >
         Speakers
       </h2>
+      {minimumSpeakers > totalClusters && (
+        <p
+          className="text-[11.5px]"
+          style={{ color: 'var(--fg-2)', margin: 0 }}
+          data-testid="speaker-minimum-count"
+        >
+          {`At least ${minimumSpeakers} people spoke, but only ${totalClusters} could be told apart. `}
+          {'Speech from a group marked as more than one person is left unassigned.'}
+        </p>
+      )}
       <div className="flex flex-col gap-1.5">
         {/* Every action below spawns a confirm-speaker subprocess that
             reads-then-atomically-rewrites this meeting's saved transcript.
@@ -266,32 +355,69 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
             clickable while a confirm was still in progress. */}
         {visibleRows.map((row) => {
           const key = rowKey(row);
-          const anyConfirmPending = confirmSpeaker.isPending;
+          const anyConfirmPending = confirmSpeaker.isPending || markCluster.isPending;
+          const isMarked = row.suggestion.contains_multiple_speakers;
+          const samples = row.suggestion.samples ?? [];
+          const isExpanded = expanded.has(key);
+          // Expanding is only worth offering when there is more than the
+          // one excerpt the collapsed row already shows.
+          const canExpand = samples.length > 1;
           return (
             <div
               key={key}
               data-testid={`speaker-row-${key}`}
-              className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
+              className="flex flex-col gap-1.5 rounded-md px-2 py-1.5"
               style={{ background: 'var(--surface-raised)', border: '1px solid var(--border-subtle)' }}
             >
+              <div className="flex items-center justify-between gap-2">
               <div className="flex min-w-0 flex-col gap-0.5">
                 <span
-                  className={`text-[13.5px] ${row.suggestion.confirmed_by_user ? 'font-medium' : ''}`}
-                  style={{ color: 'var(--fg-1)' }}
+                  className={`text-[13.5px] ${row.suggestion.confirmed_by_user || isMarked ? 'font-medium' : ''}`}
+                  style={{ color: isMarked ? 'var(--fg-2)' : 'var(--fg-1)' }}
                 >
                   {suggestionLabel(row.suggestion)}
                 </span>
                 <span className="text-[11.5px]" style={{ color: 'var(--fg-2)' }}>
                   {identificationHint(row.channel, row.suggestion)}
                 </span>
-                {row.suggestion.sample_text && (
-                  <span
-                    className="truncate text-[11.5px] italic"
-                    style={{ color: 'var(--fg-2)' }}
-                    title={row.suggestion.sample_text}
-                  >
-                    “{row.suggestion.sample_text}”
+                {isMarked ? (
+                  <span className="text-[11.5px]" style={{ color: 'var(--fg-2)' }}>
+                    Left out of naming and voice recognition.
                   </span>
+                ) : (
+                  row.suggestion.sample_text && (
+                    <span
+                      className="truncate text-[11.5px] italic"
+                      style={{ color: 'var(--fg-2)' }}
+                      title={row.suggestion.sample_text}
+                    >
+                      “{row.suggestion.sample_text}”
+                    </span>
+                  )
+                )}
+                {canExpand && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setExpanded((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(key)) next.delete(key);
+                        else next.add(key);
+                        return next;
+                      })
+                    }
+                    className="flex items-center gap-0.5 self-start text-[11.5px] underline-offset-2 hover:underline"
+                    style={{ color: 'var(--fg-2)' }}
+                    data-testid={`speaker-expand-${key}`}
+                    aria-expanded={isExpanded}
+                  >
+                    {isExpanded ? (
+                      <ChevronDown className="size-[12px]" />
+                    ) : (
+                      <ChevronRight className="size-[12px]" />
+                    )}
+                    {isExpanded ? 'Fewer excerpts' : `${samples.length} excerpts`}
+                  </button>
                 )}
                 {feedback.get(key) && (
                   <span
@@ -312,6 +438,14 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                     disabled={anyConfirmPending}
                   />
                 )}
+                {/* Every naming action disappears for a marked cluster --
+                    not merely disabled. confirm-speaker refuses it outright,
+                    so a greyed-out Approve would be a control that can never
+                    become available, and a "Change" picker would be an
+                    invitation to do the one thing this marking exists to
+                    prevent. The undo below is what stays reachable. */}
+                {!isMarked && (
+                  <>
                 {/* Hidden once confirmed_by_user is set -- re-approving an
                     already-confirmed cluster is a no-op that changes
                     nothing visible, which reads as broken. Change/New
@@ -396,6 +530,33 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                   <UserPlus className="size-[13px]" />
                   New person
                 </Button>
+                  </>
+                )}
+                {/* The one fact about a cluster that no measurement can
+                    supply. Sitting beside "New person" on purpose: both are
+                    answers to the same question a human is holding while
+                    listening, and this one has to be as easy to give as
+                    naming, or it will not be given at all. */}
+                <Button
+                  size="sm"
+                  variant={isMarked ? 'outline' : 'ghost'}
+                  aria-label={
+                    isMarked
+                      ? 'Undo: this is one person after all'
+                      : 'This is more than one person'
+                  }
+                  title={
+                    isMarked
+                      ? 'Undo: this is one person after all'
+                      : 'This is more than one person'
+                  }
+                  disabled={anyConfirmPending}
+                  onClick={() => setMultiSpeaker(row, !isMarked)}
+                  data-testid={`speaker-mark-multi-${key}`}
+                >
+                  {isMarked ? <Undo2 className="size-[13px]" /> : <Users className="size-[13px]" />}
+                  {isMarked ? 'Undo' : null}
+                </Button>
                 <Button
                   size="sm"
                   variant="ghost"
@@ -408,6 +569,57 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                   <X className="size-[13px]" />
                 </Button>
               </div>
+              </div>
+
+              {/* Several moments from the recording, chronological, each
+                  played individually. One excerpt is a single roll of the
+                  dice on whether the longest turn happens to contain
+                  anything recognizable; several are what let someone place
+                  a voice -- and hearing two different voices in one list is
+                  how the "more than one person" case becomes visible at all. */}
+              {isExpanded && (
+                <div
+                  className="flex flex-col gap-0.5 border-t pt-1.5"
+                  style={{ borderColor: 'var(--border-subtle)' }}
+                  data-testid={`speaker-samples-${key}`}
+                >
+                  {samples.map((sample, index) => (
+                    <div
+                      key={`${sample.start}-${index}`}
+                      className="flex items-center gap-1.5"
+                      data-testid={`speaker-sample-${key}-${index}`}
+                    >
+                      {recordingAvailable && (
+                        <PlaySampleButton
+                          meetingStem={meetingStem}
+                          channel={row.channel}
+                          diarizationSpeakerId={row.diarizationSpeakerId}
+                          segmentIndex={index}
+                          disabled={anyConfirmPending}
+                          label={`Play excerpt at ${formatOffset(sample.start)}`}
+                        />
+                      )}
+                      <span
+                        className="shrink-0 text-[11px] tabular-nums"
+                        style={{ color: 'var(--fg-2)' }}
+                      >
+                        {formatOffset(sample.start)}
+                      </span>
+                      <span
+                        className="truncate text-[11.5px] italic"
+                        style={{ color: 'var(--fg-2)' }}
+                        title={sample.text ?? undefined}
+                      >
+                        {/* A segment no transcript line covers still gets a
+                            row: the clip is playable, and dropping it would
+                            put every later excerpt's play button out of step
+                            with its index. */}
+                        {sample.text ? `“${sample.text}”` : 'No transcript for this moment'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           );
         })}

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -583,6 +583,22 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                   style={{ borderColor: 'var(--border-subtle)' }}
                   data-testid={`speaker-samples-${key}`}
                 >
+                  {/* Said once, not repeated per row. A meeting whose
+                      speakers sidecar was produced by the backfill has no
+                      turn manifest, and its transcript timestamps come from
+                      a different diarization run -- so no line can be
+                      attributed to a cluster with confidence, and none is
+                      shown. Listening still works, and is the reliable half
+                      anyway: the clip is cut at this cluster's own segments. */}
+                  {samples.length > 0 && !samples.some((s) => s.text) && (
+                    <span
+                      className="text-[11.5px]"
+                      style={{ color: 'var(--fg-2)' }}
+                      data-testid={`speaker-samples-textless-${key}`}
+                    >
+                      Transcript text can’t be matched to a speaker in this recording. Play to listen.
+                    </span>
+                  )}
                   {samples.map((sample, index) => (
                     <div
                       key={`${sample.start}-${index}`}
@@ -610,11 +626,18 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                         style={{ color: 'var(--fg-2)' }}
                         title={sample.text ?? undefined}
                       >
-                        {/* A segment no transcript line covers still gets a
+                        {/* A moment with no attributable line still gets a
                             row: the clip is playable, and dropping it would
                             put every later excerpt's play button out of step
-                            with its index. */}
-                        {sample.text ? `“${sample.text}”` : 'No transcript for this moment'}
+                            with its index. Left blank when the whole cluster
+                            has no text -- the one explanation above already
+                            says why, and repeating it per row reads as five
+                            separate failures. */}
+                        {sample.text
+                          ? `“${sample.text}”`
+                          : samples.some((s) => s.text)
+                            ? 'No transcript for this moment'
+                            : ''}
                       </span>
                     </div>
                   ))}

--- a/app/renderer/src/components/UndoDeleteToast.tsx
+++ b/app/renderer/src/components/UndoDeleteToast.tsx
@@ -4,6 +4,10 @@ import { Trash2, X } from 'lucide-react';
 import { ipc } from '@/lib/ipc';
 import { useUndoDeleteStore, type UndoDeleteEntry } from '@/hooks/undoDeleteStore';
 import { useUndoDeleteMeeting, useCommitDeleteMeeting } from '@/hooks/useMeetings';
+import {
+  useSpeakerNamingStatus,
+  meetingStemFromSummaryFile,
+} from '@/hooks/useSpeakerSuggestions';
 
 /**
  * Bottom-right "Note deleted — Undo?" toast stack (#234). Deletion is a
@@ -76,6 +80,32 @@ function UndoDeleteToastItem({
 
   const name = entry.meeting?.session_info?.name?.trim();
 
+  // What this delete costs that the note itself doesn't say.
+  //
+  // A person already CONFIRMED survives being deleted: their voiceprint
+  // lives in config.json bound to the person, not to any meeting (checked
+  // against a real library, where working prototypes came from meetings
+  // deleted long ago). An UNNAMED cluster does not survive, and unlike
+  // almost everything else here it cannot be reconstructed afterwards by
+  // any means: putting a name to a voice means listening to it, listening
+  // means the source audio, and committing this delete takes the audio.
+  //
+  // Shown HERE rather than in a confirmation dialog because there is no
+  // confirmation dialog -- deleting a note is deliberately immediate, with
+  // this undo window as the safety net ("asking first *and* offering undo
+  // made the flow feel heavy", see MeetingDetail/MeetingsShell). Adding a
+  // modal would undo that decision to say something a line in the toast
+  // says while the delete is still reversible. The sidecar this reads is
+  // unlinked at COMMIT, not at delete, so it is still on disk for exactly
+  // as long as the window it is describing.
+  //
+  // Purely informational: no button, no blocked delete. Someone who knows
+  // the meeting is worthless does not need to hear about its speakers.
+  const namingStatus = useSpeakerNamingStatus(
+    meetingStemFromSummaryFile(entry.summaryFile), true,
+  );
+  const unnamed = namingStatus.data?.unnamed_clusters ?? 0;
+
   return (
     <div
       className="pointer-events-auto relative flex w-[280px] flex-col overflow-hidden rounded-xl"
@@ -117,6 +147,16 @@ function UndoDeleteToastItem({
           <X size={12} />
         </button>
       </div>
+      {unnamed > 0 && (
+        <div
+          className="px-3 pb-2.5 text-[11.5px]"
+          style={{ color: 'var(--fg-2)' }}
+          data-testid="undo-delete-unnamed-speakers"
+        >
+          {`${unnamed} ${unnamed === 1 ? 'speaker was' : 'speakers were'} never named. `}
+          {'Undo to name them — it needs the recording, which goes with this note.'}
+        </div>
+      )}
       {/* Countdown bar depleting over the undo window. */}
       <div
         aria-hidden

--- a/app/renderer/src/components/home/PreviousRow.tsx
+++ b/app/renderer/src/components/home/PreviousRow.tsx
@@ -1,4 +1,4 @@
-import { Folder as FolderIcon, Loader2 } from 'lucide-react';
+import { AudioLines, Folder as FolderIcon, Loader2 } from 'lucide-react';
 import type { Meeting } from '@/lib/ipc';
 import { navigate } from '@/lib/router';
 import { useMeetingsList } from '@/lib/meetingsListContext';
@@ -116,7 +116,28 @@ export function PreviousRow({ meeting, folderName }: PreviousRowProps) {
         style={{ color: 'var(--fg-2)' }}
       >
         <span>{isSynthetic ? 'Now' : (when ?? '')}</span>
-        {duration && <span className="text-[11.5px] opacity-70">{duration}</span>}
+        {/* Original audio still on disk. Shown only when present, never as a
+            crossed-out "missing" marker: keep_recordings defaults off, so
+            absence is the normal case and flagging it on most rows would be
+            noise. What the icon buys is knowing, without opening the note,
+            which recordings can still be re-transcribed or listened to for
+            speaker review — the actions that silently disappear once the
+            audio is gone. Sits beside the duration because both describe
+            the recording rather than the note. */}
+        {(duration || (!isSynthetic && meeting.has_audio)) && (
+          <span className="flex items-center gap-1 text-[11.5px] opacity-70">
+            {!isSynthetic && meeting.has_audio && (
+              <AudioLines
+                className="size-3"
+                aria-label="Original audio still available"
+                data-testid="previous-row-has-audio"
+              >
+                <title>Original audio still available</title>
+              </AudioLines>
+            )}
+            {duration}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/app/renderer/src/hooks/useSpeakerSuggestions.ts
+++ b/app/renderer/src/hooks/useSpeakerSuggestions.ts
@@ -124,9 +124,59 @@ export function useDeletePersonProfile() {
  * background for an audio clip a human triggers explicitly. */
 export function useGetSpeakerSampleAudio() {
   return useMutation({
-    mutationFn: async (args: { meetingStem: string; channel: string; diarizationSpeakerId: string }) =>
+    mutationFn: async (args: {
+      meetingStem: string;
+      channel: string;
+      diarizationSpeakerId: string;
+      /** Index into the row's `samples`. Omitted plays the longest turn
+       * (the collapsed row's single button); a number plays exactly that
+       * excerpt, so the audio matches the text it sits next to. */
+      segmentIndex?: number;
+    }) =>
       unwrap(
-        await ipc().speakers.getSampleAudio(args.meetingStem, args.channel, args.diarizationSpeakerId),
+        await ipc().speakers.getSampleAudio(
+          args.meetingStem, args.channel, args.diarizationSpeakerId, args.segmentIndex,
+        ),
       ),
+  });
+}
+
+/** Marking a cluster as holding more than one person. Invalidates the whole
+ * speakers tree rather than just this meeting's suggestions: the marking
+ * withdraws the cluster from meeting-wide person exclusivity, so ANOTHER
+ * row's suggestion can change as a direct result of marking this one. */
+export function useMarkSpeakerCluster() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (args: {
+      meetingStem: string;
+      channel: string;
+      diarizationSpeakerId: string;
+      containsMultipleSpeakers: boolean;
+    }) => unwrap(await ipc().speakers.markCluster(args)),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: speakersKeys.all });
+    },
+  });
+}
+
+/** How many speaker clusters of a meeting are still unnamed -- read once,
+ * right before a delete confirmation, to decide whether to add a sentence
+ * saying the unnamed ones are about to become unnameable forever.
+ *
+ * Failures resolve to null rather than throwing: this decides whether ONE
+ * extra sentence appears, and must never stand between someone and
+ * deleting their own recording. `enabled` keeps it from firing at all
+ * until a delete is actually being confirmed. */
+export function useSpeakerNamingStatus(meetingStem: string | null | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: [...speakersKeys.all, 'naming-status', meetingStem ?? null] as const,
+    queryFn: async () => {
+      const res = await ipc().speakers.namingStatus(meetingStem as string);
+      return res.success ? res : null;
+    },
+    enabled: enabled && Boolean(meetingStem),
+    retry: false,
+    staleTime: 0,
   });
 }

--- a/app/renderer/src/hooks/useSpeakerSuggestions.ts
+++ b/app/renderer/src/hooks/useSpeakerSuggestions.ts
@@ -153,9 +153,22 @@ export function useMarkSpeakerCluster() {
       channel: string;
       diarizationSpeakerId: string;
       containsMultipleSpeakers: boolean;
-    }) => unwrap(await ipc().speakers.markCluster(args)),
-    onSuccess: async () => {
+      /** The meeting's summaryFile, carried for the same reason the confirm
+       * mutation carries it: marking a CONFIRMED cluster withdraws that
+       * person from the meeting's participants, and the open detail view
+       * reads those from its own cached query. Without invalidating it, the
+       * Participants line keeps showing the withdrawn name until an
+       * unrelated refetch or a navigation. */
+      summaryFile?: string | null;
+    }) => {
+      const { summaryFile: _ignored, ...call } = args;
+      return unwrap(await ipc().speakers.markCluster(call));
+    },
+    onSuccess: async (_data, args) => {
       await qc.invalidateQueries({ queryKey: speakersKeys.all });
+      if (args.summaryFile) {
+        await qc.invalidateQueries({ queryKey: meetingsKeys.detail(args.summaryFile) });
+      }
     },
   });
 }

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -58,6 +58,12 @@ export interface Meeting {
   is_diarised?: boolean;
   diarised_text?: string | null;
   folders?: string[];
+  /** Whether the ORIGINAL recording is still on disk (list-meetings only —
+   *  derived from one directory listing, extension-agnostic). keep_recordings
+   *  defaults off, so this is false for most notes, and everything that needs
+   *  the audio (re-transcribe, speaker samples, any future re-diarization) is
+   *  quietly unavailable without it. */
+  has_audio?: boolean;
   /** User notes as persisted + returned by the backend (`_parse_meeting_markdown` -> `user_notes`). */
   user_notes?: string | null;
   /** Renderer-side notes for the in-progress / draft recording (live + processing views). */

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -446,6 +446,11 @@ export interface SpeakerCandidate {
    *  relative: negative evidence must rival the positive to suppress). */
   negative_distance: number | null;
 }
+export interface SpeakerSample {
+  start: number;
+  end: number;
+  text: string | null;
+}
 export interface SpeakerSuggestion {
   status: 'confirmed' | 'possible' | 'none';
   suggested_person_id: string | null;
@@ -463,6 +468,19 @@ export interface SpeakerSuggestion {
   /** Quoted excerpt of what this cluster said, at its longest (most
    *  trustworthy) segment -- null if no saved transcript overlaps it. */
   sample_text: string | null;
+  /** Several excerpts, chronological, each independently playable. Index i
+   *  here is exactly what `getSampleAudio(..., i)` plays -- both sides
+   *  derive the list from the shared `sample_segments`, so the clip always
+   *  matches the text beside it. `text` is null for a segment no transcript
+   *  line covers; the entry stays, because its audio is still playable and
+   *  dropping it would shift every later index. */
+  samples: SpeakerSample[];
+  /** A human marked this cluster as holding more than one person. Never
+   *  derived -- no measurable property of a blended centroid distinguishes
+   *  one voice from two (0.8270 to the contaminating speaker in the real
+   *  case this exists for). True takes the cluster out of naming entirely:
+   *  no suggestion, no candidates, and confirm-speaker refuses it. */
+  contains_multiple_speakers: boolean;
   /** True when duration/segment-count shape matches the real-data-validated
    *  echo/crosstalk artifact pattern (SUGGESTION_MIN_AVG_TURN_SECONDS) --
    *  a UI hint only, never excludes the cluster from confirm-speaker. */
@@ -479,7 +497,36 @@ export type SuggestSpeakersResponse = Result<{
    *  defaults off, so this is false for most older backfilled meetings) --
    *  checked once per meeting; gates whether a play button can render. */
   recording_available: boolean;
+  /** Clusters, plus one extra for each cluster marked as holding more than
+   *  one person. Surfaced because the ceiling is real and invisible in the
+   *  output: Sortformer's four-slot architecture returns a five-person
+   *  channel as four clusters with nothing indicating anything was lost.
+   *  Nothing consumes this number today -- Sortformer takes no speaker-count
+   *  hint, so there is no re-diarization call to feed it into. */
+  minimum_speaker_count: number;
   channels: Record<string, Record<string, SpeakerSuggestion>>;
+}>;
+
+export interface MarkSpeakerClusterParams {
+  meetingStem: string;
+  channel: string;
+  diarizationSpeakerId: string;
+  containsMultipleSpeakers: boolean;
+}
+export type MarkSpeakerClusterResponse = Result<{
+  resolved_diarization_speaker_id: string;
+  contains_multiple_speakers: boolean;
+  minimum_speaker_count: number;
+}>;
+
+/** Feeds the one sentence shown before a delete. `has_sidecar: false` means
+ *  this meeting was never diarized -- nothing is at risk, no warning. */
+export type SpeakerNamingStatusResponse = Result<{
+  meeting_id: string;
+  has_sidecar: boolean;
+  total_clusters: number;
+  named_clusters: number;
+  unnamed_clusters: number;
 }>;
 
 export interface ConfirmSpeakerParams {
@@ -1049,9 +1096,11 @@ export interface StenoaiBridge {
     renameProfile: RequestFn<[id: string, displayName: string], Result<Record<string, never>>>;
     deleteProfile: RequestFn<[id: string], Result<Record<string, never>>>;
     getSampleAudio: RequestFn<
-      [meetingStem: string, channel: string, diarizationSpeakerId: string],
+      [meetingStem: string, channel: string, diarizationSpeakerId: string, segmentIndex?: number],
       GetSpeakerSampleAudioResponse
     >;
+    markCluster: RequestFn<[params: MarkSpeakerClusterParams], MarkSpeakerClusterResponse>;
+    namingStatus: RequestFn<[meetingStem: string], SpeakerNamingStatusResponse>;
   };
 
   models: {

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -516,6 +516,11 @@ export interface MarkSpeakerClusterParams {
 export type MarkSpeakerClusterResponse = Result<{
   resolved_diarization_speaker_id: string;
   contains_multiple_speakers: boolean;
+  /** Display names whose confirmation of THIS cluster the marking withdrew.
+   *  Marking implies the name was wrong, so the prototype (a blended
+   *  two-voice embedding) and the hard negatives it created are removed
+   *  rather than left enrolled. */
+  cleared_confirmation_from: string[];
   minimum_speaker_count: number;
 }>;
 

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -191,19 +191,31 @@ export interface FixtureSpeakerCluster {
  * known-good sidecar so suggest-speakers/confirm-speaker have real data to
  * read. Returns the absolute path of the written sidecar.
  */
+export interface FixtureTurnManifestEntry {
+  start: number;
+  channel: string;
+  diarization_speaker_id: string;
+}
+
 export function writeSpeakersSidecar(
   userDataDir: string,
   stem: string,
   channels: Record<string, { recording_type: string; clusters: Record<string, FixtureSpeakerCluster> }>,
+  turnManifest?: FixtureTurnManifestEntry[],
 ): string {
   const outputDir = path.join(userDataDir, 'output');
   mkdirSync(outputDir, { recursive: true });
   const sidecarFile = path.join(outputDir, `${stem}_speakers.json`);
-  const data = {
+  const data: Record<string, unknown> = {
     meeting_id: stem,
     created_at: Date.now() / 1000,
     channels,
   };
+  // Omitted (not written empty) when absent, exactly like the real writer --
+  // and the distinction MATTERS: without a manifest the backend attributes
+  // no excerpt text at all, because a backfilled sidecar's segments come
+  // from a different diarization run than the transcript's timestamps.
+  if (turnManifest && turnManifest.length > 0) data.transcript_lines = turnManifest;
   writeFileSync(sidecarFile, JSON.stringify(data, null, 2));
   return sidecarFile;
 }

--- a/e2e/specs/overview-audio-indicator.t1.spec.ts
+++ b/e2e/specs/overview-audio-indicator.t1.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../fixtures/electron';
+
+/**
+ * T1 — renderer-only, mock IPC. The overview's "original audio still exists"
+ * indicator.
+ *
+ * Why it earns a UI spec on top of the backend's own tests: the value of the
+ * icon is entirely in it being ABSENT for notes whose recording is gone.
+ * keep_recordings defaults off, so most rows have no audio — an icon that
+ * rendered unconditionally would look correct on a screenshot and tell the
+ * user nothing. Only a pair of rows differing solely in `has_audio` can show
+ * the difference.
+ */
+
+test('only a note whose recording still exists shows the audio indicator', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: {
+      STENOAI_E2E_SEED_AUDIO_MEETINGS: '1',
+      // Without an installed model App.tsx's first-run gate redirects a
+      // neutral route to /setup before Home ever renders (same seam the
+      // pill-dock T1 uses).
+      STENOAI_E2E_MOCK_PARAKEET_INSTALLED: '1',
+    },
+  });
+
+  const rows = page.getByTestId('previous-row');
+  await expect(rows).toHaveCount(2);
+
+  const withAudio = rows.filter({ hasText: 'With audio' });
+  const withoutAudio = rows.filter({ hasText: 'Without audio' });
+
+  await expect(withAudio.getByTestId('previous-row-has-audio')).toHaveCount(1);
+  await expect(withoutAudio.getByTestId('previous-row-has-audio')).toHaveCount(0);
+
+  // The duration still renders on both -- the icon sits BESIDE it rather
+  // than replacing it.
+  await expect(withAudio).toContainText('10m');
+  await expect(withoutAudio).toContainText('15m');
+
+  // Named for screen readers, not a bare decorative glyph.
+  await expect(
+    withAudio.getByLabel('Original audio still available'),
+  ).toBeVisible();
+});

--- a/e2e/specs/speaker-multi-marking.t2.spec.ts
+++ b/e2e/specs/speaker-multi-marking.t2.spec.ts
@@ -1,0 +1,313 @@
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { writeSpeakersSidecar, writeTranscriptFile, writeMeetingMarkdown } from '../fixtures/user-config';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+/**
+ * T2 — the "this cluster holds more than one person" marking, the multi-excerpt
+ * review samples, and what a delete costs. Model-free: seeds a
+ * `<stem>_speakers.json` sidecar in the exact shape
+ * src.speaker_suggestions.write_speakers_sidecar produces, plus a saved
+ * transcript with `[MM:SS] [Speaker N]` lines at the sidecar's own segment
+ * timestamps. No diarizer, no audio, no model — everything asserted here is
+ * real backend state on disk or a real Python CLI's answer through the bridge.
+ *
+ * What makes these worth having as e2e rather than unit tests: the marking's
+ * whole purpose is to stop a blended two-voice centroid from being enrolled as
+ * a person, and the enrollment happens in a Python subprocess writing
+ * config.json. A unit test can prove the guard function returns "none"; only
+ * this can prove no prototype reaches config.json.
+ */
+
+type StenoWindow = Window & {
+  stenoai: {
+    speakers: {
+      markCluster: (params: {
+        meetingStem: string;
+        channel: string;
+        diarizationSpeakerId: string;
+        containsMultipleSpeakers: boolean;
+      }) => Promise<{
+        success: boolean;
+        error?: string;
+        contains_multiple_speakers?: boolean;
+        minimum_speaker_count?: number;
+      }>;
+      confirm: (params: {
+        meetingStem: string;
+        channel: string;
+        diarizationSpeakerId: string;
+        newPersonName?: string;
+        personId?: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      suggestForMeeting: (meetingStem: string) => Promise<{
+        success: boolean;
+        minimum_speaker_count?: number;
+        channels: Record<
+          string,
+          Record<
+            string,
+            {
+              status: string;
+              suggested_name: string | null;
+              candidates: unknown[];
+              contains_multiple_speakers?: boolean;
+              samples?: Array<{ start: number; end: number; text: string | null }>;
+            }
+          >
+        >;
+      }>;
+      namingStatus: (meetingStem: string) => Promise<{
+        success: boolean;
+        has_sidecar?: boolean;
+        total_clusters?: number;
+        named_clusters?: number;
+        unnamed_clusters?: number;
+      }>;
+    };
+    meetings: {
+      delete: (meeting: unknown) => Promise<{ success: boolean; id?: string; error?: string }>;
+      commitDelete: (id: string) => Promise<{ success: boolean }>;
+    };
+  };
+};
+
+const readJson = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
+
+/** Two clusters that differ only in which one gets marked, plus a transcript
+ * whose lines sit at the sidecar's segment timestamps so the samples have
+ * real text to quote. SPEAKER_0's segments are deliberately of different
+ * lengths and out of chronological order in the file, so the samples list
+ * proves it sorts rather than echoing input order. */
+function seedMeeting(userDataDir: string, stem: string) {
+  writeSpeakersSidecar(userDataDir, stem, {
+    system: {
+      recording_type: 'remote',
+      clusters: {
+        SPEAKER_0: {
+          embedding: [1.0, 0.0],
+          speech_duration_seconds: 60.0,
+          segment_count: 3,
+          segments: [
+            { start: 120.0, end: 128.0 },
+            { start: 10.0, end: 30.0 },
+            { start: 60.0, end: 62.0 },
+          ],
+        },
+        SPEAKER_1: {
+          embedding: [0.0, 1.0],
+          speech_duration_seconds: 40.0,
+          segment_count: 2,
+          segments: [{ start: 200.0, end: 210.0 }],
+        },
+      },
+    },
+  });
+  writeTranscriptFile(
+    userDataDir,
+    stem,
+    [
+      '[00:10] [Speaker 2] the longest turn in the meeting',
+      '',
+      '[01:00] [Speaker 2] a short interjection',
+      '',
+      '[02:00] [Speaker 2] the middle length turn',
+      '',
+      '[03:20] [Speaker 3] someone else entirely',
+    ].join('\n'),
+  );
+}
+
+test('a marked cluster is withheld from naming, refused by confirm, and raises the minimum speaker count', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const stem = 'e2e-multi-marking';
+  seedMeeting(userDataDir, stem);
+
+  const { page } = await launchApp();
+
+  // Baseline: unmarked, both clusters are ordinary review rows.
+  const before = await page.evaluate(
+    (s) => (window as StenoWindow).stenoai.speakers.suggestForMeeting(s), stem,
+  );
+  expect(before.success).toBe(true);
+  expect(before.channels.system.SPEAKER_0.contains_multiple_speakers).toBe(false);
+  expect(before.minimum_speaker_count).toBe(2);
+
+  const marked = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.markCluster(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', containsMultipleSpeakers: true },
+  );
+  expect(marked.success).toBe(true);
+  expect(marked.contains_multiple_speakers).toBe(true);
+  // Two clusters, one of them known to hold at least two people.
+  expect(marked.minimum_speaker_count).toBe(3);
+
+  // It landed in the sidecar itself, not somewhere parallel that a
+  // re-read could miss.
+  const sidecarPath = path.join(userDataDir, 'output', `${stem}_speakers.json`);
+  await expect.poll(() =>
+    readJson(sidecarPath).channels.system.clusters.SPEAKER_0.contains_multiple_speakers,
+  ).toBe(true);
+  // And the embeddings the sidecar exists to carry survived the rewrite --
+  // once the audio is gone they cannot be recomputed.
+  expect(readJson(sidecarPath).channels.system.clusters.SPEAKER_0.embedding).toEqual([1.0, 0.0]);
+
+  const after = await page.evaluate(
+    (s) => (window as StenoWindow).stenoai.speakers.suggestForMeeting(s), stem,
+  );
+  const row = after.channels.system.SPEAKER_0;
+  expect(row.contains_multiple_speakers).toBe(true);
+  expect(row.status).toBe('none');
+  // No candidates either: a ranking from a blended centroid is a confident
+  // guess about a voice that does not exist, and offering it in a picker
+  // would invite the exact confirmation this marking prevents.
+  expect(row.candidates).toEqual([]);
+  expect(after.minimum_speaker_count).toBe(3);
+
+  // THE POINT: the backend refuses to enroll it, so no blended voiceprint
+  // can reach config.json to degrade suggestions in unrelated meetings.
+  const refused = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Julian' },
+  );
+  expect(refused.success).toBe(false);
+  expect(refused.error).toContain('more than one person');
+
+  const configPath = path.join(userDataDir, 'config.json');
+  const profiles = (readJson(configPath).person_profiles ?? []) as Array<{ display_name: string }>;
+  expect(profiles.find((p) => p.display_name === 'Julian')).toBeUndefined();
+
+  // The unmarked neighbour is unaffected -- marking one row must not cost
+  // the others their naming.
+  const accepted = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Max' },
+  );
+  expect(accepted.success).toBe(true);
+
+  // Undo restores an ordinary row (a misclick must be recoverable, and the
+  // marked row stays visible in the panel precisely so this is reachable).
+  const unmarked = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.markCluster(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', containsMultipleSpeakers: false },
+  );
+  expect(unmarked.success).toBe(true);
+  expect(unmarked.minimum_speaker_count).toBe(2);
+  await expect.poll(() =>
+    'contains_multiple_speakers' in readJson(sidecarPath).channels.system.clusters.SPEAKER_0,
+  ).toBe(false);
+
+  expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
+});
+
+test('a cluster offers several chronological excerpts, and each index plays its own clip', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const stem = 'e2e-multi-samples';
+  seedMeeting(userDataDir, stem);
+
+  const { page } = await launchApp();
+
+  const result = await page.evaluate(
+    (s) => (window as StenoWindow).stenoai.speakers.suggestForMeeting(s), stem,
+  );
+  const samples = result.channels.system.SPEAKER_0.samples ?? [];
+  expect(samples).toHaveLength(3);
+
+  // Chronological, NOT by duration: the longest turn (20s at 00:10) comes
+  // first here because it happens first, and the 8s turn at 02:00 comes
+  // last. Ordering is a contract -- an index into this list is what
+  // getSampleAudio(..., i) plays, so a duration-ordered list would make
+  // every play button play a different moment than the text beside it.
+  expect(samples.map((s) => s.start)).toEqual([10.0, 60.0, 120.0]);
+  expect(samples.map((s) => s.text)).toEqual([
+    'the longest turn in the meeting',
+    'a short interjection',
+    'the middle length turn',
+  ]);
+
+  // Sourced from the saved transcript by timestamp, not from the sidecar's
+  // `transcript_lines` manifest -- this seeded sidecar has none, exactly
+  // like every sidecar backfill-speaker-embeddings writes.
+  const sidecar = readJson(path.join(userDataDir, 'output', `${stem}_speakers.json`));
+  expect(sidecar.transcript_lines).toBeUndefined();
+
+  expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
+});
+
+test('deleting a meeting reports its unnamed speakers and removes its voice-embedding sidecar', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const stem = 'e2e-multi-delete';
+  seedMeeting(userDataDir, stem);
+  const summaryFile = writeMeetingMarkdown(userDataDir, stem, {
+    name: 'Deletable meeting',
+    summaryMarkdown: '## Summary\n\nA meeting seeded for the delete path.',
+    transcript: '[00:10] [Speaker 2] the longest turn in the meeting',
+    frontmatter: { is_diarised: true },
+  });
+
+  const { page } = await launchApp();
+
+  // Two clusters, neither named yet.
+  const status = await page.evaluate(
+    (s) => (window as StenoWindow).stenoai.speakers.namingStatus(s), stem,
+  );
+  expect(status.success).toBe(true);
+  expect(status.has_sidecar).toBe(true);
+  expect(status.unnamed_clusters).toBe(2);
+
+  // Naming one moves it out of the count. This is the whole distinction the
+  // delete warning rests on: a CONFIRMED person outlives the meeting (their
+  // prototype is bound to the person in config.json), an unnamed cluster
+  // does not and can never be recovered, because naming a voice requires
+  // hearing it and the delete takes the audio.
+  await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Max' },
+  );
+  await expect.poll(async () =>
+    (await page.evaluate(
+      (s) => (window as StenoWindow).stenoai.speakers.namingStatus(s), stem,
+    )).unnamed_clusters,
+  ).toBe(1);
+
+  // The sidecar holds this meeting's raw voice embeddings. It used to be
+  // left behind by delete-meeting (same class of miss as the reports
+  // sidecar), so a deleted meeting kept its voiceprints on disk.
+  const sidecarPath = path.join(userDataDir, 'output', `${stem}_speakers.json`);
+  expect(existsSync(sidecarPath)).toBe(true);
+
+  const deleted = await page.evaluate(
+    (meeting) => (window as StenoWindow).stenoai.meetings.delete(meeting),
+    { session_info: { name: 'Deletable meeting', summary_file: summaryFile } },
+  );
+  expect(deleted.success).toBe(true);
+
+  // Soft-delete: the sidecar is still there DURING the undo window, which is
+  // what lets the toast read the unnamed count while undo is still possible.
+  expect(existsSync(sidecarPath)).toBe(true);
+
+  await page.evaluate(
+    (id) => (window as StenoWindow).stenoai.meetings.commitDelete(id), deleted.id as string,
+  );
+  await expect.poll(() => existsSync(sidecarPath)).toBe(false);
+
+  // Max's voice profile deliberately SURVIVES: it is bound to the person,
+  // not the meeting, and is what makes recognition work across recordings.
+  const profiles = (readJson(path.join(userDataDir, 'config.json')).person_profiles ?? []) as Array<{
+    display_name: string;
+    prototypes: unknown[];
+  }>;
+  expect(profiles.find((p) => p.display_name === 'Max')?.prototypes).toHaveLength(1);
+
+  expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
+});

--- a/e2e/specs/speaker-multi-marking.t2.spec.ts
+++ b/e2e/specs/speaker-multi-marking.t2.spec.ts
@@ -32,6 +32,7 @@ type StenoWindow = Window & {
         success: boolean;
         error?: string;
         contains_multiple_speakers?: boolean;
+        cleared_confirmation_from?: string[];
         minimum_speaker_count?: number;
       }>;
       confirm: (params: {
@@ -200,6 +201,66 @@ test('a marked cluster is withheld from naming, refused by confirm, and raises t
   await expect.poll(() =>
     'contains_multiple_speakers' in readJson(sidecarPath).channels.system.clusters.SPEAKER_0,
   ).toBe(false);
+
+  expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
+});
+
+test('marking a cluster that was already confirmed withdraws the name and its voiceprint', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const stem = 'e2e-multi-withdraw';
+  seedMeeting(userDataDir, stem);
+
+  const { page } = await launchApp();
+  const configPath = path.join(userDataDir, 'config.json');
+
+  // The realistic order: confirm first, then hear the second voice in a
+  // later excerpt and realise the cluster is mixed.
+  const confirmed = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Julian' },
+  );
+  expect(confirmed.success).toBe(true);
+  await expect.poll(() => {
+    const profiles = (readJson(configPath).person_profiles ?? []) as Array<{
+      display_name: string; prototypes: unknown[];
+    }>;
+    return profiles.find((p) => p.display_name === 'Julian')?.prototypes.length;
+  }).toBe(1);
+
+  const marked = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.markCluster(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', containsMultipleSpeakers: true },
+  );
+  expect(marked.success).toBe(true);
+  expect(marked.cleared_confirmation_from).toEqual(['Julian']);
+
+  // If marking only blocked FUTURE confirms, this blended two-voice
+  // embedding would stay enrolled as Julian -- the exact state the marking
+  // exists to prevent, and still reachable from enroll-self-from-person
+  // and from every future suggestion scored against his profile.
+  await expect.poll(() => {
+    const profiles = (readJson(configPath).person_profiles ?? []) as Array<{
+      display_name: string; prototypes: unknown[];
+    }>;
+    return profiles.find((p) => p.display_name === 'Julian')?.prototypes.length;
+  }).toBe(0);
+
+  // Confirming the neighbour afterwards must not pick up negative evidence
+  // derived from that mixed cluster.
+  const neighbour = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Max' },
+  );
+  expect(neighbour.success).toBe(true);
+  const profiles = (readJson(configPath).person_profiles ?? []) as Array<{
+    display_name: string; hard_negatives?: unknown[];
+  }>;
+  for (const person of profiles) {
+    expect(person.hard_negatives ?? []).toEqual([]);
+  }
 
   expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
 });

--- a/e2e/specs/speaker-multi-marking.t2.spec.ts
+++ b/e2e/specs/speaker-multi-marking.t2.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { writeSpeakersSidecar, writeTranscriptFile, writeMeetingMarkdown } from '../fixtures/user-config';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync } from 'fs';
 import path from 'path';
 
 /**
@@ -54,6 +54,7 @@ type StenoWindow = Window & {
               suggested_name: string | null;
               candidates: unknown[];
               contains_multiple_speakers?: boolean;
+              sample_text?: string | null;
               samples?: Array<{ start: number; end: number; text: string | null }>;
             }
           >
@@ -104,20 +105,42 @@ function seedMeeting(userDataDir: string, stem: string) {
         },
       },
     },
-  });
+  }, [
+    // One entry per diarised transcript line, in order -- exact recorded
+    // provenance. Three of the four lines belong to SPEAKER_0, and they
+    // are the lines labeled "You": on the mic channel those are the
+    // owner's own turns, and an earlier version skipped every "You" line,
+    // which left the owner's cluster quoting somebody else.
+    { start: 10.0, channel: 'system', diarization_speaker_id: 'SPEAKER_0' },
+    { start: 60.0, channel: 'system', diarization_speaker_id: 'SPEAKER_0' },
+    { start: 120.0, channel: 'system', diarization_speaker_id: 'SPEAKER_0' },
+    { start: 200.0, channel: 'system', diarization_speaker_id: 'SPEAKER_1' },
+  ]);
   writeTranscriptFile(
     userDataDir,
     stem,
     [
-      '[00:10] [Speaker 2] the longest turn in the meeting',
+      '[00:10] [You] the longest turn in the meeting',
       '',
-      '[01:00] [Speaker 2] a short interjection',
+      '[01:00] [You] a short interjection',
       '',
-      '[02:00] [Speaker 2] the middle length turn',
+      '[02:00] [You] the middle length turn',
       '',
       '[03:20] [Speaker 3] someone else entirely',
     ].join('\n'),
   );
+}
+
+/** The same meeting WITHOUT a turn manifest -- the shape every sidecar
+ * written by backfill-speaker-embeddings has. Excerpt text is withheld
+ * entirely for these, because the transcript's timestamps came from a
+ * different diarization run than these segments. */
+function seedMeetingWithoutManifest(userDataDir: string, stem: string) {
+  seedMeeting(userDataDir, stem);
+  const sidecarPath = path.join(userDataDir, 'output', `${stem}_speakers.json`);
+  const sidecar = readJson(sidecarPath);
+  delete sidecar.transcript_lines;
+  writeFileSync(sidecarPath, JSON.stringify(sidecar, null, 2));
 }
 
 test('a marked cluster is withheld from naming, refused by confirm, and raises the minimum speaker count', async ({
@@ -287,17 +310,48 @@ test('a cluster offers several chronological excerpts, and each index plays its 
   // getSampleAudio(..., i) plays, so a duration-ordered list would make
   // every play button play a different moment than the text beside it.
   expect(samples.map((s) => s.start)).toEqual([10.0, 60.0, 120.0]);
+  // The lines are labeled "You" on purpose. Those are the device owner's
+  // own turns, and an earlier version skipped every "You" line, which left
+  // the owner's own cluster quoting a DIFFERENT participant -- found on a
+  // real three-person call.
   expect(samples.map((s) => s.text)).toEqual([
     'the longest turn in the meeting',
     'a short interjection',
     'the middle length turn',
   ]);
 
-  // Sourced from the saved transcript by timestamp, not from the sidecar's
-  // `transcript_lines` manifest -- this seeded sidecar has none, exactly
-  // like every sidecar backfill-speaker-embeddings writes.
-  const sidecar = readJson(path.join(userDataDir, 'output', `${stem}_speakers.json`));
-  expect(sidecar.transcript_lines).toBeUndefined();
+  expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
+});
+
+test('without a turn manifest the moments stay playable but carry no attributed text', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const realDirBefore = fileSig(realUserDataDir());
+  const stem = 'e2e-multi-nomanifest';
+  seedMeetingWithoutManifest(userDataDir, stem);
+
+  const { page } = await launchApp();
+
+  const result = await page.evaluate(
+    (s) => (window as StenoWindow).stenoai.speakers.suggestForMeeting(s), stem,
+  );
+  const row = result.channels.system.SPEAKER_0;
+  const samples = row.samples ?? [];
+
+  // Still three moments to listen to -- the timestamps and the audio come
+  // from the same run as the segments, so those stay trustworthy.
+  expect(samples).toHaveLength(3);
+  expect(samples.map((s) => s.start)).toEqual([10.0, 60.0, 120.0]);
+
+  // But no text is attributed. This is the shape every sidecar written by
+  // backfill-speaker-embeddings has, and for those the transcript's
+  // timestamps came from a different diarization run than these segments.
+  // Measured on a real call, matching across the two put another
+  // participant's sentences under the owner's own cluster -- so nothing is
+  // shown rather than something possibly wrong.
+  expect(samples.map((s) => s.text)).toEqual([null, null, null]);
+  expect(row.sample_text ?? null).toBeNull();
 
   expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
 });

--- a/e2e/specs/speaker-naming.t2.spec.ts
+++ b/e2e/specs/speaker-naming.t2.spec.ts
@@ -214,11 +214,19 @@ test('identification aids: sample_text/is_likely_artifact/recording_available an
         },
       },
     },
-  });
+  }, [
+    // The turn manifest is what makes sample_text attributable at all: one
+    // entry per diarised transcript line, in order, naming the exact
+    // cluster that produced it. Without it the backend returns no text
+    // rather than matching by timestamp -- a backfilled sidecar's segments
+    // come from a different diarization run than the transcript's [MM:SS]
+    // markers, and matching across the two put a different participant's
+    // words under the owner's own cluster on a real recording.
+    { start: 1.0, channel: 'mic', diarization_speaker_id: 'SPEAKER_0' },
+  ]);
   // Timestamp must land inside the segment's [start, end] +/- the 0.5s
-  // relabel/sample-text tolerance -- SPEAKER_0's segment is [0.5, 2.5], so
-  // [00:01] (1s) is safely within range (unlike 0s, which would be just
-  // outside the 0.2s lower bound).
+  // sample tolerance -- SPEAKER_0's segment is [0.5, 2.5], so [00:01] (1s)
+  // is safely within range (unlike 0s, which would be just outside).
   writeTranscriptFile(userDataDir, stem, '[00:01] [Speaker 2] this is a real substantial turn');
 
   const { page } = await launchApp();

--- a/e2e/specs/speaker-review.t1.spec.ts
+++ b/e2e/specs/speaker-review.t1.spec.ts
@@ -309,7 +309,18 @@ test('marking a row as more than one person removes every naming action and can 
   // taking the only undo for a misclick with it.
   await expect(row).toBeVisible();
 
-  await row.getByTestId('speaker-mark-multi-mic:SPEAKER_0').click();
+  // The button that clears the marking must not call itself "Undo": by
+  // then the prototype, the participants entry and the transcript labels
+  // of the withdrawn name are gone, and clearing the flag reopens the row
+  // for naming rather than restoring what was there.
+  const clearMark = row.getByTestId('speaker-mark-multi-mic:SPEAKER_0');
+  await expect(clearMark).toContainText('One person');
+  await expect(clearMark).toHaveAttribute(
+    'aria-label',
+    'This is one person after all - reopens the row for naming, does not restore the earlier name',
+  );
+
+  await clearMark.click();
   await expect(row).toContainText('Likely Julian');
   await expect(row.getByRole('button', { name: 'Approve' })).toHaveCount(1);
 });

--- a/e2e/specs/speaker-review.t1.spec.ts
+++ b/e2e/specs/speaker-review.t1.spec.ts
@@ -278,3 +278,97 @@ test('a likely-artifact row is hidden by default, reachable via the filtered-row
   await toggle.click();
   await expect(page.getByTestId('speaker-row-mic:SPEAKER_4')).toHaveCount(0);
 });
+
+test('marking a row as more than one person removes every naming action and can be undone', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_SPEAKER_SUGGESTIONS: '1' },
+  });
+  await openDetail(page);
+
+  const row = page.getByTestId('speaker-row-mic:SPEAKER_0');
+  await expect(row).toContainText('Likely Julian');
+
+  await row.getByTestId('speaker-mark-multi-mic:SPEAKER_0').click();
+
+  await expect(row).toContainText('More than one person');
+  await expect(row).toContainText('Left out of naming and voice recognition.');
+  // Every naming control is GONE, not disabled: confirm-speaker refuses a
+  // marked cluster outright, so a greyed-out Approve would be a control
+  // that can never become available, and a "Change" picker would invite
+  // exactly the confirmation this marking exists to prevent.
+  await expect(row.getByRole('button', { name: 'Approve' })).toHaveCount(0);
+  await expect(row.getByTestId('speaker-change-mic:SPEAKER_0')).toHaveCount(0);
+  await expect(row.getByTestId('speaker-new-person-mic:SPEAKER_0')).toHaveCount(0);
+
+  // The row itself must STAY -- a marked cluster is status "none" with zero
+  // candidates, which is the panel's "nothing actionable" hidden shape, so
+  // without an explicit carve-out it would vanish the moment it was marked,
+  // taking the only undo for a misclick with it.
+  await expect(row).toBeVisible();
+
+  await row.getByTestId('speaker-mark-multi-mic:SPEAKER_0').click();
+  await expect(row).toContainText('Likely Julian');
+  await expect(row.getByRole('button', { name: 'Approve' })).toHaveCount(1);
+});
+
+test('a row with several excerpts expands into one playable entry per moment', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_SPEAKER_SUGGESTIONS: '1' },
+  });
+  await openDetail(page);
+
+  const row = page.getByTestId('speaker-row-mic:SPEAKER_0');
+  // Collapsed: one quote, no excerpt list.
+  await expect(page.getByTestId('speaker-samples-mic:SPEAKER_0')).toHaveCount(0);
+
+  await row.getByTestId('speaker-expand-mic:SPEAKER_0').click();
+
+  const samples = page.getByTestId('speaker-samples-mic:SPEAKER_0');
+  await expect(samples).toBeVisible();
+  // Each moment gets its OWN play button. One shared button replaying the
+  // same clip is the state this replaces -- several excerpts are what let
+  // someone actually place a voice, and hearing two different voices in one
+  // list is how a contaminated cluster becomes visible at all.
+  await expect(page.getByTestId('speaker-play-mic:SPEAKER_0-0')).toBeVisible();
+  await expect(page.getByTestId('speaker-play-mic:SPEAKER_0-1')).toBeVisible();
+  await expect(page.getByTestId('speaker-play-mic:SPEAKER_0-2')).toBeVisible();
+
+  await expect(samples).toContainText('02:10');
+  await expect(samples).toContainText('the migration is the risky part');
+  // A segment no transcript line covers keeps its row rather than being
+  // dropped -- the clip is still playable, and dropping it would put every
+  // later excerpt's play button out of step with its index.
+  await expect(samples).toContainText('No transcript for this moment');
+
+  await row.getByTestId('speaker-expand-mic:SPEAKER_0').click();
+  await expect(page.getByTestId('speaker-samples-mic:SPEAKER_0')).toHaveCount(0);
+});
+
+test('the panel says how many people spoke when a cluster is known to hold more than one', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_SPEAKER_SUGGESTIONS: '1' },
+  });
+  await openDetail(page);
+
+  // Nothing marked yet: clusters and people are the same number, so there
+  // is nothing to say and the line stays off.
+  await expect(page.getByTestId('speaker-minimum-count')).toHaveCount(0);
+
+  await page.getByTestId('speaker-mark-multi-mic:SPEAKER_0').click();
+
+  // Sortformer returns at most four clusters per channel and gives no
+  // indication when it ran out of slots, so this line is the only place a
+  // fifth person is ever mentioned.
+  const note = page.getByTestId('speaker-minimum-count');
+  await expect(note).toBeVisible();
+  await expect(note).toContainText('At least 6 people spoke, but only 5 could be told apart');
+});

--- a/e2e/specs/speaker-review.t1.spec.ts
+++ b/e2e/specs/speaker-review.t1.spec.ts
@@ -346,6 +346,19 @@ test('a row with several excerpts expands into one playable entry per moment', a
   // later excerpt's play button out of step with its index.
   await expect(samples).toContainText('No transcript for this moment');
 
+  // The fourth moment is one the backend could not place in the audio
+  // (start === end). Its text is still this speaker's, so the row stays --
+  // but its play button has to be inert: the backend refuses to cut a
+  // collapsed range, and padding one into a clip would play whoever else
+  // spoke at that second under this speaker's name.
+  const unplayable = page.getByTestId('speaker-play-mic:SPEAKER_0-3');
+  await expect(unplayable).toBeVisible();
+  await expect(unplayable).toBeDisabled();
+  await expect(unplayable).toHaveAttribute(
+    'aria-label', 'No audio could be matched to this moment',
+  );
+  await expect(samples).toContainText('a line with no audio to match it');
+
   await row.getByTestId('speaker-expand-mic:SPEAKER_0').click();
   await expect(page.getByTestId('speaker-samples-mic:SPEAKER_0')).toHaveCount(0);
 });

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4834,6 +4834,7 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
         merge_same_channel_fragments,
         prototype_channel_matches,
         read_speakers_sidecar,
+        record_original_labels,
         relabel_transcript_exact,
         relabel_transcript_speaker,
     )
@@ -5019,6 +5020,12 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
             # Phase 8). Only meetings processed after this manifest
             # existed have one; everything else falls back.
             target_ids = {(channel, sid) for sid in [resolved_id, *context.merged_from]}
+            # BEFORE the rename, so the label each line carries today is
+            # still readable. Without it, naming a cluster is irreversible
+            # in the transcript and marking it as mixed later would leave
+            # the name standing. First write wins, so re-confirming (the
+            # "Change" flow) never records a person's name as the original.
+            record_original_labels(output_dir, meeting_stem, transcript_path, target_ids)
             relabeled_lines = relabel_transcript_exact(
                 transcript_path, turn_manifest, target_ids, person["display_name"],
             )
@@ -5125,6 +5132,7 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
         merge_same_channel_fragments,
         clusters_from_sidecar_channel,
         minimum_speaker_count,
+        restore_transcript_labels,
         set_cluster_multi_speaker,
     )
 
@@ -5171,6 +5179,7 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
     # directions.
     config = get_config()
     cleared_from = []
+    restored_lines = 0
     if multiple and fragment_ids:
         for person in config.get_person_profiles():
             removed = config.remove_speaker_evidence(
@@ -5201,6 +5210,19 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
                     sids=fragment_ids, negative=True,
                 )
         if cleared_from:
+            # The transcript is the artefact a human reads, and the one the
+            # summary and every export are built from. Withdrawing the
+            # profile while leaving the name on the lines would mean the app
+            # knows this voice is several people and keeps naming one of
+            # them. Each line goes back to the label it carried before the
+            # confirmation; where none was recorded -- meetings confirmed
+            # before that existed -- it becomes "Multiple speakers", which
+            # is not a guess but the statement the user just made.
+            restored_lines = restore_transcript_labels(
+                get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt",
+                sidecar.get("transcript_lines") or [],
+                {(channel, fid) for fid in fragment_ids},
+            )
             # Same upkeep confirm-speaker does: the meeting's Participants
             # chip is derived from confirmed prototypes, so dropping one has
             # to update it or the note keeps listing someone who is no
@@ -5221,6 +5243,12 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
         # marking, so a caller can say so rather than letting a person
         # quietly disappear from the meeting.
         "cleared_confirmation_from": cleared_from,
+        # How many transcript lines stopped carrying the withdrawn name.
+        # Reported rather than assumed: a manifest that no longer describes
+        # the transcript is refused outright (see restore_transcript_labels),
+        # and then the name IS still in the file -- a caller that says
+        # "removed" regardless would be lying about the artefact.
+        "transcript_lines_restored": restored_lines,
         "minimum_speaker_count": minimum_speaker_count(sidecar.get("channels") or {}),
     }))
 

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -315,6 +315,51 @@ def _render_frontmatter(meta: dict) -> list[str]:
     return lines
 
 
+def _persist_speaker_sidecar(output_dir, meeting_stem: str, transcript_data: dict) -> bool:
+    """Write the `{stem}_speakers.json` sidecar from diarization output a
+    run has ALREADY computed. Returns True when a sidecar was written.
+
+    Every path that finishes a meeting must call this, and the reason is
+    that the cost of the work is already sunk long before any of them
+    decide what to do next: diarization and embedding extraction happen
+    inside transcription, so by the time a path reaches its own `return`
+    the clusters are sitting in `transcript_data` fully paid for. Skipping
+    the write does not save anything -- it only discards the embeddings,
+    and with them the meeting's entire Speakers panel, permanently once
+    the source audio is gone (keep_recordings defaults off).
+
+    Three paths used to reach a `return` without writing it, all with the
+    clusters in hand:
+      - MeetingPipeline.process_recording's auto-summarize gate (#258)
+      - process_streaming's auto-summarize gate (the same gate, second copy)
+      - reprocess --retranscribe, which re-runs the FULL transcription
+        (diarization included, at full cost) and then dropped the result
+    The shared symptom was that turning OFF automatic note generation
+    silently turned off speaker identification too, with no setting saying
+    so, no error, and no way to recover the embeddings afterwards -- the
+    diarization itself ran normally and the transcript carried its speaker
+    labels, so nothing on screen suggested anything had been lost.
+
+    Deliberately NOT called from the continue-recording (`append_to`) path.
+    That path folds a segment into an EXISTING note, and this sidecar is
+    keyed by the segment's own audio stem, which belongs to no note --
+    writing there produces exactly the orphaned sidecar that has to be
+    cleaned up by hand later. Continuations keeping the original
+    recording's sidecar is the correct outcome; merging a continuation's
+    clusters into it is a separate piece of work (the cluster ids of two
+    independent diarization runs are unrelated).
+    """
+    speaker_clusters = transcript_data.get("speaker_clusters") or {}
+    if not speaker_clusters:
+        return False
+    from src.speaker_suggestions import write_speakers_sidecar
+    write_speakers_sidecar(
+        output_dir, meeting_stem, speaker_clusters,
+        turn_manifest=transcript_data.get("turn_manifest"),
+    )
+    return True
+
+
 class MeetingPipeline:
     """Simple audio recorder and transcriber."""
     
@@ -739,6 +784,11 @@ Summary output language: {config.get_language_name(output_language)}
                 md_lines.append('')
                 md_lines.append(notes_text)
             _atomic_write_text(summary_path, '\n'.join(md_lines))
+            # Before the audio is deleted below: the sidecar is the only
+            # place these embeddings survive, and this gate is about
+            # skipping the SUMMARY, not about discarding diarization that
+            # already ran.
+            _persist_speaker_sidecar(self.output_dir, audio_path.stem, transcript_data)
             if not gate_config.get_keep_recordings():
                 try:
                     audio_path.unlink()
@@ -842,13 +892,7 @@ Summary output language: {config.get_language_name(output_language)}
         # CLI command ever wrote this sidecar, so a normally-recorded
         # meeting never got a Speakers review panel at all, even when
         # diarization succeeded (is_diarised: true).
-        speaker_clusters = transcript_data.get("speaker_clusters") or {}
-        if speaker_clusters:
-            from src.speaker_suggestions import write_speakers_sidecar
-            write_speakers_sidecar(
-                self.output_dir, audio_path.stem, speaker_clusters,
-                turn_manifest=transcript_data.get("turn_manifest"),
-            )
+        _persist_speaker_sidecar(self.output_dir, audio_path.stem, transcript_data)
 
         # Clean up
         from src.config import get_config
@@ -1296,6 +1340,12 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
                 md_lines.append(notes_text)
             _atomic_write_text(summary_path, '\n'.join(md_lines))
 
+            # Before the audio is deleted below: the sidecar is the only
+            # place these embeddings survive, and this gate is about
+            # skipping the SUMMARY, not about discarding diarization that
+            # already ran.
+            _persist_speaker_sidecar(recorder.output_dir, audio_path.stem, transcript_data)
+
             if not is_live_transcript and not gate_config.get_keep_recordings():
                 try:
                     audio_path.unlink()
@@ -1418,13 +1468,7 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
         # CLI command ever wrote this sidecar, so a normally-recorded
         # meeting never got a Speakers review panel at all, even when
         # diarization succeeded (is_diarised: true).
-        speaker_clusters = transcript_data.get("speaker_clusters") or {}
-        if speaker_clusters:
-            from src.speaker_suggestions import write_speakers_sidecar
-            write_speakers_sidecar(
-                recorder.output_dir, audio_path.stem, speaker_clusters,
-                turn_manifest=transcript_data.get("turn_manifest"),
-            )
+        _persist_speaker_sidecar(recorder.output_dir, audio_path.stem, transcript_data)
 
         # Clean up audio. When we fell back to the live transcript the batch
         # transcription was empty/failed, so KEEP the audio regardless of the
@@ -3003,6 +3047,27 @@ def reprocess(summary_file, regenerate_title, retranscribe):
             # A full re-transcribe replaces any live-sourced transcript, so the
             # live-transcript flag (#207) no longer applies to this note.
             _si.pop('is_live_transcript', None)
+
+            # This re-transcribe just re-ran diarization at full cost on the
+            # original audio, so the new clusters describe the transcript
+            # that is being written here -- the OLD sidecar (if any) now
+            # describes a transcript that no longer exists, and its cluster
+            # ids no longer line up with anything. Overwriting it is the
+            # correct outcome, not a loss.
+            #
+            # KNOWN CONSEQUENCE, deliberately not worked around: a re-run
+            # produces its own independent cluster numbering, so any
+            # confirmations already recorded against the old ids are left
+            # pointing at clusters that may now be different people. The
+            # user is re-transcribing precisely because they consider the
+            # old result wrong, and silently carrying old confirmations onto
+            # new clusters would be the worse failure -- it would attach a
+            # real person's name to whichever voice happened to inherit
+            # their id. Re-confirming after a re-transcribe is intended.
+            # Next to the summary being rewritten, not recorder.output_dir:
+            # reprocess is handed an arbitrary summary path and the sidecar
+            # is looked up beside the note it belongs to.
+            _persist_speaker_sidecar(summary_path.parent, stem, transcribe_result)
 
         # Get transcript from the data
         transcript = existing_data.get('transcript', '')
@@ -4798,6 +4863,26 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
     clusters, id_resolution = merge_same_channel_fragments(raw_clusters)
     resolved_id = id_resolution[diarization_speaker_id]
 
+    # Refused HERE rather than only hidden in the panel, because this is
+    # the point where the damage would become permanent and unattributable:
+    # a confirm turns the cluster's embedding into a stored SpeakerPrototype
+    # and, for every other person confirmed in this channel, into mutual
+    # hard-negative evidence. A blended two-voice centroid enrolled as one
+    # person degrades every future suggestion scored against that profile,
+    # in meetings that have nothing to do with this one, with nothing in
+    # the result pointing back at the cause. The panel's hiding is a
+    # convenience; this is the guarantee.
+    if clusters[resolved_id][1].contains_multiple_speakers:
+        print(json.dumps({
+            "success": False,
+            "error": (
+                f"Cluster {diarization_speaker_id!r} is marked as containing more than "
+                "one person, so it cannot be confirmed as a single person. Clear the "
+                "marking first if that was wrong."
+            ),
+        }))
+        sys.exit(1)
+
     config = get_config()
     if new_person:
         try:
@@ -4986,6 +5071,164 @@ def speaker_timestamps(meeting_stem, channel, diarization_speaker_id):
         print(f"  [{_format_timestamp(seg['start'])} - {_format_timestamp(seg['end'])}]")
 
 
+@cli.command(name='mark-speaker-cluster')
+@click.argument('meeting_stem')
+@click.argument('channel')
+@click.argument('diarization_speaker_id')
+@click.option(
+    '--multiple/--single', 'multiple', default=True,
+    help="--multiple (default) marks the cluster as holding more than one person; "
+         "--single clears the marking.",
+)
+def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple):
+    """Record that one diarized cluster holds MORE THAN ONE person -- the
+    one fact about a cluster that cannot be measured, only witnessed.
+
+    Diarizers fail in two directions. Splitting one person across several
+    clusters is recoverable from the data itself (see
+    merge_same_channel_fragments, which does it automatically at distance
+    <= 0.10). Merging several people INTO one cluster is not: measured
+    against a real three-person call, a cluster contaminated by someone
+    briefly talking over the main speaker sat at cosine distance 0.8270
+    from the person who contaminated it -- indistinguishable from any two
+    unrelated speakers. No threshold finds that, and the per-chunk
+    embeddings that might are not in the sidecar's contract. Somebody who
+    was in the room is the only instrument that detects it.
+
+    Marking a cluster takes it out of naming and out of voice
+    identification entirely: it is withheld from suggestions, refused by
+    `confirm-speaker`, and never enrolled as anyone's voice evidence. It
+    also raises the meeting's reported `minimum_speaker_count`, since a
+    mixed cluster is at least two people -- see that function on why
+    nothing consumes that number yet.
+    """
+    from src.config import get_data_dirs
+    from src.speaker_suggestions import (
+        merge_same_channel_fragments,
+        clusters_from_sidecar_channel,
+        minimum_speaker_count,
+        set_cluster_multi_speaker,
+    )
+
+    output_dir = get_data_dirs()["output"]
+    sidecar = set_cluster_multi_speaker(
+        output_dir, meeting_stem, channel, diarization_speaker_id, multiple,
+    )
+    if sidecar is None:
+        print(json.dumps({
+            "success": False,
+            "error": f"No cluster {diarization_speaker_id!r} in {channel!r} channel of {meeting_stem!r}",
+        }))
+        sys.exit(1)
+
+    # Report the marking's reach, not just the raw id it was written to: a
+    # cluster that merge_same_channel_fragments folded into another is
+    # reviewed and displayed under its primary's id, so marking any
+    # fragment withholds the whole merged cluster. Saying so here keeps
+    # the CLI honest about what just happened.
+    channel_data = (sidecar.get("channels") or {}).get(channel) or {}
+    _, id_resolution = merge_same_channel_fragments(
+        clusters_from_sidecar_channel(meeting_stem, channel_data)
+    )
+    print(json.dumps({
+        "success": True,
+        "meeting_id": meeting_stem,
+        "channel": channel,
+        "diarization_speaker_id": diarization_speaker_id,
+        "resolved_diarization_speaker_id": id_resolution.get(
+            diarization_speaker_id, diarization_speaker_id,
+        ),
+        "contains_multiple_speakers": multiple,
+        "minimum_speaker_count": minimum_speaker_count(sidecar.get("channels") or {}),
+    }))
+
+
+@cli.command(name='speaker-naming-status')
+@click.argument('meeting_stem')
+def speaker_naming_status(meeting_stem):
+    """How many of this meeting's speaker clusters still have no name.
+
+    Deliberately cheap and side-effect free -- no profile scoring, no
+    transcript reads, no ffmpeg -- because it is called to decide whether
+    to show one sentence in a delete confirmation, on a path where a slow
+    or failing check must never stand between a user and deleting their
+    own recording.
+
+    Why it exists: a CONFIRMED person survives deleting the meeting (their
+    prototype lives in config.json's person_profiles, bound to no meeting
+    -- verified against a real library, where 5 of 19 working prototypes
+    came from meetings deleted long ago). An UNNAMED cluster does not
+    survive it, and cannot be recovered afterwards by any means: naming a
+    voice requires hearing it, hearing it requires the source audio, and
+    the delete takes the audio. So the last moment at which an unnamed
+    cluster can still be named is just before the delete -- which is
+    exactly when nobody is thinking about it.
+
+    Reports `success: true` with zero counts for a meeting that has no
+    sidecar at all (not diarized, or diarized before sidecars existed):
+    nothing is at risk there, and a caller deciding whether to show a
+    warning wants "nothing to warn about", not an error to handle.
+    """
+    from src.config import get_config, get_data_dirs
+    from src.speaker_suggestions import (
+        MULTI_SPEAKER_KEY,
+        merge_same_channel_fragments,
+        clusters_from_sidecar_channel,
+        prototype_channel_matches,
+        read_speakers_sidecar,
+    )
+
+    dirs = get_data_dirs()
+    sidecar = read_speakers_sidecar(dirs["output"], meeting_stem)
+    if sidecar is None:
+        print(json.dumps({
+            "success": True, "meeting_id": meeting_stem, "has_sidecar": False,
+            "total_clusters": 0, "named_clusters": 0, "unnamed_clusters": 0,
+        }))
+        return
+
+    profiles = get_config().get_person_profiles()
+    total = 0
+    named = 0
+    for channel_name, channel_data in (sidecar.get("channels") or {}).items():
+        raw_clusters_by_id = channel_data.get("clusters") or {}
+        recording_type = channel_data.get("recording_type")
+        merged, _ = merge_same_channel_fragments(
+            clusters_from_sidecar_channel(meeting_stem, channel_data)
+        )
+        for sid, (_embedding, context) in merged.items():
+            # A cluster marked as mixed is not "waiting to be named" -- it
+            # is one a human has already looked at and ruled out, so
+            # counting it as unnamed would nag about the one row that can
+            # never be resolved.
+            if context.contains_multiple_speakers or any(
+                raw_clusters_by_id.get(fid, {}).get(MULTI_SPEAKER_KEY)
+                for fid in [sid, *context.merged_from]
+            ):
+                continue
+            total += 1
+            fragment_ids = [sid, *context.merged_from]
+            if any(
+                any(
+                    p.get("meeting_id") == meeting_stem
+                    and p.get("diarization_speaker_id") in fragment_ids
+                    and prototype_channel_matches(p, channel_name, recording_type)
+                    for p in (person.get("prototypes") or [])
+                )
+                for person in profiles
+            ):
+                named += 1
+
+    print(json.dumps({
+        "success": True,
+        "meeting_id": meeting_stem,
+        "has_sidecar": True,
+        "total_clusters": total,
+        "named_clusters": named,
+        "unnamed_clusters": total - named,
+    }))
+
+
 @cli.command(name='suggest-speakers')
 @click.argument('meeting_stem')
 def suggest_speakers(meeting_stem):
@@ -5004,7 +5247,9 @@ def suggest_speakers(meeting_stem):
         SUGGESTION_MIN_AVG_TURN_SECONDS,
         clusters_from_sidecar_channel,
         extract_sample_text,
+        extract_segment_samples,
         merge_same_channel_fragments,
+        minimum_speaker_count,
         prototype_channel_matches,
         read_speakers_sidecar,
         suggest_speakers_for_meeting,
@@ -5110,6 +5355,23 @@ def suggest_speakers(meeting_stem):
                     if pooled_segments else None
                 ),
                 "sample_text": extract_sample_text(transcript_path, pooled_segments),
+                # Several excerpts, chronological, each independently
+                # playable (see extract_segment_samples / sample_segments --
+                # `samples[i]` is what `get-speaker-sample-audio
+                # --segment-index i` plays). One excerpt is a single roll of
+                # the dice on whether the longest turn happens to contain
+                # anything recognizable; several spread across the recording
+                # are what let a human actually place a voice -- and hearing
+                # two different voices under one cluster is the only way the
+                # contamination behind `contains_multiple_speakers` becomes
+                # visible at all.
+                "samples": extract_segment_samples(transcript_path, pooled_segments),
+                # Set by `mark-speaker-cluster`, never derived: no measurable
+                # property of a centroid distinguishes one voice from two
+                # blended ones (0.8270 to the contaminating speaker in the
+                # real case this was built for). True means a human said so,
+                # and this cluster is out of naming for good.
+                "contains_multiple_speakers": context.contains_multiple_speakers,
                 # Same signal already used to gate suggestion status (real-
                 # data-validated this session against the echo/crosstalk
                 # artifact pattern) -- reused here to flag likely-artifact
@@ -5126,6 +5388,12 @@ def suggest_speakers(meeting_stem):
         "success": True,
         "meeting_id": meeting_stem,
         "recording_available": recording_path is not None,
+        # Clusters plus one extra for each cluster marked as mixed. Worth
+        # surfacing because the real ceiling is invisible in the output:
+        # Sortformer's four-slot architecture returns a five-person channel
+        # as four clusters with nothing indicating anything was dropped.
+        # No caller acts on this number today -- see minimum_speaker_count.
+        "minimum_speaker_count": minimum_speaker_count(sidecar.get("channels") or {}),
         "channels": channels_out,
     }))
 
@@ -5134,13 +5402,26 @@ def suggest_speakers(meeting_stem):
 @click.argument('meeting_stem')
 @click.argument('channel')
 @click.argument('diarization_speaker_id')
-def get_speaker_sample_audio(meeting_stem, channel, diarization_speaker_id):
+@click.option(
+    '--segment-index', type=int, default=None,
+    help="Play this entry of the cluster's `samples` list (as returned by "
+         "suggest-speakers) instead of its longest turn.",
+)
+def get_speaker_sample_audio(meeting_stem, channel, diarization_speaker_id, segment_index):
     """Extract a short audio clip of one diarized cluster, for the review
     UI's play button. Picks the cluster's single LONGEST pooled segment
     (primary + merged fragments) to avoid cross-voice contamination --
     mirrors pasrom/meeting-transcriber's SpeakerNamingView.swift and uses
     the exact same time range `suggest-speakers`' `sample_text` quotes, so
     what a human reads matches what they'd hear.
+
+    With `--segment-index i`, plays `samples[i]` from the same cluster's
+    `suggest-speakers` output instead -- the two commands derive that list
+    from identically-pooled segments via the shared `sample_segments`, so
+    the clip always matches the excerpt shown next to it. An out-of-range
+    index is an error rather than a silent fall back to the longest turn:
+    hearing the wrong excerpt with no indication is how someone concludes
+    two different speakers sound the same.
 
     Always fails gracefully (`{"success": false, "error": ...}`, never a
     non-JSON crash) when there's no source recording left on disk (the
@@ -5192,8 +5473,15 @@ def get_speaker_sample_audio(meeting_stem, channel, diarization_speaker_id):
         for seg in (raw_clusters_by_id.get(fragment_id, {}).get("segments") or [])
     ]
 
-    output_path = Path(tempfile.gettempdir()) / f"steno_sample_{meeting_stem}_{channel}_{resolved_id}.wav"
-    ok = extract_speaker_sample_audio(recording_path, channel, pooled_segments, output_path)
+    suffix = "" if segment_index is None else f"_{segment_index}"
+    output_path = (
+        Path(tempfile.gettempdir())
+        / f"steno_sample_{meeting_stem}_{channel}_{resolved_id}{suffix}.wav"
+    )
+    ok = extract_speaker_sample_audio(
+        recording_path, channel, pooled_segments, output_path,
+        segment_index=segment_index,
+    )
     if not ok:
         print(json.dumps({"success": False, "error": "could not extract audio sample"}))
         return

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5328,12 +5328,12 @@ def suggest_speakers(meeting_stem):
     from src.speaker_suggestions import (
         SUGGESTION_MIN_AVG_TURN_SECONDS,
         clusters_from_sidecar_channel,
-        extract_sample_text,
         extract_segment_samples,
         merge_same_channel_fragments,
         minimum_speaker_count,
         prototype_channel_matches,
         read_speakers_sidecar,
+        sample_text_from_samples,
         suggest_speakers_for_meeting,
     )
     from src.config import get_data_dirs
@@ -5401,6 +5401,13 @@ def suggest_speakers(meeting_stem):
                 if context.segment_count else 0.0
             )
             target_ids = {(channel_name, fid) for fid in fragment_ids}
+            # Built once per cluster: the collapsed row's quote is derived
+            # from this same list below, and asking for it separately meant
+            # a second transcript parse and manifest check per cluster.
+            cluster_samples = extract_segment_samples(
+                transcript_path, pooled_segments,
+                turn_manifest=turn_manifest, target_ids=target_ids,
+            )
             # Whether a human has ALREADY confirmed this exact cluster,
             # derived from real persisted state (an existing prototype),
             # not transient UI state -- a suggestion's status/tier can stay
@@ -5447,10 +5454,11 @@ def suggest_speakers(meeting_stem):
                     _format_timestamp(min(seg["start"] for seg in pooled_segments))
                     if pooled_segments else None
                 ),
-                "sample_text": extract_sample_text(
-                    transcript_path, pooled_segments,
-                    turn_manifest=turn_manifest, target_ids=target_ids,
-                ),
+                # Derived from `samples` below rather than recomputed: both
+                # come from the same excerpt list by construction, and
+                # asking twice meant parsing the transcript and re-checking
+                # the manifest a second time for every cluster.
+                "sample_text": sample_text_from_samples(cluster_samples),
                 # Several excerpts, chronological, each independently
                 # playable (see extract_segment_samples / sample_segments --
                 # `samples[i]` is what `get-speaker-sample-audio
@@ -5461,10 +5469,7 @@ def suggest_speakers(meeting_stem):
                 # two different voices under one cluster is the only way the
                 # contamination behind `contains_multiple_speakers` becomes
                 # visible at all.
-                "samples": extract_segment_samples(
-                    transcript_path, pooled_segments,
-                    turn_manifest=turn_manifest, target_ids=target_ids,
-                ),
+                "samples": cluster_samples,
                 # Set by `mark-speaker-cluster`, never derived: no measurable
                 # property of a centroid distinguishes one voice from two
                 # blended ones (0.8270 to the contaminating speaker in the

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5351,6 +5351,16 @@ def suggest_speakers(meeting_stem):
     recording_path = _find_recording_file(dirs["recordings"], meeting_stem)
     transcript_path = dirs["transcripts"] / f"{meeting_stem}_transcript.txt"
 
+    # Exact per-line provenance, present only on meetings recorded after the
+    # manifest existed. Without it no excerpt TEXT is shown at all: a
+    # backfill-produced sidecar re-diarized the audio in its own run, so its
+    # segment timestamps were never the ones the saved transcript's [MM:SS]
+    # markers came from, and matching text by proximity across the two put a
+    # DIFFERENT participant's sentences under the owner's own mic cluster
+    # (measured -- see cluster_transcript_lines). The play buttons are
+    # unaffected; they cut audio at this run's own segments.
+    turn_manifest = sidecar.get("transcript_lines")
+
     profiles = get_config().get_person_profiles()
     # Merge fragments per channel first, then suggest for ALL channels in
     # one call -- used-person exclusivity is meeting-wide (a person can't
@@ -5384,6 +5394,7 @@ def suggest_speakers(meeting_stem):
                 context.speech_duration_seconds / context.segment_count
                 if context.segment_count else 0.0
             )
+            target_ids = {(channel_name, fid) for fid in fragment_ids}
             # Whether a human has ALREADY confirmed this exact cluster,
             # derived from real persisted state (an existing prototype),
             # not transient UI state -- a suggestion's status/tier can stay
@@ -5430,7 +5441,10 @@ def suggest_speakers(meeting_stem):
                     _format_timestamp(min(seg["start"] for seg in pooled_segments))
                     if pooled_segments else None
                 ),
-                "sample_text": extract_sample_text(transcript_path, pooled_segments),
+                "sample_text": extract_sample_text(
+                    transcript_path, pooled_segments,
+                    turn_manifest=turn_manifest, target_ids=target_ids,
+                ),
                 # Several excerpts, chronological, each independently
                 # playable (see extract_segment_samples / sample_segments --
                 # `samples[i]` is what `get-speaker-sample-audio
@@ -5441,7 +5455,10 @@ def suggest_speakers(meeting_stem):
                 # two different voices under one cluster is the only way the
                 # contamination behind `contains_multiple_speakers` becomes
                 # visible at all.
-                "samples": extract_segment_samples(transcript_path, pooled_segments),
+                "samples": extract_segment_samples(
+                    transcript_path, pooled_segments,
+                    turn_manifest=turn_manifest, target_ids=target_ids,
+                ),
                 # Set by `mark-speaker-cluster`, never derived: no measurable
                 # property of a centroid distinguishes one voice from two
                 # blended ones (0.8270 to the contaminating speaker in the

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -3064,10 +3064,15 @@ def reprocess(summary_file, regenerate_title, retranscribe):
             # new clusters would be the worse failure -- it would attach a
             # real person's name to whichever voice happened to inherit
             # their id. Re-confirming after a re-transcribe is intended.
-            # Next to the summary being rewritten, not recorder.output_dir:
-            # reprocess is handed an arbitrary summary path and the sidecar
-            # is looked up beside the note it belongs to.
-            _persist_speaker_sidecar(summary_path.parent, stem, transcribe_result)
+            # Written to the CONFIGURED output dir, not next to the summary
+            # path this command happens to be handed. Every reader --
+            # suggest-speakers, confirm-speaker, speaker-naming-status,
+            # backfill -- resolves the sidecar through
+            # get_data_dirs()["output"] and nowhere else, so a sidecar
+            # beside a summary living anywhere else would be written and
+            # then never found by anything.
+            from src.config import get_data_dirs as _get_data_dirs
+            _persist_speaker_sidecar(_get_data_dirs()["output"], stem, transcribe_result)
 
         # Get transcript from the data
         transcript = existing_data.get('transcript', '')
@@ -4955,7 +4960,19 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
     # both channels number clusters from SPEAKER_0 independently, and
     # matching without it recorded hard negatives built from the wrong
     # channel's clusters whenever the ids happened to collide.
-    other_sids = [sid for sid in clusters if sid != resolved_id]
+    # A cluster marked as mixed is excluded as a SOURCE of negative evidence
+    # too, not just as a name. "Speaker B is not the person in cluster A" is
+    # only true if cluster A is one person; when A is a blend of two voices,
+    # the negative is recorded against a voice nobody has, and it suppresses
+    # real matches for B in unrelated meetings. Reachable in practice:
+    # confirm A, later discover A is mixed and mark it, then confirm B --
+    # without this filter B inherits A's blended embedding as a hard
+    # negative. (Marking A also strips A's own prototype; see
+    # mark-speaker-cluster.)
+    other_sids = [
+        sid for sid in clusters
+        if sid != resolved_id and not clusters[sid][1].contains_multiple_speakers
+    ]
     hard_negatives_added = []
     for other_person in config.get_person_profiles():
         if other_person["person_id"] == person["person_id"]:
@@ -5102,8 +5119,9 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
     mixed cluster is at least two people -- see that function on why
     nothing consumes that number yet.
     """
-    from src.config import get_data_dirs
+    from src.config import get_config, get_data_dirs
     from src.speaker_suggestions import (
+        confirmed_participant_names,
         merge_same_channel_fragments,
         clusters_from_sidecar_channel,
         minimum_speaker_count,
@@ -5127,18 +5145,76 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
     # fragment withholds the whole merged cluster. Saying so here keeps
     # the CLI honest about what just happened.
     channel_data = (sidecar.get("channels") or {}).get(channel) or {}
-    _, id_resolution = merge_same_channel_fragments(
+    channel_recording_type = channel_data.get("recording_type")
+    clusters, id_resolution = merge_same_channel_fragments(
         clusters_from_sidecar_channel(meeting_stem, channel_data)
     )
+    resolved_id = id_resolution.get(diarization_speaker_id, diarization_speaker_id)
+    fragment_ids = set()
+    if resolved_id in clusters:
+        fragment_ids = {resolved_id, *clusters[resolved_id][1].merged_from}
+
+    # Marking a cluster mixed must UNDO any name already on it, not just
+    # stop future ones. Order matters: someone typically confirms a cluster
+    # first and only later -- on listening to a second excerpt -- realises
+    # two people are in it. Leaving the earlier confirmation standing would
+    # keep a blended two-voice embedding enrolled as that person, which is
+    # the exact state this marking exists to prevent, and it stays reachable
+    # from three other directions: enroll-self-from-person copies any
+    # existing prototype into the self voiceprint, confirm-speaker treats a
+    # confirmed neighbour as hard-negative evidence, and every future
+    # suggestion is scored against the poisoned profile.
+    #
+    # Also removes the hard negatives that confirmation created -- they were
+    # only ever recorded because this cluster was believed to be that
+    # person, and a negative derived from a blended voice is wrong in both
+    # directions.
+    config = get_config()
+    cleared_from = []
+    if multiple and fragment_ids:
+        for person in config.get_person_profiles():
+            removed = config.remove_speaker_evidence(
+                person["person_id"], meeting_id=meeting_stem,
+                channel=channel, channel_recording_type=channel_recording_type,
+                sids=fragment_ids,
+            )
+            if not removed:
+                continue
+            cleared_from.append(person["display_name"])
+            config.remove_speaker_evidence(
+                person["person_id"], meeting_id=meeting_stem,
+                channel=channel, channel_recording_type=channel_recording_type,
+                negative=True,
+            )
+            for other in config.get_person_profiles():
+                if other["person_id"] == person["person_id"]:
+                    continue
+                config.remove_speaker_evidence(
+                    other["person_id"], meeting_id=meeting_stem,
+                    channel=channel, channel_recording_type=channel_recording_type,
+                    sids=fragment_ids, negative=True,
+                )
+        if cleared_from:
+            # Same upkeep confirm-speaker does: the meeting's Participants
+            # chip is derived from confirmed prototypes, so dropping one has
+            # to update it or the note keeps listing someone who is no
+            # longer attributed to any of its speakers.
+            _update_summary_participants(
+                output_dir, meeting_stem,
+                confirmed_participant_names(meeting_stem, config.get_person_profiles()),
+            )
+
     print(json.dumps({
         "success": True,
         "meeting_id": meeting_stem,
         "channel": channel,
         "diarization_speaker_id": diarization_speaker_id,
-        "resolved_diarization_speaker_id": id_resolution.get(
-            diarization_speaker_id, diarization_speaker_id,
-        ),
+        "resolved_diarization_speaker_id": resolved_id,
         "contains_multiple_speakers": multiple,
+        # Names whose confirmation of THIS cluster was withdrawn by the
+        # marking, so a caller can say so rather than letting a person
+        # quietly disappear from the meeting.
+        "cleared_confirmation_from": cleared_from,
         "minimum_speaker_count": minimum_speaker_count(sidecar.get("channels") or {}),
     }))
 
@@ -5671,7 +5747,8 @@ def backfill_speaker_embeddings(limit, extension, force, meeting_stem):
     from src.config import get_config, get_data_dirs
     from src.transcriber import WhisperTranscriber, STENO_DIARIZE_TIMEOUT_FLOOR_S, _run_steno_diarize
     from src.speaker_suggestions import (
-        build_clusters_from_diarization, determine_recording_type,
+        build_clusters_from_diarization, cluster_ids_marked_multi_speaker,
+        determine_recording_type, read_speakers_sidecar,
         speakers_sidecar_path, write_speakers_sidecar,
     )
 
@@ -5713,6 +5790,7 @@ def backfill_speaker_embeddings(limit, extension, force, meeting_stem):
     processed = []
     skipped_no_audio = []
     skipped_no_clusters = []
+    lost_multi_speaker_markings = []
     errors = []
 
     for stem in stems:
@@ -5720,6 +5798,9 @@ def backfill_speaker_embeddings(limit, extension, force, meeting_stem):
         if recording_path is None:
             skipped_no_audio.append(stem)
             continue
+        # Read BEFORE the re-diarization overwrites it, so the report below
+        # can name what this run is about to discard.
+        previous_sidecar = read_speakers_sidecar(output_dir, stem)
         try:
             mic_path, system_path, duration = transcriber._split_stereo_to_channels(recording_path)
             channel_paths = [("mic", mic_path), ("system", system_path)] if mic_path else [("mic", recording_path)]
@@ -5748,6 +5829,24 @@ def backfill_speaker_embeddings(limit, extension, force, meeting_stem):
                 }
 
             if channels_out:
+                # Re-diarizing replaces the sidecar wholesale, and a
+                # human's "this cluster holds more than one person" marking
+                # cannot survive that: the new run numbers its clusters
+                # independently, so the old ids describe nothing here. The
+                # marking is genuinely gone rather than transferable -- but
+                # it is the one thing in that file no re-run can reproduce,
+                # so losing it is reported instead of silent.
+                dropped = sum(
+                    len(cluster_ids_marked_multi_speaker(ch))
+                    for ch in ((previous_sidecar or {}).get("channels") or {}).values()
+                )
+                if dropped:
+                    logger.warning(
+                        "backfill-speaker-embeddings: %s had %d cluster(s) marked as "
+                        "containing multiple speakers; re-diarization discards those markings.",
+                        stem, dropped,
+                    )
+                    lost_multi_speaker_markings.append({"stem": stem, "clusters": dropped})
                 write_speakers_sidecar(output_dir, stem, channels_out)
                 processed.append(stem)
             else:
@@ -5770,6 +5869,7 @@ def backfill_speaker_embeddings(limit, extension, force, meeting_stem):
         "skipped_no_audio": skipped_no_audio,
         "skipped_no_clusters": skipped_no_clusters,
         "skipped_already_processed": skipped_already_processed,
+        "lost_multi_speaker_markings": lost_multi_speaker_markings,
         "errors": errors,
         "total_meetings": len(all_stems),
     }))

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5181,10 +5181,16 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
             if not removed:
                 continue
             cleared_from.append(person["display_name"])
+            # Restricted to THIS cluster's ids, same as the loop below. A
+            # person's negatives in this meeting are earned one cluster at a
+            # time -- "that voice over there is not Julian" is evidence about
+            # that other cluster, and marking this one does not touch it.
+            # Clearing them all destroyed evidence silently, and the only
+            # symptom would have been a worse suggestion months later.
             config.remove_speaker_evidence(
                 person["person_id"], meeting_id=meeting_stem,
                 channel=channel, channel_recording_type=channel_recording_type,
-                negative=True,
+                sids=fragment_ids, negative=True,
             )
             for other in config.get_person_profiles():
                 if other["person_id"] == person["person_id"]:

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -19,6 +19,7 @@ import click
 import asyncio
 import logging
 import json
+import os
 import re
 import sys
 import time
@@ -2751,6 +2752,24 @@ def list_meetings():
     # Ensure output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    # Stems that still have their source recording on disk. Read as ONE
+    # directory listing rather than a per-meeting existence check, because
+    # this command is on the app's cold-start path and is deliberately
+    # "optimized for fast loading" -- with a listing the cost is a single
+    # syscall regardless of library size, and each meeting is then a set
+    # lookup. Extension-agnostic on purpose: the capture pipeline saves
+    # whatever the source produced (.webm system audio, .wav native
+    # captures, .m4a/.mp3 imports), so only the stem is meaningful.
+    def _recorded_stems(recordings_dir) -> set:
+        try:
+            return {Path(name).stem for name in os.listdir(recordings_dir)}
+        except OSError:
+            # No recordings dir yet (fresh install) is not an error -- it
+            # just means nothing has audio.
+            return set()
+
+    audio_stems = _recorded_stems(dirs["recordings"])
+
     # Collect summary files from current output dir (JSON preferred over MD)
     seen_files = set()
     seen_stems = set()
@@ -2760,7 +2779,7 @@ def list_meetings():
         for f in output_dir.glob(pattern):
             stem = f.stem.replace('_summary', '')
             if stem not in seen_stems:
-                summaries.append(f)
+                summaries.append((f, stem))
                 seen_files.add(f.resolve())
                 seen_stems.add(stem)
 
@@ -2774,18 +2793,21 @@ def list_meetings():
         else:
             default_output = Path(__file__).parent / "output"
         if default_output.exists():
+            # Meetings found here keep their audio in the DEFAULT recordings
+            # dir, not the custom one -- they predate the path change.
+            audio_stems |= _recorded_stems(default_output.parent / "recordings")
             for pattern in ("*_summary.json", "*_summary.md"):
                 for f in default_output.glob(pattern):
                     stem = f.stem.replace('_summary', '')
                     if f.resolve() not in seen_files and stem not in seen_stems:
-                        summaries.append(f)
+                        summaries.append((f, stem))
                         seen_files.add(f.resolve())
                         seen_stems.add(stem)
 
     meetings = []
 
     # Single-pass: read each file once, extract sort key and data together
-    for summary_file in summaries:
+    for summary_file, stem in summaries:
         try:
             if summary_file.suffix == '.md':
                 parsed = _parse_meeting_markdown(summary_file)
@@ -2815,6 +2837,13 @@ def list_meetings():
                         "folders": data.get("folders", []),
                         "user_notes": data.get("user_notes"),
                     }
+            # Whether the ORIGINAL audio is still on disk. keep_recordings
+            # defaults off, so for most notes it is not -- and everything
+            # that needs the audio (re-transcribe, speaker samples, any
+            # future re-diarization) is silently unavailable without it,
+            # with nothing in the list saying so until you open the note
+            # and find the action missing.
+            essential_meeting['has_audio'] = stem in audio_stems
             meetings.append((sort_key, essential_meeting))
         except Exception as e:
             logger.warning(f"Failed to load {summary_file}: {e}")

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5527,6 +5527,7 @@ def get_speaker_sample_audio(meeting_stem, channel, diarization_speaker_id, segm
     from src.config import get_data_dirs
     from src.speaker_suggestions import (
         clusters_from_sidecar_channel,
+        extract_segment_samples,
         extract_speaker_sample_audio,
         merge_same_channel_fragments,
         read_speakers_sidecar,
@@ -5566,6 +5567,26 @@ def get_speaker_sample_audio(meeting_stem, channel, diarization_speaker_id, segm
         for seg in (raw_clusters_by_id.get(fragment_id, {}).get("segments") or [])
     ]
 
+    # Resolve the index against the SAME list suggest-speakers rendered, so
+    # the clip and the text beside it are the same moment. Built here rather
+    # than inside the extractor because the list depends on the sidecar's
+    # turn manifest, which only this command has loaded.
+    target = None
+    if segment_index is not None:
+        samples = extract_segment_samples(
+            dirs["transcripts"] / f"{meeting_stem}_transcript.txt",
+            pooled_segments,
+            turn_manifest=sidecar.get("transcript_lines"),
+            target_ids={(channel, fid) for fid in [resolved_id, *context.merged_from]},
+        )
+        if not 0 <= segment_index < len(samples):
+            print(json.dumps({
+                "success": False,
+                "error": f"No sample {segment_index} for {diarization_speaker_id!r}",
+            }))
+            return
+        target = {"start": samples[segment_index]["start"], "end": samples[segment_index]["end"]}
+
     suffix = "" if segment_index is None else f"_{segment_index}"
     output_path = (
         Path(tempfile.gettempdir())
@@ -5573,7 +5594,7 @@ def get_speaker_sample_audio(meeting_stem, channel, diarization_speaker_id, segm
     )
     ok = extract_speaker_sample_audio(
         recording_path, channel, pooled_segments, output_path,
-        segment_index=segment_index,
+        segment_index=target,
     )
     if not ok:
         print(json.dumps({"success": False, "error": "could not extract audio sample"}))

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -2762,11 +2762,31 @@ def list_meetings():
     # captures, .m4a/.mp3 imports), so only the stem is meaningful.
     def _recorded_stems(recordings_dir) -> set:
         try:
-            return {Path(name).stem for name in os.listdir(recordings_dir)}
+            # FILES only. A directory that happens to be named like a
+            # recording (`recordings/note.wav/`) would otherwise report the
+            # note as having audio it does not have. scandir keeps this a
+            # single listing -- the is_file() check comes from the entry
+            # already returned, not from an extra stat per name.
+            return {
+                Path(entry.name).stem
+                for entry in os.scandir(recordings_dir)
+                if entry.is_file()
+            }
         except OSError:
             # No recordings dir yet (fresh install) is not an error -- it
             # just means nothing has audio.
             return set()
+
+    def _summary_stem(summary_path) -> str:
+        """`<stem>_summary.{md,json}` -> `<stem>`, stripping only a TRAILING
+        marker. `str.replace` removes every occurrence, so a note whose own
+        name contains the marker (`client_summary.v1_summary.md`) came back
+        as `client.v1`. That was harmless while the stem only fed the
+        dedup set, where a wrong-but-consistent key still dedups; matching
+        it against real filenames on disk is what makes it visible. Same
+        rule reprocess and app/main.js's delete path already use."""
+        name = summary_path.stem
+        return name[:-len('_summary')] if name.endswith('_summary') else name
 
     audio_stems = _recorded_stems(dirs["recordings"])
 
@@ -2777,7 +2797,7 @@ def list_meetings():
     # JSON first — if both .json and .md exist, JSON wins (it has structured data)
     for pattern in ("*_summary.json", "*_summary.md"):
         for f in output_dir.glob(pattern):
-            stem = f.stem.replace('_summary', '')
+            stem = _summary_stem(f)
             if stem not in seen_stems:
                 summaries.append((f, stem))
                 seen_files.add(f.resolve())
@@ -2798,7 +2818,7 @@ def list_meetings():
             audio_stems |= _recorded_stems(default_output.parent / "recordings")
             for pattern in ("*_summary.json", "*_summary.md"):
                 for f in default_output.glob(pattern):
-                    stem = f.stem.replace('_summary', '')
+                    stem = _summary_stem(f)
                     if f.resolve() not in seen_files and stem not in seen_stems:
                         summaries.append((f, stem))
                         seen_files.add(f.resolve())

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1436,10 +1436,19 @@ def extract_speaker_sample_audio(
         return False
 
     ch_idx = 0 if channel == "mic" else 1
-    start = max(0.0, target.get("start", 0) - SAMPLE_AUDIO_PADDING_SECONDS)
-    duration = (target.get("end", 0) - target.get("start", 0)) + 2 * SAMPLE_AUDIO_PADDING_SECONDS
-    if duration <= 0:
+    # Decided on the UNPADDED range, and that ordering is the whole guard.
+    # _turn_audio_range collapses a moment it cannot place to (start, start)
+    # precisely so this function refuses it; checking after the two pads
+    # were added turned that refusal into a 0.6s clip AROUND the timestamp
+    # -- the audio of whoever actually was speaking there, played under this
+    # speaker's name. The pads may widen a real clip, never create one.
+    # Written as `not span > 0` so a NaN boundary (a backend emitting one,
+    # which _format_timestamp already guards against elsewhere) refuses too.
+    span = target.get("end", 0) - target.get("start", 0)
+    if not span > 0:
         return False
+    start = max(0.0, target.get("start", 0) - SAMPLE_AUDIO_PADDING_SECONDS)
+    duration = span + 2 * SAMPLE_AUDIO_PADDING_SECONDS
 
     try:
         result = subprocess.run(

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1648,8 +1648,16 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
         seg for seg in own
         if start <= seg.get("start", 0) < min(upper, start + TRANSCRIPT_MARKER_TRUNCATION_SECONDS)
     ]
+    #
+    # Unless a sibling line shares this displayed second, which only happens
+    # on the marker fallback. Then the segment starting later in the window
+    # is most likely the SIBLING'S, and the spanning one is ours -- the
+    # opposite of the single-line case, and the one piece of evidence that
+    # tells the two apart. Found by review, with segments 9.9-10.2 and
+    # 10.8-10.9 at two lines both falling back to marker 10.0.
+    shares_second_with_next = next_start is not None and next_start <= start
     ordered = sorted(own, key=lambda seg: seg.get("start", 0))
-    if starting_in_window:
+    if starting_in_window and not shares_second_with_next:
         opening = min(seg.get("start", 0) for seg in starting_in_window)
         ordered = [seg for seg in ordered if seg.get("start", 0) >= opening]
     # Never earlier than the line itself: the segment it sits in may have

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1234,9 +1234,6 @@ def _join_texts(texts: list, max_chars: int) -> Optional[str]:
 # uninterrupted). Nobody listens to five minutes to recognise a voice, and
 # an unbounded clip would also mean an unbounded ffmpeg extraction.
 SAMPLE_MAX_SECONDS = 20.0
-# Used only when a turn has no diarization segment inside its bounds at all
-# (possible when the transcript and the sidecar came from different runs).
-SAMPLE_FALLBACK_SECONDS = 6.0
 
 
 def _turn_audio_range(segments: list, start: float, next_start: Optional[float]) -> tuple:
@@ -1248,28 +1245,48 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
     -- the earlier design -- cannot: src.transcriber merges consecutive
     segments of one speaker into a single turn carrying only the FIRST
     segment's timestamp, so every later segment of that turn contains no
-    line start at all. In practice that produced exactly two symptoms, both
-    reported from real use: most excerpts had no text, and the ones that
-    did played a clip cut at a segment boundary while the text was the
-    whole merged turn.
+    line start at all.
+
+    Every fallback here stays inside THIS CLUSTER'S OWN SEGMENTS. There is
+    deliberately no "window of N seconds around the timestamp" path, and
+    that is a correction: one existed, and a review found it reachable.
+    Transcript timestamps render as [MM:SS], so two turns inside the same
+    second carry the SAME value; `next_start` then equals `start`, the
+    bounded set comes back empty, and the window took over -- playing the
+    next speaker under this speaker's name, the exact failure this whole
+    function exists to prevent. Audio we cannot place is not played.
     """
     upper = next_start if next_start is not None else float("inf")
     own = [
         seg for seg in segments
         if start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS <= seg.get("start", 0) < upper
     ]
-    if own:
-        begin = min(seg.get("start", 0) for seg in own)
-        end = max(seg.get("end", 0) for seg in own)
-    else:
-        begin, end = start, start + SAMPLE_FALLBACK_SECONDS
-    # Never run into the next speaker's line, and never past the cap.
-    if next_start is not None:
+    if not own:
+        # Bounds hold none of this cluster's segments: same displayed
+        # second as the next line, or a manifest that disagrees with the
+        # segments. Use this cluster's nearest segment at or after the line
+        # instead -- still its own audio, unlike a blind window.
+        following = [
+            seg for seg in segments
+            if seg.get("end", 0) > start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+        ]
+        if not following:
+            return start, start
+        own = [min(following, key=lambda seg: seg.get("start", 0))]
+
+    begin = min(seg.get("start", 0) for seg in own)
+    end = max(seg.get("end", 0) for seg in own)
+
+    # Never run into the next speaker's line. Guarded on `next_start > begin`
+    # so a next line sharing this one's displayed second cannot clip the
+    # range to nothing and re-open the fallback.
+    if next_start is not None and next_start > begin:
         end = min(end, next_start)
     end = min(end, begin + SAMPLE_MAX_SECONDS)
-    if end <= begin:
-        end = begin + SAMPLE_FALLBACK_SECONDS
-    return begin, end
+    # No inventing length: a collapsed range means there is nothing this
+    # cluster demonstrably said here, and extract_speaker_sample_audio
+    # refuses a non-positive duration rather than cutting arbitrary audio.
+    return (begin, end) if end > begin else (begin, begin)
 
 
 def extract_segment_samples(

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -944,6 +944,13 @@ def _manifest_describes_lines(line_starts: list, turn_manifest: list) -> bool:
     It has to: a window merely a second wide accepts the NEIGHBOURING turn,
     and two turns swapped is exactly what a reordered manifest looks like.
 
+    Also refused: a manifest whose turn starts run backwards. Two turns
+    inside ONE second render as the same `[MM:SS]`, so no per-line
+    comparison can tell them apart however exactly it is done -- but the
+    manifest is built from a list sorted by start, so its starts never
+    decrease, and a swap does. That closes the remaining reordering case
+    the per-line check cannot see.
+
     Refused outright: an entry that is not an object at all. The sidecar is
     JSON and every caller then reaches for `entry.get(...)`, so this is both
     the safe answer and the one that keeps their never-raises contract.
@@ -954,13 +961,17 @@ def _manifest_describes_lines(line_starts: list, turn_manifest: list) -> bool:
     and refusing on missing evidence would take excerpts away from meetings
     that are fine.
     """
+    previous = None
     for line_start, entry in zip(line_starts, turn_manifest):
         if not isinstance(entry, dict):
             return False
-        if line_start is None:
-            continue
         start = entry.get("start")
         if not isinstance(start, (int, float)) or not math.isfinite(start):
+            continue
+        if previous is not None and start < previous:
+            return False
+        previous = start
+        if line_start is None:
             continue
         if max(0, int(start)) != int(line_start):
             return False

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import subprocess
@@ -923,6 +924,45 @@ def relabel_transcript_multi(transcript_path: Path, assignments: list) -> tuple:
     return changed, skipped_ambiguous
 
 
+def _manifest_describes_lines(line_starts: list, turn_manifest: list) -> bool:
+    """Whether this manifest still describes THIS transcript, so its entries
+    may be paired with the lines by position.
+
+    Positional pairing is exact only while both sequences come from the same
+    `turns` list of the same run -- and an equal length is weak evidence of
+    that. A manifest left behind by an earlier transcription of the same
+    meeting, or written in a different order, keeps its entry count and then
+    silently pairs every line with the wrong cluster: a quote, or a name,
+    from one person shown under another's, which is precisely the failure
+    the exact-provenance path exists to remove.
+
+    The evidence that the two belong together is already in both of them.
+    Each entry carries the turn's `start` in seconds; the line carries that
+    same number truncated to the second by src.transcriber._format_timestamp
+    (so `[00:20]` accepts 20.0 through 20.999...). Compared with the same
+    slop the rest of this module uses for float/boundary noise.
+
+    Skipped rather than failed: an entry with no usable `start` (or a
+    non-finite one, which _format_timestamp itself renders as 00:00) and a
+    line whose timestamp would not parse. Neither is evidence of a mismatch,
+    and refusing on missing evidence would take excerpts away from meetings
+    that are fine.
+    """
+    for line_start, entry in zip(line_starts, turn_manifest):
+        if line_start is None:
+            continue
+        start = entry.get("start") if isinstance(entry, dict) else None
+        if not isinstance(start, (int, float)) or not math.isfinite(start):
+            continue
+        if not (
+            line_start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+            <= start
+            < line_start + 1 + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+        ):
+            return False
+    return True
+
+
 def relabel_transcript_exact(transcript_path: Path, turn_manifest: list, target_ids: set, display_name: str) -> int:
     """Relabel a saved transcript using EXACT recorded speaker provenance,
     instead of relabel_transcript_speaker/relabel_transcript_multi's fuzzy
@@ -992,6 +1032,25 @@ def relabel_transcript_exact(transcript_path: Path, turn_manifest: list, target_
             "relabel_transcript_exact: %s has %d diarised lines but turn_manifest has %d entries -- "
             "refusing to guess a pairing, no-op.",
             transcript_path, len(diarised_line_indices), len(turn_manifest),
+        )
+        return 0
+    line_starts = []
+    for i in diarised_line_indices:
+        try:
+            line_starts.append(
+                _parse_transcript_timestamp(_TRANSCRIPT_LINE_RE.match(lines[i]).group(1))
+            )
+        except ValueError:
+            line_starts.append(None)
+    if not _manifest_describes_lines(line_starts, turn_manifest):
+        # An equal line count is not enough: a manifest from an earlier
+        # transcription of this meeting keeps it and would then rename lines
+        # by position that belong to somebody else. See
+        # _manifest_describes_lines.
+        logger.warning(
+            "relabel_transcript_exact: %s and its turn_manifest have %d entries each but their "
+            "turn times disagree -- the manifest no longer describes this transcript, no-op.",
+            transcript_path, len(turn_manifest),
         )
         return 0
 
@@ -1195,6 +1254,17 @@ def cluster_transcript_lines(
             "cluster_transcript_lines: %s has %d diarised lines but turn_manifest has "
             "%d entries -- refusing to guess a pairing, no excerpt text.",
             transcript_path, len(parsed), len(turn_manifest),
+        )
+        return []
+    if not _manifest_describes_lines([ts for ts, _text in parsed], turn_manifest):
+        # Same refusal one step further in: the count survives a manifest
+        # left over from an earlier transcription of this meeting, and
+        # pairing by position then quotes one person under another's name.
+        logger.warning(
+            "cluster_transcript_lines: %s and its turn_manifest have %d entries each but their "
+            "turn times disagree -- the manifest no longer describes this transcript, "
+            "no excerpt text.",
+            transcript_path, len(turn_manifest),
         )
         return []
     # (start, next_line_start, text) per owned line. The third element is

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1235,10 +1235,18 @@ def _join_texts(texts: list, max_chars: int) -> Optional[str]:
 # an unbounded clip would also mean an unbounded ffmpeg extraction.
 SAMPLE_MAX_SECONDS = 20.0
 
+# How long a hole between two of one cluster's segments may be before the
+# clip stops there instead of playing across it. A speaker pausing mid-turn
+# leaves gaps of this order; a gap much longer than a second is where the
+# diarizer heard somebody, or something, else.
+SAMPLE_TURN_GAP_TOLERANCE_SECONDS = 1.0
+
 
 def _turn_audio_range(segments: list, start: float, next_start: Optional[float]) -> tuple:
-    """The time range of ONE turn's speech by this cluster: the span of its
-    own diarization segments between this line's start and the next line's.
+    """The time range of ONE turn's speech by this cluster: its own
+    diarization segments from this line's start onward, ending at the next
+    line, at SAMPLE_MAX_SECONDS, or at the first hole this cluster did not
+    fill -- whichever comes first.
 
     This is the piece that makes a clip and the text beside it describe the
     same thing. Selecting by SEGMENT and then hunting for a line inside it
@@ -1274,8 +1282,28 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
             return start, start
         own = [min(following, key=lambda seg: seg.get("start", 0))]
 
-    begin = min(seg.get("start", 0) for seg in own)
-    end = max(seg.get("end", 0) for seg in own)
+    # From the turn's first own segment onward, and only for as long as this
+    # cluster keeps speaking. Taking min(start)/max(end) over the whole set
+    # spanned the holes between segments as well, and a hole is by
+    # definition time this cluster was NOT speaking -- on a mic channel
+    # taken without headphones, exactly where the remote voices sit.
+    # `next_start` and SAMPLE_MAX_SECONDS bound how far that can reach; they
+    # do not stop it.
+    #
+    # Pauses shorter than SAMPLE_TURN_GAP_TOLERANCE_SECONDS are still
+    # bridged: a turn IS several consecutive segments of one speaker (see
+    # src.transcriber's turn merging), separated by that speaker's own
+    # breathing, and cutting at every one of those would leave clips too
+    # short to recognise a voice from -- the one thing the panel is for.
+    ordered = sorted(own, key=lambda seg: seg.get("start", 0))
+    begin = ordered[0].get("start", 0)
+    end = ordered[0].get("end", 0)
+    for seg in ordered[1:]:
+        if seg.get("start", 0) - end > SAMPLE_TURN_GAP_TOLERANCE_SECONDS:
+            break
+        # max(), not the later end: a segment nested inside a longer one
+        # must not shorten the turn it sits in.
+        end = max(end, seg.get("end", 0))
 
     # Never run into the next speaker's line. Guarded on `next_start > begin`
     # so a next line sharing this one's displayed second cannot clip the

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -208,6 +208,12 @@ class ClusterContext:
     # informational (for transparent "merged: X, Y, Z" reporting) — nothing
     # else reads it.
     merged_from: list = field(default_factory=list)
+    # A human marked this cluster as holding more than one person (see
+    # MULTI_SPEAKER_KEY). Unlike merged_from this IS read: a mixed cluster's
+    # centroid is a blend of two people's voices, so both naming it and
+    # enrolling it as anyone's voice evidence would poison the profile it
+    # was filed under and every future suggestion scored against it.
+    contains_multiple_speakers: bool = False
 
 
 @dataclass
@@ -288,6 +294,22 @@ def suggest_speaker(embedding: list, context: ClusterContext, profiles: list) ->
     an empty/malformed `profiles` list just yields status="none", matching
     src.transcriber._apply_voiceprint_matches's "never fail a meeting"
     contract."""
+    # A cluster a human marked as mixed is withheld from naming entirely,
+    # with NO candidates -- not merely downgraded to "possible". Candidates
+    # would be worse than nothing here: the ranking is computed from a
+    # centroid blended across two people, so its top entry is not a weak
+    # guess about one person, it is a confident guess about a voice that
+    # does not exist. Returning none also keeps this cluster from consuming
+    # a person via suggest_speakers_for_meeting's used_person_ids, so the
+    # cluster that really IS that person can still claim them.
+    if context.contains_multiple_speakers:
+        return SuggestionResult(
+            diarization_speaker_id=context.diarization_speaker_id,
+            status="none", suggested_person_id=None, suggested_name=None,
+            candidates=[],
+            reasons=["marked by a human as containing more than one person"],
+        )
+
     candidates = score_candidates(embedding, context, profiles)
     if not candidates:
         return SuggestionResult(
@@ -396,6 +418,11 @@ def suggest_speakers_for_meeting(
 
     def _best_distance(entry) -> float:
         _, _, embedding, context = entry
+        # A mixed cluster never claims a person (suggest_speaker returns
+        # "none" for it), so its blended centroid must not get to sort
+        # ahead of the real clusters and influence assignment order either.
+        if context.contains_multiple_speakers:
+            return float("inf")
         candidates = score_candidates(embedding, context, profiles)
         return candidates[0].distance if candidates else float("inf")
 
@@ -507,6 +534,15 @@ def merge_same_channel_fragments(clusters: dict) -> tuple:
                 speech_duration_seconds=total_duration,
                 segment_count=total_segments,
                 merged_from=others,
+                # Contamination is a property of the AUDIO, so it survives
+                # the merge: folding a mixed fragment into a clean one
+                # produces a mixed cluster, not a clean one. Marking any
+                # fragment therefore withholds the whole merged cluster
+                # from naming -- the fail-safe direction, since the
+                # alternative is enrolling a blended voice as a person.
+                contains_multiple_speakers=any(
+                    clusters[sid][1].contains_multiple_speakers for sid in members
+                ),
             ),
         )
 
@@ -556,6 +592,100 @@ def write_speakers_sidecar(
     return path
 
 
+# --- "this cluster holds more than one person" marking ------------------
+#
+# `merge_same_channel_fragments` already models the one direction diarizers
+# get wrong -- several clusters that are really ONE person. This is the
+# opposite direction, and unlike that one it cannot be derived from the
+# data: a cluster contaminated by someone briefly talking over the main
+# speaker was measured, against a real 3-person call, at cosine distance
+# 0.8270 to the person who contaminated it -- an entirely unremarkable
+# cross-speaker distance. There is no signal in a per-speaker centroid that
+# separates "one voice" from "one voice plus 4 seconds of another"; the
+# per-chunk embeddings that could show it are not in the sidecar's contract
+# (see this module's header). A human who was in the meeting is the only
+# available source of this fact, so it is recorded as one.
+#
+# Written into the cluster entry itself rather than a parallel structure,
+# so it travels with exactly the cluster it describes and cannot be
+# orphaned by an id change. Absent means "not marked" -- the key is only
+# written when true, so every pre-existing sidecar reads correctly.
+MULTI_SPEAKER_KEY = "contains_multiple_speakers"
+
+
+def cluster_ids_marked_multi_speaker(channel_data: dict) -> set:
+    """Every raw diarization_speaker_id in one channel marked as holding
+    more than one person."""
+    return {
+        sid
+        for sid, cluster in (channel_data.get("clusters") or {}).items()
+        if cluster.get(MULTI_SPEAKER_KEY)
+    }
+
+
+def set_cluster_multi_speaker(
+    output_dir: Path, meeting_stem: str, channel: str,
+    diarization_speaker_id: str, marked: bool,
+) -> Optional[dict]:
+    """Set/clear the marking on ONE raw cluster, rewriting the sidecar in
+    place (read-modify-write, atomic temp+rename -- the sidecar carries the
+    only copy of this meeting's voice embeddings, so a torn write would
+    destroy data no re-run can recover once the audio is gone).
+
+    Returns the updated sidecar, or None when the sidecar/channel/cluster
+    doesn't exist -- callers report that as an error rather than silently
+    marking nothing.
+    """
+    sidecar = read_speakers_sidecar(output_dir, meeting_stem)
+    if sidecar is None:
+        return None
+    channel_data = (sidecar.get("channels") or {}).get(channel)
+    if channel_data is None:
+        return None
+    cluster = (channel_data.get("clusters") or {}).get(diarization_speaker_id)
+    if cluster is None:
+        return None
+
+    if marked:
+        cluster[MULTI_SPEAKER_KEY] = True
+    else:
+        cluster.pop(MULTI_SPEAKER_KEY, None)
+
+    path = speakers_sidecar_path(output_dir, meeting_stem)
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(json.dumps(sidecar, indent=2))
+    tmp_path.replace(path)
+    return sidecar
+
+
+def minimum_speaker_count(channels: dict) -> int:
+    """The smallest number of real people this meeting's diarization is
+    consistent with: every cluster is at least one person, and every
+    cluster a human marked as mixed is at least two.
+
+    Exists because the ceiling is REAL and invisible in the output --
+    FluidAudio's Sortformer has a hardcoded four-speaker-slot architecture
+    per channel (`SortformerConfig.numSpeakers`, see
+    diarize-sidecar/Sources/main.swift's header), so a five-person channel
+    is silently returned as four clusters with no indication anything was
+    lost. Confirmed by ear against a real six-person recording.
+
+    NOTHING DOWNSTREAM CONSUMES THIS NUMBER TODAY, and that is deliberate
+    rather than an oversight: Sortformer takes no speaker-count hint at
+    all, so there is no re-diarization call to feed it into. It is
+    reported so the gap is visible to the person reviewing the meeting
+    instead of silent, and so a future diarization path -- windowed
+    inference with cross-window clustering, or an engine that does accept
+    a count -- has ground truth to be measured against.
+    """
+    total = 0
+    for channel_data in (channels or {}).values():
+        clusters = channel_data.get("clusters") or {}
+        total += len(clusters)
+        total += sum(1 for c in clusters.values() if c.get(MULTI_SPEAKER_KEY))
+    return total
+
+
 def read_speakers_sidecar(output_dir: Path, meeting_stem: str) -> Optional[dict]:
     path = speakers_sidecar_path(output_dir, meeting_stem)
     if not path.exists():
@@ -582,6 +712,7 @@ def clusters_from_sidecar_channel(meeting_id: str, channel: dict) -> dict:
                 recording_type=recording_type,
                 speech_duration_seconds=cluster.get("speech_duration_seconds", 0.0),
                 segment_count=cluster.get("segment_count", 0),
+                contains_multiple_speakers=bool(cluster.get(MULTI_SPEAKER_KEY)),
             ),
         )
     return out
@@ -914,6 +1045,118 @@ def longest_segment(segments: list) -> Optional[dict]:
     return max(segments, key=lambda s: s.get("end", 0) - s.get("start", 0))
 
 
+# How many of a cluster's turns to offer as review samples. One excerpt
+# (what `extract_sample_text` alone gave the panel) is a single roll of the
+# dice: `longest_segment` picks the longest turn, which is the most likely
+# to be uninterrupted speech but says nothing about whether it happens to
+# contain anything recognizable -- a long turn can easily be someone
+# reading numbers aloud. Several spread across the recording give a human
+# a real chance to recognize the voice, and are also what makes a
+# contaminated cluster visible: hearing two different voices under one
+# cluster IS the evidence for the `MULTI_SPEAKER_KEY` marking.
+SAMPLE_SEGMENT_LIMIT = 5
+
+
+def sample_segments(segments: list, limit: int = SAMPLE_SEGMENT_LIMIT) -> list:
+    """The canonical ordered review-sample list for one cluster's pooled
+    segments: the `limit` LONGEST turns (same
+    avoid-cross-voice-contamination reasoning as `longest_segment`),
+    presented in CHRONOLOGICAL order so they read as a walk through the
+    recording rather than a duration ranking.
+
+    This ordering is a contract, not an implementation detail: it is what
+    an index into this list means. `suggest-speakers` renders the list and
+    `get-speaker-sample-audio --segment-index` plays one entry of it, and
+    the two must agree on which turn index 2 is, or the play button plays
+    audio from a different moment than the text beside it. Both call this
+    function on identically-pooled segments rather than each sorting for
+    themselves.
+    """
+    if not segments:
+        return []
+    longest = sorted(
+        segments, key=lambda s: s.get("end", 0) - s.get("start", 0), reverse=True,
+    )[:limit]
+    return sorted(longest, key=lambda s: s.get("start", 0))
+
+
+def _transcript_text_in_range(lines: list, start: float, end: float, max_chars: int) -> Optional[str]:
+    """Joined text of every non-"You" diarised transcript line whose
+    timestamp falls in [start, end] (same tolerance as relabeling)."""
+    matched = []
+    for line in lines:
+        match = _TRANSCRIPT_LINE_RE.match(line)
+        if not match:
+            continue
+        timestamp_str, label, text = match.groups()
+        if label == "You":
+            continue
+        try:
+            timestamp_seconds = _parse_transcript_timestamp(timestamp_str)
+        except ValueError:
+            continue
+        if (
+            start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+            <= timestamp_seconds
+            <= end + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+        ):
+            matched.append(text)
+    if not matched:
+        return None
+    combined = " ".join(matched).strip()
+    if len(combined) > max_chars:
+        combined = combined[:max_chars].rstrip() + "…"
+    return combined or None
+
+
+def extract_segment_samples(
+    transcript_path: Path,
+    segments: list,
+    limit: int = SAMPLE_SEGMENT_LIMIT,
+    max_chars: int = SAMPLE_TEXT_MAX_CHARS,
+) -> list:
+    """`[{"start", "end", "text"}]` for this cluster's review samples --
+    the multi-excerpt counterpart to `extract_sample_text`.
+
+    Deliberately built from `segments` (the diarizer's own per-cluster
+    timestamps) and the SAVED TRANSCRIPT, never from the sidecar's
+    `transcript_lines` turn manifest: that manifest is only written by the
+    live pipeline, so every sidecar produced by `backfill-speaker-embeddings`
+    has none at all, and a samples list sourced from it would come back
+    empty for exactly the historical meetings a human most needs help
+    identifying. `segments` are present in every sidecar by construction.
+
+    `text` is None for a segment no transcript line covers -- the entry is
+    still returned, because its audio is playable and a clip with no
+    quotable text is still useful to listen to. Never raises: a missing or
+    unreadable transcript yields text-less entries rather than an error.
+    """
+    chosen = sample_segments(segments, limit)
+    if not chosen:
+        return []
+
+    lines: list = []
+    if transcript_path.exists():
+        try:
+            lines = transcript_path.read_text(encoding="utf-8").split("\n")
+        except OSError:
+            lines = []
+
+    return [
+        {
+            "start": seg.get("start", 0),
+            "end": seg.get("end", 0),
+            "text": (
+                _transcript_text_in_range(
+                    lines, seg.get("start", 0), seg.get("end", 0), max_chars,
+                )
+                if lines else None
+            ),
+        }
+        for seg in chosen
+    ]
+
+
 def extract_sample_text(
     transcript_path: Path,
     segments: list,
@@ -976,6 +1219,7 @@ def extract_speaker_sample_audio(
     channel: str,
     segments: list,
     output_path: Path,
+    segment_index: Optional[int] = None,
 ) -> bool:
     """Extract a short audio clip covering this cluster's longest pooled
     segment from the ORIGINAL source recording, for the review UI's play
@@ -989,13 +1233,25 @@ def extract_speaker_sample_audio(
     same mapping as src.transcriber._split_stereo_to_channels, so a mono
     recording (channel index 0 only) also works correctly for "mic".
 
+    `segment_index`, when given, selects one entry of `sample_segments`
+    (this cluster's review-sample list) instead of the longest turn -- how
+    the panel plays the specific excerpt a human clicked rather than always
+    replaying the same one. Out-of-range values return False rather than
+    silently falling back to the longest segment: a caller asking for
+    excerpt 4 and hearing excerpt 1 would have no way to notice, and would
+    reasonably conclude the two speakers sound identical.
+
     Returns True on success (output_path written), False on any failure --
     no ffmpeg, no source recording (the common case for an older backfilled
     meeting with keep_recordings off), a bad time range, or an ffmpeg
     error. Never raises: this is a best-effort UI aid, never something that
     can fail the review panel.
     """
-    target = longest_segment(segments)
+    if segment_index is None:
+        target = longest_segment(segments)
+    else:
+        chosen = sample_segments(segments)
+        target = chosen[segment_index] if 0 <= segment_index < len(chosen) else None
     if target is None or not audio_filepath.exists():
         return False
 

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -649,6 +649,26 @@ def set_cluster_multi_speaker(
     if cluster is None:
         return None
 
+    # Re-read immediately before writing and apply this ONE change to the
+    # freshest copy, rather than writing back the whole document as it
+    # looked on entry. The write is atomic, the read-modify-write was not:
+    # two overlapping marks both started from the same sidecar, and whoever
+    # replaced the file second discarded the other's marking silently --
+    # along with any confirmation cleanup its caller had already performed
+    # against it. This narrows the window to re-read-until-rename instead of
+    # entry-until-rename; it does not make the sequence a transaction, and a
+    # mark landing inside that remaining window would still be lost. Closing
+    # it fully needs a lock that works on macOS and Windows alike, which is
+    # a bigger change than this defect warrants.
+    freshest = read_speakers_sidecar(output_dir, meeting_stem)
+    if freshest is not None:
+        fresh_cluster = (
+            ((freshest.get("channels") or {}).get(channel) or {}).get("clusters") or {}
+        ).get(diarization_speaker_id)
+        if fresh_cluster is not None:
+            sidecar = freshest
+            cluster = fresh_cluster
+
     if marked:
         cluster[MULTI_SPEAKER_KEY] = True
     else:
@@ -1494,10 +1514,24 @@ def extract_sample_text(
     raises, when there is nothing attributable -- a best-effort aid, not a
     requirement for the row to render.
     """
-    samples = extract_segment_samples(
+    return sample_text_from_samples(extract_segment_samples(
         transcript_path, segments, max_chars=max_chars,
         turn_manifest=turn_manifest, target_ids=target_ids,
-    )
+    ))
+
+
+def sample_text_from_samples(samples: list) -> Optional[str]:
+    """The collapsed row's quote, taken from an ALREADY BUILT excerpt list.
+
+    Split out from extract_sample_text so a caller that needs both -- the
+    suggest-speakers CLI builds `samples` for every cluster anyway -- pays
+    for the transcript parse and the manifest check once instead of twice
+    per cluster. The selection itself is unchanged, and deliberately still
+    reads out of the same list the expanded rows show: two independent
+    derivations of "the most representative thing this speaker said" drift
+    apart, and the visible symptom is a collapsed row quoting a moment that
+    expanding never offers.
+    """
     longest = max(
         (s for s in samples if s["text"]),
         key=lambda s: s["end"] - s["start"], default=None,

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -674,16 +674,24 @@ def set_cluster_multi_speaker(
     else:
         cluster.pop(MULTI_SPEAKER_KEY, None)
 
+    write_sidecar_document(output_dir, meeting_stem, sidecar)
+    return sidecar
+
+
+def write_sidecar_document(output_dir: Path, meeting_stem: str, sidecar: dict) -> None:
+    """Replace a meeting's whole sidecar document atomically.
+
+    A UNIQUE temp name, unlike the fixed "<name>.tmp" the relabel helpers
+    in this module use. Those rewrite a transcript, which can be
+    regenerated; this rewrites the only copy of a meeting's voice
+    embeddings, which cannot be once the source audio is gone. With a
+    shared temp name, two concurrent writers race on ONE file: the second
+    truncates it while the first is replacing the sidecar with it, and a
+    crash or a full disk in that window leaves the real sidecar empty.
+    Same directory as the target so the replace stays a rename within one
+    filesystem, which is what makes it atomic.
+    """
     path = speakers_sidecar_path(output_dir, meeting_stem)
-    # A UNIQUE temp name, unlike the fixed "<name>.tmp" the relabel helpers
-    # in this module use. Those rewrite a transcript, which can be
-    # regenerated; this rewrites the only copy of a meeting's voice
-    # embeddings, which cannot be once the source audio is gone. With a
-    # shared temp name, two concurrent marks race on ONE file: the second
-    # truncates it while the first is replacing the sidecar with it, and a
-    # crash or a full disk in that window leaves the real sidecar empty.
-    # Same directory as the target so the replace stays a rename within one
-    # filesystem, which is what makes it atomic.
     fd, tmp_name = tempfile.mkstemp(
         dir=str(path.parent), prefix=path.name + ".", suffix=".tmp",
     )
@@ -697,7 +705,6 @@ def set_cluster_multi_speaker(
         # later and mistake for a real sidecar.
         tmp_path.unlink(missing_ok=True)
         raise
-    return sidecar
 
 
 def minimum_speaker_count(channels: dict) -> int:
@@ -797,6 +804,16 @@ _TRANSCRIPT_LINE_RE = re.compile(r"^\[(\d+(?::\d{2}){1,2})\] \[([^\]]*)\] (.*)$"
 # a transcript line's integer-second timestamp against a sidecar segment's
 # float [start, end] range.
 RELABEL_TIMESTAMP_TOLERANCE_SECONDS = 0.5
+
+
+def _safe_transcript_timestamp(timestamp: str) -> Optional[float]:
+    """`_parse_transcript_timestamp` for callers that must keep a line's
+    position even when its timestamp is malformed -- dropping it would
+    shift every later manifest pairing by one."""
+    try:
+        return _parse_transcript_timestamp(timestamp)
+    except ValueError:
+        return None
 
 
 def _parse_transcript_timestamp(timestamp: str) -> float:
@@ -1024,6 +1041,131 @@ def _manifest_describes_lines(line_starts: list, turn_manifest: list) -> bool:
         if max(0, int(start)) != int(line_start):
             return False
     return True
+
+
+MULTI_SPEAKER_TRANSCRIPT_LABEL = "Multiple speakers"
+ORIGINAL_LABEL_KEY = "original_label"
+
+
+def record_original_labels(
+    output_dir: Path, meeting_stem: str, transcript_path: Path, target_ids: set,
+) -> int:
+    """Remember, per manifest entry, what label a line carried BEFORE a
+    confirmation renames it. Returns how many entries were newly recorded.
+
+    Without this, naming a cluster is irreversible in the transcript: the
+    original label ("You", "Others", "Speaker 3") is overwritten, and it
+    was itself derived at transcription time, so nothing can reconstruct
+    it afterwards. Marking that cluster as more than one person later
+    withdraws the profile and the participants entry but would leave the
+    name standing in the artefact that feeds the summary and every export.
+
+    FIRST WRITE WINS. Confirming the same cluster twice -- the review UI's
+    "Change" flow does exactly that -- must not record "Julian" as the
+    original, or the restore would put a person's name back on lines the
+    app has just decided are not theirs.
+
+    Written into the sidecar's own `transcript_lines` entries, so it
+    travels with the manifest it is indexed by and needs no migration: an
+    entry without the key simply has nothing recorded, which is the state
+    of every meeting confirmed before this existed.
+    """
+    sidecar = read_speakers_sidecar(output_dir, meeting_stem)
+    if sidecar is None:
+        return 0
+    manifest = sidecar.get("transcript_lines")
+    if not manifest or not target_ids or not transcript_path.exists():
+        return 0
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").split("\n")
+    except OSError:
+        return 0
+
+    matches = [_TRANSCRIPT_LINE_RE.match(line) for line in lines]
+    diarised = [m for m in matches if m]
+    if len(diarised) != len(manifest):
+        return 0
+    if not _manifest_describes_lines(
+        [_safe_transcript_timestamp(m.group(1)) for m in diarised], manifest,
+    ):
+        return 0
+
+    recorded = 0
+    for match, entry in zip(diarised, manifest):
+        if not isinstance(entry, dict):
+            continue
+        if (entry.get("channel"), entry.get("diarization_speaker_id")) not in target_ids:
+            continue
+        if ORIGINAL_LABEL_KEY in entry:
+            continue  # first write wins
+        entry[ORIGINAL_LABEL_KEY] = match.group(2)
+        recorded += 1
+
+    if recorded:
+        write_sidecar_document(output_dir, meeting_stem, sidecar)
+    return recorded
+
+
+def restore_transcript_labels(
+    transcript_path: Path, turn_manifest: list, target_ids: set,
+) -> int:
+    """Undo a confirmation's rename on ONE cluster's lines, putting back the
+    label each line carried before it -- or `MULTI_SPEAKER_TRANSCRIPT_LABEL`
+    where nothing was recorded.
+
+    The fallback is not a guess: it is the statement the user just made by
+    marking the cluster, and it is the honest thing to show for a line the
+    app can no longer attribute to one person. Guessing "You" or "Speaker
+    3" instead would invent an attribution.
+
+    Same refusals as relabel_transcript_exact -- a manifest that does not
+    line up with the transcript, by count or by turn times, is not paired
+    at all. Returns the number of lines changed; never raises.
+    """
+    if not turn_manifest or not target_ids or not transcript_path.exists():
+        return 0
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").split("\n")
+    except OSError as e:
+        logger.warning("Could not read transcript %s for label restore: %s", transcript_path, e)
+        return 0
+
+    indices = [i for i, line in enumerate(lines) if _TRANSCRIPT_LINE_RE.match(line)]
+    if len(indices) != len(turn_manifest):
+        logger.warning(
+            "restore_transcript_labels: %s has %d diarised lines but turn_manifest has %d -- "
+            "refusing to guess a pairing, no-op.",
+            transcript_path, len(indices), len(turn_manifest),
+        )
+        return 0
+    if not _manifest_describes_lines(
+        [_safe_transcript_timestamp(_TRANSCRIPT_LINE_RE.match(lines[i]).group(1)) for i in indices],
+        turn_manifest,
+    ):
+        logger.warning(
+            "restore_transcript_labels: %s and its turn_manifest disagree on turn times -- no-op.",
+            transcript_path,
+        )
+        return 0
+
+    changed = 0
+    for line_idx, entry in zip(indices, turn_manifest):
+        if not isinstance(entry, dict):
+            continue
+        if (entry.get("channel"), entry.get("diarization_speaker_id")) not in target_ids:
+            continue
+        timestamp_str, label, text = _TRANSCRIPT_LINE_RE.match(lines[line_idx]).groups()
+        restored = entry.get(ORIGINAL_LABEL_KEY) or MULTI_SPEAKER_TRANSCRIPT_LABEL
+        if label == restored:
+            continue
+        lines[line_idx] = f"[{timestamp_str}] [{restored}] {text}"
+        changed += 1
+
+    if changed:
+        tmp_path = transcript_path.with_name(transcript_path.name + ".tmp")
+        tmp_path.write_text("\n".join(lines), encoding="utf-8")
+        tmp_path.replace(transcript_path)
+    return changed
 
 
 def relabel_transcript_exact(transcript_path: Path, turn_manifest: list, target_ids: set, display_name: str) -> int:

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1501,6 +1501,19 @@ def _join_texts(texts: list, max_chars: int) -> Optional[str]:
 # an unbounded clip would also mean an unbounded ffmpeg extraction.
 SAMPLE_MAX_SECONDS = 20.0
 
+# How far a line's own speech may start AFTER the line before the moment
+# counts as unplaceable. Transcript markers render as [MM:SS], truncated to
+# whole seconds, so a small positive lead is normal and expected.
+#
+# Measured across three real meetings and thirteen clusters (37-minute call,
+# a 643-line meeting, a five-cluster call): of the lines that do not fall
+# inside one of their cluster's own segments, the nearest own segment is at
+# most 1.32 s away, with a p90 of ~1.1 s. Nothing legitimate sits further
+# out. The clips this guard rejects were 17.8 s and 35.3 s away -- this
+# speaker's voice, saying something else entirely, shown under the quoted
+# line.
+SAMPLE_TURN_MAX_LEAD_SECONDS = 2.0
+
 # How long a hole between two of one cluster's segments may be before the
 # clip stops there instead of playing across it. A speaker pausing mid-turn
 # leaves gaps of this order; a gap much longer than a second is where the
@@ -1531,9 +1544,17 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
     function exists to prevent. Audio we cannot place is not played.
     """
     upper = next_start if next_start is not None else float("inf")
+    # A segment that is ALREADY RUNNING when the line starts counts. One
+    # diarization segment routinely spans several transcript lines, so the
+    # segment a line belongs to usually began before it: measured on a real
+    # 37-minute call, 64 of one cluster's 109 lines start mid-segment.
+    # Requiring `seg.start >= line.start` skipped exactly the segment the
+    # line sits in and walked the clip forward to the next one -- 35.3 s
+    # away in the worst case, off by 0.22 s of tolerance in the mildest.
     own = [
         seg for seg in segments
-        if start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS <= seg.get("start", 0) < upper
+        if seg.get("end", 0) > start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+        and seg.get("start", 0) < upper
     ]
     if not own:
         # Bounds hold none of this cluster's segments: same displayed
@@ -1547,6 +1568,15 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
         if not following:
             return start, start
         own = [min(following, key=lambda seg: seg.get("start", 0))]
+
+    # Same cluster is not the same moment. Once the nearest own speech is
+    # further out than the truncation of a [MM:SS] marker can explain, there
+    # is nothing here this line demonstrably said, and playing the next thing
+    # this voice happens to say is the failure this pairing exists to
+    # prevent -- made worse by the panel showing the CLIP's timestamp beside
+    # the quote, so the mismatch looks like a transcription error.
+    if min(seg.get("start", 0) for seg in own) - start > SAMPLE_TURN_MAX_LEAD_SECONDS:
+        return start, start
 
     # From the turn's first own segment onward, and only for as long as this
     # cluster keeps speaking. Taking min(start)/max(end) over the whole set
@@ -1562,7 +1592,10 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
     # breathing, and cutting at every one of those would leave clips too
     # short to recognise a voice from -- the one thing the panel is for.
     ordered = sorted(own, key=lambda seg: seg.get("start", 0))
-    begin = ordered[0].get("start", 0)
+    # Never earlier than the line itself: the segment it sits in may have
+    # begun long before, and that earlier speech belongs to the PREVIOUS
+    # line, which is quoted elsewhere in this same list.
+    begin = max(start, ordered[0].get("start", 0))
     end = ordered[0].get("end", 0)
     for seg in ordered[1:]:
         if seg.get("start", 0) - end > SAMPLE_TURN_GAP_TOLERANCE_SECONDS:

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -936,11 +936,17 @@ def _manifest_describes_lines(line_starts: list, turn_manifest: list) -> bool:
     from one person shown under another's, which is precisely the failure
     the exact-provenance path exists to remove.
 
-    The evidence that the two belong together is already in both of them.
-    Each entry carries the turn's `start` in seconds; the line carries that
-    same number truncated to the second by src.transcriber._format_timestamp
-    (so `[00:20]` accepts 20.0 through 20.999...). Compared with the same
-    slop the rest of this module uses for float/boundary noise.
+    The evidence that the two belong together is already in both of them,
+    and it is exact rather than approximate: src.transcriber builds the
+    entry's `start` and the line's `[MM:SS]` from the SAME float in the same
+    loop, the latter through _format_timestamp, which is `max(0, int(...))`.
+    So the check mirrors that formatting instead of allowing slop around it.
+    It has to: a window merely a second wide accepts the NEIGHBOURING turn,
+    and two turns swapped is exactly what a reordered manifest looks like.
+
+    Refused outright: an entry that is not an object at all. The sidecar is
+    JSON and every caller then reaches for `entry.get(...)`, so this is both
+    the safe answer and the one that keeps their never-raises contract.
 
     Skipped rather than failed: an entry with no usable `start` (or a
     non-finite one, which _format_timestamp itself renders as 00:00) and a
@@ -949,16 +955,14 @@ def _manifest_describes_lines(line_starts: list, turn_manifest: list) -> bool:
     that are fine.
     """
     for line_start, entry in zip(line_starts, turn_manifest):
+        if not isinstance(entry, dict):
+            return False
         if line_start is None:
             continue
-        start = entry.get("start") if isinstance(entry, dict) else None
+        start = entry.get("start")
         if not isinstance(start, (int, float)) or not math.isfinite(start):
             continue
-        if not (
-            line_start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-            <= start
-            < line_start + 1 + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-        ):
+        if max(0, int(start)) != int(line_start):
             return False
     return True
 

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1470,17 +1470,39 @@ def cluster_transcript_lines(
     # (`if turns and turns[-1][1] == speaker: turns[-1][2].append(text)`).
     # The next line's start is therefore the only available upper bound on
     # where this turn's speech stops.
+    #
+    # Take that start from the MANIFEST wherever it offers one, not from the
+    # rendered marker. `[MM:SS]` is truncated with int(), so the marker loses
+    # up to a second and two turns inside one second become indistinguishable
+    # -- measured on real meetings, 18 of 264 and 34 of 643 lines share a
+    # displayed second, and only the manifest can tell them apart. The
+    # manifest keeps each turn's real start (251 of those 264 entries carry a
+    # fractional value), from the same run as the segments, and
+    # _manifest_describes_lines has already confirmed the two agree position
+    # by position. With the exact values 88.6 % of lines fall straight inside
+    # one of their own cluster's segments; with the markers far fewer do, and
+    # the difference is what _turn_audio_range then has to guess at.
+    starts = []
+    for (marker_ts, _text), entry in zip(parsed, turn_manifest):
+        manifest_ts = entry.get("start") if isinstance(entry, dict) else None
+        if isinstance(manifest_ts, (int, float)) and math.isfinite(manifest_ts):
+            starts.append(float(manifest_ts))
+        else:
+            starts.append(marker_ts)
+
     next_starts = []
-    for index in range(len(parsed)):
+    for index in range(len(starts)):
         following = next(
-            (parsed[j][0] for j in range(index + 1, len(parsed)) if parsed[j][0] is not None),
+            (starts[j] for j in range(index + 1, len(starts)) if starts[j] is not None),
             None,
         )
         next_starts.append(following)
 
     return [
         (ts, next_start, text)
-        for (ts, text), next_start, entry in zip(parsed, next_starts, turn_manifest)
+        for ts, (_marker, text), next_start, entry in zip(
+            starts, parsed, next_starts, turn_manifest,
+        )
         if (entry.get("channel"), entry.get("diarization_speaker_id")) in target_ids
         and ts is not None
     ]
@@ -1500,6 +1522,12 @@ def _join_texts(texts: list, max_chars: int) -> Optional[str]:
 # uninterrupted). Nobody listens to five minutes to recognise a voice, and
 # an unbounded clip would also mean an unbounded ffmpeg extraction.
 SAMPLE_MAX_SECONDS = 20.0
+
+# src.transcriber's _format_timestamp renders a turn's start with int(), so
+# a transcript marker is truncated to the whole second below it: the speech
+# it labels begins somewhere in [marker, marker + 1). Only relevant where the
+# manifest carried no exact start to use instead.
+TRANSCRIPT_MARKER_TRUNCATION_SECONDS = 1.0
 
 # How far a line's own speech may start AFTER the line before the moment
 # counts as unplaceable. Transcript markers render as [MM:SS], truncated to
@@ -1543,7 +1571,18 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
     next speaker under this speaker's name, the exact failure this whole
     function exists to prevent. Audio we cannot place is not played.
     """
-    upper = next_start if next_start is not None else float("inf")
+    # An upper bound at or before the line itself bounds nothing. Where the
+    # manifest supplied no exact start, `start` falls back to the truncated
+    # marker, and two turns inside one second then carry the same value.
+    # Bounding at `start` would admit only segments overlapping the marker --
+    # the previous line's tail -- and exclude this line's own speech a
+    # fraction of a second later. Found by review, with segments 9.9-10.2 and
+    # 10.8-10.9 at two lines both marked 10.0.
+    upper = (
+        next_start
+        if next_start is not None and next_start > start
+        else float("inf")
+    )
     # A segment that is ALREADY RUNNING when the line starts counts. One
     # diarization segment routinely spans several transcript lines, so the
     # segment a line belongs to usually began before it: measured on a real
@@ -1551,20 +1590,23 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
     # Requiring `seg.start >= line.start` skipped exactly the segment the
     # line sits in and walked the clip forward to the next one -- 35.3 s
     # away in the worst case, off by 0.22 s of tolerance in the mildest.
+    #
+    # Strictly `end > start`, with no backward tolerance: a segment that has
+    # already finished by the line's start is the tail of the PREVIOUS turn.
+    # Admitting one cost the line its own audio -- it sorted first, and the
+    # gap rule then stopped the range before the real speech began, reporting
+    # the moment unplayable. Found by review, with segments 9.0-9.8 and
+    # 10.9-11.5 at a line starting 10.0.
     own = [
         seg for seg in segments
-        if seg.get("end", 0) > start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-        and seg.get("start", 0) < upper
+        if seg.get("end", 0) > start and seg.get("start", 0) < upper
     ]
     if not own:
         # Bounds hold none of this cluster's segments: same displayed
         # second as the next line, or a manifest that disagrees with the
         # segments. Use this cluster's nearest segment at or after the line
         # instead -- still its own audio, unlike a blind window.
-        following = [
-            seg for seg in segments
-            if seg.get("end", 0) > start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-        ]
+        following = [seg for seg in segments if seg.get("end", 0) > start]
         if not following:
             return start, start
         own = [min(following, key=lambda seg: seg.get("start", 0))]
@@ -1591,7 +1633,25 @@ def _turn_audio_range(segments: list, start: float, next_start: Optional[float])
     # src.transcriber's turn merging), separated by that speaker's own
     # breathing, and cutting at every one of those would leave clips too
     # short to recognise a voice from -- the one thing the panel is for.
+    # A segment spanning the line is ambiguous: usually it is the one the
+    # line sits in, but it can also be the previous turn's tail reaching past
+    # it. Where `start` came from a truncated marker rather than the
+    # manifest, this line's real speech begins within one second of it, so a
+    # segment STARTING in that window is the better opening, and only when
+    # none does is the spanning segment the right answer -- the common case,
+    # a line well inside a long segment. Found by review, with segments
+    # 9.5-10.2 and 10.9-11.5 at a line marked 10.0.
+    #
+    # This picks only where the range OPENS. Everything from there on stays
+    # in play, so a turn made of several segments is still bridged below.
+    starting_in_window = [
+        seg for seg in own
+        if start <= seg.get("start", 0) < min(upper, start + TRANSCRIPT_MARKER_TRUNCATION_SECONDS)
+    ]
     ordered = sorted(own, key=lambda seg: seg.get("start", 0))
+    if starting_in_window:
+        opening = min(seg.get("start", 0) for seg in starting_in_window)
+        ordered = [seg for seg in ordered if seg.get("start", 0) >= opening]
     # Never earlier than the line itself: the segment it sits in may have
     # begun long before, and that earlier speech belongs to the PREVIOUS
     # line, which is quoted elsewhere in this same list.

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1101,30 +1101,114 @@ def sample_segments(segments: list, limit: int = SAMPLE_SEGMENT_LIMIT) -> list:
     return sorted(longest, key=lambda s: s.get("start", 0))
 
 
-def _transcript_text_in_range(lines: list, start: float, end: float, max_chars: int) -> Optional[str]:
-    """Joined text of every non-"You" diarised transcript line whose
-    timestamp falls in [start, end] (same tolerance as relabeling)."""
-    matched = []
-    for line in lines:
+def _covers(segments: list, timestamp_seconds: float) -> bool:
+    return any(
+        seg.get("start", 0) - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+        <= timestamp_seconds
+        <= seg.get("end", 0) + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+        for seg in segments
+    )
+
+
+def cluster_transcript_lines(
+    transcript_path: Path,
+    turn_manifest: Optional[list] = None,
+    target_ids: Optional[set] = None,
+) -> list:
+    """`[(timestamp_seconds, text)]` of the saved transcript's lines that
+    belong to ONE diarized cluster. Never raises; returns [] when the
+    transcript is missing or has no diarised lines.
+
+    Deliberately does NOT skip lines labeled "You", unlike the relabel
+    functions in this module. Not skipping them is the whole point: on the
+    MIC channel the device owner's own turns are exactly the lines labeled
+    "You", so excluding them left the owner's cluster with none of its own
+    speech and filled its excerpts with whatever happened to overlap in
+    time on the system channel -- i.e. a different person's words shown
+    while a human decides whose voice this is. Found against a real
+    three-person call, where all 11 of the owner's lines were dropped this
+    way. The exclusion was inherited from `relabel_transcript_speaker`,
+    where it IS correct (never rewrite the owner's label); reading and
+    rewriting simply want opposite rules.
+
+    Two ways to decide ownership, best first:
+
+    `turn_manifest` + `target_ids` (the sidecar's "transcript_lines", one
+    entry per diarised line in order): exact recorded provenance, the same
+    mechanism confirm-speaker prefers. No ambiguity to resolve at all. A
+    manifest whose length doesn't match the transcript's diarised-line
+    count is refused rather than mispaired, same as
+    `relabel_transcript_exact`.
+
+    WITHOUT a manifest this returns NOTHING, deliberately, rather than
+    falling back to timestamp proximity. Measured against a real
+    three-person call whose sidecar came from `backfill-speaker-embeddings`:
+
+        label      in-mic  in-sys  in-both  in-neither
+        You             0       3        7           1
+        <other>         4      13        4           0
+
+    Not one of the owner's eleven lines falls inside a mic segment alone,
+    while four of the other participants' lines do. Proximity here is not
+    merely noisy, it is INVERTED, and no exclusion rule recovers from that.
+    Two causes, both structural: a backfill re-diarizes the audio in a
+    separate run, so its segment boundaries were never the ones the saved
+    transcript's timestamps came from; and on a call taken without
+    headphones the mic channel also carries the remote voices through the
+    speakers, so mic segments genuinely cover the remote speaker's turns.
+
+    The cost of guessing is not a missing quote. It is a quote from a
+    DIFFERENT PERSON displayed under this speaker's name, at the exact
+    moment a human is deciding whose voice this is -- the failure that
+    prompted this function. The play button is unaffected and stays the
+    honest half: it cuts audio at this cluster's own segments, which are
+    internally consistent with the run that produced them.
+    """
+    if not transcript_path.exists():
+        return []
+    try:
+        content = transcript_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    parsed = []
+    for line in content.split("\n"):
         match = _TRANSCRIPT_LINE_RE.match(line)
         if not match:
             continue
-        timestamp_str, label, text = match.groups()
-        if label == "You":
-            continue
+        timestamp_str, _label, text = match.groups()
         try:
-            timestamp_seconds = _parse_transcript_timestamp(timestamp_str)
+            parsed.append((_parse_transcript_timestamp(timestamp_str), text))
         except ValueError:
-            continue
-        if (
-            start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-            <= timestamp_seconds
-            <= end + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-        ):
-            matched.append(text)
-    if not matched:
+            # A line whose timestamp will not parse still occupies a
+            # manifest position, so keep it in the sequence rather than
+            # silently shifting every later pairing by one.
+            parsed.append((None, text))
+
+    if not turn_manifest or not target_ids:
+        return []
+    if len(turn_manifest) != len(parsed):
+        # Same refusal as relabel_transcript_exact: a manifest that does not
+        # line up with the transcript cannot be paired by position, and
+        # guessing a pairing is how a line ends up under the wrong speaker.
+        logger.warning(
+            "cluster_transcript_lines: %s has %d diarised lines but turn_manifest has "
+            "%d entries -- refusing to guess a pairing, no excerpt text.",
+            transcript_path, len(parsed), len(turn_manifest),
+        )
+        return []
+    return [
+        (ts, text)
+        for (ts, text), entry in zip(parsed, turn_manifest)
+        if (entry.get("channel"), entry.get("diarization_speaker_id")) in target_ids
+        and ts is not None
+    ]
+
+
+def _join_texts(texts: list, max_chars: int) -> Optional[str]:
+    if not texts:
         return None
-    combined = " ".join(matched).strip()
+    combined = " ".join(texts).strip()
     if len(combined) > max_chars:
         combined = combined[:max_chars].rstrip() + "…"
     return combined or None
@@ -1135,6 +1219,8 @@ def extract_segment_samples(
     segments: list,
     limit: int = SAMPLE_SEGMENT_LIMIT,
     max_chars: int = SAMPLE_TEXT_MAX_CHARS,
+    turn_manifest: Optional[list] = None,
+    target_ids: Optional[set] = None,
 ) -> list:
     """`[{"start", "end", "text"}]` for this cluster's review samples --
     the multi-excerpt counterpart to `extract_sample_text`.
@@ -1156,22 +1242,16 @@ def extract_segment_samples(
     if not chosen:
         return []
 
-    lines: list = []
-    if transcript_path.exists():
-        try:
-            lines = transcript_path.read_text(encoding="utf-8").split("\n")
-        except OSError:
-            lines = []
+    owned = cluster_transcript_lines(
+        transcript_path, turn_manifest=turn_manifest, target_ids=target_ids,
+    )
 
     return [
         {
             "start": seg.get("start", 0),
             "end": seg.get("end", 0),
-            "text": (
-                _transcript_text_in_range(
-                    lines, seg.get("start", 0), seg.get("end", 0), max_chars,
-                )
-                if lines else None
+            "text": _join_texts(
+                [text for ts, text in owned if _covers([seg], ts)], max_chars,
             ),
         }
         for seg in chosen
@@ -1182,50 +1262,29 @@ def extract_sample_text(
     transcript_path: Path,
     segments: list,
     max_chars: int = SAMPLE_TEXT_MAX_CHARS,
+    turn_manifest: Optional[list] = None,
+    target_ids: Optional[set] = None,
 ) -> Optional[str]:
-    """A short quoted excerpt of what this cluster actually said, read from
-    the saved transcript at the cluster's longest segment's timestamp range
-    -- gives a human reviewing an "Unidentified speaker" row something to
-    recognize them by without leaving the app. Read-only counterpart to
-    `relabel_transcript_speaker`'s timestamp-matching (never "You" lines,
-    same tolerance). Returns None (never raises) if the transcript is
-    missing/unreadable, has no segments to match, or no line overlaps the
-    longest segment's range -- a soft, best-effort aid, not a hard
+    """A short quoted excerpt of what this cluster actually said, taken from
+    its longest (most trustworthy) segment -- gives a human reviewing an
+    "Unidentified speaker" row something to recognize them by without
+    leaving the app.
+
+    Ownership of a transcript line is decided by `cluster_transcript_lines`,
+    not by the line's label: this used to skip every line labeled "You",
+    which silently guaranteed that the device owner's own mic cluster
+    quoted somebody ELSE (see that function). Returns None (never raises)
+    when the transcript is missing, there are no segments, or no line this
+    cluster owns falls in the longest one -- a best-effort aid, never a
     requirement for the row to render.
     """
     target = longest_segment(segments)
-    if target is None or not transcript_path.exists():
+    if target is None:
         return None
-    try:
-        content = transcript_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-
-    matched_texts = []
-    for line in content.split("\n"):
-        match = _TRANSCRIPT_LINE_RE.match(line)
-        if not match:
-            continue
-        timestamp_str, label, text = match.groups()
-        if label == "You":
-            continue
-        try:
-            timestamp_seconds = _parse_transcript_timestamp(timestamp_str)
-        except ValueError:
-            continue
-        if (
-            target.get("start", 0) - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-            <= timestamp_seconds
-            <= target.get("end", 0) + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-        ):
-            matched_texts.append(text)
-
-    if not matched_texts:
-        return None
-    combined = " ".join(matched_texts).strip()
-    if len(combined) > max_chars:
-        combined = combined[:max_chars].rstrip() + "…"
-    return combined or None
+    owned = cluster_transcript_lines(
+        transcript_path, turn_manifest=turn_manifest, target_ids=target_ids,
+    )
+    return _join_texts([text for ts, text in owned if _covers([target], ts)], max_chars)
 
 
 # Small buffer around the longest segment's exact boundaries so a clip

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1197,9 +1197,24 @@ def cluster_transcript_lines(
             transcript_path, len(parsed), len(turn_manifest),
         )
         return []
+    # (start, next_line_start, text) per owned line. The third element is
+    # what makes a turn bounded at all: a transcript line carries only ONE
+    # timestamp, its START, because src.transcriber merges consecutive
+    # segments of the same speaker into one turn
+    # (`if turns and turns[-1][1] == speaker: turns[-1][2].append(text)`).
+    # The next line's start is therefore the only available upper bound on
+    # where this turn's speech stops.
+    next_starts = []
+    for index in range(len(parsed)):
+        following = next(
+            (parsed[j][0] for j in range(index + 1, len(parsed)) if parsed[j][0] is not None),
+            None,
+        )
+        next_starts.append(following)
+
     return [
-        (ts, text)
-        for (ts, text), entry in zip(parsed, turn_manifest)
+        (ts, next_start, text)
+        for (ts, text), next_start, entry in zip(parsed, next_starts, turn_manifest)
         if (entry.get("channel"), entry.get("diarization_speaker_id")) in target_ids
         and ts is not None
     ]
@@ -1214,6 +1229,49 @@ def _join_texts(texts: list, max_chars: int) -> Optional[str]:
     return combined or None
 
 
+# A review clip is never longer than this, even when the next transcript
+# line is minutes away (a long pause, or the speaker holding the floor
+# uninterrupted). Nobody listens to five minutes to recognise a voice, and
+# an unbounded clip would also mean an unbounded ffmpeg extraction.
+SAMPLE_MAX_SECONDS = 20.0
+# Used only when a turn has no diarization segment inside its bounds at all
+# (possible when the transcript and the sidecar came from different runs).
+SAMPLE_FALLBACK_SECONDS = 6.0
+
+
+def _turn_audio_range(segments: list, start: float, next_start: Optional[float]) -> tuple:
+    """The time range of ONE turn's speech by this cluster: the span of its
+    own diarization segments between this line's start and the next line's.
+
+    This is the piece that makes a clip and the text beside it describe the
+    same thing. Selecting by SEGMENT and then hunting for a line inside it
+    -- the earlier design -- cannot: src.transcriber merges consecutive
+    segments of one speaker into a single turn carrying only the FIRST
+    segment's timestamp, so every later segment of that turn contains no
+    line start at all. In practice that produced exactly two symptoms, both
+    reported from real use: most excerpts had no text, and the ones that
+    did played a clip cut at a segment boundary while the text was the
+    whole merged turn.
+    """
+    upper = next_start if next_start is not None else float("inf")
+    own = [
+        seg for seg in segments
+        if start - RELABEL_TIMESTAMP_TOLERANCE_SECONDS <= seg.get("start", 0) < upper
+    ]
+    if own:
+        begin = min(seg.get("start", 0) for seg in own)
+        end = max(seg.get("end", 0) for seg in own)
+    else:
+        begin, end = start, start + SAMPLE_FALLBACK_SECONDS
+    # Never run into the next speaker's line, and never past the cap.
+    if next_start is not None:
+        end = min(end, next_start)
+    end = min(end, begin + SAMPLE_MAX_SECONDS)
+    if end <= begin:
+        end = begin + SAMPLE_FALLBACK_SECONDS
+    return begin, end
+
+
 def extract_segment_samples(
     transcript_path: Path,
     segments: list,
@@ -1222,40 +1280,44 @@ def extract_segment_samples(
     turn_manifest: Optional[list] = None,
     target_ids: Optional[set] = None,
 ) -> list:
-    """`[{"start", "end", "text"}]` for this cluster's review samples --
-    the multi-excerpt counterpart to `extract_sample_text`.
+    """`[{"start", "end", "text"}]` -- the moments offered for review, in
+    chronological order, each independently playable.
 
-    Deliberately built from `segments` (the diarizer's own per-cluster
-    timestamps) and the SAVED TRANSCRIPT, never from the sidecar's
-    `transcript_lines` turn manifest: that manifest is only written by the
-    live pipeline, so every sidecar produced by `backfill-speaker-embeddings`
-    has none at all, and a samples list sourced from it would come back
-    empty for exactly the historical meetings a human most needs help
-    identifying. `segments` are present in every sidecar by construction.
+    Driven by this cluster's TURNS when the sidecar carries a manifest, and
+    only by its segments otherwise. The distinction is the whole point: a
+    turn is a unit of speech that has text, a segment is a unit of acoustics
+    that usually does not, and pairing a clip with a quote requires the
+    former (see `_turn_audio_range`).
 
-    `text` is None for a segment no transcript line covers -- the entry is
-    still returned, because its audio is playable and a clip with no
-    quotable text is still useful to listen to. Never raises: a missing or
-    unreadable transcript yields text-less entries rather than an error.
+    Without a manifest there are no turns to attribute, so the entries carry
+    the cluster's longest segments and `text: None`. Those are still worth
+    offering -- the audio is this cluster's own, and listening is what
+    identifies a voice; a quote was always the lesser half.
     """
-    chosen = sample_segments(segments, limit)
-    if not chosen:
-        return []
-
     owned = cluster_transcript_lines(
         transcript_path, turn_manifest=turn_manifest, target_ids=target_ids,
     )
 
-    return [
-        {
-            "start": seg.get("start", 0),
-            "end": seg.get("end", 0),
-            "text": _join_texts(
-                [text for ts, text in owned if _covers([seg], ts)], max_chars,
-            ),
-        }
-        for seg in chosen
-    ]
+    if not owned:
+        return [
+            {"start": seg.get("start", 0), "end": seg.get("end", 0), "text": None}
+            for seg in sample_segments(segments, limit)
+        ]
+
+    candidates = []
+    for start, next_start, text in owned:
+        begin, end = _turn_audio_range(segments, start, next_start)
+        candidates.append({
+            "start": begin,
+            "end": end,
+            "text": _join_texts([text], max_chars),
+        })
+
+    # The longest turns, then chronological -- same reasoning as
+    # sample_segments (a long uninterrupted turn is the most likely to be
+    # genuine, unmixed speech), now applied to units that have text.
+    chosen = sorted(candidates, key=lambda c: c["end"] - c["start"], reverse=True)[:limit]
+    return sorted(chosen, key=lambda c: c["start"])
 
 
 def extract_sample_text(
@@ -1265,26 +1327,33 @@ def extract_sample_text(
     turn_manifest: Optional[list] = None,
     target_ids: Optional[set] = None,
 ) -> Optional[str]:
-    """A short quoted excerpt of what this cluster actually said, taken from
-    its longest (most trustworthy) segment -- gives a human reviewing an
-    "Unidentified speaker" row something to recognize them by without
-    leaving the app.
+    """A short quoted excerpt of what this cluster actually said -- the one
+    line shown on the collapsed row, so a human scanning the panel has
+    something to recognise a voice by without expanding anything.
 
-    Ownership of a transcript line is decided by `cluster_transcript_lines`,
-    not by the line's label: this used to skip every line labeled "You",
-    which silently guaranteed that the device owner's own mic cluster
-    quoted somebody ELSE (see that function). Returns None (never raises)
-    when the transcript is missing, there are no segments, or no line this
-    cluster owns falls in the longest one -- a best-effort aid, never a
+    Deliberately the SAME text as `extract_segment_samples`' first-ranked
+    entry, obtained by asking that function rather than repeating its
+    selection: two independent derivations of "the most representative
+    thing this speaker said" drift apart, and the visible symptom is a
+    collapsed row quoting one moment while expanding it offers five others
+    that never include it.
+
+    Ownership comes from the sidecar's turn manifest, never from a line's
+    label: an earlier version skipped every line labeled "You", which
+    silently guaranteed that the device owner's own mic cluster quoted
+    somebody ELSE (see cluster_transcript_lines). Returns None, never
+    raises, when there is nothing attributable -- a best-effort aid, not a
     requirement for the row to render.
     """
-    target = longest_segment(segments)
-    if target is None:
-        return None
-    owned = cluster_transcript_lines(
-        transcript_path, turn_manifest=turn_manifest, target_ids=target_ids,
+    samples = extract_segment_samples(
+        transcript_path, segments, max_chars=max_chars,
+        turn_manifest=turn_manifest, target_ids=target_ids,
     )
-    return _join_texts([text for ts, text in owned if _covers([target], ts)], max_chars)
+    longest = max(
+        (s for s in samples if s["text"]),
+        key=lambda s: s["end"] - s["start"], default=None,
+    )
+    return longest["text"] if longest else None
 
 
 # Small buffer around the longest segment's exact boundaries so a clip
@@ -1299,7 +1368,7 @@ def extract_speaker_sample_audio(
     channel: str,
     segments: list,
     output_path: Path,
-    segment_index: Optional[int] = None,
+    segment_index=None,
 ) -> bool:
     """Extract a short audio clip covering this cluster's longest pooled
     segment from the ORIGINAL source recording, for the review UI's play
@@ -1313,13 +1382,14 @@ def extract_speaker_sample_audio(
     same mapping as src.transcriber._split_stereo_to_channels, so a mono
     recording (channel index 0 only) also works correctly for "mic".
 
-    `segment_index`, when given, selects one entry of `sample_segments`
-    (this cluster's review-sample list) instead of the longest turn -- how
-    the panel plays the specific excerpt a human clicked rather than always
-    replaying the same one. Out-of-range values return False rather than
-    silently falling back to the longest segment: a caller asking for
-    excerpt 4 and hearing excerpt 1 would have no way to notice, and would
-    reasonably conclude the two speakers sound identical.
+    `segment_index` selects WHICH moment to cut. It accepts either an
+    explicit `{"start", "end"}` range -- what the CLI passes, taken straight
+    from the entry the user clicked -- or an integer index into
+    `sample_segments` for callers that have only segments. Out-of-range
+    integers return False rather than silently falling back to the longest
+    segment: a caller asking for excerpt 4 and hearing excerpt 1 would have
+    no way to notice, and would reasonably conclude the two speakers sound
+    identical.
 
     Returns True on success (output_path written), False on any failure --
     no ffmpeg, no source recording (the common case for an older backfilled
@@ -1327,7 +1397,14 @@ def extract_speaker_sample_audio(
     error. Never raises: this is a best-effort UI aid, never something that
     can fail the review panel.
     """
-    if segment_index is None:
+    if isinstance(segment_index, dict):
+        # An explicit {"start", "end"} range, which is how the CLI passes the
+        # entry the user actually clicked. Re-deriving the list here instead
+        # would mean two independent selections of "sample i" that must agree
+        # forever -- and they would not, since the list is built from TURNS
+        # when a manifest exists and from segments when it does not.
+        target = segment_index
+    elif segment_index is None:
         target = longest_segment(segments)
     else:
         chosen = sample_segments(segments)

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -699,13 +699,41 @@ def minimum_speaker_count(channels: dict) -> int:
     instead of silent, and so a future diarization path -- windowed
     inference with cross-window clustering, or an engine that does accept
     a count -- has ground truth to be measured against.
+
+    Counted on the MERGED view, and taken as the LARGEST channel rather
+    than the sum. Both corrections come from the same demand: a minimum
+    that overstates is simply wrong, while one that understates is merely
+    weak. Raw clusters overstate because the panel itself collapses
+    diarizer fragments of one voice into one row, so the number would
+    contradict the list beside it. Summing channels overstates because a
+    remote voice coming out of the speakers is picked up by the microphone
+    as well -- the module's own excerpt reasoning rests on that -- so a mic
+    cluster and a system cluster can be one person, and nothing in the
+    sidecar says whether they are.
     """
-    total = 0
+    largest = 0
     for channel_data in (channels or {}).values():
-        clusters = channel_data.get("clusters") or {}
-        total += len(clusters)
-        total += sum(1 for c in clusters.values() if c.get(MULTI_SPEAKER_KEY))
-    return total
+        raw = channel_data.get("clusters") or {}
+        if not raw:
+            continue
+        try:
+            merged, _id_resolution = merge_same_channel_fragments(
+                clusters_from_sidecar_channel("", channel_data)
+            )
+            groups = [[sid, *ctx.merged_from] for sid, (_emb, ctx) in merged.items()]
+        except (KeyError, TypeError, ValueError):
+            # A sidecar without usable embeddings cannot be merged; count
+            # the raw ids rather than reporting nothing at all.
+            groups = [[sid] for sid in raw]
+        # A group counts as mixed if ANY of its members was marked: the
+        # human said two people share that voice, and merging it with a
+        # fragment of itself does not make that untrue.
+        marked = sum(
+            1 for members in groups
+            if any(raw.get(member, {}).get(MULTI_SPEAKER_KEY) for member in members)
+        )
+        largest = max(largest, len(groups) + marked)
+    return largest
 
 
 def read_speakers_sidecar(output_dir: Path, meeting_stem: str) -> Optional[dict]:
@@ -1173,15 +1201,6 @@ def sample_segments(segments: list, limit: int = SAMPLE_SEGMENT_LIMIT) -> list:
         segments, key=lambda s: s.get("end", 0) - s.get("start", 0), reverse=True,
     )[:limit]
     return sorted(longest, key=lambda s: s.get("start", 0))
-
-
-def _covers(segments: list, timestamp_seconds: float) -> bool:
-    return any(
-        seg.get("start", 0) - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-        <= timestamp_seconds
-        <= seg.get("end", 0) + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-        for seg in segments
-    )
 
 
 def cluster_transcript_lines(

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -40,8 +40,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import subprocess
+import tempfile
 import time
 from collections import Counter
 from dataclasses import dataclass, field
@@ -652,9 +654,28 @@ def set_cluster_multi_speaker(
         cluster.pop(MULTI_SPEAKER_KEY, None)
 
     path = speakers_sidecar_path(output_dir, meeting_stem)
-    tmp_path = path.with_name(path.name + ".tmp")
-    tmp_path.write_text(json.dumps(sidecar, indent=2))
-    tmp_path.replace(path)
+    # A UNIQUE temp name, unlike the fixed "<name>.tmp" the relabel helpers
+    # in this module use. Those rewrite a transcript, which can be
+    # regenerated; this rewrites the only copy of a meeting's voice
+    # embeddings, which cannot be once the source audio is gone. With a
+    # shared temp name, two concurrent marks race on ONE file: the second
+    # truncates it while the first is replacing the sidecar with it, and a
+    # crash or a full disk in that window leaves the real sidecar empty.
+    # Same directory as the target so the replace stays a rename within one
+    # filesystem, which is what makes it atomic.
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(sidecar, fh, indent=2)
+        tmp_path.replace(path)
+    except OSError:
+        # Never leave a half-written temp file behind for someone to find
+        # later and mistake for a real sidecar.
+        tmp_path.unlink(missing_ok=True)
+        raise
     return sidecar
 
 

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -1183,18 +1183,6 @@ def _tag_channel_segments(
         finally:
             print(f"PROGRESS:diarize:{legacy_label}:done", flush=True)
 
-    # Only borrowing the WRONG speaker is a problem, and with a single
-    # distinct cluster there is no wrong one -- a gap line's provenance is
-    # unambiguous however far it sits from the nearest segment. Bound the
-    # lookup only where a second cluster exists to be borrowed from (the
-    # dominance-collapsed shape), so the common single-voice channel keeps
-    # exact provenance for every line.
-    provenance_tolerance = (
-        DIAR_LABEL_FALLBACK_TOLERANCE_S
-        if diar_segments_for_provenance
-        and len({seg["speaker"] for seg in diar_segments_for_provenance}) > 1
-        else None
-    )
     legacy_tagged: list[tuple[float, str, str, Optional[str]]] = []
     for s in asr_segments:
         text = (s.get("text") or "").strip()
@@ -1212,11 +1200,20 @@ def _tag_channel_segments(
             # this path's visible output -- still required to be
             # byte-identical to the pre-Phase-8 legacy behaviour. This is
             # purely a read-only side lookup for exact-match provenance.
+            #
+            # Bounded like the labeling path, and for the same reason even
+            # when the channel holds a single cluster: raw_sid claims THIS
+            # cluster produced THIS line, and a line sitting far outside
+            # every segment the diarizer emitted has no evidence behind
+            # that claim -- it may well be someone the diarizer never
+            # segmented at all. A later rename would then put a name on a
+            # line that was never that person's. None is the honest answer;
+            # the text still reaches the transcript under legacy_label.
             idx = _find_nearest_diar_segment(
                 start,
                 float(s.get("end") or start),
                 diar_segments_for_provenance,
-                provenance_tolerance,
+                DIAR_LABEL_FALLBACK_TOLERANCE_S,
             )
             if idx is not None:
                 raw_sid = diar_segments_for_provenance[idx]["speaker"]

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -535,11 +535,37 @@ def _merge_close_diar_segments(segments: list[dict], max_gap: float) -> list[dic
 # whenever it actually overlaps more than one distinct diarizer speaker.
 LONG_SENTENCE_SPLIT_THRESHOLD_S = 5.0
 
+# How far outside every diarizer segment an ASR timestamp may sit and still
+# be attributed to the nearest speaker. Without a bound, "nearest" is
+# unconditional: text at 0-1s with the channel's only diarizer segment at
+# 2-3s was attributed in full to a speaker who, by the diarizer's own
+# output, was not speaking anywhere near it -- and that attribution also
+# reached the raw cluster id used for voiceprints, so one unplaceable line
+# could feed a profile. Normal ASR-vs-diarizer boundary disagreement is
+# well under a second (a clipped onset, a trailing word, breath before a
+# turn); a whole second of diarizer-side silence around a sentence means
+# the diarizer heard nobody there, not that it heard someone nearby.
+#
+# Judgment value, not a measured optimum: chosen to sit clearly above
+# observed boundary slop and well above STENO_DIARIZE_MERGE_GAP_S, so only
+# genuinely unplaceable text is affected. Raising it moves behaviour back
+# toward the old unconditional nearest.
+DIAR_LABEL_FALLBACK_TOLERANCE_S = 1.0
 
-def _find_nearest_diar_segment(start: float, end: float, diar_segments: list[dict]) -> Optional[int]:
+
+def _find_nearest_diar_segment(
+    start: float,
+    end: float,
+    diar_segments: list[dict],
+    max_gap: Optional[float] = None,
+) -> Optional[int]:
     """Index of the diar segment containing [start, end]'s midpoint, or the
     nearest one by boundary distance if the midpoint falls in an uncovered
-    gap. Returns None only when diar_segments is empty."""
+    gap.
+
+    With ``max_gap`` set, a midpoint further than that from every segment is
+    reported as unplaceable (None) instead of borrowing the nearest speaker.
+    Returns None when diar_segments is empty."""
     midpoint = (start + end) / 2
     best_i, best_dist = None, float("inf")
     for i, segment in enumerate(diar_segments):
@@ -552,10 +578,14 @@ def _find_nearest_diar_segment(start: float, end: float, diar_segments: list[dic
         )
         if dist < best_dist:
             best_i, best_dist = i, dist
+    if max_gap is not None and best_dist > max_gap:
+        return None
     return best_i
 
 
-def _assign_asr_segments_to_diar_segments(asr_segments: list[dict], diar_segments: list[dict]) -> None:
+def _assign_asr_segments_to_diar_segments(
+    asr_segments: list[dict], diar_segments: list[dict]
+) -> list[dict]:
     """Assign each ASR (Parakeet) sentence to the diarizer segment(s) it
     belongs to.
 
@@ -577,12 +607,21 @@ def _assign_asr_segments_to_diar_segments(asr_segments: list[dict], diar_segment
     whisper.cpp backend, or an older cached result), the sentence falls back
     to whole-block assignment like the normal case.
 
-    Mutates diar_segments in place, attaching joined text as segment["text"]."""
+    Unplaceable case: a sentence whose midpoint sits further than
+    DIAR_LABEL_FALLBACK_TOLERANCE_S outside every diarizer segment is not
+    attributed to anyone. It is returned to the caller instead, which keeps
+    the text in the transcript under the channel's own label rather than
+    naming a speaker the diarizer never heard there. Text is never dropped.
+
+    Mutates diar_segments in place, attaching joined text as
+    segment["text"]. Returns the ASR segments that could not be placed, in
+    input order (empty list in the normal case)."""
     for segment in diar_segments:
         segment["text"] = ""
     if not diar_segments:
-        return
+        return list(asr_segments)
 
+    unplaceable: list[dict] = []
     texts_by_segment: dict[int, list[str]] = {i: [] for i in range(len(diar_segments))}
     for asr_segment in asr_segments:
         text = (asr_segment.get("text") or "").strip()
@@ -610,8 +649,17 @@ def _assign_asr_segments_to_diar_segments(asr_segments: list[dict], diar_segment
                     continue
                 t_start = float(token.get("start") or 0.0)
                 t_end = float(token.get("end") or t_start)
-                idx = _find_nearest_diar_segment(t_start, t_end, diar_segments)
+                idx = _find_nearest_diar_segment(
+                    t_start, t_end, diar_segments, DIAR_LABEL_FALLBACK_TOLERANCE_S
+                )
                 if idx is None:
+                    # This word carries no usable speaker evidence. Keep it
+                    # with the turn it is already inside instead of opening
+                    # one for a speaker the diarizer didn't hear here --
+                    # words before the first placeable one simply stay
+                    # buffered in run_words and lead that first run, so the
+                    # sentence's word order survives either way.
+                    run_words.append(token_text)
                     continue
                 if run_index is not None and idx != run_index:
                     texts_by_segment[run_index].append("".join(run_words))
@@ -620,13 +668,23 @@ def _assign_asr_segments_to_diar_segments(asr_segments: list[dict], diar_segment
                 run_words.append(token_text)
             if run_index is not None and run_words:
                 texts_by_segment[run_index].append("".join(run_words))
+            elif run_index is None:
+                # Not one word in the sentence could be placed -- including
+                # the case where the token list carries no usable text at
+                # all, which used to drop the sentence silently.
+                unplaceable.append(asr_segment)
         else:
-            idx = _find_nearest_diar_segment(start, end, diar_segments)
+            idx = _find_nearest_diar_segment(
+                start, end, diar_segments, DIAR_LABEL_FALLBACK_TOLERANCE_S
+            )
             if idx is not None:
                 texts_by_segment[idx].append(text)
+            else:
+                unplaceable.append(asr_segment)
 
     for i, segment in enumerate(diar_segments):
         segment["text"] = " ".join(t.strip() for t in texts_by_segment[i] if t.strip()).strip()
+    return unplaceable
 
 
 # How often to print a HEARTBEAT: line while blocked waiting on
@@ -1064,7 +1122,7 @@ def _tag_channel_segments(
                     cluster_labels = _apply_voiceprint_matches(
                         speaker_embeddings, cluster_labels, legacy_label, allow_self_match,
                     )
-                    _assign_asr_segments_to_diar_segments(asr_segments, diar_segments)
+                    unplaceable = _assign_asr_segments_to_diar_segments(asr_segments, diar_segments)
                     diar_tagged = []
                     for segment in diar_segments:
                         text = (segment.get("text") or "").strip()
@@ -1073,6 +1131,18 @@ def _tag_channel_segments(
                                 segment["start"], cluster_labels[segment["speaker"]], text,
                                 segment["speaker"],
                             ))
+                    # Text the diarizer left unplaceable still belongs in the
+                    # transcript -- under this channel's own label, with no
+                    # raw cluster id, so it reads as "someone on this side"
+                    # and can never feed a voiceprint. Dropping it would lose
+                    # real speech; naming a speaker for it would invent one.
+                    for asr_segment in unplaceable:
+                        text = (asr_segment.get("text") or "").strip()
+                        if text:
+                            diar_tagged.append((
+                                float(asr_segment.get("start") or 0.0), legacy_label, text, None,
+                            ))
+                    diar_tagged.sort(key=lambda turn: turn[0])
                     if diar_tagged:
                         logger.info(
                             f"Diarizing {legacy_label} channel found "
@@ -1113,6 +1183,18 @@ def _tag_channel_segments(
         finally:
             print(f"PROGRESS:diarize:{legacy_label}:done", flush=True)
 
+    # Only borrowing the WRONG speaker is a problem, and with a single
+    # distinct cluster there is no wrong one -- a gap line's provenance is
+    # unambiguous however far it sits from the nearest segment. Bound the
+    # lookup only where a second cluster exists to be borrowed from (the
+    # dominance-collapsed shape), so the common single-voice channel keeps
+    # exact provenance for every line.
+    provenance_tolerance = (
+        DIAR_LABEL_FALLBACK_TOLERANCE_S
+        if diar_segments_for_provenance
+        and len({seg["speaker"] for seg in diar_segments_for_provenance}) > 1
+        else None
+    )
     legacy_tagged: list[tuple[float, str, str, Optional[str]]] = []
     for s in asr_segments:
         text = (s.get("text") or "").strip()
@@ -1130,7 +1212,12 @@ def _tag_channel_segments(
             # this path's visible output -- still required to be
             # byte-identical to the pre-Phase-8 legacy behaviour. This is
             # purely a read-only side lookup for exact-match provenance.
-            idx = _find_nearest_diar_segment(start, float(s.get("end") or start), diar_segments_for_provenance)
+            idx = _find_nearest_diar_segment(
+                start,
+                float(s.get("end") or start),
+                diar_segments_for_provenance,
+                provenance_tolerance,
+            )
             if idx is not None:
                 raw_sid = diar_segments_for_provenance[idx]["speaker"]
         legacy_tagged.append((start, legacy_label, text, raw_sid))

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -516,7 +516,12 @@ def _merge_close_diar_segments(segments: list[dict], max_gap: float) -> list[dic
     for segment in segments[1:]:
         last = merged[-1]
         if segment["speaker"] == last["speaker"] and segment["start"] - last["end"] <= max_gap:
-            last["end"] = segment["end"]
+            # max(), not assignment: sorted-by-start does not mean the next
+            # segment ends later. A same-speaker segment nested inside the
+            # one before it (Sortformer emits these, and clamping can leave
+            # one behind) would otherwise pull the merged end BACKWARDS and
+            # delete speaking time that was really there.
+            last["end"] = max(last["end"], segment["end"])
         else:
             merged.append(dict(segment))
     return merged

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -2195,9 +2195,18 @@ class WhisperTranscriber:
             # or transcript_text), so the summariser strips these [MM:SS] markers
             # back out on the way in (summarizer._strip_leading_timestamps) —
             # summarisation is unaffected by this display feature.
+            # A turn is one span of ONE provenance, so the run breaks on the
+            # raw cluster id as well as the label. Merging on the label alone
+            # was reachable and wrong: text the diarizer could not place is
+            # appended under the CHANNEL's own label (raw_sid None), and
+            # _cluster_channel_labels hands that same label to the channel's
+            # dominant cluster -- so an unplaceable sentence next to that
+            # cluster's turn was folded in and recorded as its speech, which
+            # is exactly the attribution the unplaceable path withholds it
+            # from. Same reasoning in the mono path's copy of this loop.
             turns: list[tuple[float, str, list[str], str, Optional[str]]] = []
             for start, speaker, text, channel, raw_sid in tagged:
-                if turns and turns[-1][1] == speaker:
+                if turns and turns[-1][1] == speaker and turns[-1][4] == raw_sid:
                     turns[-1][2].append(text)
                 else:
                     turns.append((start, speaker, [text], channel, raw_sid))
@@ -2311,9 +2320,11 @@ class WhisperTranscriber:
         tagged.sort(key=lambda t: t[0])
         tagged = _resolve_speaker_placeholders(tagged)
 
+        # Breaks on the raw cluster id too -- see the stereo path's comment
+        # above its copy of this loop for the attribution that depends on it.
         turns: list[tuple[float, str, list[str], str, Optional[str]]] = []
         for start, speaker, text, channel, raw_sid in tagged:
-            if turns and turns[-1][1] == speaker:
+            if turns and turns[-1][1] == speaker and turns[-1][4] == raw_sid:
                 turns[-1][2].append(text)
             else:
                 turns.append((start, speaker, [text], channel, raw_sid))

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -522,6 +522,35 @@ def _merge_close_diar_segments(segments: list[dict], max_gap: float) -> list[dic
     return merged
 
 
+def _clamp_overlapping_diar_segments(segments: list[dict]) -> list[dict]:
+    """Give each moment of audio to one speaker only, by pulling a segment's
+    start up to where the previous speaker actually stopped. Segments must
+    already be sorted by start time; the result is re-sorted by the caller.
+
+    Sortformer really does emit overlapping segments -- observed on
+    single-mic audio, see the note above LONG_SENTENCE_SPLIT_THRESHOLD_S.
+    Left as-is, the overlapped span is counted twice: once for each cluster.
+    That inflated total is what _cluster_channel_labels weighs against
+    CHANNEL_DOMINANCE_THRESHOLD to decide whether a channel is one voice or
+    gets split into "Speaker N" at all, so a run of overlap can decide the
+    speaker count on double-counted time.
+
+    A segment lying ENTIRELY inside an earlier one is left untouched:
+    clamping it would leave nothing of it, and a cluster that only ever
+    speaks inside someone else's turn would vanish from the channel
+    completely -- deleting a speaker to fix an arithmetic error is the
+    worse trade. Its span stays double-counted, which is the rarer case."""
+    clamped: list[dict] = []
+    running_end: Optional[float] = None
+    for segment in segments:
+        current = dict(segment)
+        if running_end is not None and current["start"] < running_end < current["end"]:
+            current["start"] = running_end
+        clamped.append(current)
+        running_end = current["end"] if running_end is None else max(running_end, current["end"])
+    return clamped
+
+
 # A single mic capturing two people is a much harder acoustic problem than a
 # clean mic-vs-system-audio split — the diarizer's own turn boundaries can be
 # genuinely noisy/overlapping there (observed empirically: alternating and
@@ -897,7 +926,16 @@ def _run_steno_diarize(
         ),
         key=lambda s: s["start"],
     )
+    # Merge first so a same-speaker overlap (the flicker case) collapses into
+    # one turn instead of being clamped into two touching ones; then clamp
+    # what is left, which is overlap between DIFFERENT speakers; then merge
+    # again, since clamping can leave two same-speaker segments flush.
+    # Clamping only ever moves a start forward, so re-sort before the second
+    # merge -- a segment nested inside a longer one keeps its original start
+    # and can end up out of order.
     merged = _merge_close_diar_segments(segments, STENO_DIARIZE_MERGE_GAP_S)
+    clamped = sorted(_clamp_overlapping_diar_segments(merged), key=lambda s: s["start"])
+    merged = _merge_close_diar_segments(clamped, STENO_DIARIZE_MERGE_GAP_S)
     embeddings = {str(k): [float(x) for x in v] for k, v in raw_embeddings.items()}
     return merged, embeddings
 

--- a/tests/test_list_meetings_has_audio.py
+++ b/tests/test_list_meetings_has_audio.py
@@ -94,24 +94,47 @@ class ListMeetingsHasAudioTests(unittest.TestCase):
             _write_recording(tmp, "note-2.wav")
             self.assertFalse(_run(tmp)[0]["has_audio"])
 
+    def test_a_directory_named_like_a_recording_does_not_count(self):
+        # os.listdir returns directories too, so a folder called
+        # "note.wav" would otherwise report audio that does not exist.
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_note(tmp, "note", "Note")
+            (Path(tmp) / "recordings" / "note.wav").mkdir(parents=True)
+            self.assertFalse(_run(tmp)[0]["has_audio"])
+
+    def test_a_note_whose_own_name_contains_the_summary_marker(self):
+        # `str.replace` strips EVERY occurrence, so
+        # "client_summary.v1_summary.md" used to yield the stem
+        # "client.v1" -- harmless while the stem only fed the dedup set,
+        # wrong the moment it is matched against real filenames.
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_note(tmp, "client_summary.v1", "Client")
+            _write_recording(tmp, "client_summary.v1.wav")
+            meetings = _run(tmp)
+            self.assertEqual(len(meetings), 1)
+            self.assertTrue(
+                meetings[0]["has_audio"],
+                "the stem must keep everything but a TRAILING _summary",
+            )
+
     def test_the_recordings_dir_is_listed_once_not_once_per_meeting(self):
         # The guard on the "optimized for fast loading" promise: a
         # per-meeting existence check would make cold start scale with
-        # library size. Counting listdir calls is what actually holds the
-        # implementation to a single listing.
+        # library size. Counting the directory listings is what actually
+        # holds the implementation to a single one.
         with tempfile.TemporaryDirectory() as tmp:
             for i in range(12):
                 _write_note(tmp, f"note{i}", f"Note {i}")
             _write_recording(tmp, "note3.wav")
 
-            real_listdir = os.listdir
+            real_scandir = os.scandir
             calls = []
 
-            def counting_listdir(path):
+            def counting_scandir(path):
                 calls.append(str(path))
-                return real_listdir(path)
+                return real_scandir(path)
 
-            with mock.patch("os.listdir", side_effect=counting_listdir):
+            with mock.patch("os.scandir", side_effect=counting_scandir):
                 meetings = _run(tmp)
 
             recordings_dir = str(Path(tmp) / "recordings")

--- a/tests/test_list_meetings_has_audio.py
+++ b/tests/test_list_meetings_has_audio.py
@@ -1,0 +1,126 @@
+"""`has_audio` on list-meetings: does this note's original recording still
+exist on disk?
+
+keep_recordings defaults OFF, so for most notes it does not -- and
+everything that depends on the audio (re-transcribe, the speaker panel's
+listening samples, any future re-diarization) is quietly unavailable
+without it, with nothing in the list saying so until you open the note and
+find the action missing.
+
+Derived from ONE directory listing rather than a per-meeting existence
+check: this command is on the app's cold-start path and its docstring
+calls it "optimized for fast loading", so the cost must not scale with
+library size.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from click.testing import CliRunner
+
+import simple_recorder
+from src.config import Config
+
+
+def _run(tmp, cfg=None):
+    cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+    with mock.patch("src.config.get_config", return_value=cfg), \
+         mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
+        result = CliRunner().invoke(simple_recorder.list_meetings, [])
+    return json.loads(
+        [ln for ln in result.output.splitlines() if ln.strip().startswith("[")][-1]
+    )
+
+
+def _write_note(tmp, stem, title):
+    output_dir = Path(tmp) / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / f"{stem}_summary.md").write_text(
+        f'---\ntitle: "{title}"\ndate: "2026-08-02T10:00:00"\n'
+        f'duration_seconds: 600\nlanguage: "en"\nis_diarised: false\n---\n\n'
+        "## Summary\n\nbody\n",
+        encoding="utf-8",
+    )
+
+
+def _write_recording(tmp, name):
+    recordings = Path(tmp) / "recordings"
+    recordings.mkdir(parents=True, exist_ok=True)
+    (recordings / name).write_bytes(b"stub")
+
+
+class ListMeetingsHasAudioTests(unittest.TestCase):
+    def test_flags_only_the_notes_whose_recording_survives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_note(tmp, "kept", "Kept")
+            _write_note(tmp, "gone", "Gone")
+            _write_recording(tmp, "kept.webm")
+
+            by_title = {m["session_info"]["name"]: m for m in _run(tmp)}
+            self.assertTrue(by_title["Kept"]["has_audio"])
+            self.assertFalse(by_title["Gone"]["has_audio"])
+
+    def test_any_recording_format_counts(self):
+        # The capture pipeline saves whatever the source produced -- .webm
+        # for system audio, .wav for native captures, .m4a/.mp3 for
+        # imports. Matching on the stem alone is what makes this correct
+        # for all of them; an extension whitelist would silently mark
+        # imported meetings as audio-less.
+        for extension in ("webm", "wav", "m4a", "mp3"):
+            with tempfile.TemporaryDirectory() as tmp:
+                _write_note(tmp, "note", "Note")
+                _write_recording(tmp, f"note.{extension}")
+                self.assertTrue(
+                    _run(tmp)[0]["has_audio"], f".{extension} was not recognised",
+                )
+
+    def test_a_recordings_dir_that_does_not_exist_is_not_an_error(self):
+        # Fresh install: nothing has audio, and the list must still render.
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_note(tmp, "note", "Note")
+            self.assertFalse(Path(tmp, "recordings").exists())
+            meetings = _run(tmp)
+            self.assertEqual(len(meetings), 1)
+            self.assertFalse(meetings[0]["has_audio"])
+
+    def test_a_similarly_named_recording_does_not_count_for_another_note(self):
+        # Prefix matching would wrongly flag "note" from "note-2.wav".
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_note(tmp, "note", "Note")
+            _write_recording(tmp, "note-2.wav")
+            self.assertFalse(_run(tmp)[0]["has_audio"])
+
+    def test_the_recordings_dir_is_listed_once_not_once_per_meeting(self):
+        # The guard on the "optimized for fast loading" promise: a
+        # per-meeting existence check would make cold start scale with
+        # library size. Counting listdir calls is what actually holds the
+        # implementation to a single listing.
+        with tempfile.TemporaryDirectory() as tmp:
+            for i in range(12):
+                _write_note(tmp, f"note{i}", f"Note {i}")
+            _write_recording(tmp, "note3.wav")
+
+            real_listdir = os.listdir
+            calls = []
+
+            def counting_listdir(path):
+                calls.append(str(path))
+                return real_listdir(path)
+
+            with mock.patch("os.listdir", side_effect=counting_listdir):
+                meetings = _run(tmp)
+
+            recordings_dir = str(Path(tmp) / "recordings")
+            self.assertEqual(
+                [c for c in calls if c == recordings_dir], [recordings_dir],
+                "the recordings dir must be listed exactly once for the whole list",
+            )
+            self.assertEqual(sum(1 for m in meetings if m["has_audio"]), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -363,6 +363,65 @@ class SampleSegmentsTests(unittest.TestCase):
             self.assertEqual(samples[0]["start"], 10.0)
             self.assertEqual(samples[0]["end"], 30.0)  # capped at SAMPLE_MAX_SECONDS
 
+    def test_a_gap_between_two_of_this_clusters_segments_is_not_spanned(self):
+        # Found by review. The range was min(start) to max(end) over every
+        # own segment inside the turn's bounds, so two segments with a hole
+        # between them produced ONE clip covering the hole as well. The hole
+        # is, by definition, time this cluster was NOT speaking; on a mic
+        # channel taken without headphones that is exactly where the remote
+        # voices sit. next_start and SAMPLE_MAX_SECONDS bound how far this
+        # can reach, they do not stop it.
+        #
+        # Here the cluster speaks 10-12 and again 20-22, and the next line
+        # is a minute away, so nothing else clips the range.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Speaker 2] first bit\n[01:00] [You] much later\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 10.0, "end": 12.0}, {"start": 20.0, "end": 22.0}],
+                turn_manifest=[
+                    {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                    {"start": 60.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(samples[0]["text"], "first bit")
+            self.assertEqual(
+                (samples[0]["start"], samples[0]["end"]), (10.0, 12.0),
+                "the clip stops where this cluster stopped speaking",
+            )
+
+    def test_a_short_pause_inside_one_turn_is_still_one_clip(self):
+        # The counterweight to the test above: a turn IS several consecutive
+        # segments of one speaker (src.transcriber merges them), separated
+        # by that speaker's own breathing pauses. Cutting at every one of
+        # those would leave two-second clips nobody can recognise a voice
+        # from -- the point of the panel.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Speaker 2] one continuous turn\n[01:00] [You] much later\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                [
+                    {"start": 10.0, "end": 15.0},
+                    {"start": 15.4, "end": 19.0},   # 0.4s pause
+                    {"start": 20.0, "end": 24.0},   # 1.0s pause
+                ],
+                turn_manifest=[
+                    {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                    {"start": 60.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual((samples[0]["start"], samples[0]["end"]), (10.0, 24.0))
+
     def test_two_turns_in_the_same_displayed_second_never_widen_the_clip(self):
         # Found by review, and it is the same failure class as the one
         # reported from real use. Transcript timestamps render as [MM:SS],

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -124,6 +124,49 @@ class MarkingPersistenceTests(unittest.TestCase):
             self.assertEqual(after["transcript_lines"], before["transcript_lines"])
             self.assertEqual(after["created_at"], before["created_at"])
 
+    def test_a_mark_landing_between_read_and_write_is_not_erased(self):
+        # From the review: the write is atomic, the read-modify-write is
+        # not. Two marks that overlap both start from the same sidecar, and
+        # the one that replaces the file second silently discards the
+        # other's marking -- along with whatever confirmation cleanup its
+        # caller already performed against it.
+        #
+        # Interleaved deterministically rather than with threads: a
+        # COMPLETE second marking lands after the first has read and before
+        # it writes, which is exactly the order that loses data.
+        import src.speaker_suggestions as ss
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp, clusters={
+                "SPEAKER_0": {"embedding": [1.0, 0.0], "speech_duration_seconds": 60.0,
+                              "segment_count": 10, "segments": []},
+                "SPEAKER_1": {"embedding": [0.0, 1.0], "speech_duration_seconds": 40.0,
+                              "segment_count": 8, "segments": []},
+            })
+            real_read = ss.read_speakers_sidecar
+            interleaved = {"done": False}
+
+            def read_then_let_someone_else_write(*args, **kwargs):
+                data = real_read(*args, **kwargs)
+                if not interleaved["done"]:
+                    interleaved["done"] = True
+                    ss.set_cluster_multi_speaker(
+                        output_dir, "mtg001", "system", "SPEAKER_1", True,
+                    )
+                return data
+
+            with mock.patch.object(
+                ss, "read_speakers_sidecar", side_effect=read_then_let_someone_else_write,
+            ):
+                ss.set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
+
+            clusters = read_speakers_sidecar(output_dir, "mtg001")["channels"]["system"]["clusters"]
+            self.assertTrue(clusters["SPEAKER_0"].get(MULTI_SPEAKER_KEY))
+            self.assertTrue(
+                clusters["SPEAKER_1"].get(MULTI_SPEAKER_KEY),
+                "the marking that landed in between must survive",
+            )
+
     def test_unknown_cluster_channel_or_meeting_returns_none(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = self._seed(tmp)

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -394,6 +394,78 @@ class SampleSegmentsTests(unittest.TestCase):
             )
             self.assertEqual([s["text"] for s in system], ["someone else speaking"])
 
+    def test_a_line_starting_inside_a_running_segment_plays_from_the_line(self):
+        # Measured on a real 37-minute call (system channel, 279 segments,
+        # 109 attributed lines): 64 of those lines start in the MIDDLE of one
+        # of the cluster's own segments rather than at its beginning, because
+        # a diarization segment routinely spans several transcript lines.
+        #
+        # Selecting only segments that START at or after the line skipped the
+        # very segment the line sits in, and the clip jumped to the next one.
+        # The two moments the panel actually showed:
+        #
+        #   line 28.0s  inside own segment 27.28-62.32  -> clip started 63.28 (+35.3s)
+        #   line 435.0s inside own segment 415.28-452.40 -> clip started 452.80 (+17.8s)
+        #
+        # The first misses the 0.5s tolerance by 0.22s. The quote and the
+        # audio then describe different moments, which is the one thing this
+        # pairing exists to prevent -- and it is worse than a missing clip,
+        # because the timestamp shown next to the quote is the CLIP's.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:28] [Others] the line that sits inside a running segment\n"
+                "[01:40] [Others] a later line of the same speaker\n",
+                encoding="utf-8",
+            )
+            manifest = [
+                {"start": 28.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 100.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            samples = extract_segment_samples(
+                transcript,
+                [
+                    {"start": 27.28, "end": 62.32},
+                    {"start": 63.28, "end": 83.0},
+                    {"start": 100.0, "end": 110.0},
+                ],
+                turn_manifest=manifest, target_ids={("system", "SPEAKER_0")},
+            )
+            first = next(s for s in samples if s["text"].startswith("the line that sits"))
+            self.assertAlmostEqual(
+                first["start"], 28.0, places=2,
+                msg="the clip must start at the quoted line, not at the next segment",
+            )
+            self.assertGreater(first["end"], first["start"])
+
+    def test_a_line_with_no_own_speech_anywhere_near_it_is_not_offered(self):
+        # The other half of the same defect. When the cluster genuinely has
+        # no segment covering or closely following the line, there is no
+        # moment to play: the old code walked forward to the cluster's next
+        # segment however far away that was (measured: up to 40s), producing
+        # this speaker's voice saying something entirely different from the
+        # quote. An unplayable entry is honest; a wrong one is not.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] a line this cluster has no audio for\n"
+                "[02:00] [Others] a line it does have audio for\n",
+                encoding="utf-8",
+            )
+            manifest = [
+                {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 120.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            samples = extract_segment_samples(
+                transcript, [{"start": 120.0, "end": 140.0}],
+                turn_manifest=manifest, target_ids={("system", "SPEAKER_0")},
+            )
+            orphan = next(s for s in samples if s["text"].startswith("a line this cluster has no"))
+            self.assertEqual(
+                orphan["start"], orphan["end"],
+                "a line 110s from this cluster's nearest speech is not playable",
+            )
+
     def test_a_manifest_that_does_not_line_up_is_refused_rather_than_mispaired(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = Path(tmp) / "t.txt"

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -438,6 +438,115 @@ class SampleSegmentsTests(unittest.TestCase):
             )
             self.assertGreater(first["end"], first["start"])
 
+    def test_the_tail_of_the_previous_turn_does_not_swallow_this_line(self):
+        # From the review of the fix above. Admitting a segment that has
+        # already ENDED by the line's marker (it fell inside the 0.5s
+        # tolerance) made it sort first; the 1.0s gap rule then stopped the
+        # range before the line's real speech began, and the moment came back
+        # unplayable. _format_timestamp truncates with int(), so a marker is
+        # never later than the speech it labels and a finished segment is
+        # always the previous turn's tail.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] the line whose own speech starts at 10.9\n"
+                "[00:12] [Others] the next line\n",
+                encoding="utf-8",
+            )
+            manifest = [
+                {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 12.0, "channel": "system", "diarization_speaker_id": "SPEAKER_1"},
+            ]
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 9.0, "end": 9.8}, {"start": 10.9, "end": 11.5}],
+                turn_manifest=manifest, target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(len(samples), 1)
+            self.assertAlmostEqual(samples[0]["start"], 10.9, places=2)
+            self.assertAlmostEqual(samples[0]["end"], 11.5, places=2)
+
+    def test_two_lines_in_the_same_displayed_second_still_reach_their_own_speech(self):
+        # Also from review. Markers are truncated to whole seconds, so two
+        # turns inside one second carry the same value and next_start ==
+        # start. Bounding the search at that value admitted only segments
+        # overlapping the marker -- the previous line's tail -- and excluded
+        # this line's own speech a fraction of a second later, playing 0.2s
+        # of the wrong person.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] the earlier line in this second\n"
+                "[00:10] [You] the later line in the same second\n",
+                encoding="utf-8",
+            )
+            manifest = [
+                {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 10.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 10.8, "end": 10.9}],
+                turn_manifest=manifest, target_ids={("mic", "SPEAKER_0")},
+            )
+            self.assertEqual(len(samples), 1)
+            self.assertGreater(
+                samples[0]["end"], samples[0]["start"],
+                "the later line's own segment must still be reachable",
+            )
+            self.assertAlmostEqual(samples[0]["end"], 10.9, places=2)
+
+    def test_a_segment_starting_in_the_marker_second_beats_the_previous_tail(self):
+        # Third review finding. A segment spanning the marker is ambiguous:
+        # usually it is the one the line sits in, but it can be the previous
+        # line's tail reaching past it. Since markers truncate, this line's
+        # speech starts within one second of its marker, so a segment
+        # STARTING in that window wins over a spanning one. Without this the
+        # clip opened on 0.2s of the previous line.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] the quoted line, speaking from 10.9\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 9.5, "end": 10.2}, {"start": 10.9, "end": 11.5}],
+                turn_manifest=[{"start": 10.0, "channel": "system",
+                                "diarization_speaker_id": "SPEAKER_0"}],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertAlmostEqual(samples[0]["start"], 10.9, places=2)
+            self.assertAlmostEqual(samples[0]["end"], 11.5, places=2)
+
+    def test_the_manifests_exact_start_beats_the_truncated_marker(self):
+        # [MM:SS] is rendered with int(), so two turns inside one second
+        # carry the same marker and cannot be told apart by it -- measured on
+        # real meetings, 18 of 264 and 34 of 643 lines share a displayed
+        # second. The manifest keeps each turn's real start, from the same
+        # run as the segments, so the pairing uses that. Here both lines are
+        # marked [00:10]; only the manifest says the second one starts at
+        # 10.8.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] the earlier turn in this second\n"
+                "[00:10] [Others] the later turn in the same second\n",
+                encoding="utf-8",
+            )
+            manifest = [
+                {"start": 10.1, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 10.8, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 10.1, "end": 10.2}, {"start": 10.8, "end": 11.5}],
+                turn_manifest=manifest, target_ids={("system", "SPEAKER_0")},
+            )
+            later = next(s for s in samples if s["text"].startswith("the later turn"))
+            self.assertAlmostEqual(later["start"], 10.8, places=2)
+            self.assertAlmostEqual(later["end"], 11.5, places=2)
+
     def test_a_line_with_no_own_speech_anywhere_near_it_is_not_offered(self):
         # The other half of the same defect. When the cluster genuinely has
         # no segment covering or closely following the line, there is no

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -247,12 +247,15 @@ class SampleSegmentsTests(unittest.TestCase):
                          [{"start": 1.0, "end": 2.0}])
         self.assertEqual(sample_segments([], limit=5), [])
 
-    def test_samples_survive_a_sidecar_with_no_turn_manifest(self):
+    def test_a_sidecar_without_a_turn_manifest_yields_playable_but_TEXTLESS_samples(self):
         # Every sidecar written by backfill-speaker-embeddings has no
-        # transcript_lines at all -- only the live pipeline writes one. A
-        # samples list sourced from that manifest would come back empty for
-        # exactly the historical meetings a human most needs help with, so
-        # this reads the saved transcript by timestamp instead.
+        # transcript_lines, and for those the transcript's [MM:SS] markers
+        # came from a DIFFERENT diarization run than the segments here.
+        # Measured on a real three-person call: not one of the owner's
+        # eleven lines fell inside a mic segment alone, while four of the
+        # other participants' lines did -- proximity was inverted, not just
+        # noisy. So no text is attributed at all. The timestamps and the
+        # audio stay, because those come from the same run as the segments.
         with tempfile.TemporaryDirectory() as tmp:
             transcript = Path(tmp) / "t.txt"
             transcript.write_text(
@@ -263,22 +266,58 @@ class SampleSegmentsTests(unittest.TestCase):
             samples = extract_segment_samples(
                 transcript, [{"start": 8.0, "end": 20.0}, {"start": 48.0, "end": 55.0}],
             )
-            self.assertEqual([s["text"] for s in samples],
-                             ["first excerpt here", "second excerpt here"])
+            self.assertEqual(len(samples), 2, "the moments are still offered to listen to")
+            self.assertEqual([s["text"] for s in samples], [None, None])
+            self.assertEqual([s["start"] for s in samples], [8.0, 48.0])
 
-    def test_segment_with_no_transcript_line_still_yields_a_playable_entry(self):
+    def test_a_turn_manifest_attributes_each_line_to_its_own_cluster(self):
+        # With exact provenance there is nothing to match: the i-th diarised
+        # line pairs with turn_manifest[i]. Crucially this INCLUDES lines
+        # labeled "You" -- on the mic channel the owner's own turns are
+        # exactly those, and the earlier code skipped them, which left the
+        # owner's cluster quoting whoever happened to overlap in time.
         with tempfile.TemporaryDirectory() as tmp:
             transcript = Path(tmp) / "t.txt"
-            transcript.write_text("[00:10] [Speaker 2] only line\n", encoding="utf-8")
-            samples = extract_segment_samples(
-                transcript, [{"start": 8.0, "end": 20.0}, {"start": 900.0, "end": 910.0}],
+            transcript.write_text(
+                "[00:10] [You] the owner speaking\n"
+                "[00:20] [Others] someone else speaking\n"
+                "[00:30] [You] the owner again\n",
+                encoding="utf-8",
             )
-            self.assertEqual(len(samples), 2)
-            self.assertIsNone(samples[1]["text"])
-            # Kept rather than dropped: the clip is still playable, and a
-            # dropped entry would shift every later index out of step with
-            # get-speaker-sample-audio --segment-index.
-            self.assertEqual(samples[1]["start"], 900.0)
+            manifest = [
+                {"start": 10.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 20.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 30.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            mic = extract_segment_samples(
+                transcript, [{"start": 8.0, "end": 15.0}, {"start": 28.0, "end": 35.0}],
+                turn_manifest=manifest, target_ids={("mic", "SPEAKER_0")},
+            )
+            self.assertEqual(
+                [s["text"] for s in mic],
+                ["the owner speaking", "the owner again"],
+                "the owner's own lines must reach the owner's own cluster",
+            )
+
+            system = extract_segment_samples(
+                transcript, [{"start": 18.0, "end": 25.0}],
+                turn_manifest=manifest, target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual([s["text"] for s in system], ["someone else speaking"])
+
+    def test_a_manifest_that_does_not_line_up_is_refused_rather_than_mispaired(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [You] one\n[00:20] [Others] two\n[00:30] [You] three\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript, [{"start": 8.0, "end": 15.0}],
+                turn_manifest=[{"start": 10.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"}],
+                target_ids={("mic", "SPEAKER_0")},
+            )
+            self.assertEqual([s["text"] for s in samples], [None])
 
     def test_segment_index_selects_the_matching_excerpt_and_refuses_out_of_range(self):
         # The single point where "play excerpt 3" turns into a time range.

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -499,6 +499,32 @@ class SampleSegmentsTests(unittest.TestCase):
                 "a swapped manifest must not put bob's line under alice's cluster",
             )
 
+    def test_two_turns_swapped_inside_one_second_are_refused(self):
+        # The narrower version of the test above, from the bot review: two
+        # turns at 10.1 and 10.8 BOTH render as [00:10], so comparing each
+        # entry against its line's displayed second cannot separate them,
+        # however exactly it is done. What still separates them is order --
+        # the manifest is built from a list sorted by start, so its starts
+        # never decrease. A swap does.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Speaker 2] alice speaking\n[00:10] [Speaker 3] bob speaking\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript, [{"start": 10.1, "end": 10.5}],
+                turn_manifest=[
+                    {"start": 10.8, "channel": "system", "diarization_speaker_id": "SPEAKER_1"},
+                    {"start": 10.1, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(
+                [s["text"] for s in samples], [None],
+                "a manifest whose turns run backwards cannot describe this transcript",
+            )
+
     def test_a_manifest_entry_that_is_not_an_object_is_refused_not_raised(self):
         # Also from that review: the sidecar is JSON, so an entry can be
         # anything, while every caller reaches straight for entry.get(...) --

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -416,6 +416,38 @@ class SampleSegmentsTests(unittest.TestCase):
             self.assertEqual(samples[0]["text"], "said something")
             self.assertEqual(samples[0]["start"], samples[0]["end"])
 
+    def test_the_unplaceable_moment_is_refused_by_the_half_that_plays_it(self):
+        # The other half of the test above, and the pairing that has broken
+        # twice already: the list says "nothing placeable here" with a
+        # zero-length range, and the extractor is what has to honour it. It
+        # did not -- its duration check ran after the two 0.3s pads, so the
+        # unplaceable moment came back as a 0.6s clip of whoever was
+        # actually speaking at that timestamp. Asserting the two functions
+        # against each other, not each against its own idea of the contract.
+        from src.speaker_suggestions import extract_speaker_sample_audio
+
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text("[01:00] [Speaker 2] said something\n", encoding="utf-8")
+            segments = [{"start": 5.0, "end": 8.0}]
+            samples = extract_segment_samples(
+                transcript, segments,
+                turn_manifest=[
+                    {"start": 60.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            audio = Path(tmp) / "a.wav"
+            audio.write_bytes(b"stub")
+            with mock.patch("src.transcriber._resolve_ffmpeg", return_value="/bin/ffmpeg"), \
+                 mock.patch("src.speaker_suggestions.subprocess.run") as run_mock:
+                played = extract_speaker_sample_audio(
+                    audio, "system", segments, Path(tmp) / "out.wav",
+                    segment_index=samples[0],
+                )
+            self.assertFalse(played)
+            run_mock.assert_not_called()
+
     def test_a_clip_never_runs_into_the_next_speakers_line(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = Path(tmp) / "t.txt"

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -28,6 +28,7 @@ import simple_recorder
 from src.config import Config
 from src.speaker_suggestions import (
     MULTI_SPEAKER_KEY,
+    extract_sample_text,
     ClusterContext,
     clusters_from_sidecar_channel,
     extract_segment_samples,
@@ -318,6 +319,94 @@ class SampleSegmentsTests(unittest.TestCase):
                 target_ids={("mic", "SPEAKER_0")},
             )
             self.assertEqual([s["text"] for s in samples], [None])
+
+    def test_a_multi_segment_turn_still_gets_its_text_and_a_matching_clip(self):
+        # The defect this pins, reported from real use: "the clips do not
+        # match the text 1:1, and often there is no text at all".
+        #
+        # src.transcriber merges consecutive segments of one speaker into a
+        # single TURN carrying only the FIRST segment's timestamp
+        # (transcriber.py: `if turns and turns[-1][1] == speaker:
+        # turns[-1][2].append(text)`). Selecting the longest SEGMENTS and
+        # then hunting for a line starting inside each one therefore misses
+        # every segment that is not a turn's first -- which is most of them.
+        #
+        # Here one turn at 10s spans three segments, the longest of which
+        # (30-45s) contains no line start at all. Segment-driven selection
+        # would offer that segment with no text; turn-driven selection
+        # offers the turn, with its text, and a clip covering the whole turn.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] one long uninterrupted turn\n"
+                "[01:00] [You] a reply from the owner\n",
+                encoding="utf-8",
+            )
+            segments = [
+                {"start": 10.0, "end": 20.0},
+                {"start": 21.0, "end": 29.0},
+                {"start": 30.0, "end": 45.0},   # longest, and holds no line start
+            ]
+            manifest = [
+                {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 60.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            samples = extract_segment_samples(
+                transcript, segments,
+                turn_manifest=manifest, target_ids={("system", "SPEAKER_0")},
+            )
+
+            self.assertEqual(len(samples), 1, "one turn, not three segments")
+            self.assertEqual(samples[0]["text"], "one long uninterrupted turn")
+            # The clip spans the WHOLE turn, not just one of its segments,
+            # so what is heard is what is written beside it.
+            self.assertEqual(samples[0]["start"], 10.0)
+            self.assertEqual(samples[0]["end"], 30.0)  # capped at SAMPLE_MAX_SECONDS
+
+    def test_a_clip_never_runs_into_the_next_speakers_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] first speaker\n[00:15] [You] second speaker\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                # The segment overruns the next line's start by 10s.
+                [{"start": 10.0, "end": 25.0}],
+                turn_manifest=[
+                    {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                    {"start": 15.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(samples[0]["end"], 15.0,
+                             "playing past the next line means playing the other person")
+
+    def test_the_collapsed_quote_is_one_of_the_expanded_excerpts(self):
+        # Two independent derivations of "the most representative thing this
+        # speaker said" drift apart, and the visible symptom is a collapsed
+        # row quoting a moment that expanding never offers.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] short one\n"
+                "[00:20] [Others] the substantially longer turn here\n"
+                "[02:00] [You] owner\n",
+                encoding="utf-8",
+            )
+            segments = [{"start": 10.0, "end": 12.0}, {"start": 20.0, "end": 40.0}]
+            manifest = [
+                {"start": 10.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 20.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 120.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            kwargs = dict(turn_manifest=manifest, target_ids={("system", "SPEAKER_0")})
+            samples = extract_segment_samples(transcript, segments, **kwargs)
+            quote = extract_sample_text(transcript, segments, **kwargs)
+
+            self.assertIn(quote, [s["text"] for s in samples])
+            self.assertEqual(quote, "the substantially longer turn here")
 
     def test_segment_index_selects_the_matching_excerpt_and_refuses_out_of_range(self):
         # The single point where "play excerpt 3" turns into a time range.

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -472,6 +472,47 @@ class SampleSegmentsTests(unittest.TestCase):
             )
             self.assertEqual([s["text"] for s in samples], ["one"])
 
+    def test_two_adjacent_turns_swapped_in_the_manifest_are_refused(self):
+        # Found by the cross-family review of the check above. Half a second
+        # of slop on each side made the accepted window two seconds wide for
+        # a one-second bucket, so two turns a second apart could be swapped
+        # and still pass -- and a swap is exactly what a reordered manifest
+        # is. No slop is needed: the manifest's `start` and the line's
+        # [MM:SS] are the SAME float, one of them truncated by
+        # src.transcriber._format_timestamp, so this can be checked exactly.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Speaker 2] alice speaking\n[00:11] [Speaker 3] bob speaking\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript, [{"start": 10.0, "end": 10.9}],
+                turn_manifest=[
+                    {"start": 11.0, "channel": "system", "diarization_speaker_id": "SPEAKER_1"},
+                    {"start": 10.5, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(
+                [s["text"] for s in samples], [None],
+                "a swapped manifest must not put bob's line under alice's cluster",
+            )
+
+    def test_a_manifest_entry_that_is_not_an_object_is_refused_not_raised(self):
+        # Also from that review: the sidecar is JSON, so an entry can be
+        # anything, while every caller reaches straight for entry.get(...) --
+        # and cluster_transcript_lines documents a never-raises contract.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text("[00:10] [Speaker 2] hello\n", encoding="utf-8")
+            samples = extract_segment_samples(
+                transcript, [{"start": 10.0, "end": 14.0}],
+                turn_manifest=[None],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual([s["text"] for s in samples], [None])
+
     def test_two_turns_in_the_same_displayed_second_never_widen_the_clip(self):
         # Found by review, and it is the same failure class as the one
         # reported from real use. Transcript timestamps render as [MM:SS],

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -363,6 +363,59 @@ class SampleSegmentsTests(unittest.TestCase):
             self.assertEqual(samples[0]["start"], 10.0)
             self.assertEqual(samples[0]["end"], 30.0)  # capped at SAMPLE_MAX_SECONDS
 
+    def test_two_turns_in_the_same_displayed_second_never_widen_the_clip(self):
+        # Found by review, and it is the same failure class as the one
+        # reported from real use. Transcript timestamps render as [MM:SS],
+        # so two turns inside ONE second carry the SAME value -- next_start
+        # then equals start, the bounded segment set comes back empty, and
+        # an earlier "window of N seconds around the timestamp" fallback
+        # took over. That window covered the NEXT speaker, i.e. it played
+        # somebody else under this speaker's name.
+        #
+        # Here Alice speaks 10.1-10.5 and Bob starts at 10.8; both lines
+        # render as [00:10]. Alice's clip must stay inside Alice's segment.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Speaker 2] alice speaking\n"
+                "[00:10] [Speaker 3] bob speaking\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 10.1, "end": 10.5}],
+                turn_manifest=[
+                    {"start": 10.1, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                    {"start": 10.8, "channel": "system", "diarization_speaker_id": "SPEAKER_1"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(samples[0]["text"], "alice speaking")
+            self.assertEqual((samples[0]["start"], samples[0]["end"]), (10.1, 10.5))
+            self.assertLess(
+                samples[0]["end"], 10.8,
+                "the clip must not reach the next speaker's segment",
+            )
+
+    def test_a_turn_with_no_segment_of_its_own_yields_no_playable_range(self):
+        # When nothing of this cluster sits at or after the line, there is
+        # no honest clip to offer. A zero-length range makes
+        # extract_speaker_sample_audio refuse (duration <= 0) rather than
+        # cutting arbitrary audio around the timestamp.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text("[01:00] [Speaker 2] said something\n", encoding="utf-8")
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 5.0, "end": 8.0}],   # entirely before the line
+                turn_manifest=[
+                    {"start": 60.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(samples[0]["text"], "said something")
+            self.assertEqual(samples[0]["start"], samples[0]["end"])
+
     def test_a_clip_never_runs_into_the_next_speakers_line(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = Path(tmp) / "t.txt"

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -547,6 +547,36 @@ class SampleSegmentsTests(unittest.TestCase):
             self.assertAlmostEqual(later["start"], 10.8, places=2)
             self.assertAlmostEqual(later["end"], 11.5, places=2)
 
+    def test_without_manifest_starts_a_shared_second_keeps_its_spanning_segment(self):
+        # Fifth review finding, reachable only on the marker fallback:
+        # _manifest_describes_lines skips entries with no usable start rather
+        # than refusing the manifest, so both lines here fall back to their
+        # rendered marker and share it. Preferring the segment that starts
+        # later in the truncation window then handed this line the SIBLING's
+        # speech. A shared second is itself the evidence that the later
+        # segment belongs to the sibling.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Others] the earlier turn in this second\n"
+                "[00:10] [Others] the later turn in the same second\n",
+                encoding="utf-8",
+            )
+            manifest = [
+                {"channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                {"channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            samples = extract_segment_samples(
+                transcript,
+                [{"start": 9.9, "end": 10.2}, {"start": 10.8, "end": 10.9}],
+                turn_manifest=manifest, target_ids={("system", "SPEAKER_0")},
+            )
+            earlier = next(s for s in samples if s["text"].startswith("the earlier turn"))
+            self.assertAlmostEqual(
+                earlier["start"], 10.0, places=2,
+                msg="the earlier line opens on the segment spanning its marker, not the sibling's",
+            )
+
     def test_a_line_with_no_own_speech_anywhere_near_it_is_not_offered(self):
         # The other half of the same defect. When the cluster genuinely has
         # no segment covering or closely following the line, there is no

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -429,6 +429,84 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 [p for p in cfg.get_person_profiles() if p.get("prototypes")], [],
             )
 
+    def test_marking_withdraws_a_confirmation_already_made_on_that_cluster(self):
+        # The realistic order of events: someone confirms a cluster, then
+        # listens to a second excerpt and realises two people are in it. If
+        # marking only blocked FUTURE confirms, the blended embedding would
+        # stay enrolled as that person -- the exact state this exists to
+        # prevent -- and stays reachable from enroll-self-from-person and
+        # from every future suggestion scored against that profile.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "system", "SPEAKER_0", "--new-person", "Julian"], tmp, cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            julian = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Julian")
+            self.assertEqual(len(julian["prototypes"]), 1)
+
+            marked = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "system", "SPEAKER_0"], tmp, cfg=cfg,
+            )
+            data = _last_json(marked.output)
+            self.assertTrue(data["success"])
+            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+
+            julian = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Julian")
+            self.assertEqual(
+                julian["prototypes"], [],
+                "a blended two-voice embedding must not stay enrolled as a person",
+            )
+
+    def test_a_marked_cluster_is_not_used_as_hard_negative_evidence(self):
+        # "Speaker B is not the person in cluster A" is only meaningful when
+        # A is one person. If A is a blend of two voices, the negative is
+        # recorded against a voice nobody has, and it suppresses real
+        # matches for B in unrelated meetings.
+        #
+        # The marking is applied via set_cluster_multi_speaker DIRECTLY, not
+        # via the CLI, and that is the point of the test. The CLI also
+        # strips A's confirmation (see the test above), which normally keeps
+        # A out of the hard-negative loop for a second reason -- so driving
+        # it through the CLI would pass whether or not this filter exists.
+        # This reproduces the state the filter alone has to handle: a marked
+        # cluster whose confirmation survived, which is reachable for real
+        # when remove_speaker_evidence cannot match a legacy prototype that
+        # predates the `channel` field.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+
+            self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "system", "SPEAKER_0", "--new-person", "Julian"], tmp, cfg=cfg,
+            )
+            julian = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Julian")
+            self.assertEqual(len(julian["prototypes"]), 1)
+
+            set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
+
+            result = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "system", "SPEAKER_1", "--new-person", "Max"], tmp, cfg=cfg,
+            )
+            data = _last_json(result.output)
+            self.assertTrue(data["success"])
+            self.assertEqual(
+                data["hard_negatives_added_against"], [],
+                "a mixed cluster must not be treated as confirmed-different evidence",
+            )
+
+            for person in cfg.get_person_profiles():
+                self.assertEqual(
+                    person.get("hard_negatives") or [], [],
+                    f"{person['display_name']} gained negative evidence from a mixed cluster",
+                )
+
     def test_confirm_speaker_still_accepts_an_unmarked_cluster(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -893,6 +893,132 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 "a negative earned by a DIFFERENT cluster is not this marking's to delete",
             )
 
+    def _seed_with_transcript(self, tmp, body, manifest):
+        output_dir = Path(tmp) / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        write_speakers_sidecar(output_dir, "mtg001", {
+            "mic": {
+                "recording_type": "in_person",
+                "clusters": {
+                    "SPEAKER_00": {
+                        "embedding": [1.0, 0.0], "speech_duration_seconds": 30.0,
+                        "segment_count": 5, "segments": [{"start": 4.0, "end": 6.0}],
+                    },
+                },
+            },
+        }, turn_manifest=manifest)
+        transcripts_dir = Path(tmp) / "transcripts"
+        transcripts_dir.mkdir(parents=True, exist_ok=True)
+        path = transcripts_dir / "mtg001_transcript.txt"
+        path.write_text(
+            "Session: mtg001\n\n" + "=" * 60 + "\n\n" + body, encoding="utf-8",
+        )
+        return path
+
+    def test_marking_a_confirmed_cluster_takes_the_name_out_of_the_transcript(self):
+        # The last of the three P1s from the bot review, and the one a user
+        # actually reads. confirm-speaker --relabel-transcript rewrites the
+        # cluster's lines to "Julian". Marking it as more than one person
+        # afterwards withdraws the profile, the prototype and the
+        # participants chip -- but left "Julian" standing in the saved
+        # transcript, which is what feeds the summary and every export. The
+        # app then knows the cluster holds several people while the
+        # artefact keeps naming one of them.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there\n\n[00:20] [You] hi back",
+                [
+                    {"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"},
+                    {"start": 20.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_01"},
+                ],
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            with mock.patch("src.config.get_config", return_value=cfg), \
+                 mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
+                confirmed = CliRunner().invoke(simple_recorder.confirm_speaker, [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Julian",
+                    "--relabel-transcript",
+                ])
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            self.assertIn("[00:05] [Julian] hello there", transcript.read_text())
+
+            result = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"], tmp, cfg=cfg,
+            )
+            data = _last_json(result.output)
+            self.assertTrue(data["success"])
+            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+
+            text = transcript.read_text()
+            self.assertNotIn("Julian", text, "the withdrawn name must leave the transcript too")
+            self.assertIn(
+                "[00:05] [Speaker 2] hello there", text,
+                "and the label the line carried before the confirmation comes back",
+            )
+            self.assertIn("[00:20] [You] hi back", text)  # never this cluster's line
+
+    def test_without_a_recorded_original_the_line_says_multiple_speakers(self):
+        # Every meeting confirmed before the original label was recorded has
+        # nothing to restore. Putting back "You" or "Speaker 3" would invent
+        # an attribution; leaving the person's name would keep the lie. The
+        # fallback states exactly what the user just decided.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp, "[00:05] [Julian] hello there",
+                [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Julian")
+            cfg.add_speaker_prototype(
+                person["person_id"], [1.0, 0.0], recording_type="in_person",
+                meeting_id="mtg001", diarization_speaker_id="SPEAKER_00",
+                speech_duration_seconds=30.0, segment_count=5,
+                created_from="user_confirmed", channel="mic",
+            )
+            result = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"], tmp, cfg=cfg,
+            )
+            data = _last_json(result.output)
+            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+            self.assertEqual(data["transcript_lines_restored"], 1)
+            self.assertIn("[00:05] [Multiple speakers] hello there", transcript.read_text())
+
+    def test_a_manifest_that_no_longer_fits_leaves_the_transcript_alone(self):
+        # The refusal branch. If the manifest cannot be paired with the
+        # transcript, the app does not know which lines belong to this
+        # cluster -- rewriting any of them would be guessing, and guessing
+        # here means putting a label on someone else's words. The file
+        # stays as it is, and the count says so instead of claiming a
+        # cleanup that never happened.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp, "[00:05] [Julian] hello there\n\n[00:20] [You] hi back",
+                # One entry, two diarised lines: cannot be paired.
+                [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Julian")
+            cfg.add_speaker_prototype(
+                person["person_id"], [1.0, 0.0], recording_type="in_person",
+                meeting_id="mtg001", diarization_speaker_id="SPEAKER_00",
+                speech_duration_seconds=30.0, segment_count=5,
+                created_from="user_confirmed", channel="mic",
+            )
+            result = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"], tmp, cfg=cfg,
+            )
+            data = _last_json(result.output)
+            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+            self.assertEqual(
+                data["transcript_lines_restored"], 0,
+                "a refusal must be reported as zero, not as a silent success",
+            )
+            self.assertIn("[00:05] [Julian] hello there", transcript.read_text())
+
     def test_unknown_cluster_fails_loudly_rather_than_marking_nothing(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -422,6 +422,56 @@ class SampleSegmentsTests(unittest.TestCase):
             )
             self.assertEqual((samples[0]["start"], samples[0]["end"]), (10.0, 24.0))
 
+    def test_a_stale_manifest_of_the_same_length_is_refused_rather_than_mispaired(self):
+        # The length check was the ONLY check, so a manifest that no longer
+        # describes this transcript -- written by an earlier transcription,
+        # or reordered -- passed it whenever the line count happened to
+        # survive, and every line was then attributed positionally to
+        # whatever cluster sat at that index. That is a quote from one
+        # person shown under another person's name, which is the single
+        # thing this panel must never do.
+        #
+        # Same three lines, same three entries, but the manifest's turns sit
+        # at 10/45/70 while the transcript's lines sit at 10/20/30.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [You] one\n[00:20] [Others] two\n[00:30] [You] three\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript, [{"start": 8.0, "end": 15.0}],
+                turn_manifest=[
+                    {"start": 10.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                    {"start": 45.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                    {"start": 70.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("mic", "SPEAKER_0")},
+            )
+            self.assertEqual(
+                [s["text"] for s in samples], [None],
+                "an unverifiable pairing yields the textless, audio-only fallback",
+            )
+
+    def test_a_manifest_that_still_describes_the_transcript_is_accepted(self):
+        # The guard above must not refuse the normal case: manifest starts
+        # are floats, the transcript's [MM:SS] is that float truncated to
+        # the second, so entry 20.9 legitimately pairs with the line [00:20].
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [You] one\n[00:20] [Others] two\n", encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript, [{"start": 10.0, "end": 15.0}],
+                turn_manifest=[
+                    {"start": 10.4, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                    {"start": 20.9, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+                ],
+                target_ids={("mic", "SPEAKER_0")},
+            )
+            self.assertEqual([s["text"] for s in samples], ["one"])
+
     def test_two_turns_in_the_same_displayed_second_never_widen_the_clip(self):
         # Found by review, and it is the same failure class as the one
         # reported from real use. Transcript timestamps render as [MM:SS],

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1,0 +1,517 @@
+"""The "this cluster holds more than one person" marking, and the
+multi-excerpt review samples built alongside it.
+
+Both exist for the same reason: a diarized cluster that quietly contains
+two people is invisible in every number the system produces. Measured
+against a real three-person call, the contaminated cluster sat at cosine
+distance 0.8270 from the person who contaminated it -- an ordinary
+cross-speaker distance, nowhere near any threshold. So the marking cannot
+be derived and has to be witnessed, and the samples are what let a human
+witness it (hearing two voices under one row).
+
+The tests that matter most here are the ones asserting what a marked
+cluster must NOT do, because those are the failure modes that are silent:
+a mixed cluster enrolled as a person poisons that profile for every future
+meeting, and nothing in the wrong suggestion months later points back at
+this cluster.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from click.testing import CliRunner
+
+import simple_recorder
+from src.config import Config
+from src.speaker_suggestions import (
+    MULTI_SPEAKER_KEY,
+    ClusterContext,
+    clusters_from_sidecar_channel,
+    extract_segment_samples,
+    merge_same_channel_fragments,
+    minimum_speaker_count,
+    read_speakers_sidecar,
+    sample_segments,
+    set_cluster_multi_speaker,
+    suggest_speaker,
+    suggest_speakers_for_meeting,
+    write_speakers_sidecar,
+)
+
+
+def _last_json(output):
+    line = [ln for ln in output.splitlines() if ln.strip().startswith("{")][-1]
+    return json.loads(line)
+
+
+def _profile(person_id, name, embedding, recording_type="remote", meetings=("m1", "m2")):
+    """A person with enough independent evidence to clear every gate, so a
+    test asserting "no suggestion" is asserting the marking's effect and
+    not some unrelated threshold quietly doing the work."""
+    return {
+        "person_id": person_id,
+        "display_name": name,
+        "prototypes": [
+            {"embedding_mean": embedding, "recording_type": recording_type, "meeting_id": m}
+            for m in meetings
+        ],
+        "hard_negatives": [],
+    }
+
+
+def _context(sid="SPEAKER_0", **kwargs):
+    base = dict(
+        meeting_id="mtg001", diarization_speaker_id=sid, recording_type="remote",
+        speech_duration_seconds=120.0, segment_count=20,
+    )
+    base.update(kwargs)
+    return ClusterContext(**base)
+
+
+class MarkingPersistenceTests(unittest.TestCase):
+    def _seed(self, tmp, clusters=None):
+        output_dir = Path(tmp) / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        write_speakers_sidecar(output_dir, "mtg001", {
+            "system": {
+                "recording_type": "remote",
+                "clusters": clusters or {
+                    "SPEAKER_0": {
+                        "embedding": [1.0, 0.0], "speech_duration_seconds": 60.0,
+                        "segment_count": 10, "segments": [{"start": 1.0, "end": 5.0}],
+                    },
+                },
+            },
+        }, turn_manifest=[{"start": 1.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"}])
+        return output_dir
+
+    def test_marking_round_trips_and_clears(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
+            sidecar = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertTrue(
+                sidecar["channels"]["system"]["clusters"]["SPEAKER_0"][MULTI_SPEAKER_KEY]
+            )
+
+            set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", False)
+            sidecar = read_speakers_sidecar(output_dir, "mtg001")
+            # Cleared by REMOVING the key, not by writing false -- absent and
+            # "not marked" must read identically, or every sidecar written
+            # before this feature existed would need a migration.
+            self.assertNotIn(
+                MULTI_SPEAKER_KEY, sidecar["channels"]["system"]["clusters"]["SPEAKER_0"],
+            )
+
+    def test_marking_preserves_embeddings_and_turn_manifest(self):
+        # The sidecar carries the only copy of this meeting's voice
+        # embeddings; once the source audio is gone they cannot be
+        # recomputed. A marking write that dropped them would destroy data
+        # silently, so assert the whole payload survives, not just the flag.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            before = read_speakers_sidecar(output_dir, "mtg001")
+            set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
+            after = read_speakers_sidecar(output_dir, "mtg001")
+
+            cluster_after = after["channels"]["system"]["clusters"]["SPEAKER_0"]
+            self.assertEqual(cluster_after["embedding"], [1.0, 0.0])
+            self.assertEqual(cluster_after["segments"], [{"start": 1.0, "end": 5.0}])
+            self.assertEqual(after["transcript_lines"], before["transcript_lines"])
+            self.assertEqual(after["created_at"], before["created_at"])
+
+    def test_unknown_cluster_channel_or_meeting_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            self.assertIsNone(
+                set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_9", True)
+            )
+            self.assertIsNone(
+                set_cluster_multi_speaker(output_dir, "mtg001", "mic", "SPEAKER_0", True)
+            )
+            self.assertIsNone(
+                set_cluster_multi_speaker(output_dir, "nope", "system", "SPEAKER_0", True)
+            )
+
+
+class MarkedClusterIsWithheldTests(unittest.TestCase):
+    def test_marked_cluster_gets_no_suggestion_despite_an_exact_match(self):
+        # The embedding is IDENTICAL to the profile's, so without the
+        # marking this is an unambiguous "confirmed". Anything short of
+        # status "none" here means the guard is not doing its job.
+        profiles = [_profile("p1", "Julian", [1.0, 0.0])]
+        unmarked = suggest_speaker([1.0, 0.0], _context(), profiles)
+        self.assertEqual(unmarked.status, "confirmed")
+
+        marked = suggest_speaker(
+            [1.0, 0.0], _context(contains_multiple_speakers=True), profiles,
+        )
+        self.assertEqual(marked.status, "none")
+        self.assertIsNone(marked.suggested_person_id)
+        # No candidates either: a ranking computed from a centroid blended
+        # across two people is not a weak guess about one person, it is a
+        # confident guess about a voice that does not exist. Offering it in
+        # a "Change" picker would invite exactly the wrong confirmation.
+        self.assertEqual(marked.candidates, [])
+
+    def test_marked_cluster_does_not_consume_the_person_it_resembles(self):
+        # Meeting-wide exclusivity means a "confirmed" cluster takes that
+        # person off the table for every other cluster. A mixed cluster
+        # must not be able to do that -- otherwise marking a contaminated
+        # cluster would COST the real cluster its correct suggestion,
+        # punishing the user for telling the truth.
+        profiles = [_profile("p1", "Julian", [1.0, 0.0])]
+        results = suggest_speakers_for_meeting({
+            "system": {
+                "SPEAKER_0": (
+                    [1.0, 0.0], _context("SPEAKER_0", contains_multiple_speakers=True),
+                ),
+                "SPEAKER_1": ([0.999, 0.045], _context("SPEAKER_1")),
+            },
+        }, profiles)
+
+        self.assertEqual(results["system"]["SPEAKER_0"].status, "none")
+        self.assertEqual(results["system"]["SPEAKER_1"].status, "confirmed")
+        self.assertEqual(results["system"]["SPEAKER_1"].suggested_person_id, "p1")
+
+    def test_marking_survives_a_fragment_merge(self):
+        # Contamination is a property of the audio, so folding a mixed
+        # fragment into a clean one yields a mixed cluster. The merged
+        # entry is what the panel and confirm-speaker actually operate on,
+        # so a marking that did not propagate would be silently ignored.
+        clusters = {
+            "SPEAKER_0": ([1.0, 0.0], _context("SPEAKER_0", speech_duration_seconds=90.0)),
+            "SPEAKER_1": (
+                [1.0, 0.0],
+                _context("SPEAKER_1", speech_duration_seconds=10.0,
+                         contains_multiple_speakers=True),
+            ),
+        }
+        merged, id_resolution = merge_same_channel_fragments(clusters)
+        self.assertEqual(id_resolution["SPEAKER_1"], "SPEAKER_0")
+        self.assertTrue(merged["SPEAKER_0"][1].contains_multiple_speakers)
+
+    def test_sidecar_flag_reaches_the_cluster_context(self):
+        clusters = clusters_from_sidecar_channel("mtg001", {
+            "recording_type": "remote",
+            "clusters": {
+                "SPEAKER_0": {"embedding": [1.0, 0.0], MULTI_SPEAKER_KEY: True},
+                "SPEAKER_1": {"embedding": [0.0, 1.0]},
+            },
+        })
+        self.assertTrue(clusters["SPEAKER_0"][1].contains_multiple_speakers)
+        self.assertFalse(clusters["SPEAKER_1"][1].contains_multiple_speakers)
+
+
+class MinimumSpeakerCountTests(unittest.TestCase):
+    def test_counts_clusters_plus_one_per_marked_cluster(self):
+        channels = {
+            "system": {"clusters": {
+                "SPEAKER_0": {MULTI_SPEAKER_KEY: True},
+                "SPEAKER_1": {},
+                "SPEAKER_2": {},
+                "SPEAKER_3": {},
+            }},
+            "mic": {"clusters": {"SPEAKER_0": {}}},
+        }
+        # Four system clusters (Sortformer's hard ceiling) with one of them
+        # known-mixed, plus the owner's mic cluster: at least six people
+        # were in a meeting the diarizer described with five clusters.
+        self.assertEqual(minimum_speaker_count(channels), 6)
+
+    def test_empty_and_absent_channels_are_zero(self):
+        self.assertEqual(minimum_speaker_count({}), 0)
+        self.assertEqual(minimum_speaker_count({"system": {}}), 0)
+
+
+class SampleSegmentsTests(unittest.TestCase):
+    def test_picks_the_longest_turns_but_returns_them_chronologically(self):
+        segments = [
+            {"start": 100.0, "end": 101.0},   # 1s  - dropped
+            {"start": 10.0, "end": 25.0},     # 15s
+            {"start": 50.0, "end": 58.0},     # 8s
+            {"start": 200.0, "end": 202.0},   # 2s  - dropped
+            {"start": 5.0, "end": 15.0},      # 10s
+        ]
+        chosen = sample_segments(segments, limit=3)
+        self.assertEqual(
+            [s["start"] for s in chosen], [5.0, 10.0, 50.0],
+            "the three longest turns, in the order they occur in the recording",
+        )
+
+    def test_fewer_segments_than_the_limit_is_not_padded(self):
+        self.assertEqual(sample_segments([{"start": 1.0, "end": 2.0}], limit=5),
+                         [{"start": 1.0, "end": 2.0}])
+        self.assertEqual(sample_segments([], limit=5), [])
+
+    def test_samples_survive_a_sidecar_with_no_turn_manifest(self):
+        # Every sidecar written by backfill-speaker-embeddings has no
+        # transcript_lines at all -- only the live pipeline writes one. A
+        # samples list sourced from that manifest would come back empty for
+        # exactly the historical meetings a human most needs help with, so
+        # this reads the saved transcript by timestamp instead.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text(
+                "[00:10] [Speaker 2] first excerpt here\n"
+                "[00:50] [Speaker 2] second excerpt here\n",
+                encoding="utf-8",
+            )
+            samples = extract_segment_samples(
+                transcript, [{"start": 8.0, "end": 20.0}, {"start": 48.0, "end": 55.0}],
+            )
+            self.assertEqual([s["text"] for s in samples],
+                             ["first excerpt here", "second excerpt here"])
+
+    def test_segment_with_no_transcript_line_still_yields_a_playable_entry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "t.txt"
+            transcript.write_text("[00:10] [Speaker 2] only line\n", encoding="utf-8")
+            samples = extract_segment_samples(
+                transcript, [{"start": 8.0, "end": 20.0}, {"start": 900.0, "end": 910.0}],
+            )
+            self.assertEqual(len(samples), 2)
+            self.assertIsNone(samples[1]["text"])
+            # Kept rather than dropped: the clip is still playable, and a
+            # dropped entry would shift every later index out of step with
+            # get-speaker-sample-audio --segment-index.
+            self.assertEqual(samples[1]["start"], 900.0)
+
+    def test_segment_index_selects_the_matching_excerpt_and_refuses_out_of_range(self):
+        # The single point where "play excerpt 3" turns into a time range.
+        # Getting it wrong is invisible to the person using it -- they hear a
+        # different moment than the text beside it and conclude two speakers
+        # sound alike -- so an out-of-range index must fail rather than fall
+        # back to the longest turn.
+        from src.speaker_suggestions import extract_speaker_sample_audio
+
+        segments = [
+            {"start": 120.0, "end": 128.0},
+            {"start": 10.0, "end": 30.0},
+            {"start": 60.0, "end": 62.0},
+        ]
+        captured = []
+
+        class _Result:
+            returncode = 0
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            Path(cmd[-1]).write_bytes(b"wav")
+            return _Result()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio = Path(tmp) / "a.wav"
+            audio.write_bytes(b"stub")
+            out = Path(tmp) / "out.wav"
+
+            with mock.patch("src.transcriber._resolve_ffmpeg", return_value="/bin/ffmpeg"), \
+                 mock.patch("subprocess.run", side_effect=fake_run):
+                # Index 1 is the SECOND entry chronologically (60.0), not the
+                # second-longest -- the list is chronological by contract.
+                self.assertTrue(
+                    extract_speaker_sample_audio(audio, "system", segments, out, segment_index=1)
+                )
+                start_arg = captured[-1][captured[-1].index("-ss") + 1]
+                self.assertAlmostEqual(float(start_arg), 60.0 - 0.3, places=3)
+
+                self.assertFalse(
+                    extract_speaker_sample_audio(audio, "system", segments, out, segment_index=9)
+                )
+                self.assertFalse(
+                    extract_speaker_sample_audio(audio, "system", segments, out, segment_index=-1)
+                )
+
+    def test_missing_transcript_yields_textless_entries_not_an_error(self):
+        samples = extract_segment_samples(
+            Path("/nonexistent/t.txt"), [{"start": 1.0, "end": 5.0}],
+        )
+        self.assertEqual(len(samples), 1)
+        self.assertIsNone(samples[0]["text"])
+
+
+class MarkSpeakerClusterCliTests(unittest.TestCase):
+    def _seed(self, tmp, clusters=None):
+        output_dir = Path(tmp) / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        write_speakers_sidecar(output_dir, "mtg001", {
+            "system": {
+                "recording_type": "remote",
+                "clusters": clusters or {
+                    "SPEAKER_0": {
+                        "embedding": [1.0, 0.0], "speech_duration_seconds": 60.0,
+                        "segment_count": 10, "segments": [{"start": 1.0, "end": 5.0}],
+                    },
+                    "SPEAKER_1": {
+                        "embedding": [0.0, 1.0], "speech_duration_seconds": 40.0,
+                        "segment_count": 8, "segments": [{"start": 20.0, "end": 24.0}],
+                    },
+                },
+            },
+        })
+        return output_dir
+
+    def _run(self, command, args, tmp, cfg=None):
+        cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        with mock.patch("src.config.get_config", return_value=cfg), \
+             mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
+            return CliRunner().invoke(command, args)
+
+    def test_marks_and_reports_the_new_minimum_speaker_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            result = self._run(
+                simple_recorder.mark_speaker_cluster, ["mtg001", "system", "SPEAKER_0"], tmp,
+            )
+            data = _last_json(result.output)
+            self.assertTrue(data["success"])
+            self.assertTrue(data["contains_multiple_speakers"])
+            self.assertEqual(data["minimum_speaker_count"], 3)
+
+    def test_unknown_cluster_fails_loudly_rather_than_marking_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            result = self._run(
+                simple_recorder.mark_speaker_cluster, ["mtg001", "system", "SPEAKER_9"], tmp,
+            )
+            self.assertEqual(result.exit_code, 1)
+            self.assertFalse(_last_json(result.output)["success"])
+
+    def test_suggest_speakers_reports_the_marking_and_withholds_the_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Julian")
+            for meeting in ("other1", "other2"):
+                cfg.add_speaker_prototype(
+                    person["person_id"], [1.0, 0.0], recording_type="remote",
+                    meeting_id=meeting, diarization_speaker_id="SPEAKER_0",
+                    speech_duration_seconds=120.0, segment_count=20,
+                    created_from="user_confirmed", channel="system",
+                )
+
+            before = _last_json(
+                self._run(simple_recorder.suggest_speakers, ["mtg001"], tmp, cfg=cfg).output
+            )
+            self.assertEqual(before["channels"]["system"]["SPEAKER_0"]["status"], "confirmed")
+
+            set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
+            after = _last_json(
+                self._run(simple_recorder.suggest_speakers, ["mtg001"], tmp, cfg=cfg).output
+            )
+            cluster = after["channels"]["system"]["SPEAKER_0"]
+            self.assertEqual(cluster["status"], "none")
+            self.assertTrue(cluster["contains_multiple_speakers"])
+            self.assertEqual(after["minimum_speaker_count"], 3)
+
+    def test_confirm_speaker_refuses_a_marked_cluster(self):
+        # The guarantee, as opposed to the panel's convenience: a confirm
+        # turns this blended centroid into a stored prototype AND into
+        # hard-negative evidence against everyone else in the channel,
+        # degrading suggestions in unrelated future meetings with nothing
+        # pointing back at the cause.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
+
+            result = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "system", "SPEAKER_0", "--new-person", "Julian"], tmp, cfg=cfg,
+            )
+            self.assertEqual(result.exit_code, 1)
+            self.assertFalse(_last_json(result.output)["success"])
+            # And nothing was half-written on the way to refusing.
+            self.assertEqual(
+                [p for p in cfg.get_person_profiles() if p.get("prototypes")], [],
+            )
+
+    def test_confirm_speaker_still_accepts_an_unmarked_cluster(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            result = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "system", "SPEAKER_1", "--new-person", "Julian"], tmp, cfg=cfg,
+            )
+            self.assertTrue(_last_json(result.output)["success"])
+
+
+class SpeakerNamingStatusCliTests(unittest.TestCase):
+    """Feeds the one sentence shown before a delete. A CONFIRMED person
+    survives the delete (their prototype lives in config.json, bound to no
+    meeting); an UNNAMED cluster does not, and cannot be recovered by any
+    means once the audio is gone -- naming a voice requires hearing it."""
+
+    def _run(self, args, tmp, cfg=None):
+        cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        with mock.patch("src.config.get_config", return_value=cfg), \
+             mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
+            return CliRunner().invoke(simple_recorder.speaker_naming_status, args)
+
+    def _seed(self, tmp):
+        output_dir = Path(tmp) / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        write_speakers_sidecar(output_dir, "mtg001", {
+            "system": {
+                "recording_type": "remote",
+                "clusters": {
+                    "SPEAKER_0": {"embedding": [1.0, 0.0], "speech_duration_seconds": 60.0,
+                                  "segment_count": 10, "segments": [{"start": 1.0, "end": 5.0}]},
+                    "SPEAKER_1": {"embedding": [0.0, 1.0], "speech_duration_seconds": 40.0,
+                                  "segment_count": 8, "segments": [{"start": 20.0, "end": 24.0}]},
+                },
+            },
+        })
+        return output_dir
+
+    def test_counts_unnamed_clusters(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            data = _last_json(self._run(["mtg001"], tmp).output)
+            self.assertTrue(data["has_sidecar"])
+            self.assertEqual(data["total_clusters"], 2)
+            self.assertEqual(data["unnamed_clusters"], 2)
+
+    def test_a_confirmed_cluster_no_longer_counts_as_unnamed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Julian")
+            cfg.add_speaker_prototype(
+                person["person_id"], [1.0, 0.0], recording_type="remote",
+                meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
+                speech_duration_seconds=60.0, segment_count=10,
+                created_from="user_confirmed", channel="system",
+            )
+            data = _last_json(self._run(["mtg001"], tmp, cfg=cfg).output)
+            self.assertEqual(data["named_clusters"], 1)
+            self.assertEqual(data["unnamed_clusters"], 1)
+
+    def test_a_marked_cluster_is_not_counted_as_waiting_to_be_named(self):
+        # It has already been reviewed and ruled out. Counting it would nag
+        # about the one row that can never be resolved.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
+            data = _last_json(self._run(["mtg001"], tmp).output)
+            self.assertEqual(data["total_clusters"], 1)
+            self.assertEqual(data["unnamed_clusters"], 1)
+
+    def test_a_meeting_with_no_sidecar_is_success_with_nothing_at_risk(self):
+        # Not an error: a caller deciding whether to show a warning wants
+        # "nothing to warn about", and a delete must never be blocked by
+        # this check failing.
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "output").mkdir(parents=True, exist_ok=True)
+            data = _last_json(self._run(["never-diarised"], tmp).output)
+            self.assertTrue(data["success"])
+            self.assertFalse(data["has_sidecar"])
+            self.assertEqual(data["unnamed_clusters"], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -208,7 +208,7 @@ class MarkedClusterIsWithheldTests(unittest.TestCase):
 
 
 class MinimumSpeakerCountTests(unittest.TestCase):
-    def test_counts_clusters_plus_one_per_marked_cluster(self):
+    def test_counts_the_largest_channel_plus_one_per_marked_cluster(self):
         channels = {
             "system": {"clusters": {
                 "SPEAKER_0": {MULTI_SPEAKER_KEY: True},
@@ -219,13 +219,58 @@ class MinimumSpeakerCountTests(unittest.TestCase):
             "mic": {"clusters": {"SPEAKER_0": {}}},
         }
         # Four system clusters (Sortformer's hard ceiling) with one of them
-        # known-mixed, plus the owner's mic cluster: at least six people
-        # were in a meeting the diarizer described with five clusters.
-        self.assertEqual(minimum_speaker_count(channels), 6)
+        # known-mixed: at least five people were on that channel alone.
+        #
+        # This assertion used to read 6, adding the owner's mic cluster on
+        # top. That was a claim the data does not support: a remote voice
+        # coming out of the speakers lands in the microphone too, so the mic
+        # cluster may be one of the four already counted. Five is the
+        # smallest count consistent with the sidecar, and a minimum that
+        # overstates is wrong in a way that understating is not -- it would
+        # tell someone to go looking for a person who was never there.
+        self.assertEqual(minimum_speaker_count(channels), 5)
 
     def test_empty_and_absent_channels_are_zero(self):
         self.assertEqual(minimum_speaker_count({}), 0)
         self.assertEqual(minimum_speaker_count({"system": {}}), 0)
+
+    def test_two_fragments_of_one_voice_count_as_one_person(self):
+        # From the bot review. The panel collapses diarizer fragments of one
+        # voice into a single row (merge_same_channel_fragments), so counting
+        # raw sidecar clusters told the user "at least 2 people" while
+        # showing them one -- a number that contradicts the list beside it.
+        channels = {
+            "system": {
+                "recording_type": "remote",
+                "clusters": {
+                    # Pairwise distance far below the merge threshold: one voice.
+                    "SPEAKER_0": {"embedding": [1.0, 0.0], "speech_duration_seconds": 60.0,
+                                  "segment_count": 10, "segments": []},
+                    "SPEAKER_1": {"embedding": [0.999, 0.045], "speech_duration_seconds": 30.0,
+                                  "segment_count": 5, "segments": []},
+                },
+            },
+        }
+        self.assertEqual(minimum_speaker_count(channels), 1)
+
+    def test_channels_are_not_summed_because_one_voice_can_be_in_both(self):
+        # Also from the review, and the reason the old number could exceed
+        # the truth: a remote voice coming out of the speakers is picked up
+        # by the microphone too, so a mic cluster and a system cluster can be
+        # the SAME person. Nothing in the sidecar says whether they are, so
+        # the smallest count consistent with the data is the larger channel,
+        # not the sum. A minimum that overstates is simply wrong; one that
+        # understates is merely weak.
+        channels = {
+            "system": {"recording_type": "remote", "clusters": {
+                "SPEAKER_0": {"embedding": [1.0, 0.0]},
+                "SPEAKER_1": {"embedding": [0.0, 1.0]},
+            }},
+            "mic": {"recording_type": "local", "clusters": {
+                "SPEAKER_0": {"embedding": [1.0, 0.0]},
+            }},
+        }
+        self.assertEqual(minimum_speaker_count(channels), 2)
 
 
 class SampleSegmentsTests(unittest.TestCase):
@@ -759,6 +804,51 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertTrue(data["success"])
             self.assertTrue(data["contains_multiple_speakers"])
             self.assertEqual(data["minimum_speaker_count"], 3)
+
+    def test_marking_one_cluster_keeps_the_negatives_earned_by_the_others(self):
+        # From the bot review, and it destroys data. A person's hard
+        # negatives are created when OTHER clusters are confirmed as
+        # somebody else -- "this voice is not Julian" is evidence about
+        # THAT cluster. Marking cluster A as mixed cleared every negative
+        # the person had in this meeting and channel, including the ones
+        # earned by clusters B and C, which are untouched by the marking
+        # and stay true. The loss is silent and only shows up months later
+        # as a worse suggestion.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Julian")
+            pid = person["person_id"]
+            # Confirmed on SPEAKER_0 (the cluster about to be marked)...
+            cfg.add_speaker_prototype(
+                pid, [1.0, 0.0], recording_type="remote", meeting_id="mtg001",
+                diarization_speaker_id="SPEAKER_0", speech_duration_seconds=60.0,
+                segment_count=10, created_from="user_confirmed", channel="system",
+            )
+            # ...and ruled OUT for SPEAKER_1 by a different confirmation.
+            cfg.add_speaker_prototype(
+                pid, [0.0, 1.0], recording_type="remote", meeting_id="mtg001",
+                diarization_speaker_id="SPEAKER_1", speech_duration_seconds=40.0,
+                segment_count=8, created_from="user_confirmed", channel="system",
+                negative=True,
+            )
+
+            result = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "system", "SPEAKER_0"], tmp, cfg=cfg,
+            )
+            self.assertTrue(_last_json(result.output)["success"])
+
+            profile = cfg.get_person_profile(pid)
+            self.assertEqual(
+                [p["diarization_speaker_id"] for p in profile["prototypes"]], [],
+                "the marked cluster's own prototype must go",
+            )
+            self.assertEqual(
+                [n["diarization_speaker_id"] for n in profile["hard_negatives"]],
+                ["SPEAKER_1"],
+                "a negative earned by a DIFFERENT cluster is not this marking's to delete",
+            )
 
     def test_unknown_cluster_fails_loudly_rather_than_marking_nothing(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_speaker_suggestions.py
+++ b/tests/test_speaker_suggestions.py
@@ -1195,6 +1195,26 @@ class ExtractSpeakerSampleAudioTests(unittest.TestCase):
             cmd = run_mock.call_args[0][0]
             self.assertIn("pan=mono|c0=c0", cmd)
 
+    def test_padding_never_turns_a_zero_length_range_into_a_clip(self):
+        # _turn_audio_range returns (start, start) when this cluster has no
+        # segment of its own at or after the line, and its docstring says
+        # this function then refuses. It did not: the duration check ran
+        # AFTER the two 0.3s pads were added, so a range meaning "we cannot
+        # place this moment" still cut 0.6s of audio around the timestamp --
+        # i.e. potentially the voice of whoever WAS speaking there, played
+        # under this speaker's name.
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_path = Path(tmp) / "mtg001.wav"
+            audio_path.write_bytes(b"stub")
+            with mock.patch("src.transcriber._resolve_ffmpeg", return_value="/usr/bin/ffmpeg"), \
+                 mock.patch("src.speaker_suggestions.subprocess.run") as run_mock:
+                ok = extract_speaker_sample_audio(
+                    audio_path, "mic", [{"start": 4.0, "end": 6.0}], Path(tmp) / "out.wav",
+                    segment_index={"start": 60.0, "end": 60.0},
+                )
+            self.assertFalse(ok)
+            run_mock.assert_not_called()
+
     def test_returns_false_when_ffmpeg_fails(self):
         with tempfile.TemporaryDirectory() as tmp:
             audio_path = Path(tmp) / "mtg001.wav"

--- a/tests/test_speaker_suggestions.py
+++ b/tests/test_speaker_suggestions.py
@@ -983,6 +983,17 @@ class RelabelTranscriptExactTests(unittest.TestCase):
             self.assertIn("[00:05] [Speaker 2] first", text)
             self.assertIn("[00:10] [Speaker 3] second", text)
 
+    def test_a_manifest_entry_that_is_not_an_object_is_refused_not_raised(self):
+        # This function documents the same never-raises contract as
+        # relabel_transcript_speaker, and the manifest comes out of a JSON
+        # sidecar, so an entry can be anything -- while the pairing loop
+        # reaches straight for entry.get(...).
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
+            changed = relabel_transcript_exact(path, [None], {("mic", "SPEAKER_0")}, "Julian")
+            self.assertEqual(changed, 0)
+            self.assertIn("[00:05] [Speaker 2] hello there", path.read_text())
+
     def test_length_mismatch_refuses_to_guess_and_returns_zero(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(

--- a/tests/test_speaker_suggestions.py
+++ b/tests/test_speaker_suggestions.py
@@ -1108,14 +1108,24 @@ class ExtractSampleTextTests(unittest.TestCase):
             path = Path(tmp) / "nonexistent.txt"
             self.assertIsNone(extract_sample_text(path, [{"start": 4.0, "end": 6.0}]))
 
-    def test_returns_none_when_nothing_overlaps(self):
+    def test_the_manifest_wins_when_the_segments_disagree_with_it(self):
+        # The manifest records which cluster produced each line at the
+        # moment the line was written; the segments are the same run's
+        # acoustics. When they disagree -- here the only segment sits at
+        # 4-6s while the owned line is at 50s -- the manifest is the more
+        # precise record, so the quote stands and the clip falls back to a
+        # window at the line's own timestamp. Withholding the text instead
+        # would drop a line this cluster demonstrably spoke.
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:50] [Speaker 2] hello there")
-            self.assertIsNone(extract_sample_text(
-                path, [{"start": 4.0, "end": 6.0}],
-                turn_manifest=self._manifest((50.0, "system", "SPEAKER_0")),
-                target_ids={("system", "SPEAKER_0")},
-            ))
+            self.assertEqual(
+                extract_sample_text(
+                    path, [{"start": 4.0, "end": 6.0}],
+                    turn_manifest=self._manifest((50.0, "system", "SPEAKER_0")),
+                    target_ids={("system", "SPEAKER_0")},
+                ),
+                "hello there",
+            )
 
 
 class ExtractSpeakerSampleAudioTests(unittest.TestCase):

--- a/tests/test_speaker_suggestions.py
+++ b/tests/test_speaker_suggestions.py
@@ -987,6 +987,31 @@ class LongestSegmentTests(unittest.TestCase):
 
 
 class ExtractSampleTextTests(unittest.TestCase):
+    """Excerpt text is attributed by the sidecar's turn manifest ONLY.
+
+    This class used to assert timestamp-proximity matching plus a blanket
+    "never quote a line labeled You" rule. Both were changed after a real
+    three-person call showed what they produce together: the device owner's
+    own mic cluster quoted ANOTHER participant's sentences. The owner's
+    turns are exactly the lines labeled "You", so skipping them left that
+    cluster with none of its own speech, and proximity then supplied
+    whatever overlapped in time on the other channel.
+
+    Measured on that recording, label against which channel's segments
+    covered the line's timestamp:
+
+        label      in-mic  in-sys  in-both  in-neither
+        You             0       3        7           1
+        <other>         4      13        4           0
+
+    Not one owner line in a mic segment alone; four of the other
+    participants' lines in one. Proximity was inverted, not noisy -- a
+    backfilled sidecar re-diarizes in its own run, so its boundaries were
+    never the ones the saved transcript's timestamps came from, and a call
+    taken without headphones puts the remote voices into the mic channel
+    too. See cluster_transcript_lines.
+    """
+
     def _write_transcript(self, tmp, body):
         path = Path(tmp) / "mtg001_transcript.txt"
         path.write_text(
@@ -995,12 +1020,23 @@ class ExtractSampleTextTests(unittest.TestCase):
         )
         return path
 
+    @staticmethod
+    def _manifest(*entries):
+        return [
+            {"start": start, "channel": channel, "diarization_speaker_id": sid}
+            for start, channel, sid in entries
+        ]
+
     def test_extracts_text_at_the_longest_segment(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(
                 tmp, "[00:05] [Speaker 2] hello there, how are you doing today",
             )
-            text = extract_sample_text(path, [{"start": 4.0, "end": 6.0}])
+            text = extract_sample_text(
+                path, [{"start": 4.0, "end": 6.0}],
+                turn_manifest=self._manifest((5.0, "system", "SPEAKER_0")),
+                target_ids={("system", "SPEAKER_0")},
+            )
             self.assertEqual(text, "hello there, how are you doing today")
 
     def test_picks_the_longest_segment_when_several_given(self):
@@ -1015,20 +1051,50 @@ class ExtractSampleTextTests(unittest.TestCase):
             )
             text = extract_sample_text(
                 path, [{"start": 4.0, "end": 6.0}, {"start": 299.0, "end": 339.0}],
+                turn_manifest=self._manifest(
+                    (5.0, "system", "SPEAKER_0"), (300.0, "system", "SPEAKER_0"),
+                ),
+                target_ids={("system", "SPEAKER_0")},
             )
             self.assertEqual(text, "this is the real substantial turn that should be quoted")
 
-    def test_never_quotes_you(self):
+    def test_the_owners_own_line_IS_quoted_for_the_owners_own_cluster(self):
+        # The correction. A "You" line is the owner speaking, so it is
+        # exactly what the mic cluster should quote -- refusing it is what
+        # made the owner's row show someone else's words.
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [You] this is the device owner talking")
-            text = extract_sample_text(path, [{"start": 4.0, "end": 6.0}])
+            text = extract_sample_text(
+                path, [{"start": 4.0, "end": 6.0}],
+                turn_manifest=self._manifest((5.0, "mic", "SPEAKER_0")),
+                target_ids={("mic", "SPEAKER_0")},
+            )
+            self.assertEqual(text, "this is the device owner talking")
+
+    def test_another_channels_line_is_never_quoted_for_this_cluster(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_transcript(tmp, "[00:05] [Speaker 2] someone else entirely")
+            text = extract_sample_text(
+                path, [{"start": 4.0, "end": 6.0}],
+                turn_manifest=self._manifest((5.0, "system", "SPEAKER_0")),
+                target_ids={("mic", "SPEAKER_0")},
+            )
             self.assertIsNone(text)
+
+    def test_no_manifest_means_no_text_rather_than_a_guess(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
+            self.assertIsNone(extract_sample_text(path, [{"start": 4.0, "end": 6.0}]))
 
     def test_truncates_long_text_with_ellipsis(self):
         with tempfile.TemporaryDirectory() as tmp:
             long_text = "word " * 60
             path = self._write_transcript(tmp, f"[00:05] [Speaker 2] {long_text.strip()}")
-            text = extract_sample_text(path, [{"start": 4.0, "end": 6.0}], max_chars=20)
+            text = extract_sample_text(
+                path, [{"start": 4.0, "end": 6.0}], max_chars=20,
+                turn_manifest=self._manifest((5.0, "system", "SPEAKER_0")),
+                target_ids={("system", "SPEAKER_0")},
+            )
             self.assertLessEqual(len(text), 21)  # 20 + ellipsis char
             self.assertTrue(text.endswith("…"))
 
@@ -1045,7 +1111,11 @@ class ExtractSampleTextTests(unittest.TestCase):
     def test_returns_none_when_nothing_overlaps(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:50] [Speaker 2] hello there")
-            self.assertIsNone(extract_sample_text(path, [{"start": 4.0, "end": 6.0}]))
+            self.assertIsNone(extract_sample_text(
+                path, [{"start": 4.0, "end": 6.0}],
+                turn_manifest=self._manifest((50.0, "system", "SPEAKER_0")),
+                target_ids={("system", "SPEAKER_0")},
+            ))
 
 
 class ExtractSpeakerSampleAudioTests(unittest.TestCase):

--- a/tests/test_speaker_suggestions.py
+++ b/tests/test_speaker_suggestions.py
@@ -960,6 +960,29 @@ class RelabelTranscriptExactTests(unittest.TestCase):
             self.assertIn("[00:05] [Speaker 2] first", text)  # untouched -- position 0, mic
             self.assertIn("[00:05] [Inga Hahn] second", text)  # relabeled -- position 1, system
 
+    def test_a_stale_manifest_of_the_same_length_refuses_and_returns_zero(self):
+        # The length check was the only check, so a manifest describing a
+        # DIFFERENT transcription of this meeting -- a re-transcription, or
+        # a reordered write -- passed whenever the line count survived, and
+        # positional pairing then wrote a name onto lines that belong to
+        # someone else. Positional pairing is only sound while the two
+        # sequences still come from the same run, and the manifest's own
+        # `start` is the evidence for that: the transcript's [MM:SS] is that
+        # float truncated to the second.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_transcript(
+                tmp, "[00:05] [Speaker 2] first\n\n[00:10] [Speaker 3] second",
+            )
+            manifest = [
+                {"start": 5.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+                {"start": 42.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
+            ]
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_0")}, "Julian")
+            self.assertEqual(changed, 0)
+            text = path.read_text()
+            self.assertIn("[00:05] [Speaker 2] first", text)
+            self.assertIn("[00:10] [Speaker 3] second", text)
+
     def test_length_mismatch_refuses_to_guess_and_returns_zero(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(

--- a/tests/test_suggest_speakers_cli.py
+++ b/tests/test_suggest_speakers_cli.py
@@ -228,6 +228,13 @@ class SuggestSpeakersCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "output"
             output_dir.mkdir(parents=True, exist_ok=True)
+            # A turn_manifest is what makes the quote attributable at all.
+            # Without one the CLI returns no text rather than matching by
+            # timestamp -- a backfilled sidecar's segments come from a
+            # different diarization run than the transcript's [MM:SS]
+            # markers, and matching across the two put another
+            # participant's words under the owner's own cluster on a real
+            # recording (see cluster_transcript_lines).
             write_speakers_sidecar(output_dir, "mtg001", {
                 "system": {
                     "recording_type": "remote",
@@ -238,7 +245,9 @@ class SuggestSpeakersCliTests(unittest.TestCase):
                         },
                     },
                 },
-            })
+            }, turn_manifest=[
+                {"start": 5.0, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
+            ])
             transcripts_dir = Path(tmp) / "transcripts"
             transcripts_dir.mkdir(parents=True, exist_ok=True)
             (transcripts_dir / "mtg001_transcript.txt").write_text(

--- a/tests/test_suggest_speakers_cli.py
+++ b/tests/test_suggest_speakers_cli.py
@@ -369,7 +369,7 @@ class GetSpeakerSampleAudioCliTests(unittest.TestCase):
             self._seed_sidecar_and_recording(tmp)
             with mock.patch(
                 "src.speaker_suggestions.extract_speaker_sample_audio",
-                side_effect=lambda audio_path, channel, segments, output_path: (
+                side_effect=lambda audio_path, channel, segments, output_path, segment_index=None: (
                     output_path.write_bytes(b"wav-stub-bytes") or True
                 ),
             ):
@@ -384,7 +384,7 @@ class GetSpeakerSampleAudioCliTests(unittest.TestCase):
             self._seed_sidecar_and_recording(tmp)
             captured_path = {}
 
-            def fake_extract(audio_path, channel, segments, output_path):
+            def fake_extract(audio_path, channel, segments, output_path, segment_index=None):
                 captured_path["path"] = output_path
                 output_path.write_bytes(b"stub")
                 return True
@@ -461,7 +461,7 @@ class GetSpeakerSampleAudioCliTests(unittest.TestCase):
             (recordings_dir / "mtg001.wav").write_bytes(b"stub")
             captured = {}
 
-            def fake_extract(audio_path, channel, segments, output_path):
+            def fake_extract(audio_path, channel, segments, output_path, segment_index=None):
                 captured["output_path"] = output_path
                 captured["segments"] = segments
                 output_path.write_bytes(b"wav-stub")

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -327,6 +327,53 @@ class TranscribeDiarisedMultiSpeakerTests(unittest.TestCase):
         self.assertEqual(manifest[0]["start"], 0.0)
         self.assertEqual(manifest[3]["start"], 9.2)
 
+    def test_unplaceable_text_never_inherits_a_neighbouring_clusters_provenance(self):
+        # Found by review. Text the diarizer could not place is appended
+        # under the CHANNEL's own label -- and _cluster_channel_labels gives
+        # the channel's dominant cluster that exact same label. The turn
+        # loop coalesced on the label alone and kept the FIRST entry's
+        # raw_sid, so an unplaceable sentence landing after a dominant-
+        # cluster turn was silently recorded as that cluster's own speech.
+        #
+        # It would then reach a human twice: quoted under that speaker in
+        # the review panel, and rewritten to that person's name by
+        # confirm-speaker's relabel. Keeping the text while withholding the
+        # cluster id is the entire point of that fallback, and merging by
+        # label alone handed the id back.
+        mic_diar = [
+            {"start": 0.0, "end": 8.0, "speaker": "SPEAKER_1"},
+            {"start": 10.0, "end": 20.0, "speaker": "SPEAKER_0"},  # dominant -> labelled "You"
+        ]
+        # The system channel speaks EARLY, so nothing sits between the mic's
+        # dominant-cluster turn and the unplaceable sentence -- otherwise
+        # the other channel's turn breaks the run and hides the defect.
+        system_diar = [{"start": 5.0, "end": 5.5, "speaker": "SPEAKER_0"}]
+        with patch("src.transcriber._run_steno_diarize", side_effect=[(mic_diar, {}), (system_diar, {})]):
+            self.transcriber.transcribe_audio = Mock(side_effect=[
+                {"text": "Someone else. The owner. A stray sentence.", "segments": [
+                    {"text": "Someone else.", "start": 1.0, "end": 2.0},
+                    {"text": "The owner.", "start": 11.0, "end": 12.0},
+                    # Forty seconds from any mic segment: unplaceable, and it
+                    # sorts directly after the dominant cluster's turn.
+                    {"text": "A stray sentence.", "start": 60.0, "end": 61.0},
+                ]},
+                {"text": "Ok.", "segments": [{"text": "Ok.", "start": 5.2, "end": 5.4}]},
+            ])
+            result = self.transcriber.transcribe_diarised(self.audio_path)
+
+        mic_entries = [m for m in result["turn_manifest"] if m["channel"] == "mic"]
+        self.assertEqual(
+            [m["diarization_speaker_id"] for m in mic_entries],
+            ["SPEAKER_1", "SPEAKER_0", None],
+            "the unplaceable sentence must stay its own turn, with no cluster id",
+        )
+        # And it must not have been folded into the owner's line, which is
+        # what would put it under the owner's name on a relabel.
+        owner_line = [
+            line for line in result["diarised_text"].split("\n\n") if "The owner." in line
+        ][0]
+        self.assertNotIn("A stray sentence.", owner_line)
+
     def test_turn_manifest_has_none_raw_sid_entries_when_diarization_totally_fails(self):
         # is_diarised is about cross-channel label distinctness (You vs
         # Others), not per-channel diarization success -- a total
@@ -490,6 +537,37 @@ class TranscribeDiarisedMonoTests(unittest.TestCase):
         self.assertIn("[You] Great.", result["diarised_text"])
         # The plain text field is untouched by diarisation.
         self.assertEqual(result["text"], "Hi there. Not bad. Great.")
+
+    def test_unplaceable_text_never_inherits_a_neighbouring_clusters_provenance(self):
+        # The mono path builds its turns with its own copy of the same loop,
+        # so it needs its own assertion -- this file's history is that a fix
+        # applied to one path and not the other is how the defect comes back.
+        # See the stereo test of the same name for what is at stake.
+        diar_segments = [
+            {"start": 0.0, "end": 8.0, "speaker": "SPEAKER_1"},
+            {"start": 10.0, "end": 20.0, "speaker": "SPEAKER_0"},  # dominant -> labelled "You"
+        ]
+        with patch("src.transcriber._run_steno_diarize", return_value=(diar_segments, {})):
+            self.transcriber.transcribe_audio = Mock(return_value={
+                "text": "Someone else. The owner. A stray sentence.",
+                "segments": [
+                    {"text": "Someone else.", "start": 1.0, "end": 2.0},
+                    {"text": "The owner.", "start": 11.0, "end": 12.0},
+                    {"text": "A stray sentence.", "start": 60.0, "end": 61.0},
+                ],
+                "duration_seconds": 61.0,
+            })
+            result = self.transcriber.transcribe_diarised(self.audio_path)
+
+        self.assertEqual(
+            [m["diarization_speaker_id"] for m in result["turn_manifest"]],
+            ["SPEAKER_1", "SPEAKER_0", None],
+            "the unplaceable sentence must stay its own turn, with no cluster id",
+        )
+        owner_line = [
+            line for line in result["diarised_text"].split("\n\n") if "The owner." in line
+        ][0]
+        self.assertNotIn("A stray sentence.", owner_line)
 
     def test_single_speaker_mono_is_not_diarised(self):
         # Byte-identical-to-legacy fast path: one real cluster means nothing

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -34,6 +34,7 @@ from src.transcriber import (
     WhisperTranscriber,
     _apply_voiceprint_matches,
     _assign_asr_segments_to_diar_segments,
+    _clamp_overlapping_diar_segments,
     _cluster_channel_labels,
     _diarised_split_timeout,
     _format_timestamp,
@@ -807,6 +808,58 @@ class MergeCloseDiarSegmentsTests(unittest.TestCase):
         self.assertEqual(segments, [{"start": 0.0, "end": 1.0, "speaker": "SPEAKER_0"}])
 
 
+class ClampOverlappingDiarSegmentsTests(unittest.TestCase):
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(_clamp_overlapping_diar_segments([]), [])
+
+    def test_partial_overlap_is_given_to_the_earlier_speaker(self):
+        segments = [
+            {"start": 0.0, "end": 5.0, "speaker": "SPEAKER_0"},
+            {"start": 3.0, "end": 8.0, "speaker": "SPEAKER_1"},
+        ]
+        self.assertEqual(_clamp_overlapping_diar_segments(segments), [
+            {"start": 0.0, "end": 5.0, "speaker": "SPEAKER_0"},
+            {"start": 5.0, "end": 8.0, "speaker": "SPEAKER_1"},
+        ])
+
+    def test_untouched_when_nothing_overlaps(self):
+        segments = [
+            {"start": 0.0, "end": 2.0, "speaker": "SPEAKER_0"},
+            {"start": 2.5, "end": 4.0, "speaker": "SPEAKER_1"},
+        ]
+        self.assertEqual(_clamp_overlapping_diar_segments(segments), segments)
+
+    def test_fully_contained_segment_survives_instead_of_being_clamped_away(self):
+        # Clamping this one leaves nothing of it, and a cluster that only
+        # ever speaks inside someone else's turn would disappear from the
+        # channel entirely. Double-counted time is the cheaper mistake.
+        segments = [
+            {"start": 0.0, "end": 10.0, "speaker": "SPEAKER_0"},
+            {"start": 3.0, "end": 4.0, "speaker": "SPEAKER_1"},
+        ]
+        self.assertEqual(_clamp_overlapping_diar_segments(segments), segments)
+
+    def test_clamps_against_the_furthest_end_seen_not_just_the_previous(self):
+        # A long segment followed by a short nested one must not let the
+        # next real turn start back inside the long one.
+        segments = [
+            {"start": 0.0, "end": 10.0, "speaker": "SPEAKER_0"},
+            {"start": 3.0, "end": 4.0, "speaker": "SPEAKER_1"},
+            {"start": 8.0, "end": 12.0, "speaker": "SPEAKER_1"},
+        ]
+        self.assertEqual(_clamp_overlapping_diar_segments(segments)[2], {
+            "start": 10.0, "end": 12.0, "speaker": "SPEAKER_1",
+        })
+
+    def test_does_not_mutate_input(self):
+        segments = [
+            {"start": 0.0, "end": 5.0, "speaker": "SPEAKER_0"},
+            {"start": 3.0, "end": 8.0, "speaker": "SPEAKER_1"},
+        ]
+        _clamp_overlapping_diar_segments(segments)
+        self.assertEqual(segments[1]["start"], 3.0)
+
+
 class AssignAsrSegmentsToDiarSegmentsTests(unittest.TestCase):
     def test_empty_diar_segments_is_a_no_op(self):
         diar_segments = []
@@ -1517,6 +1570,42 @@ class RunStenoDiarizeTests(unittest.TestCase):
             ],
         )
         self.assertEqual(embeddings, {"SPEAKER_0": [0.1, 0.2], "SPEAKER_1": [0.3, 0.4]})
+
+    def test_cross_speaker_overlap_is_clamped_before_the_result_is_returned(self):
+        # Sortformer really does emit overlapping segments on single-mic
+        # audio. Returned as-is, the overlapped span counts toward BOTH
+        # clusters' speaking time, and that total is what decides whether
+        # a channel is treated as one voice or split into "Speaker N".
+        payload = json.dumps({
+            "segments": [
+                {"speakerId": "SPEAKER_0", "start": 0.0, "end": 5.0},
+                {"speakerId": "SPEAKER_1", "start": 3.0, "end": 8.0},
+            ],
+            "speakers": {},
+        }).encode()
+        with patch("src.transcriber._resolve_steno_diarize", return_value="/fake/steno-diarize"), \
+             _patch_popen(stdout=payload, stderr=b"", returncode=0):
+            segments, _ = _run_steno_diarize(Path("/fake/mic.wav"), 60)
+        self.assertEqual(segments, [
+            {"start": 0.0, "end": 5.0, "speaker": "SPEAKER_0"},
+            {"start": 5.0, "end": 8.0, "speaker": "SPEAKER_1"},
+        ])
+
+    def test_same_speaker_overlap_collapses_into_one_turn(self):
+        # Same-speaker overlap is diarizer flicker, not two voices -- it
+        # must merge into one turn rather than be clamped into two
+        # touching ones.
+        payload = json.dumps({
+            "segments": [
+                {"speakerId": "SPEAKER_0", "start": 0.0, "end": 5.0},
+                {"speakerId": "SPEAKER_0", "start": 3.0, "end": 8.0},
+            ],
+            "speakers": {},
+        }).encode()
+        with patch("src.transcriber._resolve_steno_diarize", return_value="/fake/steno-diarize"), \
+             _patch_popen(stdout=payload, stderr=b"", returncode=0):
+            segments, _ = _run_steno_diarize(Path("/fake/mic.wav"), 60)
+        self.assertEqual(segments, [{"start": 0.0, "end": 8.0, "speaker": "SPEAKER_0"}])
 
     def test_parses_json_with_trailing_warning_after_payload(self):
         # A real ~3.5h channel measured a late CoreML/Metal warning printed

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -25,6 +25,7 @@ from unittest.mock import Mock, patch
 from src.transcriber import (
     BLEED_JACCARD_THRESHOLD,
     CHANNEL_DOMINANCE_THRESHOLD,
+    DIAR_LABEL_FALLBACK_TOLERANCE_S,
     DIARISED_SPLIT_TIMEOUT_S,
     MIN_RMS_THRESHOLD,
     STENO_DIARIZE_MERGE_GAP_S,
@@ -924,6 +925,110 @@ class AssignAsrSegmentsToDiarSegmentsTests(unittest.TestCase):
         texts = [d["text"] for d in diar_segments]
         self.assertEqual(texts.count("one two three four"), 1)
 
+    def test_sentence_far_from_every_segment_is_returned_not_attributed(self):
+        # Regression for an unconditional "nearest" fallback: with the
+        # channel's only diarizer segment at 2-3s, text at 0-1s was
+        # attributed in full to a speaker the diarizer never heard there.
+        # It must come back unplaceable instead -- and the text must
+        # survive, so the caller can keep it under the channel's own label.
+        diar_segments = [{"start": 2.0, "end": 3.0, "speaker": "SPEAKER_0"}]
+        asr_segment = {"text": "Nobody was speaking here.", "start": 0.0, "end": 1.0}
+        unplaceable = _assign_asr_segments_to_diar_segments([asr_segment], diar_segments)
+        self.assertEqual(diar_segments[0]["text"], "")
+        self.assertEqual(unplaceable, [asr_segment])
+
+    def test_sentence_just_inside_the_tolerance_still_attaches(self):
+        # The bound only rejects text with no plausible turn nearby --
+        # ordinary boundary slop (a clipped onset, breath before a turn)
+        # must still land on the adjacent speaker, as it always has.
+        gap = DIAR_LABEL_FALLBACK_TOLERANCE_S / 2
+        diar_segments = [{"start": 2.0, "end": 3.0, "speaker": "SPEAKER_0"}]
+        unplaceable = _assign_asr_segments_to_diar_segments(
+            [{"text": "Just before the turn.", "start": 2.0 - gap - 0.2, "end": 2.0 - gap + 0.2}],
+            diar_segments,
+        )
+        self.assertEqual(diar_segments[0]["text"], "Just before the turn.")
+        self.assertEqual(unplaceable, [])
+
+    def test_unplaceable_word_stays_with_the_current_turn(self):
+        # Word-level splitting must not invent a turn for a word that
+        # carries no speaker evidence, and must not drop it either -- it
+        # belongs to whichever turn it is already inside.
+        diar_segments = [
+            {"start": 0.0, "end": 3.0, "speaker": "SPEAKER_0"},
+            {"start": 20.0, "end": 23.0, "speaker": "SPEAKER_1"},
+        ]
+        tokens = [
+            {"text": " one", "start": 0.5, "end": 1.0},
+            # Sits in the long uncovered gap, far from both speakers.
+            {"text": " two", "start": 10.0, "end": 10.5},
+            {"text": " three", "start": 21.0, "end": 21.5},
+        ]
+        unplaceable = _assign_asr_segments_to_diar_segments(
+            [{"text": "one two three", "start": 0.5, "end": 21.5, "tokens": tokens}],
+            diar_segments,
+        )
+        self.assertEqual(diar_segments[0]["text"], "one two")
+        self.assertEqual(diar_segments[1]["text"], "three")
+        self.assertEqual(unplaceable, [])
+
+    def test_leading_unplaceable_words_lead_the_first_real_turn(self):
+        # Words before the first placeable one have no turn to stay with
+        # yet -- they must still keep their position in the sentence.
+        diar_segments = [
+            {"start": 12.0, "end": 14.0, "speaker": "SPEAKER_0"},
+            {"start": 20.0, "end": 23.0, "speaker": "SPEAKER_1"},
+        ]
+        tokens = [
+            # Ahead of every segment, so no turn is open yet.
+            {"text": " one", "start": 0.5, "end": 1.0},
+            {"text": " two", "start": 13.0, "end": 13.5},
+            {"text": " three", "start": 21.0, "end": 21.5},
+        ]
+        unplaceable = _assign_asr_segments_to_diar_segments(
+            [{"text": "one two three", "start": 0.5, "end": 21.5, "tokens": tokens}],
+            diar_segments,
+        )
+        self.assertEqual(diar_segments[0]["text"], "one two")
+        self.assertEqual(diar_segments[1]["text"], "three")
+        self.assertEqual(unplaceable, [])
+
+    def test_sentence_with_no_placeable_word_is_returned_whole(self):
+        diar_segments = [
+            {"start": 40.0, "end": 43.0, "speaker": "SPEAKER_0"},
+            {"start": 50.0, "end": 53.0, "speaker": "SPEAKER_1"},
+        ]
+        tokens = [
+            {"text": " one", "start": 0.5, "end": 1.0},
+            {"text": " two", "start": 5.0, "end": 5.5},
+        ]
+        asr_segment = {"text": "one two", "start": 0.5, "end": 5.5, "tokens": tokens}
+        unplaceable = _assign_asr_segments_to_diar_segments([asr_segment], diar_segments)
+        self.assertEqual([d["text"] for d in diar_segments], ["", ""])
+        self.assertEqual(unplaceable, [asr_segment])
+
+    def test_long_sentence_whose_tokens_carry_no_text_is_not_dropped(self):
+        # Word-level splitting reached on a token list with nothing usable
+        # in it used to leave the sentence in no segment at all -- the text
+        # simply disappeared from the transcript.
+        diar_segments = [
+            {"start": 0.0, "end": 3.0, "speaker": "SPEAKER_0"},
+            {"start": 3.0, "end": 6.0, "speaker": "SPEAKER_1"},
+        ]
+        tokens = [{"text": "  ", "start": 0.5, "end": 1.0}, {"text": "", "start": 5.0, "end": 5.5}]
+        asr_segment = {"text": "one two", "start": 0.5, "end": 5.5, "tokens": tokens}
+        unplaceable = _assign_asr_segments_to_diar_segments([asr_segment], diar_segments)
+        self.assertEqual([d["text"] for d in diar_segments], ["", ""])
+        self.assertEqual(unplaceable, [asr_segment])
+
+    def test_empty_diar_segments_reports_everything_unplaceable(self):
+        # Nothing to place text against -- the caller must hear about it
+        # rather than the text quietly disappearing.
+        asr_segment = {"text": "Hello", "start": 0.0, "end": 1.0}
+        self.assertEqual(
+            _assign_asr_segments_to_diar_segments([asr_segment], []), [asr_segment]
+        )
+
 
 class ClusterChannelLabelsTests(unittest.TestCase):
     def test_single_speaker_returns_none(self):
@@ -1039,6 +1144,35 @@ class TagChannelSegmentsTests(unittest.TestCase):
         # But the sidecar-bound clusters_out now has the real embedding.
         self.assertEqual(set(clusters_out.keys()), {"SPEAKER_0"})
         self.assertEqual(clusters_out["SPEAKER_0"]["embedding"], [0.7, 0.1])
+
+    def test_unplaceable_text_keeps_the_channel_label_and_no_raw_sid(self):
+        # A sentence the diarizer left no segment anywhere near must stay in
+        # the transcript, but under the channel's own label and with no raw
+        # cluster id -- so it reads as "someone on this side", can never feed
+        # a voiceprint, and still sorts into place chronologically.
+        d = tempfile.TemporaryDirectory()
+        self.addCleanup(d.cleanup)
+        channel_path = Path(d.name) / "system.wav"
+        channel_path.write_bytes(b"stub")
+
+        diar_segments = [
+            {"start": 10.0, "end": 14.0, "speaker": "SPEAKER_0"},
+            {"start": 14.5, "end": 18.0, "speaker": "SPEAKER_1"},
+        ]
+        embeddings = {"SPEAKER_0": [0.7, 0.1], "SPEAKER_1": [0.1, 0.7]}
+        asr_segments = [
+            # Sits in a stretch the diarizer reported nobody speaking in.
+            {"text": "Orphan line.", "start": 0.5, "end": 1.5},
+            {"text": "Hello there.", "start": 11.0, "end": 12.0},
+            {"text": "Sounds good.", "start": 15.0, "end": 16.0},
+        ]
+        with patch("src.transcriber._run_steno_diarize", return_value=(diar_segments, embeddings)):
+            result = _tag_channel_segments(asr_segments, channel_path, 20.0, "Others")
+
+        self.assertEqual(result[0], (0.5, "Others", "Orphan line.", None))
+        self.assertEqual([turn[0] for turn in result], sorted(turn[0] for turn in result))
+        # The two placeable lines still get their exact cluster provenance.
+        self.assertEqual([turn[3] for turn in result[1:]], ["SPEAKER_0", "SPEAKER_1"])
 
     def test_prints_progress_diarize_start_and_done_around_a_successful_run(self):
         # Processing.tsx (the renderer) drives its 'diarizing' stage/sub-label

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -972,6 +972,31 @@ class AssignAsrSegmentsToDiarSegmentsTests(unittest.TestCase):
         self.assertEqual(diar_segments[1]["text"], "three")
         self.assertEqual(unplaceable, [])
 
+    def test_unplaceable_word_stays_put_even_when_the_next_turn_is_nearer(self):
+        # Deliberate behaviour change, not a side effect: this word used to
+        # go to whichever segment was nearest, so being closer to the NEXT
+        # speaker moved it there. Out of tolerance, "nearest" is not
+        # evidence -- continuing the turn the word is already in beats
+        # opening one for a speaker who starts five seconds later.
+        diar_segments = [
+            {"start": 0.0, "end": 3.0, "speaker": "SPEAKER_0"},
+            {"start": 20.0, "end": 23.0, "speaker": "SPEAKER_1"},
+        ]
+        tokens = [
+            {"text": " one", "start": 1.0, "end": 1.5},
+            # Nearer to SPEAKER_1 (5s) than to SPEAKER_0 (12s), but far
+            # outside both.
+            {"text": " two", "start": 15.0, "end": 15.5},
+            {"text": " three", "start": 21.0, "end": 21.5},
+        ]
+        unplaceable = _assign_asr_segments_to_diar_segments(
+            [{"text": "one two three", "start": 1.0, "end": 21.5, "tokens": tokens}],
+            diar_segments,
+        )
+        self.assertEqual(diar_segments[0]["text"], "one two")
+        self.assertEqual(diar_segments[1]["text"], "three")
+        self.assertEqual(unplaceable, [])
+
     def test_leading_unplaceable_words_lead_the_first_real_turn(self):
         # Words before the first placeable one have no turn to stay with
         # yet -- they must still keep their position in the sentence.
@@ -1173,6 +1198,32 @@ class TagChannelSegmentsTests(unittest.TestCase):
         self.assertEqual([turn[0] for turn in result], sorted(turn[0] for turn in result))
         # The two placeable lines still get their exact cluster provenance.
         self.assertEqual([turn[3] for turn in result[1:]], ["SPEAKER_0", "SPEAKER_1"])
+
+    def test_single_cluster_does_not_claim_provenance_for_a_far_away_line(self):
+        # A single distinct cluster leaves no OTHER speaker to borrow, but
+        # raw_sid still claims this cluster produced this line. A line far
+        # outside every segment the diarizer emitted has nothing behind
+        # that claim -- it may be someone the diarizer never segmented --
+        # and a later rename would put a name on words that were never
+        # that person's. The text still ships under the channel label.
+        d = tempfile.TemporaryDirectory()
+        self.addCleanup(d.cleanup)
+        channel_path = Path(d.name) / "system.wav"
+        channel_path.write_bytes(b"stub")
+
+        diar_segments = [{"start": 100.0, "end": 101.0, "speaker": "SPEAKER_0"}]
+        with patch("src.transcriber._run_steno_diarize", return_value=(diar_segments, {})):
+            result = _tag_channel_segments(
+                [
+                    {"text": "Miles away.", "start": 0.0, "end": 1.0},
+                    {"text": "Right here.", "start": 100.2, "end": 100.8},
+                ],
+                channel_path, 120.0, "Others",
+            )
+        self.assertEqual(result, [
+            (0.0, "Others", "Miles away.", None),
+            (100.2, "Others", "Right here.", "SPEAKER_0"),
+        ])
 
     def test_prints_progress_diarize_start_and_done_around_a_successful_run(self):
         # Processing.tsx (the renderer) drives its 'diarizing' stage/sub-label

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -802,6 +802,18 @@ class MergeCloseDiarSegmentsTests(unittest.TestCase):
         merged = _merge_close_diar_segments(segments, 0.3)
         self.assertEqual(len(merged), 2)
 
+    def test_nested_same_speaker_segment_does_not_shorten_the_turn(self):
+        # Sorted by start does not mean each segment ends later than the
+        # one before. A nested same-speaker segment used to pull the merged
+        # end backwards, deleting speaking time that was really there --
+        # and that time feeds the dominance share deciding the speaker count.
+        segments = [
+            {"start": 0.0, "end": 4.0, "speaker": "SPEAKER_0"},
+            {"start": 2.0, "end": 3.0, "speaker": "SPEAKER_0"},
+        ]
+        merged = _merge_close_diar_segments(segments, 0.3)
+        self.assertEqual(merged, [{"start": 0.0, "end": 4.0, "speaker": "SPEAKER_0"}])
+
     def test_does_not_mutate_input(self):
         segments = [{"start": 0.0, "end": 1.0, "speaker": "SPEAKER_0"}]
         _merge_close_diar_segments(segments, STENO_DIARIZE_MERGE_GAP_S)
@@ -858,6 +870,26 @@ class ClampOverlappingDiarSegmentsTests(unittest.TestCase):
         ]
         _clamp_overlapping_diar_segments(segments)
         self.assertEqual(segments[1]["start"], 3.0)
+
+    def test_a_nested_same_speaker_segment_survives_the_whole_pipeline(self):
+        # A[0,4] B[1,5] A[2,3]: clamping moves B behind A, which leaves the
+        # nested A next to the outer one and used to truncate the outer A
+        # from 4 to 3 in the second merge. A must keep every second it held.
+        payload = json.dumps({
+            "segments": [
+                {"speakerId": "SPEAKER_0", "start": 0.0, "end": 4.0},
+                {"speakerId": "SPEAKER_1", "start": 1.0, "end": 5.0},
+                {"speakerId": "SPEAKER_0", "start": 2.0, "end": 3.0},
+            ],
+            "speakers": {},
+        }).encode()
+        with patch("src.transcriber._resolve_steno_diarize", return_value="/fake/steno-diarize"), \
+             _patch_popen(stdout=payload, stderr=b"", returncode=0):
+            segments, _ = _run_steno_diarize(Path("/fake/mic.wav"), 60)
+        self.assertEqual(segments, [
+            {"start": 0.0, "end": 4.0, "speaker": "SPEAKER_0"},
+            {"start": 4.0, "end": 5.0, "speaker": "SPEAKER_1"},
+        ])
 
 
 class AssignAsrSegmentsToDiarSegmentsTests(unittest.TestCase):

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -1477,10 +1477,19 @@ class HeartbeatWhileWaitingTests(unittest.TestCase):
         import io
         from src.transcriber import _heartbeat_while_waiting
 
+        # Waits for the beats instead of sleeping a fixed 0.09s and hoping
+        # four 0.02s ticks fit inside it. On a loaded CI runner they did
+        # not, and the job failed on timing rather than on behaviour -- seen
+        # on this branch, green on the same commit locally. The wait exits
+        # as soon as the second beat lands, so the fast path stays fast.
         buf = io.StringIO()
+        deadline = time.monotonic() + 5.0
         with patch("sys.stdout", buf):
             with _heartbeat_while_waiting("diarize:You", interval_s=0.02):
-                time.sleep(0.09)
+                while time.monotonic() < deadline:
+                    if buf.getvalue().count("HEARTBEAT:diarize:You") >= 2:
+                        break
+                    time.sleep(0.01)
         lines = [l for l in buf.getvalue().splitlines() if l == "HEARTBEAT:diarize:You"]
         self.assertGreaterEqual(len(lines), 2)
 


### PR DESCRIPTION
Stacked on `feat/speaker-diarization`, on top of #455 and #472. Everything here serves one invariant: **the review panel must never present another person's voice or words under a speaker's name.** Losing a clip is acceptable; playing the wrong one is not — the panel is where a human decides whose voice this is, so a wrong excerpt is not noise, it is a wrong answer at the exact moment the answer matters.

## What this adds

**Mark a cluster as holding more than one person.** A diarized cluster that quietly contains two people is invisible in every number the system produces — measured against a real three-person call, the contaminated cluster sat at cosine distance 0.8270 from the person who contaminated it, an ordinary cross-speaker distance nowhere near any threshold. So the marking cannot be derived and has to be witnessed. A marked cluster gets no suggestion, no candidates, and cannot be enrolled; it also does not consume the person it resembles, so marking a contaminated cluster never costs the real cluster its correct suggestion.

**Several excerpts per row instead of one.** One excerpt is a single roll of the dice on whether the longest turn happens to contain anything recognizable; several spread across the recording are what let someone place a voice — and hearing two different voices in one list is how a contaminated cluster becomes visible at all.

**Say what a delete costs** before the user confirms it.

## Fixes on top, each with the failing test that proved it first

The clip/quote pairing broke in the same class of way repeatedly — the fallback path never got the same check as the main path — so each of these pins a specific way a foreign voice or a foreign sentence could reach a speaker's row:

- Excerpts are paired with the **turn** they belong to, not the segment they overlap. `src.transcriber` merges consecutive segments of one speaker into a turn carrying only the first segment's timestamp, so selecting by segment and hunting for a line inside it misses most segments outright.
- No audio is invented around a timestamp we cannot place. Every fallback stays inside **this cluster's own segments**; there is deliberately no "window of N seconds around the line" path.
- A collapsed range is refused by the extractor rather than **padded back into a clip**. The duration check ran after the two 0.3s pads, so a range meaning "we cannot place this moment" still cut 0.6s around the timestamp.
- A clip stops at a hole in the turn. `min(start)`/`max(end)` over all own segments spanned the gaps as well, and a gap is by definition time this cluster was not speaking — on a mic channel taken without headphones, exactly where the remote voices sit. Pauses under a second are still bridged, so a multi-segment turn does not fall apart into clips too short to recognize a voice from.
- A **turn manifest that no longer describes the transcript** is refused, in the reading path *and* the writing one. An equal line count was the only evidence required for positional pairing; a manifest left behind by an earlier transcription keeps that count and then attributes — and relabels — every line to whatever cluster sits at that index. The manifest's `start` and the line's `[MM:SS]` come from the same float in the same loop, so the pairing is now checked exactly against `_format_timestamp`'s own truncation, with no slop: a window merely a second wide accepts the neighbouring turn, and two turns swapped is exactly what a reordered manifest looks like.
- A manifest entry that is not an object at all is refused instead of raising through the never-raises contract both callers document.

## Tests

892 Python tests (up from 882 on the base), including five new T2 e2e specs in `speaker-multi-marking.t2` and three new T1 tests in `speaker-review.t1` covering the marking, the excerpt list, playback per moment, the no-manifest case, and the delete cost.

Verified locally: full Python suite green, `ruff` unchanged against the base, renderer typecheck clean, renderer lint unchanged (37 warnings / 0 errors), `speaker-review.t1` 15/15. T2 was left to CI — this worktree has no backend bundle, and the changes are Python covered by the unit suite.

## Review notes

- The clip may still bridge a pause of up to one second inside a turn. That is a deliberate trade-off, argued in the code: cutting at every inter-segment gap leaves clips too short to be useful, which defeats the panel.
- The refusals above are silent by design in the UI (no excerpt text, no relabel) but each logs a warning naming the transcript and what disagreed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let reviewers expand a speaker into several excerpts and mark a cluster as “more than one person” so the panel never plays or quotes another person under the wrong name. The overview now shows which notes still have their original audio.

- **New Features**
  - Mark a cluster as “More than one person.” Removes suggestions and candidates, blocks confirm/enroll, withdraws any prior confirm (prototype and participants entry), and is reversible — clearing only reopens naming and restores nothing. The marking is saved in the meeting’s speakers sidecar.
  - Review several excerpts per row, in time order, each with its own play button. `getSampleAudio` accepts an optional `segmentIndex` so the clip always matches the text beside it. The collapsed row’s quote comes from the same list, and quotes are shown only when a turn manifest exists; older/backfilled meetings show timestamps without quotes.
  - The undo delete toast shows how many unnamed speakers will be lost. Deleting a meeting now removes `<stem>_speakers.json>`; confirmed profiles stay. New IPC: `mark-speaker-cluster`, `speaker-naming-status`.
  - Notes overview: show an audio icon only when the original recording exists. `list-meetings` exposes `has_audio` from one directory scan; no icon when absent (default with `keep_recordings` off).

- **Bug Fixes**
  - Quote/clip alignment: include a segment already running at the line, start the clip at the line, pair on the manifest’s exact start (not the rendered [MM:SS]), ignore segments that already ended, handle shared-second fallbacks, and report the moment unplayable past a 2s lead — reducing drift and preventing wrong audio.
  - Keep clips and quotes honest: pair by turns, play the clicked excerpt exactly, never invent audio around a timestamp we cannot place, refuse zero-length ranges, don’t bridge holes in a turn, and bound “nearest segment” lookups.
  - Stop wrong attributions from stale/bad manifests: verify manifest-to-transcript pairing exactly (no slop, non-decreasing starts), ignore junk entries, and never read from a manifest when it no longer describes the transcript.
  - Diarization robustness: handle overlapping/nested segments so merged turns don’t shrink and overlapped time is counted once.
  - Marking safety: withdraws confirmations already made on a cluster; does not clear unrelated hard negatives; confirm no longer takes hard-negative evidence from a marked cluster; participants display updates; clearing the mark is not labeled “Undo.”
  - Transcript cleanup: marking restores original labels for that cluster’s lines in the saved transcript (recorded at confirm time), or falls back to “Multiple speakers.” Refuses to restore when the manifest no longer matches the transcript.
  - Data integrity: always write the speakers sidecar on every path that finishes a meeting and include it in delete/undo. Sidecar updates re-read before write to avoid losing a concurrent mark.
  - Performance: build each cluster’s excerpts once and derive the collapsed quote from that list. Minimum speaker count is now computed on the merged view and taken from the largest channel, avoiding overstatement.
  - Tests: stabilize the transcriber heartbeat test by waiting for the second beat instead of relying on fixed timing.

<sup>Written for commit e92dcc8f3e3d0fc868a51986e8a04b7bf99dbb3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

