### PR TITLE
feat(speakers): let one person own several clusters, correctly

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -23,10 +23,41 @@
 const fs = require('fs');
 const { EXPORT_CANCELED } = require('./ipc-sentinels');
 
-// A real (silent, zero-sample) 16-bit mono 16kHz WAV file's bytes,
-// base64-encoded -- valid enough for the renderer's blob: URL + <audio>
-// playback path to actually decode, unlike an arbitrary placeholder string.
-const MINIMAL_WAV_BASE64 = 'UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQAAAAA=';
+// A real, silent, 16-bit mono 8kHz WAV -- valid enough for the renderer's
+// blob: URL + <audio> path to actually decode, unlike a placeholder string.
+//
+// It has real DURATION, and that is the point. The previous fixture was a
+// 44-byte header with zero sample data, so the media element reported
+// duration 0 and fired `ended` about 300ms after play() -- measured in this
+// very renderer. PlaySampleButton flips its label back to "Play sample" on
+// `ended`, so the "toggling to stop" spec was racing a state that existed
+// for a third of a second: green on a Mac, red on a CI runner whose first
+// assertion poll landed after the clip had already finished. A spec about
+// playing a sample needs a sample that plays.
+const SILENT_WAV_SECONDS = 5;
+const SILENT_WAV_SAMPLE_RATE = 8000;
+
+function buildSilentWavBase64(seconds, sampleRate) {
+  const bytesPerSample = 2; // 16-bit
+  const dataBytes = seconds * sampleRate * bytesPerSample;
+  const buf = Buffer.alloc(44 + dataBytes); // zero-filled == silence
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(36 + dataBytes, 4);
+  buf.write('WAVE', 8);
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16); // PCM fmt chunk size
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * bytesPerSample, 28); // byte rate
+  buf.writeUInt16LE(bytesPerSample, 32); // block align
+  buf.writeUInt16LE(16, 34); // bits per sample
+  buf.write('data', 36);
+  buf.writeUInt32LE(dataBytes, 40);
+  return buf.toString('base64');
+}
+
+const MINIMAL_WAV_BASE64 = buildSilentWavBase64(SILENT_WAV_SECONDS, SILENT_WAV_SAMPLE_RATE);
 
 // A deterministic meeting the transcript-export T1 spec navigates to. Seeded
 // only when STENOAI_E2E_SEED_MEETING=1 so the other T1 specs keep an empty Home.

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -837,6 +837,7 @@ function install({ ipcMain }) {
           suggested_name: cluster.suggested_name,
           candidates: cluster.candidates,
           confirmed_by_user: cluster.confirmed_by_user,
+          confirmed_person_id: cluster.confirmed_person_id,
         };
         cluster.status = 'none';
         cluster.suggested_person_id = null;
@@ -849,6 +850,7 @@ function install({ ipcMain }) {
         if (cluster.confirmed_by_user) {
           clearedFrom.push(cluster.confirmed_by_user);
           cluster.confirmed_by_user = null;
+          cluster.confirmed_person_id = null;
         }
       } else if (cluster.prevSuggestion) {
         Object.assign(cluster, cluster.prevSuggestion);
@@ -937,6 +939,7 @@ function install({ ipcMain }) {
       const previous = channelSuggestions[diarizationSpeakerId] || {
         speech_duration_seconds: 0, segment_count: 0, first_timestamp: null,
         sample_text: null, is_likely_artifact: false, confirmed_by_user: null,
+        confirmed_person_id: null,
       };
       channelSuggestions[diarizationSpeakerId] = {
         ...previous,
@@ -949,6 +952,10 @@ function install({ ipcMain }) {
         // SpeakerPrototype), so it survives a simulated navigate-away-and-back
         // (a fresh suggest-speakers refetch) even after this panel unmounts.
         confirmed_by_user: person.display_name,
+        // The id travels with the name: the panel decides which people
+        // already hold a cluster of this meeting by id, never by display
+        // name (a rename can leave two profiles reading alike).
+        confirmed_person_id: person.person_id,
       };
 
       return {
@@ -1002,6 +1009,7 @@ function install({ ipcMain }) {
               suggestion.suggested_person_id = null;
               suggestion.suggested_name = null;
               suggestion.confirmed_by_user = null;
+              suggestion.confirmed_person_id = null;
               suggestion.candidates = suggestion.candidates.filter((c) => c.person_id !== id);
             }
           }

--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -287,3 +287,27 @@ test('every extracted seam module is required AND invoked in main.js (reachabili
     `extracted module(s) not wired into main.js (dead registration?): ${unwired.join('; ')}`,
   );
 });
+
+// The T1 speaker spec asserts the play button toggles to "Stop sample" while
+// a clip is playing. PlaySampleButton flips that label back on the media
+// element's `ended` event, so the assertion is only stable while the fixture
+// clip is still running. The original fixture was a 44-byte header with zero
+// sample data: measured in the real renderer, it reported duration 0 and
+// fired `ended` ~300ms after play(). That is why the spec was green on a Mac
+// and red on CI - the runner's first assertion poll landed after the clip had
+// already finished.
+//
+// Pinned here rather than left to the spec, because shrinking the fixture
+// again would not fail loudly: it would just make that one test flaky, on
+// someone else's machine, weeks later.
+test('the mock sample clip is long enough for a playing state to be observable', () => {
+  const mock = require('./e2e-mock-ipc.js');
+  void mock; // required only so a syntax error in the fixture fails here too
+
+  const match = MOCK.match(/const SILENT_WAV_SECONDS = (\d+)/);
+  assert.ok(match, 'e2e-mock-ipc.js no longer declares SILENT_WAV_SECONDS');
+  assert.ok(
+    Number(match[1]) >= 2,
+    `the fixture clip is ${match[1]}s; under ~2s the "toggling to stop" assertion races the ended event`,
+  );
+});

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -72,13 +72,13 @@ function namesCollide(a: string, b: string): boolean {
  *  someone I already named here", and that answer gets commoner the more the
  *  diarizer splits a voice -- burying it in a global list of everyone ever
  *  named is what pushes a hurried reviewer towards "New person" instead. */
-export function orderProfilesForRow<T extends { display_name: string }>(
+export function orderProfilesForRow<T extends { display_name: string; person_id: string }>(
   profiles: T[],
   alreadyInMeeting: Set<string>,
 ): T[] {
   return [...profiles].sort((a, b) => {
-    const aHere = alreadyInMeeting.has(a.display_name);
-    const bHere = alreadyInMeeting.has(b.display_name);
+    const aHere = alreadyInMeeting.has(a.person_id);
+    const bHere = alreadyInMeeting.has(b.person_id);
     if (aHere !== bHere) return aHere ? -1 : 1;
     return a.display_name.localeCompare(b.display_name);
   });
@@ -279,9 +279,16 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
   // couple of decisions actually cover -- and the more the diarizer splits a
   // recording, the further that diverges from channel/cluster-id order,
   // which is only an artifact of how the diarizer numbered its slots.
+  // Number.isFinite, not `?? 0`: a non-numeric duration would make the
+  // subtraction NaN, and `||` treats NaN as falsy, so a single bad value
+  // would silently drop the whole list back to cluster-id order.
+  const speechSeconds = (row: Row) =>
+    Number.isFinite(row.suggestion.speech_duration_seconds)
+      ? row.suggestion.speech_duration_seconds
+      : 0;
   rows.sort(
     (a, b) =>
-      (b.suggestion.speech_duration_seconds ?? 0) - (a.suggestion.speech_duration_seconds ?? 0)
+      speechSeconds(b) - speechSeconds(a)
       || a.channel.localeCompare(b.channel)
       || a.diarizationSpeakerId.localeCompare(b.diarizationSpeakerId),
   );
@@ -289,8 +296,11 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
   // over-segmenting diarizer one person owns several clusters, so this is
   // the set the reviewer reaches for most, not the long tail of everyone
   // they have ever named.
+  // By person_id, never by display name: a rename can leave two profiles
+  // reading alike, and marking the wrong one as present here would invite
+  // exactly the misassignment this is meant to prevent.
   const alreadyInMeeting = new Set(
-    rows.map((row) => row.suggestion.confirmed_by_user).filter((name): name is string => !!name),
+    rows.map((row) => row.suggestion.confirmed_person_id).filter((id): id is string => !!id),
   );
   const notDismissed = rows.filter((row) => !dismissed.has(rowKey(row)));
   // A row a human has explicitly marked stays in the main list even if its
@@ -544,7 +554,7 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                             data-testid={`speaker-pick-person-${profile.person_id}`}
                           >
                             <span className="truncate">{profile.display_name}</span>
-                            {alreadyInMeeting.has(profile.display_name) && (
+                            {alreadyInMeeting.has(profile.person_id) && (
                               // The diarizer splits one voice across several
                               // clusters routinely, so "this is the person I
                               // already named above" is a frequent, correct

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -67,6 +67,23 @@ function namesCollide(a: string, b: string): boolean {
   return a.trim().toLowerCase() === b.trim().toLowerCase();
 }
 
+/** People already assigned somewhere in this meeting first, the rest after,
+ *  each group alphabetical. The picker is the only route to "this cluster is
+ *  someone I already named here", and that answer gets commoner the more the
+ *  diarizer splits a voice -- burying it in a global list of everyone ever
+ *  named is what pushes a hurried reviewer towards "New person" instead. */
+export function orderProfilesForRow<T extends { display_name: string }>(
+  profiles: T[],
+  alreadyInMeeting: Set<string>,
+): T[] {
+  return [...profiles].sort((a, b) => {
+    const aHere = alreadyInMeeting.has(a.display_name);
+    const bHere = alreadyInMeeting.has(b.display_name);
+    if (aHere !== bHere) return aHere ? -1 : 1;
+    return a.display_name.localeCompare(b.display_name);
+  });
+}
+
 // "mic" is always the device owner's own recording side (in-person audio);
 // "system" is loopback capture of the other call participant(s) -- see
 // determine_recording_type (src/speaker_suggestions.py) for the same
@@ -257,8 +274,23 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
       rows.push({ channel, diarizationSpeakerId, suggestion });
     }
   }
+  // Most speaking time first. Reviewing is voluntary and can be abandoned at
+  // any point, so the order decides how much of the transcript the first
+  // couple of decisions actually cover -- and the more the diarizer splits a
+  // recording, the further that diverges from channel/cluster-id order,
+  // which is only an artifact of how the diarizer numbered its slots.
   rows.sort(
-    (a, b) => a.channel.localeCompare(b.channel) || a.diarizationSpeakerId.localeCompare(b.diarizationSpeakerId),
+    (a, b) =>
+      (b.suggestion.speech_duration_seconds ?? 0) - (a.suggestion.speech_duration_seconds ?? 0)
+      || a.channel.localeCompare(b.channel)
+      || a.diarizationSpeakerId.localeCompare(b.diarizationSpeakerId),
+  );
+  // People this meeting has already been given a cluster for. Under an
+  // over-segmenting diarizer one person owns several clusters, so this is
+  // the set the reviewer reaches for most, not the long tail of everyone
+  // they have ever named.
+  const alreadyInMeeting = new Set(
+    rows.map((row) => row.suggestion.confirmed_by_user).filter((name): name is string => !!name),
   );
   const notDismissed = rows.filter((row) => !dismissed.has(rowKey(row)));
   // A row a human has explicitly marked stays in the main list even if its
@@ -499,7 +531,7 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                         No known people yet
                       </div>
                     ) : (
-                      (profilesQuery.data ?? []).map((profile) => (
+                      orderProfilesForRow(profilesQuery.data ?? [], alreadyInMeeting).map((profile) => (
                         <div key={profile.person_id} className="flex items-center gap-0.5">
                           <button
                             type="button"
@@ -507,10 +539,29 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
                               setChangeOpenFor(null);
                               confirm(row, { personId: profile.person_id });
                             }}
-                            className="flex min-w-0 flex-1 items-center truncate rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
+                            className="flex min-w-0 flex-1 items-center gap-1.5 truncate rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-[color:var(--surface-hover)]"
                             style={{ color: 'var(--fg-1)' }}
+                            data-testid={`speaker-pick-person-${profile.person_id}`}
                           >
-                            {profile.display_name}
+                            <span className="truncate">{profile.display_name}</span>
+                            {alreadyInMeeting.has(profile.display_name) && (
+                              // The diarizer splits one voice across several
+                              // clusters routinely, so "this is the person I
+                              // already named above" is a frequent, correct
+                              // answer -- and one that has to be visibly
+                              // available, because the alternative a hurried
+                              // user reaches for is "New person", which
+                              // records the same voice as two people and
+                              // makes them a hard negative against
+                              // themselves.
+                              <span
+                                className="shrink-0 text-[11px]"
+                                style={{ color: 'var(--fg-2)' }}
+                                title="Already assigned in this meeting"
+                              >
+                                here
+                              </span>
+                            )}
                           </button>
                           <button
                             type="button"

--- a/app/renderer/src/components/speakerReviewOrdering.test.ts
+++ b/app/renderer/src/components/speakerReviewOrdering.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { orderProfilesForRow } from './SpeakerReviewPanel';
+
+const p = (display_name: string) => ({ display_name, person_id: display_name.toLowerCase() });
+
+describe('orderProfilesForRow', () => {
+  it('puts people already assigned in this meeting first', () => {
+    const ordered = orderProfilesForRow(
+      [p('Zoe'), p('Alice'), p('Max')],
+      new Set(['Max']),
+    );
+    expect(ordered.map((x) => x.display_name)).toEqual(['Max', 'Alice', 'Zoe']);
+  });
+
+  it('keeps each group alphabetical', () => {
+    const ordered = orderProfilesForRow(
+      [p('Zoe'), p('Alice'), p('Max'), p('Bea')],
+      new Set(['Max', 'Zoe']),
+    );
+    expect(ordered.map((x) => x.display_name)).toEqual(['Max', 'Zoe', 'Alice', 'Bea']);
+  });
+
+  it('leaves the order alone when nobody is assigned yet', () => {
+    const ordered = orderProfilesForRow([p('Zoe'), p('Alice')], new Set());
+    expect(ordered.map((x) => x.display_name)).toEqual(['Alice', 'Zoe']);
+  });
+
+  it('does not mutate the list it was given', () => {
+    const input = [p('Zoe'), p('Alice')];
+    orderProfilesForRow(input, new Set(['Alice']));
+    expect(input.map((x) => x.display_name)).toEqual(['Zoe', 'Alice']);
+  });
+});

--- a/app/renderer/src/components/speakerReviewOrdering.test.ts
+++ b/app/renderer/src/components/speakerReviewOrdering.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import { orderProfilesForRow } from './SpeakerReviewPanel';
 
-const p = (display_name: string) => ({ display_name, person_id: display_name.toLowerCase() });
+const p = (display_name: string) => ({ display_name, person_id: `id-${display_name.toLowerCase()}` });
 
 describe('orderProfilesForRow', () => {
   it('puts people already assigned in this meeting first', () => {
     const ordered = orderProfilesForRow(
       [p('Zoe'), p('Alice'), p('Max')],
-      new Set(['Max']),
+      new Set(['id-max']),
     );
     expect(ordered.map((x) => x.display_name)).toEqual(['Max', 'Alice', 'Zoe']);
   });
@@ -16,7 +16,7 @@ describe('orderProfilesForRow', () => {
   it('keeps each group alphabetical', () => {
     const ordered = orderProfilesForRow(
       [p('Zoe'), p('Alice'), p('Max'), p('Bea')],
-      new Set(['Max', 'Zoe']),
+      new Set(['id-max', 'id-zoe']),
     );
     expect(ordered.map((x) => x.display_name)).toEqual(['Max', 'Zoe', 'Alice', 'Bea']);
   });
@@ -28,7 +28,19 @@ describe('orderProfilesForRow', () => {
 
   it('does not mutate the list it was given', () => {
     const input = [p('Zoe'), p('Alice')];
-    orderProfilesForRow(input, new Set(['Alice']));
+    orderProfilesForRow(input, new Set(['id-alice']));
     expect(input.map((x) => x.display_name)).toEqual(['Zoe', 'Alice']);
+  });
+});
+
+describe('orderProfilesForRow identity', () => {
+  it('matches on person_id, not on the display name', () => {
+    // Two profiles can read alike after a rename. Marking the never-assigned
+    // one as present in this meeting would invite the exact misassignment
+    // the "here" hint exists to prevent.
+    const assigned = { display_name: 'Alex', person_id: 'id-a' };
+    const other = { display_name: 'Alex', person_id: 'id-b' };
+    const ordered = orderProfilesForRow([other, assigned], new Set(['id-a']));
+    expect(ordered.map((x) => x.person_id)).toEqual(['id-a', 'id-b']);
   });
 });

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -496,6 +496,11 @@ export interface SpeakerSuggestion {
    *  confirmed. Persists across navigation/reload unlike the panel's
    *  transient post-click feedback, which is plain component state. */
   confirmed_by_user: string | null;
+  /** The same confirmation's person_id. Display names are not identity -- a
+   *  rename can leave two profiles reading alike -- so anything deciding
+   *  WHICH person a cluster went to compares this, not the name. Optional:
+   *  a payload predating this field simply carries no id. */
+  confirmed_person_id?: string | null;
 }
 export type SuggestSpeakersResponse = Result<{
   meeting_id: string;

--- a/docs/superpowers/plans/2026-08-04-speaker-review-run-provenance.md
+++ b/docs/superpowers/plans/2026-08-04-speaker-review-run-provenance.md
@@ -1,0 +1,223 @@
+# Speaker review: run provenance and persisted review state - implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the speaker review survive being interrupted and stop it from silently attributing a new diarization run's clusters to people confirmed against an older one.
+
+**Architecture:** Purely additive. The sidecar gains a run id and one per-cluster review marker, prototypes record which run they were confirmed against, and one shared predicate decides "is this evidence current" for every reader and writer so the two cannot drift apart. Nothing existing is migrated and nothing is deleted; every new key is optional and its absence means today's behaviour.
+
+**Tech Stack:** Python 3 (`src/`, `simple_recorder.py`, `unittest`), Electron main + preload (`app/`), React + TanStack Query renderer (vitest), Playwright e2e.
+
+**Source spec:** `docs/superpowers/specs/2026-08-04-speaker-review-run-provenance-design.md`. Read it before Task 1. Where this plan and the spec disagree, the spec wins and the plan is wrong.
+
+## Global Constraints
+
+- Every new sidecar key and every new prototype field is **optional**; absent means legacy and must read exactly as today. No migration, no backfill.
+- `src/speaker_suggestions.py`'s public helpers keep their **never-raises** contracts. New CLI commands print `{"success": false, "error": ...}` and `sys.exit(1)`; never a traceback, never bare `exit()`.
+- The staleness rule exists **once**, as a shared predicate in `src/speaker_suggestions.py`, imported by `src/config.py` and `simple_recorder.py` the same way `prototype_channel_matches` already is. A second copy of the rule is a defect.
+- Participants (`confirmed_participant_names`) stay **meeting-scoped, never run-scoped**. This is deliberate and the code must say so.
+- The e2e fixture `writeSpeakersSidecar` (`e2e/fixtures/user-config.ts`) stays **legacy-shaped**. Its specs staying green is the backward-compatibility proof; changing it destroys the proof.
+- Verification baseline to compare against, measured on this branch before Task 1: **944 Python tests**, ruff **41**, renderer lint **37 warnings / 0 errors**, typecheck clean. `tests/test_bundle_mlx.py` fails only in the full `discover` run and is green in isolation - pre-existing, not caused by this work.
+- Diarization is macOS-only, but every file touched here is cross-platform Python or JS. Nothing in this slice may branch on platform.
+
+---
+
+## File structure
+
+| File | Responsibility in this slice |
+|---|---|
+| `src/speaker_suggestions.py` | Mint the run block; own the shared staleness predicate; own the review-state write helper and its merged-row propagation |
+| `src/config.py` | Store `diarization_run_id` on evidence; apply run scope when removing evidence |
+| `simple_recorder.py` | Pass run ids through `confirm-speaker` / `mark-speaker-cluster`; apply the predicate in every reader; new `set-cluster-review-state` CLI; report lost markings |
+| `app/main.js`, `app/preload.js` | Bridge the new CLI to the renderer, following the `mark-speaker-cluster` handler exactly |
+| `app/renderer/src/hooks/useSpeakerSuggestions.ts` | Mutation + cache invalidation for the new state |
+| `app/renderer/src/components/SpeakerReviewPanel.tsx` | Persisted marker replaces `dismissed`; button gating; stale notice |
+| `tests/test_speaker_suggestions.py` | Sidecar round-trip, predicate matrix, merged propagation |
+| `tests/test_confirm_speaker_cli.py` | Run-scoped removal, run stamping, transitions |
+| `tests/test_speaker_multi_marking.py` | The new CLI, its never-raises contract, lost-marking reports |
+| `app/renderer/src/components/speakerReviewState.test.ts` | Renderer-side derivation of the marker and the notice |
+| `e2e/specs/speaker-multi-marking.t2.spec.ts` | One review-state round-trip through the preload bridge |
+
+---
+
+### Task 1: The run block in the sidecar
+
+**Files:**
+- Modify: `src/speaker_suggestions.py` (`write_speakers_sidecar`)
+- Test: `tests/test_speaker_suggestions.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: sidecar documents carrying an optional top-level `diarization_run` object with the string key `run_id` and the float key `created_at`. Every later task reads it via `sidecar.get("diarization_run")` and tolerates `None`.
+
+- [ ] **Step 1: Write the failing tests.** In `tests/test_speaker_suggestions.py`, beside the existing sidecar tests, add three. First: `write_speakers_sidecar` produces a document whose `diarization_run.run_id` is a non-empty string and whose `created_at` is a float. Second: two successive `write_speakers_sidecar` calls for the same meeting produce **different** run ids, because each call is a new run. Third: a handwritten legacy document with no `diarization_run` key round-trips through `read_speakers_sidecar` unchanged and yields `None` for `.get("diarization_run")`.
+- [ ] **Step 2: Run them and watch the first two fail.** `python -m unittest tests.test_speaker_suggestions -v`. The legacy test must already pass; if it does not, stop, because the reader is not as tolerant as the spec assumes.
+- [ ] **Step 3: Mint the block.** In `write_speakers_sidecar`, add the `diarization_run` key to the payload it builds, with a fresh `uuid4` string and `time.time()`. Document in the docstring why it is minted **here**: all three new-run producers funnel through this function, so no call site needs new plumbing, and the read-modify-write helpers (`write_sidecar_document`, `set_cluster_multi_speaker`) rewrite the whole document and therefore preserve it - a rewrite is not a new run.
+- [ ] **Step 4: Add the rewrite-preservation test.** Write a sidecar, call `set_cluster_multi_speaker` on it, and assert the run id is **unchanged**. This is the test that stops someone from later "helpfully" re-minting on every write.
+- [ ] **Step 5: Run the module green.** `python -m unittest tests.test_speaker_suggestions`.
+- [ ] **Step 6: Commit.** `git add src/speaker_suggestions.py tests/test_speaker_suggestions.py` with a message stating that a rewrite is deliberately not a new run.
+
+---
+
+### Task 2: The shared staleness predicate
+
+**Files:**
+- Modify: `src/speaker_suggestions.py`
+- Test: `tests/test_speaker_suggestions.py`
+
+**Interfaces:**
+- Consumes: Task 1's run block shape.
+- Produces: `prototype_run_matches(entry: dict, sidecar_run_id: Optional[str]) -> bool`, a module-level function beside `prototype_channel_matches`. `entry` is a prototype or hard-negative dict; `sidecar_run_id` is the current sidecar's run id or `None`. Every later task imports this one function and never re-implements the comparison.
+
+- [ ] **Step 1: Write the failing test.** One test per row of the spec's section 4 table, named for the row: both absent means current; both present and equal means current; both present and different means stale; entry absent with sidecar present means stale; entry present with sidecar absent means stale. Assert `True` for current and `False` for stale.
+- [ ] **Step 2: Run and watch all five fail.** `python -m unittest tests.test_speaker_suggestions -k run_matches -v`. Expected: the name does not exist.
+- [ ] **Step 3: Implement the predicate.** Keep it small enough to read in one glance. The docstring carries the reasoning the table encodes, especially the asymmetry: an unstamped entry against a stamped sidecar can only arise if the meeting was re-diarized after the confirmation, which is the exact hazard this slice exists for, and the reverse combination is pinned stale defensively because only an older build could produce it.
+- [ ] **Step 4: Run green.** `python -m unittest tests.test_speaker_suggestions -k run_matches`.
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 3: Evidence remembers its run
+
+**Files:**
+- Modify: `src/config.py` (`add_speaker_prototype`), `simple_recorder.py` (`confirm-speaker`)
+- Test: `tests/test_config.py`, `tests/test_confirm_speaker_cli.py`
+
+**Interfaces:**
+- Consumes: Task 1's run block.
+- Produces: prototypes and hard negatives that may carry a `diarization_run_id` string. Task 4 and Task 5 read it only through Task 2's predicate.
+
+- [ ] **Step 1: Write the failing tests.** In `tests/test_config.py`: `add_speaker_prototype` called with `diarization_run_id="r1"` stores it on the entry, and called without it stores **no such key at all** (not `None`) - matching how `channel` is handled. In `tests/test_confirm_speaker_cli.py`: confirming against a sidecar that has a run block produces a prototype carrying that exact run id, and confirming against a legacy sidecar produces a prototype with no run id. Both hard negatives and positives must carry it, so use the existing two-cluster fixture and assert on both profiles.
+- [ ] **Step 2: Run and watch them fail.**
+- [ ] **Step 3: Thread the id.** Add the keyword-only parameter to `add_speaker_prototype` with default `None`, written only when not `None`. In `confirm-speaker`, read the run id once from the loaded sidecar and pass it to every `add_speaker_prototype` call in that command, including the mutual-hard-negative writes in both directions.
+- [ ] **Step 4: Run both modules green.**
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 4: Run scope on the write path
+
+**Files:**
+- Modify: `src/config.py` (`remove_speaker_evidence`, `delete_person_profile`), `simple_recorder.py` (`confirm-speaker`, `mark-speaker-cluster`)
+- Test: `tests/test_config.py`, `tests/test_confirm_speaker_cli.py`
+
+**Interfaces:**
+- Consumes: Task 2's predicate, Task 3's stored id.
+- Produces: `remove_speaker_evidence` with an added keyword-only run-scope parameter whose default is a distinct **sentinel meaning "unscoped"**, so any caller that does not pass it keeps today's behaviour exactly. Passing `None` explicitly means "scope to a run-less sidecar" and is not the same as not passing it.
+
+- [ ] **Step 1: Write the failing test - the central one.** Two clusters, a legacy-free flow: confirm `SPEAKER_0` as Max against run `r1`; then simulate a re-diarization by writing a fresh sidecar (new run `r2`) whose `SPEAKER_0` is a different voice; then confirm the new `SPEAKER_0` as Sarah. Assert Max **still holds** his `r1` prototype, and Sarah holds one carrying `r2`. This currently deletes Max's prototype, which is the defect.
+- [ ] **Step 2: Write the companion legacy test.** The same sequence with no run blocks anywhere must still remove the superseded prototype, exactly as today. Without this test the fix is free to over-correct and break the correction path on legacy libraries.
+- [ ] **Step 3: Run and watch the first fail, the second pass.**
+- [ ] **Step 4: Add the scope.** Give `remove_speaker_evidence` the sentinel-defaulted parameter; when scoped, an entry must additionally satisfy Task 2's predicate against the passed id to be removed. Then pass the sidecar's current run id from every in-repo caller: `confirm-speaker`'s reassignment loop and its negative-cleanup and idempotency-rebuild removals, and `mark-speaker-cluster`'s confirmation-withdrawal loop. In `delete_person_profile`'s cross-profile hard-negative cleanup, pass **each source prototype's own** run id, because those negatives were created in the same confirm and therefore the same run.
+- [ ] **Step 5: Run both modules green, then the whole suite.** `python -m unittest discover tests`. Compare against the 944 baseline; only `test_bundle_mlx` may be red.
+- [ ] **Step 6: Commit,** stating in the message the trade the spec accepts: a wrong old-run confirmation can no longer be corrected by re-confirming, because silently destroying genuine evidence is the worse failure and the one happening today.
+
+---
+
+### Task 5: Run awareness on the read path
+
+**Files:**
+- Modify: `simple_recorder.py` (`suggest-speakers`, `confirm-speaker`'s `still_present` and mutual-negative `matches` loop, `speaker-naming-status`)
+- Test: `tests/test_suggest_speakers_cli.py`, `tests/test_confirm_speaker_cli.py`
+
+**Interfaces:**
+- Consumes: Task 2's predicate.
+- Produces: `suggest-speakers` gains a top-level `stale_assignments` array of `{person_id, display_name}`. The renderer (Task 7) renders one meeting-level notice from it. Absent or empty means nothing to report.
+
+- [ ] **Step 1: Write the failing tests.** A prototype from run `r1` against a sidecar stamped `r2` must **not** produce `confirmed_by_user` or `confirmed_person_id` for that cluster, and must appear once in `stale_assignments`. A prototype from `r2` against `r2` behaves exactly as today. A legacy pair (no ids at all) behaves exactly as today. Add one test that `speaker-naming-status` does not count a stale prototype's cluster as named.
+- [ ] **Step 2: Run and watch them fail.**
+- [ ] **Step 3: Apply the predicate at every reader.** The `confirmed_by_user` / `confirmed_person_id` derivation; `still_present`; the mutual-negative `matches` selection - without scoping there, a stale old-run prototype whose sid collides with a new-run sid would be treated as owning the new cluster and would seed negatives built from the new run's embeddings. Then assemble `stale_assignments`, deduped per person.
+- [ ] **Step 4: Leave participants alone, and say why in the code.** `confirmed_participant_names` stays meeting-scoped. Add the comment: attendance is a property of the meeting, not of a run, and run-filtering the `full-reprocess` restore would empty the section on every reprocess. Without that comment a later reader will "fix" it.
+- [ ] **Step 5: Run green, then the whole suite.**
+- [ ] **Step 6: Commit.**
+
+---
+
+### Task 6: Persisted review state, backend
+
+**Files:**
+- Modify: `src/speaker_suggestions.py` (write helper, merged propagation), `simple_recorder.py` (new CLI, transitions, `suggest-speakers` echo)
+- Test: `tests/test_speaker_multi_marking.py`, `tests/test_speaker_suggestions.py`
+
+**Interfaces:**
+- Consumes: the sidecar document helpers.
+- Produces: per-cluster optional key `review_state` with the single value `"generic"`; CLI `set-cluster-review-state <meeting_stem> <channel> <diarization_speaker_id> --generic|--clear`; `suggest-speakers` echoes `review_state` per cluster so the renderer can read it.
+
+- [ ] **Step 1: Write the failing tests.** The helper sets and clears the key on the exact raw id it was handed. A merged row reads as generic when **any** raw member carries it, mirroring how `merge_same_channel_fragments` already computes `contains_multiple_speakers` with `any()`. `confirm-speaker` clears it from **every fragment id** of the confirmed cluster, and `mark-speaker-cluster --multiple` does the same - so no orphaned key on a non-primary fragment can keep a row generic after a confirm. The CLI's never-raises contract: missing sidecar, missing channel, and missing cluster each produce `success: false` JSON and exit 1, with no traceback.
+- [ ] **Step 2: Run and watch them fail.**
+- [ ] **Step 3: Implement the helper and the CLI.** The write helper mirrors `set_cluster_multi_speaker`: re-read the freshest sidecar immediately before writing, apply the one change, replace atomically via `write_sidecar_document`. The CLI mirrors `mark-speaker-cluster`'s argument shape and reports the merged reach (resolved id plus fragment set) in its JSON.
+- [ ] **Step 4: Wire the transitions and the echo.** Clear on confirm and on mark; echo `review_state` per cluster from `suggest-speakers`.
+- [ ] **Step 5: Run green, then the whole suite.**
+- [ ] **Step 6: Commit.**
+
+---
+
+### Task 7: Persisted review state, renderer
+
+**Files:**
+- Modify: `app/main.js`, `app/preload.js`, `app/renderer/src/hooks/useSpeakerSuggestions.ts`, `app/renderer/src/components/SpeakerReviewPanel.tsx`, `app/renderer/src/lib/ipc.ts`
+- Create: `app/renderer/src/components/speakerReviewState.test.ts`
+- Test: the new vitest file, plus `e2e/specs/speaker-review.t1.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 6's CLI and echo, Task 5's `stale_assignments`.
+- Produces: `speakers.setClusterReviewState({ meetingStem, channel, diarizationSpeakerId, generic })` on the preload bridge, and `useSetClusterReviewState` in the hooks module.
+
+- [ ] **Step 1: Write the failing renderer tests.** Beside `speakerReviewOrdering.test.ts`, test the pure derivations rather than the component internals: a row whose suggestion carries `review_state: "generic"` reads as kept-generic; the notice text is produced when `stale_assignments` is non-empty and not when it is empty. Extract the derivations as exported helpers so they are testable without mounting, the same way `orderProfilesForRow` already is.
+- [ ] **Step 2: Add the failing T1 assertions.** In `speaker-review.t1.spec.ts`: after clicking "Keep generic" the row stays visible and reads as kept generic; the button is absent on a confirmed row and on a mixed row. Extend `app/e2e-mock-ipc.js` with the new handler and the `review_state` echo so the mock matches the real contract.
+- [ ] **Step 3: Run both and watch them fail.** `npx vitest run` and `npm run test:e2e -- --project=t1 --grep speaker`.
+- [ ] **Step 4: Bridge and wire.** The `ipcMain.handle` mirrors the `mark-speaker-cluster` handler including `parsePythonFailureJson` on error; the preload entry joins the existing `speakers` group; the hook invalidates `speakersKeys.suggestions(meetingStem)`. In the panel, the button calls the mutation, and the `dismissed` state and its `notDismissed` filtering are **removed** - the marker now comes from query data, which is what makes it survive a remount by construction. Gate the button off on confirmed and mixed rows; today it renders on both because it sits outside the `!isMarked` conditional.
+- [ ] **Step 5: Run typecheck, lint, vitest, T1.** Compare lint against the 37/0 baseline.
+- [ ] **Step 6: Commit.**
+
+---
+
+### Task 8: Report the lost markings
+
+**Files:**
+- Modify: `simple_recorder.py` (`backfill-speaker-embeddings`, `reprocess --retranscribe` via `_persist_speaker_sidecar`)
+- Test: `tests/test_backfill_cli.py`, `tests/test_speaker_multi_marking.py`
+
+**Interfaces:**
+- Consumes: Task 6's key.
+- Produces: no new public surface; a counted, logged report on both paths.
+
+- [ ] **Step 1: Write the failing tests.** `backfill-speaker-embeddings --force` over a sidecar carrying `review_state` markings reports their count alongside the existing `lost_multi_speaker_markings`. The `reprocess --retranscribe` path emits a warning naming both counts where today it emits nothing - this is the pre-existing silent loss, so assert on the current silence first to prove the test bites.
+- [ ] **Step 2: Run and watch them fail.**
+- [ ] **Step 3: Implement.** The backfill already reads the previous sidecar before overwriting; extend its accounting. Give `_persist_speaker_sidecar` the same read-before-overwrite accounting, reported as a `logger.warning` plus one greppable stdout line mirroring the backfill's wording, because `reprocess` streams lines rather than one JSON document. Do not surface it in the renderer; that is out of scope.
+- [ ] **Step 4: Run green.**
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 9: The e2e round-trip
+
+**Files:**
+- Modify: `e2e/specs/speaker-multi-marking.t2.spec.ts`
+- Test: itself
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the standing-rule coverage for a user-facing change.
+
+- [ ] **Step 1: Write the failing spec.** Drive `window.stenoai.speakers.setClusterReviewState` through the preload bridge against the real backend, then read the meeting's `_speakers.json` from disk and assert the `review_state` key on the right cluster; clear it and assert it is gone. Model-free, following the existing T2 speaker specs.
+- [ ] **Step 2: Run and watch it fail.** `npm run test:e2e -- --project=t2 --grep-invert @pipeline`.
+- [ ] **Step 3: Confirm the compatibility proof still holds.** `speaker-naming.t2` and `speaker-multi-marking.t2` must pass against the **unchanged**, legacy-shaped `writeSpeakersSidecar` fixture. If a change to that fixture was needed to make anything pass, the backward compatibility is broken and the cause is in Tasks 1-6, not in the fixture.
+- [ ] **Step 4: Full verification.** `ruff check .`, `python -m unittest discover tests`, `npm run typecheck:renderer`, `npm run lint:renderer`, `npx vitest run`, T1 and model-free T2. Compare every number against the baseline in Global Constraints and classify any difference.
+- [ ] **Step 5: Commit.**
+
+---
+
+## Review gate
+
+This slice changes a persisted format and the evidence-mutation path, so it earns the full loop rather than the light one:
+
+- Run `/codex:review --base origin/feat/speaker-diarization` over the whole branch diff, not per task. The failure mode this slice can produce is silent and cross-file (evidence deleted or wrongly kept), which per-task review does not see.
+- Reconcile every finding: adopt it, or reject it with a stated reason. Never drop one silently.
+- Then stop. Pushing and opening the PR is Ben's call.
+
+## Self-review notes
+
+Checked against the spec: sections 1-8, backward compatibility, and the whole testing section each map to a task above. Section 4's `stale_assignments` output is produced in Task 5 and consumed in Task 7; section 6's merged propagation is in Task 6; section 8's pre-existing `reprocess` bug is in Task 8. The one spec item deliberately without a task is the participants decision, which is a **non**-change plus a comment, and is folded into Task 5 Step 4 where a reader would otherwise be tempted to change it.
+
+Deviation from the writing-plans skill, on the repo owner's standing instruction: the steps carry exact file, function and assertion descriptions rather than finished code blocks. Finished code in a plan switches the implementer's thinking off, and the reasoning in the prose is the part that has to survive.

--- a/docs/superpowers/specs/2026-08-04-speaker-review-run-provenance-design.md
+++ b/docs/superpowers/specs/2026-08-04-speaker-review-run-provenance-design.md
@@ -1,0 +1,204 @@
+# Speaker review: run provenance and persisted review state - design
+
+Date: 2026-08-04.
+Branch: `feat/speaker-many-to-one`.
+Status: agreed design, pressure-tested by two independent reviews; this document is the build contract for the slice.
+
+This slice is deliberately ADDITIVE.
+Today `confirm-speaker` immediately writes a global person profile plus a voiceprint prototype, so the prototype IS the assignment.
+A later slice will invert that (assignments as source of truth, evidence derived from them); nothing here anticipates that inversion beyond not blocking it.
+
+## The two defects this slice targets
+
+Both are real in the code today.
+
+1. **"Keep generic" is not persisted.**
+   The review panel's "Keep generic" button only adds the row key to the `dismissed` React `useState` set and filters the row out client-side (`app/renderer/src/components/SpeakerReviewPanel.tsx`, the `dismissed` state and the `speaker-keep-generic-*` button).
+   A half-finished review starts from zero after an app restart, a navigation away, or even a panel remount.
+2. **Nothing notices a new diarization run.**
+   `reprocess --retranscribe` (via `_persist_speaker_sidecar`, `simple_recorder.py`), `backfill-speaker-embeddings --force`, and `full-reprocess` each produce a fresh diarization run whose `SPEAKER_N` ids are numbered independently of the previous run, so the same id now means a different voice.
+   Old prototypes keep pointing at those ids: the `confirmed_by_user` / `confirmed_person_id` derivation in `suggest-speakers` (`simple_recorder.py`) matches only on `(meeting_id, diarization_speaker_id, channel)`, so a new run's `SPEAKER_0` silently shows up as "Confirmed as X" from a prototype recorded against a different voice.
+   `reprocess --retranscribe` even documents the consequence in a code comment ("KNOWN CONSEQUENCE, deliberately not worked around") - this slice is the working-around.
+
+## 1. Run identity
+
+`write_speakers_sidecar` (`src/speaker_suggestions.py`) gains a new optional top-level sidecar key:
+
+```json
+"diarization_run": { "run_id": "<uuid4>", "created_at": 1754300000.0 }
+```
+
+- A fresh `run_id` (uuid4) is minted inside `write_speakers_sidecar` itself.
+  Every fresh diarization run funnels through this one function - the live pipeline and `reprocess --retranscribe` via `_persist_speaker_sidecar`, `full-reprocess` via `process-streaming` and then the same helper, and `backfill-speaker-embeddings` directly - so minting there needs no new plumbing at any call site.
+- Read-modify-write paths (`set_cluster_multi_speaker` / `write_sidecar_document`) rewrite the whole document and therefore preserve the block untouched.
+  A rewrite is not a new run.
+- **No audio fingerprint.**
+  `keep_recordings` defaults to false (`src/config.py`), so the source audio is usually gone right after processing; a fingerprint could never be re-verified later, while costing a full file hash on every run.
+  The run id identifies the run event, not the audio.
+- **No engine / engine_version fields.**
+  Cut from this slice by review: they would need new plumbing from the transcriber into the sidecar writer, and nothing in this slice consumes them.
+
+## 2. Evidence remembers its run
+
+`add_speaker_prototype` (`src/config.py`) gains a keyword argument `diarization_run_id: Optional[str] = None`, stored on the entry beside `meeting_id` and `diarization_speaker_id`, and only written when not None - the same absent-means-legacy convention the `channel` field already uses there.
+It applies to hard negatives exactly as to positive prototypes: both are built from the current sidecar's clusters, so both carry the run they came from.
+
+`confirm-speaker` (`simple_recorder.py`) reads the sidecar's current run id (`sidecar.get("diarization_run")`, absent on legacy sidecars) and passes it into every `add_speaker_prototype` call it makes, including the mutual-hard-negative writes.
+
+## 3. Persisted review state
+
+One new optional per-cluster sidecar key, written into the cluster entry itself (same placement rationale as `MULTI_SPEAKER_KEY` in `src/speaker_suggestions.py`: it travels with exactly the cluster it describes and cannot be orphaned by an id change):
+
+```json
+"review_state": "generic"
+```
+
+Exactly one value in this slice, and deliberately so:
+
+- `assigned` is derivable from a matching prototype (that is what `confirmed_by_user` already does).
+- `mixed` already exists as `contains_multiple_speakers`.
+- `unreviewed` is the absence of everything.
+
+Recording any of those as a second copy would create a consistency obligation with no information gain.
+The key is only written when set; absent means "not marked", so every pre-existing sidecar reads correctly.
+`review_state` changes no scoring and no suggestion status - it is purely a persisted review-progress marker.
+
+**New CLI `set-cluster-review-state`** (`simple_recorder.py`), mirroring `mark-speaker-cluster`'s shape: positional `meeting_stem channel diarization_speaker_id`, a `--generic/--clear` flag pair, JSON output.
+The write helper mirrors `set_cluster_multi_speaker` (re-read the freshest sidecar immediately before writing, apply the one change, replace atomically via `write_sidecar_document`).
+Never-raises contract: any failure (missing sidecar, channel, or cluster; unreadable file) prints `{"success": false, "error": ...}` and exits 1 - never a traceback.
+
+**IPC and renderer wiring**, all following the existing `mark-speaker-cluster` pattern:
+
+- `app/main.js`: an `ipcMain.handle('set-cluster-review-state', ...)` that shells out and returns `parsePythonFailureJson` on error, like the `mark-speaker-cluster` handler.
+- `app/preload.js`: `speakers.setClusterReviewState(params)` in the existing `speakers` group.
+- `app/renderer/src/hooks/useSpeakerSuggestions.ts`: a `useSetClusterReviewState` mutation invalidating `speakersKeys.suggestions(meetingStem)`.
+- `SpeakerReviewPanel.tsx`: the existing "Keep generic" button calls the mutation instead of `setDismissed`.
+  The `dismissed` local state and its `notDismissed` filtering are removed; the marker is read from the suggestions query (`suggest-speakers` echoes `review_state` per cluster), so it survives remounts and restarts by construction.
+- **Behavior change, deliberate:** today the button hides the row for the session.
+  Under this design the row stays visible, quietly marked as kept generic, with the undo one click away - a persisted-but-hidden row would make the undo undiscoverable.
+
+## 4. Staleness on the read path
+
+`suggest-speakers` compares each prototype's `diarization_run_id` with the sidecar's current run id.
+The rule is deliberately ASYMMETRIC because of how the two ids can come to disagree:
+
+| prototype run id | sidecar run id | verdict | why |
+|---|---|---|---|
+| absent | absent | current | pure legacy, nothing was ever re-diarized with run stamping |
+| present | present, equal | current | confirmed against exactly this run |
+| present | present, different | stale | confirmed against a different run's clusters |
+| absent | present | stale | can only arise if the recording was re-diarized after the confirmation - the confirm predates run stamping, the sidecar postdates it |
+| present | absent | stale | defensive: only reachable if a build without run stamping re-diarized after a stamped confirm; the sidecar's clusters are then not provably the confirm-time run |
+
+The rule lives as one shared predicate in `src/speaker_suggestions.py` (beside `prototype_channel_matches`, which `src/config.py` already imports the same way), so the read path and the write path below cannot drift apart.
+
+Consequences in `suggest-speakers`:
+
+- Only prototypes current under the rule may populate `confirmed_by_user` / `confirmed_person_id` (and thereby the panel's `alreadyInMeeting` set).
+- Stale prototypes are collected into a new top-level output field, e.g. `stale_assignments: [{person_id, display_name}]`, and the panel renders one meeting-level notice from it: this meeting was re-diarized, earlier assignments no longer map to the clusters below, re-confirm them.
+- **Nothing is deleted.**
+  Stale prototypes remain real voice evidence of a real person and keep feeding candidate scoring - `score_candidates` (`src/speaker_suggestions.py`) pools all of a person's prototypes by recording type and is untouched by this slice.
+
+## 5. Run scope on the write path (the central review finding)
+
+`remove_speaker_evidence` (`src/config.py`) matches only on `(meeting_id, channel-or-recording-type, sids)` today.
+After a re-diarization the new run's first cluster is called `SPEAKER_0` again, so confirming it as a different person walks the reassignment loop in `confirm-speaker` and deletes the previous person's genuine old-run prototype - the one recorded against a genuinely different voice.
+Without run-scoped removal the design contradicts its own promise that nothing is deleted.
+
+- `remove_speaker_evidence` gains a keyword-only run-scope parameter with a distinct "unscoped" sentinel default (so out-of-tree callers keep today's behavior), and every in-repo caller passes a run id, possibly None.
+  When scoped, an entry must additionally be run-compatible with the passed id under the shared predicate from section 4 to be removed.
+  Note the legacy symmetry this preserves: confirming on a never-restamped legacy sidecar (both ids absent, "current") still removes the superseded legacy prototype, exactly as today.
+- Callers and what they pass:
+  - `confirm-speaker`'s reassignment loop and all its negative-cleanup and idempotency-rebuild removals: the sidecar's current run id.
+  - `mark-speaker-cluster`'s confirmation-withdrawal loop: the sidecar's current run id.
+  - `delete_person_profile`'s cross-profile hard-negative cleanup (`src/config.py`): each source prototype's OWN run id, since the derived negatives were created in the same confirm and therefore the same run.
+- The same run awareness applies anywhere evidence is READ as a current assignment, all via the shared predicate:
+  - `confirm-speaker`'s `still_present` check (does this person still own a cluster in this channel) and its mutual-hard-negative `matches` loop - without scoping, a stale old-run prototype whose sid happens to collide with a new-run sid would be treated as owning the new cluster and would seed wrong negatives from the new run's embeddings.
+  - `suggest-speakers`' `confirmed_by_user` / `confirmed_person_id` derivation (section 4).
+  - `speaker-naming-status`' named-cluster count (`simple_recorder.py`) - a stale prototype must not make a new, actually-unnamed cluster count as named in the delete-confirmation warning.
+- **Participants stay meeting-scoped, and that is the deliberate form of run awareness there.**
+  `confirmed_participant_names` (`src/speaker_suggestions.py`) matches on `meeting_id` only.
+  Attendance is a property of the meeting, not of a diarization run: a stale prototype still proves that person was confirmed as present in this meeting, and run-filtering the `full-reprocess` participants restore would empty the section on every reprocess, deleting correct information.
+  So the participants derivation (restore in `full-reprocess`, upkeep in `confirm-speaker` and `mark-speaker-cluster`) reports the union across runs, deduped per person, and the code says so explicitly so a later reader does not "fix" it into run scoping.
+- **Known limitation, stated rather than hidden:** with run-scoped removal, re-confirming a new run's cluster can no longer correct a WRONG old-run confirmation (the old prototype now survives on purpose).
+  The remedies are deleting the person, the existing repair CLI's precise `remove_speaker_evidence_by_ids` path, or the future assignment-inversion slice.
+  This trade is accepted: silently destroying genuine evidence is the worse failure, and it is the one happening today.
+
+## 6. Merged rows
+
+`review_state` is written on raw cluster ids, while the panel shows rows merged by `merge_same_channel_fragments` (`src/speaker_suggestions.py`).
+Two rules, both copied from how `contains_multiple_speakers` already handles the same mismatch:
+
+- `set-cluster-review-state` accepts any raw id and writes to exactly the id it was handed, the same way `mark-speaker-cluster` / `set_cluster_multi_speaker` do, reporting the merged reach (resolved id plus fragment set) in its JSON output.
+- The merged view propagates with `any()`: a merged row reads as generic when ANY of its raw members carries the key - the same deliberate choice `merge_same_channel_fragments` makes when it computes the merged context's `contains_multiple_speakers` from its members.
+- Clears initiated by transitions (section 7) sweep the full fragment set, so no orphaned key on a non-primary fragment can keep a row generic after a confirm.
+
+## 7. Explicit transitions
+
+`generic` means "a human chose to stop here"; any stronger statement supersedes it.
+
+- `confirm-speaker` clears `review_state` from every fragment id of the confirmed cluster.
+- `mark-speaker-cluster --multiple` clears it the same way.
+- The "Keep generic" button disappears on confirmed rows and on mixed rows.
+  Today it is still rendered there: in `SpeakerReviewPanel.tsx` the button sits outside the `!isMarked` conditional that hides the naming actions, and nothing gates it on `confirmed_by_user` - verified against the component.
+
+## 8. Report the loss
+
+A re-diarization drops review markings (`review_state` and `contains_multiple_speakers` alike): the new run numbers its clusters independently, so the old ids describe nothing, and carrying the markings forward would attach human statements to whichever voices happened to inherit the ids.
+Losing them is semantically right; losing them SILENTLY is not.
+
+- `backfill-speaker-embeddings` already reads the previous sidecar before overwriting and reports `lost_multi_speaker_markings` in its JSON result plus a `logger.warning` (`simple_recorder.py`).
+  It additionally counts and reports lost `review_state` markings the same way.
+- **Pre-existing bug, fixed in this slice because it touches exactly this path:** `reprocess --retranscribe` rewrites the sidecar through `_persist_speaker_sidecar` with no such report - the markings vanish silently.
+  It gains the same read-before-overwrite accounting.
+  `reprocess` streams line-oriented output rather than one JSON document, so the report there is a `logger.warning` plus a clearly greppable stdout line, mirroring the backfill's wording; surfacing it in the renderer beyond the section 4 stale notice is not part of this slice.
+- `full-reprocess` backs the old sidecar up as `.bak-<timestamp>` before overwriting and already prints a note that confirmations were reset, which satisfies the reporting requirement there.
+
+## Backward compatibility
+
+- Both new sidecar keys are optional; `read_speakers_sidecar` and every consumer treat absence as legacy.
+- A legacy sidecar (no run block) still supports confirm/suggest/mark/set-review-state; confirms from it store no run id, and the staleness rule's both-absent row keeps everything current.
+- Prototypes without `diarization_run_id` behave exactly as today until the first stamped re-diarization of their meeting, at which point the absent-vs-present row correctly reports them stale.
+- The e2e fixture `writeSpeakersSidecar` (`e2e/fixtures/user-config.ts`) stays legacy-shaped with no run block on purpose: `speaker-naming.t2.spec.ts` and `speaker-multi-marking.t2.spec.ts` staying green against it IS the backward-compatibility proof.
+
+## Not in scope
+
+Stated as explicitly as what is in scope:
+
+- The assignment/evidence inversion (assignments as source of truth, prototypes derived).
+- Meeting-local placeholder people.
+- Deliberate over-segmentation of the diarizer.
+- Any diarization engine change, and the `engine` / `engine_version` sidecar fields.
+- An audio fingerprint in the run block.
+- Migrating or backfilling run ids onto existing prototypes or sidecars.
+- Any renderer surfacing of the lost-markings report beyond the stale-assignment notice.
+
+## Testing
+
+Python (`tests/`, following the existing `test_speaker_suggestions.py` / `test_confirm_speaker_cli.py` / `test_speaker_multi_marking.py` patterns):
+
+- Sidecar round-trip through `write_speakers_sidecar` / `read_speakers_sidecar` with the new keys present, and a handwritten legacy document without them reading cleanly.
+- The staleness matrix from section 4 against the shared predicate - the four reachable cases plus the defensive fifth row.
+- Run-scoped removal: an old-run prototype for `(meeting, mic, SPEAKER_0)` survives a re-confirm of the new run's `SPEAKER_0` as a different person, while the new prototype carries the new run id; and the legacy both-absent re-confirm still removes the superseded prototype as today.
+- `set-cluster-review-state` end to end, including its never-raises contract: missing sidecar, channel, and cluster each produce JSON `success: false` and exit code 1, no traceback.
+- Merged-row propagation: with two raw clusters close enough to merge, `review_state` written on the non-primary fragment marks the merged row, and a confirm clears the whole fragment set.
+
+Renderer (vitest + testing-library, beside `speakerReviewOrdering.test.ts`):
+
+- The generic marking survives a panel remount (it derives from query data, not component state).
+- The stale-assignment notice renders when `stale_assignments` is non-empty.
+- The "Keep generic" button is absent on confirmed rows and on mixed rows.
+
+e2e:
+
+- `speaker-naming.t2.spec.ts` and `speaker-multi-marking.t2.spec.ts` run unchanged against the legacy-shaped fixture (the compatibility proof above).
+- Per the repo's standing e2e rule, the model-free T2 speaker spec gains one minimal review-state round-trip: drive `speakers.setClusterReviewState` through the preload bridge and assert the `review_state` key in the sidecar JSON on disk - the fixture itself stays legacy-shaped.
+
+## Claims checked against the code
+
+Every code reference above was read in this checkout before being cited.
+The briefed design matched the code at every load-bearing point; two findings sharpen it rather than contradict it:
+
+- The new-run producers are three, not two: `full-reprocess` also produces a fresh run (via `process-streaming`).
+  All three funnel through `write_speakers_sidecar`, which is why minting the run id there covers them without new plumbing.
+- The staleness rule as briefed enumerates four cases; the fifth combination (prototype stamped, sidecar unstamped) is unreachable through this slice's own writers but reachable through an older build, so it is pinned defensively as stale above rather than left undefined.

--- a/e2e/specs/speaker-review.t1.spec.ts
+++ b/e2e/specs/speaker-review.t1.spec.ts
@@ -396,3 +396,54 @@ test('the panel says how many people spoke when a cluster is known to hold more 
   await expect(note).toBeVisible();
   await expect(note).toContainText('At least 6 people spoke, but only 5 could be told apart');
 });
+
+test('rows are ordered by speaking time, so the first decisions cover the most transcript', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_SPEAKER_SUGGESTIONS: '1' },
+  });
+  await openDetail(page);
+
+  // The seed's durations are 245 / 80 / 30 s (plus two filtered rows), and
+  // the cluster ids run the other way for SPEAKER_2, so channel+id order --
+  // what the panel used before -- would be a different sequence. Reviewing
+  // is voluntary and abandonable, so whoever stops after one row should
+  // have covered the biggest speaker, not the lowest-numbered slot.
+  const keys = await page
+    .getByTestId('speaker-review-panel')
+    .locator('[data-testid^="speaker-row-"]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
+
+  expect(keys).toEqual([
+    'speaker-row-mic:SPEAKER_0',
+    'speaker-row-mic:SPEAKER_1',
+    'speaker-row-mic:SPEAKER_2',
+  ]);
+});
+
+test('the Change picker offers people already assigned in this meeting first', async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_SPEAKER_SUGGESTIONS: '1' },
+  });
+  await openDetail(page);
+
+  // One person owning several clusters is the normal case once the diarizer
+  // splits a voice, and it has to be at least as easy to say as "New
+  // person" -- naming the same voice twice makes it a hard negative against
+  // itself, which suppresses that speaker's future suggestions for good.
+  await page.getByTestId('speaker-approve-mic:SPEAKER_0').click();
+  await expect(page.getByTestId('speaker-row-mic:SPEAKER_0')).toContainText('Confirmed as Julian');
+
+  await page.getByTestId('speaker-change-mic:SPEAKER_1').click();
+  const names = await page
+    .locator('[data-testid^="speaker-pick-person-"]')
+    .evaluateAll((els) => els.map((el) => el.textContent?.trim() ?? ''));
+
+  expect(names[0]).toContain('Julian');
+  expect(names[0]).toContain('here');
+});

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5016,11 +5016,26 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
         if not removed or existing_person["person_id"] == person["person_id"]:
             continue
         reassigned_from.append(existing_person["display_name"])
-        config.remove_speaker_evidence(
-            existing_person["person_id"], meeting_id=meeting_stem,
-            channel=channel, channel_recording_type=channel_recording_type,
-            negative=True,
+        # Their negatives here rest on them having been present in this
+        # channel at all, not on this one cluster -- so drop them only once
+        # they own NO cluster here any more. Under many-to-one one person
+        # legitimately owns several clusters of a meeting; taking one away
+        # used to strip the negatives the clusters they KEEP still justify,
+        # and the rebuild below only restores negatives for the person being
+        # confirmed now, so that evidence was simply lost.
+        still_present = any(
+            p.get("meeting_id") == meeting_stem
+            and prototype_channel_matches(p, channel, channel_recording_type)
+            for p in (config.get_person_profile(existing_person["person_id"]) or {}).get(
+                "prototypes",
+            ) or []
         )
+        if not still_present:
+            config.remove_speaker_evidence(
+                existing_person["person_id"], meeting_id=meeting_stem,
+                channel=channel, channel_recording_type=channel_recording_type,
+                negative=True,
+            )
         for other in config.get_person_profiles():
             if other["person_id"] == existing_person["person_id"]:
                 continue
@@ -5067,35 +5082,41 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
     for other_person in config.get_person_profiles():
         if other_person["person_id"] == person["person_id"]:
             continue
-        match = next(
-            (p for p in (other_person.get("prototypes") or [])
-             if p.get("meeting_id") == meeting_stem
-             and p.get("diarization_speaker_id") in other_sids
-             and prototype_channel_matches(p, channel, channel_recording_type)),
-            None,
-        )
-        if match is None:
+        # EVERY cluster that person owns here, not just the first one. One
+        # person legitimately owns several clusters of a meeting -- the
+        # diarizer splits a voice, and the reviewer assigns both halves to
+        # them. Matching only the first prototype left the second cluster
+        # with no negative evidence at all, so a later meeting could still
+        # match this speaker to it.
+        matches = [
+            p for p in (other_person.get("prototypes") or [])
+            if p.get("meeting_id") == meeting_stem
+            and p.get("diarization_speaker_id") in other_sids
+            and prototype_channel_matches(p, channel, channel_recording_type)
+        ]
+        if not matches:
             continue
-        other_sid = match["diarization_speaker_id"]
-        other_embedding, other_context = clusters[other_sid]
-        config.add_speaker_prototype(
-            person["person_id"], other_embedding,
-            recording_type=other_context.recording_type, meeting_id=meeting_stem,
-            diarization_speaker_id=other_sid,
-            speech_duration_seconds=other_context.speech_duration_seconds,
-            segment_count=other_context.segment_count,
-            created_from="user_confirmed", negative=True,
-            channel=channel,
-        )
-        config.add_speaker_prototype(
-            other_person["person_id"], embedding,
-            recording_type=context.recording_type, meeting_id=meeting_stem,
-            diarization_speaker_id=resolved_id,
-            speech_duration_seconds=context.speech_duration_seconds,
-            segment_count=context.segment_count,
-            created_from="user_confirmed", negative=True,
-            channel=channel,
-        )
+        for match in matches:
+            other_sid = match["diarization_speaker_id"]
+            other_embedding, other_context = clusters[other_sid]
+            config.add_speaker_prototype(
+                person["person_id"], other_embedding,
+                recording_type=other_context.recording_type, meeting_id=meeting_stem,
+                diarization_speaker_id=other_sid,
+                speech_duration_seconds=other_context.speech_duration_seconds,
+                segment_count=other_context.segment_count,
+                created_from="user_confirmed", negative=True,
+                channel=channel,
+            )
+            config.add_speaker_prototype(
+                other_person["person_id"], embedding,
+                recording_type=context.recording_type, meeting_id=meeting_stem,
+                diarization_speaker_id=resolved_id,
+                speech_duration_seconds=context.speech_duration_seconds,
+                segment_count=context.segment_count,
+                created_from="user_confirmed", negative=True,
+                channel=channel,
+            )
         hard_negatives_added.append(other_person["display_name"])
 
     relabeled_lines = 0

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5078,6 +5078,25 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
         sid for sid in clusters
         if sid != resolved_id and not clusters[sid][1].contains_multiple_speakers
     ]
+    # Rebuild rather than append. Confirming the same cluster as the same
+    # person again -- the review UI's Approve on an already-confirmed row, or
+    # simply redoing an assignment -- used to run the loop below a second
+    # time and stack a duplicate of every negative in both directions, once
+    # more on each repeat. Dropping the evidence this cluster produced first
+    # makes the whole step idempotent: the loop then writes exactly the set
+    # the current assignments justify.
+    for existing_person in config.get_person_profiles():
+        config.remove_speaker_evidence(
+            existing_person["person_id"], meeting_id=meeting_stem,
+            channel=channel, channel_recording_type=channel_recording_type,
+            sids=fragment_ids, negative=True,
+        )
+    config.remove_speaker_evidence(
+        person["person_id"], meeting_id=meeting_stem,
+        channel=channel, channel_recording_type=channel_recording_type,
+        negative=True,
+    )
+
     hard_negatives_added = []
     for other_person in config.get_person_profiles():
         if other_person["person_id"] == person["person_id"]:
@@ -5096,6 +5115,8 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
         ]
         if not matches:
             continue
+        # One negative per THEIR cluster, in this direction only: "the person
+        # I am confirming is none of those clusters".
         for match in matches:
             other_sid = match["diarization_speaker_id"]
             other_embedding, other_context = clusters[other_sid]
@@ -5108,15 +5129,19 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
                 created_from="user_confirmed", negative=True,
                 channel=channel,
             )
-            config.add_speaker_prototype(
-                other_person["person_id"], embedding,
-                recording_type=context.recording_type, meeting_id=meeting_stem,
-                diarization_speaker_id=resolved_id,
-                speech_duration_seconds=context.speech_duration_seconds,
-                segment_count=context.segment_count,
-                created_from="user_confirmed", negative=True,
-                channel=channel,
-            )
+        # And exactly ONE the other way: THIS cluster is a single piece of
+        # evidence about them, however many clusters they own. Adding it per
+        # match duplicated it, and every copy is another reason the matcher
+        # refuses a real match for them later.
+        config.add_speaker_prototype(
+            other_person["person_id"], embedding,
+            recording_type=context.recording_type, meeting_id=meeting_stem,
+            diarization_speaker_id=resolved_id,
+            speech_duration_seconds=context.speech_duration_seconds,
+            segment_count=context.segment_count,
+            created_from="user_confirmed", negative=True,
+            channel=channel,
+        )
         hard_negatives_added.append(other_person["display_name"])
 
     relabeled_lines = 0
@@ -5554,6 +5579,7 @@ def suggest_speakers(meeting_stem):
             # is gone the moment the panel unmounts (e.g. navigating away
             # and back). This survives both.
             confirmed_by_user = None
+            confirmed_person_id = None
             for person in profiles:
                 if any(
                     p.get("meeting_id") == meeting_stem
@@ -5562,6 +5588,11 @@ def suggest_speakers(meeting_stem):
                     for p in (person.get("prototypes") or [])
                 ):
                     confirmed_by_user = person["display_name"]
+                    # The id as well as the name: display names are not a
+                    # stable identity (a rename can make two profiles read
+                    # alike), and the panel uses this to tell which people
+                    # already hold a cluster of THIS meeting.
+                    confirmed_person_id = person["person_id"]
                     break
             cluster_out[sid] = {
                 "status": r.status,
@@ -5623,6 +5654,7 @@ def suggest_speakers(meeting_stem):
                 # sidecar or from confirm-speaker -- purely a UI hint.
                 "is_likely_artifact": avg_turn < SUGGESTION_MIN_AVG_TURN_SECONDS,
                 "confirmed_by_user": confirmed_by_user,
+                "confirmed_person_id": confirmed_person_id,
             }
         channels_out[channel_name] = cluster_out
 

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1723,12 +1723,28 @@ def extract_segment_samples(
             "start": begin,
             "end": end,
             "text": _join_texts([text], max_chars),
+            # Whether this turn survives BOTH display caps whole. The quote
+            # is cut at max_chars and the clip at SAMPLE_MAX_SECONDS, and
+            # nothing related the two: measured on a real 9-minute call, a
+            # 40.5 s / 742-character turn showed 19 % of its text beside
+            # 20 s of audio. Reading one sentence while hearing twenty
+            # seconds reads as the wrong clip, even though both start at
+            # the same instant.
+            "fits": len(text) <= max_chars and (end - begin) < SAMPLE_MAX_SECONDS,
         })
 
-    # The longest turns, then chronological -- same reasoning as
-    # sample_segments (a long uninterrupted turn is the most likely to be
-    # genuine, unmixed speech), now applied to units that have text.
-    chosen = sorted(candidates, key=lambda c: c["end"] - c["start"], reverse=True)[:limit]
+    # Whole turns first, longest among them; overflowing ones only fill the
+    # remaining slots. Ranking by raw duration alone preferred precisely the
+    # turns that overflow, because overflowing is what being long means here
+    # -- the same amplification that made a drifted clip more likely to be
+    # shown before _turn_audio_range stopped drifting. A turn that fits is
+    # still chosen longest-first, so the clip stays long enough to
+    # recognise a voice from.
+    chosen = sorted(
+        candidates,
+        key=lambda c: (c["fits"], c["end"] - c["start"]),
+        reverse=True,
+    )[:limit]
     return sorted(chosen, key=lambda c: c["start"])
 
 

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1517,6 +1517,20 @@ def _join_texts(texts: list, max_chars: int) -> Optional[str]:
     return combined or None
 
 
+# Below this a clip cannot carry a voice, however faithfully its quote
+# matches it -- and matching the quote is not the point of the panel,
+# recognising a speaker is. Without this floor, preferring turns that
+# survive both display caps handed a 0.1 s "Ja" priority over a 19 s turn
+# whose quote missed the character cap by one character.
+#
+# CHOSEN, not measured, unlike SUGGESTION_MIN_AVG_TURN_SECONDS above (which
+# is ground-truthed against a real library, but answers a different
+# question: whether a cluster's average turn looks like an artifact). Two
+# seconds is about the shortest clip a listener can place a voice from; it
+# sits just above that measured 1.55 s neighbour, which is the right order
+# of magnitude but not evidence for this number.
+SAMPLE_MIN_USEFUL_SECONDS = 2.0
+
 # A review clip is never longer than this, even when the next transcript
 # line is minutes away (a long pause, or the speaker holding the floor
 # uninterrupted). Nobody listens to five minutes to recognise a voice, and
@@ -1730,7 +1744,15 @@ def extract_segment_samples(
             # 20 s of audio. Reading one sentence while hearing twenty
             # seconds reads as the wrong clip, even though both start at
             # the same instant.
-            "fits": len(text) <= max_chars and (end - begin) < SAMPLE_MAX_SECONDS,
+            # `<=` on both caps: a turn ending exactly at the audio limit
+            # survives it whole, exactly as a quote of exactly max_chars
+            # does. And a clip too short to place a voice earns no
+            # preference, however completely it is quoted.
+            "fits": (
+                len(text) <= max_chars
+                and (end - begin) <= SAMPLE_MAX_SECONDS
+                and (end - begin) >= SAMPLE_MIN_USEFUL_SECONDS
+            ),
         })
 
     # Whole turns first, longest among them; overflowing ones only fill the

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -147,6 +147,85 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self.assertEqual(len(sarah_profile["hard_negatives"]), 1)
             self.assertEqual(sarah_profile["hard_negatives"][0]["embedding_mean"], [1.0, 0.0])
 
+    def _seed_three_cluster_sidecar(self, tmp, meeting_stem="mtg001"):
+        """One channel, three clusters -- the shape that appears as soon as the
+        diarizer splits one person across two clusters, which is the normal
+        case under deliberate over-segmentation."""
+        output_dir = Path(tmp) / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        write_speakers_sidecar(output_dir, meeting_stem, {
+            "mic": {
+                "recording_type": "in_person",
+                "clusters": {
+                    # Two clusters of ONE voice, deliberately far enough apart
+                    # that merge_same_channel_fragments leaves them separate.
+                    "SPEAKER_00": {"embedding": [1.0, 0.0], "speech_duration_seconds": 30.0, "segment_count": 5},
+                    "SPEAKER_02": {"embedding": [0.0, 0.0, 1.0], "speech_duration_seconds": 20.0, "segment_count": 4},
+                    "SPEAKER_01": {"embedding": [0.0, 1.0], "speech_duration_seconds": 25.0, "segment_count": 4},
+                },
+            },
+        })
+
+    def test_one_person_owning_two_clusters_keeps_both_hard_negatives(self):
+        # Many-to-one: the user assigns SPEAKER_00 and SPEAKER_02 to Max, and
+        # SPEAKER_01 to Sarah. Sarah must be a hard negative against BOTH of
+        # Max's clusters -- the loop matched only the FIRST prototype per
+        # person (`next(...)`), so the second cluster of a person silently
+        # produced no negative evidence at all.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_three_cluster_sidecar(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+
+            r1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg)
+            max_id = _last_json(r1.output)["person_id"]
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_02", "--person-id", max_id], tmp, cfg=cfg)
+            r3, cfg = self._run(["mtg001", "mic", "SPEAKER_01", "--new-person", "Sarah"], tmp, cfg=cfg)
+            sarah_id = _last_json(r3.output)["person_id"]
+
+            max_profile = cfg.get_person_profile(max_id)
+            sarah_profile = cfg.get_person_profile(sarah_id)
+
+            self.assertEqual(
+                len(max_profile["prototypes"]), 2,
+                "one person may own several clusters of the same meeting",
+            )
+            negative_sids = sorted(
+                h.get("diarization_speaker_id") for h in sarah_profile["hard_negatives"]
+            )
+            self.assertEqual(
+                negative_sids, ["SPEAKER_00", "SPEAKER_02"],
+                "Sarah is demonstrably not either of Max's clusters",
+            )
+
+    def test_reassigning_one_cluster_keeps_the_persons_other_negatives(self):
+        # The displaced person's negatives were removed for the WHOLE
+        # meeting+channel rather than only those citing the cluster being
+        # taken away. With one person owning two clusters that silently
+        # stripped the evidence belonging to the cluster they keep.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_three_cluster_sidecar(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+
+            r1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg)
+            max_id = _last_json(r1.output)["person_id"]
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_02", "--person-id", max_id], tmp, cfg=cfg)
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_01", "--new-person", "Sarah"], tmp, cfg=cfg)
+
+            # Max loses SPEAKER_02 to a third person; SPEAKER_00 stays his.
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_02", "--new-person", "Tom"], tmp, cfg=cfg)
+
+            max_profile = cfg.get_person_profile(max_id)
+            self.assertEqual(
+                [p["diarization_speaker_id"] for p in max_profile["prototypes"]], ["SPEAKER_00"],
+            )
+            negative_sids = sorted(
+                h.get("diarization_speaker_id") for h in max_profile["hard_negatives"]
+            )
+            self.assertIn(
+                "SPEAKER_01", negative_sids,
+                "the evidence that Max is not Sarah belongs to the cluster he kept",
+            )
+
     def test_hard_negatives_scoped_to_same_channel_only(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "output"

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -636,3 +636,43 @@ class ConfirmSpeakerUpdatesParticipantsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ConfirmSpeakerEvidenceHygieneTests(ConfirmSpeakerCliTests):
+    """Hard negatives are permanent suppression evidence, so a duplicate is
+    not merely untidy: every copy is another reason the matcher will refuse a
+    real match later."""
+
+    def test_a_person_with_two_clusters_does_not_collect_duplicate_negatives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_three_cluster_sidecar(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            r1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg)
+            max_id = _last_json(r1.output)["person_id"]
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_02", "--person-id", max_id], tmp, cfg=cfg)
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_01", "--new-person", "Sarah"], tmp, cfg=cfg)
+
+            max_negatives = [
+                h.get("diarization_speaker_id")
+                for h in cfg.get_person_profile(max_id)["hard_negatives"]
+            ]
+            self.assertEqual(
+                max_negatives, ["SPEAKER_01"],
+                "Sarah's one cluster is one piece of evidence, however many clusters Max owns",
+            )
+
+    def test_reconfirming_the_same_person_does_not_stack_negatives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_sidecar(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            r1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg)
+            max_id = _last_json(r1.output)["person_id"]
+            r2, cfg = self._run(["mtg001", "mic", "SPEAKER_01", "--new-person", "Sarah"], tmp, cfg=cfg)
+            sarah_id = _last_json(r2.output)["person_id"]
+
+            # The UI's Approve on an already-confirmed row, or a user simply
+            # redoing the same assignment.
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--person-id", max_id], tmp, cfg=cfg)
+
+            self.assertEqual(len(cfg.get_person_profile(max_id)["hard_negatives"]), 1)
+            self.assertEqual(len(cfg.get_person_profile(sarah_id)["hard_negatives"]), 1)

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1511,3 +1511,71 @@ class ExcerptFitTests(unittest.TestCase):
             )
             self.assertEqual(len(samples), 1, "a partial excerpt beats no excerpt")
             self.assertTrue(samples[0]["text"].endswith("…"))
+
+
+class ExcerptFitBoundaryTests(unittest.TestCase):
+    """Both from the review of the fit ranking. Preferring a turn that
+    survives both display caps is right, but "fits" is not on its own a
+    measure of usefulness: the panel exists so a human can recognise a
+    voice, and a fraction of a second cannot carry one however faithfully
+    it is quoted."""
+
+    def _write(self, tmp, body):
+        path = Path(tmp) / "t.txt"
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    @staticmethod
+    def _manifest(*starts):
+        return [
+            {"start": s, "channel": "system", "diarization_speaker_id": "SPEAKER_0"}
+            for s in starts
+        ]
+
+    def test_a_fraction_of_a_second_does_not_beat_a_long_readable_turn(self):
+        # A 0.1 s turn quoting one word fits both caps; a 19 s turn misses
+        # the character cap by a single character. The short one is useless
+        # for recognising a voice and the long one's quote stays readable.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._write(
+                tmp,
+                "[00:10] [Others] Ja\n"
+                f"[00:30] [Others] {'a' * 141}\n"
+                "[01:00] [Others] trailing line\n",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                [
+                    {"start": 10.0, "end": 10.1},
+                    {"start": 30.0, "end": 49.0},
+                    {"start": 60.0, "end": 61.0},
+                ],
+                limit=1,
+                turn_manifest=self._manifest(10.0, 30.0, 60.0),
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertAlmostEqual(samples[0]["start"], 30.0, places=1)
+
+    def test_a_clip_exactly_at_the_audio_cap_counts_as_fitting(self):
+        # `< SAMPLE_MAX_SECONDS` classed a turn of exactly the cap as
+        # overflowing, while the character cap is compared with `<=`. A turn
+        # that ends exactly at the limit survives it whole.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._write(
+                tmp,
+                "[00:10] [Others] a turn that lands exactly on the audio cap\n"
+                "[00:40] [Others] Ja\n"
+                "[00:50] [Others] trailing line\n",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                [
+                    {"start": 10.0, "end": 30.0},   # exactly SAMPLE_MAX_SECONDS
+                    {"start": 40.0, "end": 40.1},
+                    {"start": 50.0, "end": 51.0},
+                ],
+                limit=1,
+                turn_manifest=self._manifest(10.0, 40.0, 50.0),
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertAlmostEqual(samples[0]["start"], 10.0, places=1)

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1452,3 +1452,62 @@ class SpeakerNamingStatusCliTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class ExcerptFitTests(unittest.TestCase):
+    """A quote and its clip are two views of one turn, and each has its own
+    cap: 140 characters and 20 seconds. Nothing related them, so a long turn
+    showed a fifth of its text beside half of its audio - measured on a real
+    9-minute call, a 40.5 s / 742-character turn showed 19 % of the text and
+    played 20 s. The user reads one sentence and hears twenty seconds, which
+    reads as a wrong clip even though both start at the same instant."""
+
+    def _write(self, tmp, body):
+        path = Path(tmp) / "t.txt"
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    @staticmethod
+    def _manifest(*starts):
+        return [
+            {"start": s, "channel": "system", "diarization_speaker_id": "SPEAKER_0"}
+            for s in starts
+        ]
+
+    def test_a_turn_that_fits_both_caps_beats_a_longer_one_that_overflows(self):
+        long_text = "wort " * 200  # far past SAMPLE_TEXT_MAX_CHARS
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._write(
+                tmp,
+                f"[00:10] [Others] {long_text.strip()}\n"
+                "[01:00] [Others] a turn short enough to be shown whole\n"
+                "[01:20] [Others] trailing line that bounds the one above\n",
+            )
+            samples = extract_segment_samples(
+                transcript,
+                [
+                    {"start": 10.0, "end": 55.0},   # 45 s: over the audio cap
+                    {"start": 60.0, "end": 68.0},   # 8 s: fits
+                    {"start": 80.0, "end": 82.0},
+                ],
+                limit=1,
+                turn_manifest=self._manifest(10.0, 60.0, 80.0),
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(len(samples), 1)
+            self.assertIn(
+                "short enough", samples[0]["text"],
+                "ranking by raw duration prefers exactly the turns that overflow both caps",
+            )
+
+    def test_an_overflowing_turn_is_still_offered_when_nothing_else_fits(self):
+        long_text = "wort " * 200
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._write(tmp, f"[00:10] [Others] {long_text.strip()}\n")
+            samples = extract_segment_samples(
+                transcript, [{"start": 10.0, "end": 55.0}],
+                turn_manifest=self._manifest(10.0),
+                target_ids={("system", "SPEAKER_0")},
+            )
+            self.assertEqual(len(samples), 1, "a partial excerpt beats no excerpt")
+            self.assertTrue(samples[0]["text"].endswith("…"))


### PR DESCRIPTION
Three things, all in the speaker review: one person owning several clusters, the excerpt selection, and the written groundwork for the next slice.

### One person, several clusters

The diarizer splits a voice routinely, and the wider it splits the likelier that gets. Assigning several clusters to the same person was already possible, but neither obvious nor fully correct.

- The mutual hard-negative loop matched only the **first** prototype per other person, so a second cluster produced no negative evidence at all.
- Reassigning a cluster away from someone removed **all** their negatives for that meeting, including those the cluster they keep still justifies. The removal is now conditional on them owning no cluster in the channel any more.
- Found in review and fixed here, pre-dating the branch: re-confirming the same cluster as the same person stacked a duplicate of every negative in both directions, once more per repeat. The evidence is now dropped before it is rebuilt, making the step idempotent.

Rows are ordered by speaking time, because reviewing is voluntary and abandonable, so the order decides how much of the transcript the first decisions cover. The Change picker lists people already assigned in this meeting first, marked "here" - the alternative a hurried reviewer reaches for is "New person", which records one voice as two people and makes them a hard negative against themselves. `suggest-speakers` gained `confirmed_person_id` for this, since display names are not identity.

### Excerpt selection

A quote is cut at 140 characters and its clip at 20 seconds, and nothing related the two. Measured on a real 9-minute call: a 40.5 s / 742-character turn showed 19 % of its text beside 20 s of audio, which reads as the wrong clip although both start at the same instant. Ranking by raw duration made it likelier, not less likely. Turns that survive both caps now rank first, longest among them.

Two review corrections on that: a clip has to be long enough to place a voice before it earns the preference (a 0.1 s quote was outranking a 19 s turn that missed the character cap by one character), and both caps are compared inclusively.

### Groundwork, no behaviour

A design spec and its implementation plan for the next slice: run provenance in the sidecar and a persisted review state, so an interrupted review resumes and a re-diarization stops silently attributing new clusters to people confirmed against an older run. Both documents only; nothing in this PR implements them.

### Verification

946 Python tests, 157 vitest, 17/17 `speaker-review.t1` including new specs, typecheck clean, lint 37/0 and ruff 41 as the basis. `test_bundle_mlx` fails only in the full discover run and is green in isolation, pre-existing.

Reviewed cross-family by Codex across several rounds; every finding it raised is either fixed here or answered in the commit that rejects it.
