### PR TITLE
fix(transcribe): rescue incomplete batch transcripts

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -313,8 +313,8 @@ function install({ ipcMain }) {
   const speakerState = {
     personProfiles: seedSpeakers
       ? [
-          { person_id: 'p-julian', display_name: 'Julian', prototype_counts: { remote: 2 }, hard_negative_counts: {}, updated_at: 0 },
-          { person_id: 'p-christian', display_name: 'Christian Weyer', prototype_counts: { remote: 1 }, hard_negative_counts: {}, updated_at: 0 },
+          { person_id: 'p-alpha', display_name: 'Person Alpha', prototype_counts: { remote: 2 }, hard_negative_counts: {}, updated_at: 0 },
+          { person_id: 'p-beta', display_name: 'Person Beta', prototype_counts: { remote: 1 }, hard_negative_counts: {}, updated_at: 0 },
         ]
       : [],
     // channels -> { diarization_speaker_id: SpeakerSuggestion }
@@ -322,9 +322,9 @@ function install({ ipcMain }) {
       ? {
           mic: {
             SPEAKER_0: {
-              status: 'confirmed', suggested_person_id: 'p-julian', suggested_name: 'Julian',
+              status: 'confirmed', suggested_person_id: 'p-alpha', suggested_name: 'Person Alpha',
               merged_from: [],
-              candidates: [{ person_id: 'p-julian', display_name: 'Julian', distance: 0.05, hard_negative_conflict: false, negative_distance: null }],
+              candidates: [{ person_id: 'p-alpha', display_name: 'Person Alpha', distance: 0.05, hard_negative_conflict: false, negative_distance: null }],
               reasons: [],
               speech_duration_seconds: 245, segment_count: 60, first_timestamp: '02:10',
               sample_text: 'I think we should ship this on Friday',
@@ -350,9 +350,9 @@ function install({ ipcMain }) {
             // (the real suggest_speaker always attaches the best candidate,
             // regardless of confidence tier) -- only "none" has them null.
             SPEAKER_1: {
-              status: 'possible', suggested_person_id: 'p-christian', suggested_name: 'Christian Weyer',
+              status: 'possible', suggested_person_id: 'p-beta', suggested_name: 'Person Beta',
               merged_from: [],
-              candidates: [{ person_id: 'p-christian', display_name: 'Christian Weyer', distance: 0.28, hard_negative_conflict: false, negative_distance: null }],
+              candidates: [{ person_id: 'p-beta', display_name: 'Person Beta', distance: 0.28, hard_negative_conflict: false, negative_distance: null }],
               reasons: [],
               speech_duration_seconds: 80, segment_count: 20, first_timestamp: '05:45',
               sample_text: 'let me check the numbers again',
@@ -367,7 +367,7 @@ function install({ ipcMain }) {
             SPEAKER_2: {
               status: 'none', suggested_person_id: null, suggested_name: null,
               merged_from: [],
-              candidates: [{ person_id: 'p-julian', display_name: 'Julian', distance: 0.55, hard_negative_conflict: false, negative_distance: null }],
+              candidates: [{ person_id: 'p-alpha', display_name: 'Person Alpha', distance: 0.55, hard_negative_conflict: false, negative_distance: null }],
               reasons: [],
               speech_duration_seconds: 30, segment_count: 8, first_timestamp: '00:42',
               sample_text: null,
@@ -389,9 +389,9 @@ function install({ ipcMain }) {
             // Real-library shape (short scattered turns) -- hidden by
             // default behind the panel's "Show N filtered rows" toggle.
             SPEAKER_4: {
-              status: 'possible', suggested_person_id: 'p-christian', suggested_name: 'Christian Weyer',
+              status: 'possible', suggested_person_id: 'p-beta', suggested_name: 'Person Beta',
               merged_from: [],
-              candidates: [{ person_id: 'p-christian', display_name: 'Christian Weyer', distance: 0.35, hard_negative_conflict: false, negative_distance: null }],
+              candidates: [{ person_id: 'p-beta', display_name: 'Person Beta', distance: 0.35, hard_negative_conflict: false, negative_distance: null }],
               reasons: [],
               speech_duration_seconds: 12, segment_count: 20, first_timestamp: '08:03',
               sample_text: null,

--- a/app/renderer/src/components/SpeakerReviewPanel.tsx
+++ b/app/renderer/src/components/SpeakerReviewPanel.tsx
@@ -880,7 +880,7 @@ export function SpeakerReviewPanel({ summaryFile, isDiarised }: SpeakerReviewPan
           <Input
             value={newPersonName}
             onChange={(e) => setNewPersonName(e.target.value)}
-            placeholder="e.g. Julian"
+            placeholder="e.g. Person Alpha"
             autoFocus
             onKeyDown={(e) => {
               if (e.key === 'Enter' && newPersonRow && newPersonName.trim() && !duplicateProfile) {

--- a/e2e/specs/speaker-multi-marking.t2.spec.ts
+++ b/e2e/specs/speaker-multi-marking.t2.spec.ts
@@ -209,20 +209,20 @@ test('a marked cluster is withheld from naming, refused by confirm, and raises t
   // can reach config.json to degrade suggestions in unrelated meetings.
   const refused = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Julian' },
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Person Alpha' },
   );
   expect(refused.success).toBe(false);
   expect(refused.error).toContain('more than one person');
 
   const configPath = path.join(userDataDir, 'config.json');
   const profiles = (readJson(configPath).person_profiles ?? []) as Array<{ display_name: string }>;
-  expect(profiles.find((p) => p.display_name === 'Julian')).toBeUndefined();
+  expect(profiles.find((p) => p.display_name === 'Person Alpha')).toBeUndefined();
 
   // The unmarked neighbour is unaffected -- marking one row must not cost
   // the others their naming.
   const accepted = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Max' },
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Person Gamma' },
   );
   expect(accepted.success).toBe(true);
 
@@ -256,14 +256,14 @@ test('marking a cluster that was already confirmed withdraws the name and its vo
   // later excerpt and realise the cluster is mixed.
   const confirmed = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Julian' },
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Person Alpha' },
   );
   expect(confirmed.success).toBe(true);
   await expect.poll(() => {
     const profiles = (readJson(configPath).person_profiles ?? []) as Array<{
       display_name: string; prototypes: unknown[];
     }>;
-    return profiles.find((p) => p.display_name === 'Julian')?.prototypes.length;
+    return profiles.find((p) => p.display_name === 'Person Alpha')?.prototypes.length;
   }).toBe(1);
 
   const marked = await page.evaluate(
@@ -271,24 +271,24 @@ test('marking a cluster that was already confirmed withdraws the name and its vo
     { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', containsMultipleSpeakers: true },
   );
   expect(marked.success).toBe(true);
-  expect(marked.cleared_confirmation_from).toEqual(['Julian']);
+  expect(marked.cleared_confirmation_from).toEqual(['Person Alpha']);
 
   // If marking only blocked FUTURE confirms, this blended two-voice
-  // embedding would stay enrolled as Julian -- the exact state the marking
+  // embedding would stay enrolled as Person Alpha -- the exact state the marking
   // exists to prevent, and still reachable from enroll-self-from-person
   // and from every future suggestion scored against his profile.
   await expect.poll(() => {
     const profiles = (readJson(configPath).person_profiles ?? []) as Array<{
       display_name: string; prototypes: unknown[];
     }>;
-    return profiles.find((p) => p.display_name === 'Julian')?.prototypes.length;
+    return profiles.find((p) => p.display_name === 'Person Alpha')?.prototypes.length;
   }).toBe(0);
 
   // Confirming the neighbour afterwards must not pick up negative evidence
   // derived from that mixed cluster.
   const neighbour = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Max' },
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Person Gamma' },
   );
   expect(neighbour.success).toBe(true);
   const profiles = (readJson(configPath).person_profiles ?? []) as Array<{
@@ -400,7 +400,7 @@ test('deleting a meeting reports its unnamed speakers and removes its voice-embe
   // hearing it and the delete takes the audio.
   await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Max' },
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_1', newPersonName: 'Person Gamma' },
   );
   await expect.poll(async () =>
     (await page.evaluate(
@@ -429,13 +429,13 @@ test('deleting a meeting reports its unnamed speakers and removes its voice-embe
   );
   await expect.poll(() => existsSync(sidecarPath)).toBe(false);
 
-  // Max's voice profile deliberately SURVIVES: it is bound to the person,
+  // Person Gamma's voice profile deliberately SURVIVES: it is bound to the person,
   // not the meeting, and is what makes recognition work across recordings.
   const profiles = (readJson(path.join(userDataDir, 'config.json')).person_profiles ?? []) as Array<{
     display_name: string;
     prototypes: unknown[];
   }>;
-  expect(profiles.find((p) => p.display_name === 'Max')?.prototypes).toHaveLength(1);
+  expect(profiles.find((p) => p.display_name === 'Person Gamma')?.prototypes).toHaveLength(1);
 
   expect(fileSig(realUserDataDir())).toEqual(realDirBefore);
 });

--- a/e2e/specs/speaker-naming.t2.spec.ts
+++ b/e2e/specs/speaker-naming.t2.spec.ts
@@ -102,10 +102,10 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
 
   const result = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Julian' },
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Person Alpha' },
   );
   expect(result.success).toBe(true);
-  expect(result.display_name).toBe('Julian');
+  expect(result.display_name).toBe('Person Alpha');
   expect(result.relabeled_lines).toBe(1);
 
   // The PersonProfile landed in config.json with one confirmed prototype.
@@ -113,32 +113,32 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
   await expect.poll(() => {
     const cfg = readJson(configPath);
     const profiles = (cfg.person_profiles ?? []) as Array<{ display_name: string; prototypes: unknown[] }>;
-    return profiles.find((p) => p.display_name === 'Julian')?.prototypes.length;
+    return profiles.find((p) => p.display_name === 'Person Alpha')?.prototypes.length;
   }).toBe(1);
 
   // The saved transcript now shows the real name at the confirmed segment's
   // timestamp, and the untouched "You" line is unaffected.
   await expect.poll(() => readFileSync(transcriptFile, 'utf8')).toEqual(
-    expect.stringContaining('[00:05] [Julian] hello there'),
+    expect.stringContaining('[00:05] [Person Alpha] hello there'),
   );
   expect(readFileSync(transcriptFile, 'utf8')).toContain('[00:20] [You] hi back');
 
   // A second confirm of the SAME cluster (the review UI's "Change"
   // correction) REASSIGNS it: the transcript re-labels idempotently rather
-  // than duplicating lines, and Julian's superseded prototype is removed
+  // than duplicating lines, and Person Alpha's superseded prototype is removed
   // so the mis-confirm can't keep poisoning cross-meeting matching.
   const secondResult = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Max' },
+    { meetingStem: stem, channel: 'system', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Person Gamma' },
   );
   expect(secondResult.success).toBe(true);
-  expect(secondResult.reassigned_from).toEqual(['Julian']);
+  expect(secondResult.reassigned_from).toEqual(['Person Alpha']);
   await expect.poll(() => readFileSync(transcriptFile, 'utf8')).toEqual(
-    expect.stringContaining('[00:05] [Max] hello there'),
+    expect.stringContaining('[00:05] [Person Gamma] hello there'),
   );
-  expect(readFileSync(transcriptFile, 'utf8')).not.toContain('[Julian]');
+  expect(readFileSync(transcriptFile, 'utf8')).not.toContain('[Person Alpha]');
 
-  // On disk: Julian keeps his (now evidence-less) profile, Max owns the
+  // On disk: Person Alpha keeps his (now evidence-less) profile, Person Gamma owns the
   // cluster with a prototype marked as a correction.
   await expect.poll(() => {
     const cfg = readJson(configPath);
@@ -146,21 +146,21 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
       display_name: string;
       prototypes: Array<{ created_from: string; channel?: string }>;
     }>;
-    const julian = profiles.find((p) => p.display_name === 'Julian');
-    const max = profiles.find((p) => p.display_name === 'Max');
+    const personAlpha = profiles.find((p) => p.display_name === 'Person Alpha');
+    const personGamma = profiles.find((p) => p.display_name === 'Person Gamma');
     return {
-      julianPrototypes: julian?.prototypes.length,
-      maxCreatedFrom: max?.prototypes[0]?.created_from,
-      maxChannel: max?.prototypes[0]?.channel,
+      alphaPrototypes: personAlpha?.prototypes.length,
+      gammaCreatedFrom: personGamma?.prototypes[0]?.created_from,
+      gammaChannel: personGamma?.prototypes[0]?.channel,
     };
-  }).toEqual({ julianPrototypes: 0, maxCreatedFrom: 'user_corrected', maxChannel: 'system' });
+  }).toEqual({ alphaPrototypes: 0, gammaCreatedFrom: 'user_corrected', gammaChannel: 'system' });
 
   // Re-running suggest-speakers reflects the corrected state. Status is
   // "possible", not "confirmed" -- SUGGESTION_MIN_CONFIRMED_MEETINGS (=2)
-  // caps any person with evidence from only ONE meeting there, and Max
+  // caps any person with evidence from only ONE meeting there, and Person Gamma
   // only has this single meeting confirmed so far. suggested_name is
-  // still set at "possible" tier (see suggest_speaker). Julian has no
-  // prototypes left, so he can't out-rank Max the way his stale
+  // still set at "possible" tier (see suggest_speaker). Person Alpha has no
+  // prototypes left, so he can't out-rank Person Gamma the way his stale
   // same-cluster prototype used to before the reassignment fix.
   const suggestions = await page.evaluate(
     (meetingStem) => (window as StenoWindow).stenoai.speakers.suggestForMeeting(meetingStem),
@@ -168,16 +168,16 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
   );
   expect(suggestions.success).toBe(true);
   expect(suggestions.channels.system.SPEAKER_0.status).toBe('possible');
-  expect(suggestions.channels.system.SPEAKER_0.suggested_name).toBe('Max');
+  expect(suggestions.channels.system.SPEAKER_0.suggested_name).toBe('Person Gamma');
   // The identification anchor (where to go listen) computed end-to-end by
   // the real backend from the sidecar's seeded segment ({start: 5.0}).
   expect(suggestions.channels.system.SPEAKER_0.first_timestamp).toBe('00:05');
   // confirmed_by_user is real, persisted evidence (a matching
   // SpeakerPrototype), not the transient panel-only feedback line -- it
   // survives a completely fresh process (this IS a fresh suggest-speakers
-  // call, not a cached value). After the reassignment it names Max --
-  // Julian's superseded prototype no longer exists to be found.
-  expect(suggestions.channels.system.SPEAKER_0.confirmed_by_user).toBe('Max');
+  // call, not a cached value). After the reassignment it names Person Gamma --
+  // Person Alpha's superseded prototype no longer exists to be found.
+  expect(suggestions.channels.system.SPEAKER_0.confirmed_by_user).toBe('Person Gamma');
 
   // Keystone: the real user-data dir is byte-for-byte untouched.
   expect(fileSig(realUserDataDir())).toBe(realDirBefore);
@@ -285,7 +285,7 @@ test('duplicate person names are rejected, and delete-person-profile removes a p
 
   const first = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'mic', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Julian' },
+    { meetingStem: stem, channel: 'mic', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Person Alpha' },
   );
   expect(first.success).toBe(true);
 
@@ -294,7 +294,7 @@ test('duplicate person names are rejected, and delete-person-profile removes a p
   // one real person must not get split across two person_ids.
   const duplicate = await page.evaluate(
     (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
-    { meetingStem: stem, channel: 'mic', diarizationSpeakerId: 'SPEAKER_1', newPersonName: '  julian ' },
+    { meetingStem: stem, channel: 'mic', diarizationSpeakerId: 'SPEAKER_1', newPersonName: '  person alpha ' },
   );
   expect(duplicate.success).toBe(false);
   expect(duplicate.error).toContain('already exists');
@@ -310,12 +310,12 @@ test('duplicate person names are rejected, and delete-person-profile removes a p
   // delete-person-profile removes them entirely.
   const listed = await page.evaluate(() => (window as StenoWindow).stenoai.speakers.listProfiles());
   expect(listed.success).toBe(true);
-  const julian = listed.person_profiles?.find((p) => p.display_name === 'Julian');
-  expect(julian).toBeDefined();
+  const personAlpha = listed.person_profiles?.find((p) => p.display_name === 'Person Alpha');
+  expect(personAlpha).toBeDefined();
 
   const deleted = await page.evaluate(
     (id) => (window as StenoWindow).stenoai.speakers.deleteProfile(id),
-    julian!.person_id,
+    personAlpha!.person_id,
   );
   expect(deleted.success).toBe(true);
 

--- a/e2e/specs/speaker-review.t1.spec.ts
+++ b/e2e/specs/speaker-review.t1.spec.ts
@@ -28,7 +28,7 @@ test('Approve confirms the suggested person for a "confirmed"-tier row', async (
   await openDetail(page);
 
   const row = page.getByTestId('speaker-row-mic:SPEAKER_0');
-  await expect(row).toContainText('Likely Julian');
+  await expect(row).toContainText('Likely Person Alpha');
   // Identification anchor (channel + first-heard timestamp + duration) --
   // without this, an "Unidentified speaker" row gives a human nothing to
   // go on to figure out who a cluster actually is.
@@ -40,8 +40,8 @@ test('Approve confirms the suggested person for a "confirmed"-tier row', async (
   // (real persisted evidence) always wins over the distance-based
   // "Likely X" text, so there's no separate, potentially-contradictory
   // feedback line to keep in sync with it.
-  await expect(row).toContainText('✓ Confirmed as Julian');
-  await expect(row).not.toContainText('Likely Julian');
+  await expect(row).toContainText('✓ Confirmed as Person Alpha');
+  await expect(row).not.toContainText('Likely Person Alpha');
   // Re-approving an already-confirmed cluster is a no-op that would change
   // nothing visible -- the button is hidden rather than inviting a
   // pointless click.
@@ -56,15 +56,15 @@ test('Change picks a different existing person for a "possible"-tier row', async
   await openDetail(page);
 
   const row = page.getByTestId('speaker-row-mic:SPEAKER_1');
-  await expect(row).toContainText('Might be Christian Weyer');
+  await expect(row).toContainText('Might be Person Beta');
   await row.getByRole('button', { name: 'Change' }).click();
 
   // The popover portals outside the row's DOM subtree, so target it at the
-  // page level -- there's only one "Julian" entry visible while the popover
+  // page level -- there's only one "Person Alpha" entry visible while the popover
   // is open.
-  await page.getByRole('button', { name: 'Julian', exact: true }).click();
+  await page.getByRole('button', { name: 'Person Alpha', exact: true }).click();
 
-  await expect(row).toContainText('✓ Confirmed as Julian');
+  await expect(row).toContainText('✓ Confirmed as Person Alpha');
 });
 
 test('New person creates and confirms a brand-new profile', async ({ launchApp }) => {
@@ -78,10 +78,10 @@ test('New person creates and confirms a brand-new profile', async ({ launchApp }
   await expect(row).toContainText('Unidentified speaker');
   await row.getByRole('button', { name: 'New person' }).click();
 
-  await page.getByTestId('speaker-new-person-input').fill('Max');
+  await page.getByTestId('speaker-new-person-input').fill('Person Gamma');
   await page.getByTestId('speaker-new-person-submit').click();
 
-  await expect(row).toContainText('✓ Confirmed as Max');
+  await expect(row).toContainText('✓ Confirmed as Person Gamma');
 });
 
 test('New person blocks creating a duplicate of an existing person', async ({ launchApp }) => {
@@ -94,11 +94,11 @@ test('New person blocks creating a duplicate of an existing person', async ({ la
   const row = page.getByTestId('speaker-row-mic:SPEAKER_2');
   await row.getByRole('button', { name: 'New person' }).click();
 
-  // "Julian" already exists (seeded). Typing it verbatim -- or any
+  // "Person Alpha" already exists (seeded). Typing it verbatim -- or any
   // case/whitespace variant -- must surface the collision and block
-  // Create, rather than silently splitting Julian's evidence across two
+  // Create, rather than silently splitting Person Alpha's evidence across two
   // person_ids.
-  await page.getByTestId('speaker-new-person-input').fill('  julian ');
+  await page.getByTestId('speaker-new-person-input').fill('  person alpha ');
   await expect(page.getByTestId('speaker-new-person-duplicate')).toBeVisible();
   await expect(page.getByTestId('speaker-new-person-submit')).toBeDisabled();
 
@@ -119,13 +119,13 @@ test('a person profile can be deleted from the Change popover, unwinding any row
 
   const row = page.getByTestId('speaker-row-mic:SPEAKER_0');
   await row.getByRole('button', { name: 'Approve' }).click();
-  await expect(row).toContainText('✓ Confirmed as Julian');
+  await expect(row).toContainText('✓ Confirmed as Person Alpha');
 
   await row.getByRole('button', { name: 'Change' }).click();
-  await page.getByTestId('speaker-delete-person-p-julian').click();
+  await page.getByTestId('speaker-delete-person-p-alpha').click();
 
   const confirmDialog = page.locator('[data-confirm-dialog]');
-  await expect(confirmDialog).toContainText('Delete Julian?');
+  await expect(confirmDialog).toContainText('Delete Person Alpha?');
   await confirmDialog.getByRole('button', { name: 'Delete' }).click();
   await expect(confirmDialog).toHaveCount(0);
 
@@ -133,11 +133,11 @@ test('a person profile can be deleted from the Change popover, unwinding any row
   // confirmed as them reverts to unidentified, not left pointing at a
   // person that no longer exists.
   await expect(row).toContainText('Unidentified speaker');
-  await expect(row).not.toContainText('Julian');
+  await expect(row).not.toContainText('Person Alpha');
 
   // And they're gone from the Change list too.
   await row.getByRole('button', { name: 'Change' }).click();
-  await expect(page.getByRole('button', { name: 'Julian', exact: true })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Person Alpha', exact: true })).toHaveCount(0);
 });
 
 // Replaces 'Keep generic dismisses the row locally, no confirm call needed',
@@ -212,7 +212,7 @@ test('Keep generic is not offered on a row that is already decided', async ({ la
   // contradictory things about the same cluster.
   const confirmed = page.getByTestId('speaker-row-mic:SPEAKER_0');
   await confirmed.getByRole('button', { name: 'Approve' }).click();
-  await expect(confirmed).toContainText('✓ Confirmed as Julian');
+  await expect(confirmed).toContainText('✓ Confirmed as Person Alpha');
   await expect(confirmed.getByRole('button', { name: 'Keep generic label' })).toHaveCount(0);
 
   // Marked as several people: same reasoning from the other direction.
@@ -272,7 +272,7 @@ test('confirmation persists after navigating away and back, unlike the transient
 
   const row = page.getByTestId('speaker-row-mic:SPEAKER_0');
   await row.getByRole('button', { name: 'Approve' }).click();
-  await expect(row).toContainText('✓ Confirmed as Julian');
+  await expect(row).toContainText('✓ Confirmed as Person Alpha');
 
   // Navigate away (unmounts SpeakerReviewPanel, destroying all of its local
   // state -- there is no more "feedback" Map to fall back on) and back --
@@ -286,7 +286,7 @@ test('confirmation persists after navigating away and back, unlike the transient
   await openDetail(page);
 
   const rowAfter = page.getByTestId('speaker-row-mic:SPEAKER_0');
-  await expect(rowAfter).toContainText('✓ Confirmed as Julian');
+  await expect(rowAfter).toContainText('✓ Confirmed as Person Alpha');
   await expect(rowAfter.getByRole('button', { name: 'Approve' })).toHaveCount(0);
 });
 
@@ -322,7 +322,7 @@ test('confirming one row disables every OTHER row\'s actions too, not just the o
   await expect(rowB.getByRole('button', { name: 'Keep generic label' })).toBeDisabled();
 
   // And once rowA's confirm resolves, rowB's actions become available again.
-  await expect(rowA).toContainText('✓ Confirmed as Julian');
+  await expect(rowA).toContainText('✓ Confirmed as Person Alpha');
   await expect(rowB.getByRole('button', { name: 'Change' })).toBeEnabled();
 });
 
@@ -358,7 +358,7 @@ test('marking a row as more than one person removes every naming action and can 
   await openDetail(page);
 
   const row = page.getByTestId('speaker-row-mic:SPEAKER_0');
-  await expect(row).toContainText('Likely Julian');
+  await expect(row).toContainText('Likely Person Alpha');
 
   await row.getByTestId('speaker-mark-multi-mic:SPEAKER_0').click();
 
@@ -390,7 +390,7 @@ test('marking a row as more than one person removes every naming action and can 
   );
 
   await clearMark.click();
-  await expect(row).toContainText('Likely Julian');
+  await expect(row).toContainText('Likely Person Alpha');
   await expect(row.getByRole('button', { name: 'Approve' })).toHaveCount(1);
 });
 
@@ -506,13 +506,13 @@ test('the Change picker offers people already assigned in this meeting first', a
   // person" -- naming the same voice twice makes it a hard negative against
   // itself, which suppresses that speaker's future suggestions for good.
   await page.getByTestId('speaker-approve-mic:SPEAKER_0').click();
-  await expect(page.getByTestId('speaker-row-mic:SPEAKER_0')).toContainText('Confirmed as Julian');
+  await expect(page.getByTestId('speaker-row-mic:SPEAKER_0')).toContainText('Confirmed as Person Alpha');
 
   await page.getByTestId('speaker-change-mic:SPEAKER_1').click();
   const names = await page
     .locator('[data-testid^="speaker-pick-person-"]')
     .evaluateAll((els) => els.map((el) => el.textContent?.trim() ?? ''));
 
-  expect(names[0]).toContain('Julian');
+  expect(names[0]).toContain('Person Alpha');
   expect(names[0]).toContain('here');
 });

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5554,7 +5554,7 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
             cleared_from.append(person["display_name"])
             # Restricted to THIS cluster's ids, same as the loop below. A
             # person's negatives in this meeting are earned one cluster at a
-            # time -- "that voice over there is not Julian" is evidence about
+            # time -- "that voice over there is not Person Alpha" is evidence about
             # that other cluster, and marking this one does not touch it.
             # Clearing them all destroyed evidence silently, and the only
             # symptom would have been a worse suggestion months later.

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -648,6 +648,14 @@ Summary output language: {config.get_language_name(output_language)}
             "output_language": output_language,
             "speaker_clusters": speaker_clusters,
             "turn_manifest": turn_manifest,
+            # Fraction of transcription windows that came back usable, worst
+            # channel, or None where the backend does no windowing of its own.
+            # None means "unknown", not "complete" -- see the live-transcript
+            # fallback in process_streaming.
+            "window_coverage": (
+                transcript_result.get("window_coverage")
+                if isinstance(transcript_result, dict) else None
+            ),
         }
 
     def _handle_transcription_failure(
@@ -1000,6 +1008,43 @@ try:
 except ImportError:
     _SILENCE_SENTINEL = "No speech detected in audio"
 
+# Below this share of usable transcription windows a batch transcript stops
+# being "the transcript" and the complete live transcript is the better
+# rescue. Deliberately low: a meeting that lost a window or two is still far
+# better than the streaming text, and swapping too eagerly is how the old
+# length threshold made things worse (see the fallback in process_streaming).
+# Half the file missing is not a gap, it is a different recording.
+_MIN_BATCH_WINDOW_COVERAGE = 0.5
+
+
+def _unusable_batch_reason(
+    batch_text: str,
+    batch_failed: bool,
+    window_coverage: Optional[float],
+) -> Optional[str]:
+    """Why the batch transcript can't stand as the meeting's transcript, or
+    None when it can.
+
+    Three ways it can't: the transcription crashed, it came back as exactly
+    the silence sentinel, or it lost more than half its transcription windows
+    (see _MIN_BATCH_WINDOW_COVERAGE). Deliberately NOT length -- a five-minute
+    stand-up is allowed to be short, and an earlier length threshold here
+    replaced correct transcripts because of it.
+
+    ``window_coverage`` is None for a backend that does no windowing of its
+    own; unknown is not a reason to throw a result away.
+
+    Lives outside process_streaming so the decision can be tested as itself
+    rather than restated in a test that could drift away from it.
+    """
+    if batch_failed:
+        return "failed"
+    if batch_text.strip() == _SILENCE_SENTINEL:
+        return "returned only silence"
+    if window_coverage is not None and window_coverage < _MIN_BATCH_WINDOW_COVERAGE:
+        return f"covered only {window_coverage:.0%} of its transcription windows"
+    return None
+
 
 def _append_segment_to_note(target: Path, new_text: str, duration_seconds):
     """Fold a continue-recording segment into an existing note.
@@ -1203,16 +1248,31 @@ def process_streaming(audio_file, name, notes, live_transcript, append_to):
         # We only swap in the live text when the batch result is genuinely
         # unusable (failed or silence sentinel). Any non-whitespace live content
         # is better than a silent failure — even a brief session deserves rescue.
+        # Third case, added later: a batch that neither crashed nor returned
+        # silence, but lost most of its transcription windows. The onnx
+        # backend skips a window whose recognize() raises on purpose, so one
+        # bad window doesn't fail a meeting -- but the transcript then covers
+        # less audio than the recording holds, and nothing said so. Such a
+        # result is not empty, so it used to pass this gate and silently
+        # replace a complete live transcript with a full-of-holes one.
+        #
+        # Keyed on COVERAGE, not on length: the length threshold this gate
+        # used to have was removed for good reason (Fix 4) because it
+        # replaced correct-but-short transcripts. Coverage says how much of
+        # the audio was actually read, independent of how much was said in
+        # it. None means the backend does no windowing of its own and cannot
+        # report -- unknown is never treated as bad.
         batch_text = transcript_data.get("transcript_text", "") or ""
         batch_failed = bool(transcript_data.get("transcription_failed"))
-        batch_is_silence = batch_text.strip() == _SILENCE_SENTINEL
+        reason = _unusable_batch_reason(
+            batch_text, batch_failed, transcript_data.get("window_coverage")
+        )
         is_live_transcript = False
-        if (batch_failed or batch_is_silence) and live_transcript_text \
-                and live_transcript_text.strip():
+        if reason and live_transcript_text and live_transcript_text.strip():
             logger.warning(
                 "Batch transcription %s; falling back to the live transcript "
                 "captured during recording (%d chars)",
-                "failed" if batch_failed else "returned only silence",
+                reason,
                 len(live_transcript_text),
             )
             is_live_transcript = True

--- a/src/_parakeet_onnx.py
+++ b/src/_parakeet_onnx.py
@@ -286,12 +286,20 @@ def _result_to_dict(result: Any, language: Optional[str]) -> dict:
         duration = float(_ts_end(last_ts))
 
     detected_language = language if (language and language != "auto") else None
+    # None when the result came from a single non-windowed pass (onnx-asr's
+    # own TimestampedResult, or a file shorter than one window) -- there is
+    # no windowing there, so there is nothing that could have been lost.
+    attempted = int(getattr(result, "windows_attempted", 0) or 0)
+    recognized = int(getattr(result, "windows_recognized", 0) or 0)
+    coverage = (recognized / attempted) if attempted > 0 else None
+
     return {
         "text": text or None,
         "segments": segments,
         "duration_seconds": duration,
         "detected_language": detected_language,
         "detected_language_probability": None,
+        "window_coverage": coverage,
     }
 
 
@@ -406,10 +414,19 @@ class _SimpleResult:
     ``_group_tokens_into_sentences`` read — ``text``, ``tokens``,
     ``timestamps`` — so a merged multi-window transcript flows through the
     exact same shaping path as a single-window TimestampedResult.
+
+    ``windows_attempted`` / ``windows_recognized`` carry how much of the file
+    actually made it through. A window whose ``recognize`` raises is skipped
+    on purpose (one bad window shouldn't fail a whole meeting), but the
+    resulting transcript then covers less audio than the recording holds, and
+    nothing downstream could tell. onnx-asr's own TimestampedResult has no
+    such fields, so every reader goes through ``getattr`` with a default.
     """
     text: str
     tokens: list
     timestamps: list
+    windows_attempted: int = 0
+    windows_recognized: int = 0
 
 
 def _load_wav_16k_mono(audio_path: Path):
@@ -539,4 +556,18 @@ def _transcribe_windows(ts_model: Any, samples) -> _SimpleResult:
     text = "".join(
         tok if isinstance(tok, str) else str(tok) for tok in merged_tokens
     ).strip()
-    return _SimpleResult(text=text, tokens=merged_tokens, timestamps=merged_timestamps)
+    if windows_recognized < windows_attempted:
+        logger.warning(
+            "ONNX transcription covered %d of %d windows (%d failed) — the "
+            "transcript is missing roughly %.0fs of audio",
+            windows_recognized, windows_attempted,
+            windows_attempted - windows_recognized,
+            (windows_attempted - windows_recognized) * PARAKEET_CHUNK_DURATION_S,
+        )
+    return _SimpleResult(
+        text=text,
+        tokens=merged_tokens,
+        timestamps=merged_timestamps,
+        windows_attempted=windows_attempted,
+        windows_recognized=windows_recognized,
+    )

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -90,7 +90,7 @@ SUGGESTION_MIN_SEGMENT_COUNT = 3
 # against the user's real meeting library: every false-positive suggestion
 # found (8 clusters, all confirmed-not-that-person by the user) had an
 # average turn of 1.525s or less; the weakest genuine confirmed match (an
-# actual Julian anchor prototype) sits at 1.61s. Set with margin on both
+# a representative anchor prototype) sits at 1.61s. Set with margin on both
 # sides of that gap.
 SUGGESTION_MIN_AVG_TURN_SECONDS = 1.55
 # A person needs evidence from at least this many DISTINCT meetings -- not
@@ -1308,7 +1308,7 @@ def record_original_labels(
     name standing in the artefact that feeds the summary and every export.
 
     FIRST WRITE WINS. Confirming the same cluster twice -- the review UI's
-    "Change" flow does exactly that -- must not record "Julian" as the
+    "Change" flow does exactly that -- must not record "Person Alpha" as the
     original, or the restore would put a person's name back on lines the
     app has just decided are not theirs.
 

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -945,6 +945,20 @@ def _run_steno_diarize(
     return merged, embeddings
 
 
+def _worst_window_coverage(*results: Optional[dict]) -> Optional[float]:
+    """Lowest reported window coverage across the channels that reported one.
+
+    Returns None when nothing reported -- a backend that does no windowing
+    of its own cannot lose a window, but it also cannot vouch for the file,
+    so "unknown" stays distinct from "complete"."""
+    values = [
+        float(r["window_coverage"])
+        for r in results
+        if isinstance(r, dict) and r.get("window_coverage") is not None
+    ]
+    return min(values) if values else None
+
+
 def _cluster_channel_labels(diar_segments: list[dict], legacy_label: str) -> Optional[dict[str, str]]:
     """Map each diarizer speaker id in diar_segments to either the channel's
     legacy label (the cluster with the most total speaking time) or a
@@ -1584,6 +1598,12 @@ class WhisperTranscriber:
             "duration_seconds": result.get("duration_seconds"),
             "detected_language": result.get("detected_language"),
             "detected_language_probability": result.get("detected_language_probability"),
+            # Fraction of transcription windows that came back usable, or None
+            # where the backend does no windowing of its own. Only the onnx
+            # backend can lose a window silently (parakeet-mlx has no per-chunk
+            # except, so a bad window fails the whole call loudly) -- but the
+            # key travels on both paths so callers never have to branch.
+            "window_coverage": result.get("window_coverage"),
         }
 
     def _convert_to_16khz(self, audio_filepath: Path) -> tuple[Path, Optional[float]]:
@@ -2014,6 +2034,11 @@ class WhisperTranscriber:
             mic_empty_on_energy = False
             system_empty_on_energy = False
             empty_error: Optional[str] = None
+            # A channel the energy gate skipped never gets a result -- bind
+            # both up front so anything reading them after the branches (the
+            # window-coverage roll-up at the end) can't hit an unbound name.
+            mic_result: Optional[dict] = None
+            sys_result: Optional[dict] = None
 
             # Split channels are already 16 kHz mono + high-passed by the
             # split ffmpeg pass above — skip the mono pre-processing pass.
@@ -2273,6 +2298,12 @@ class WhisperTranscriber:
                 # list[{"start", "channel", "diarization_speaker_id"}], one
                 # per turn -- see comment above turn_manifest's construction.
                 "turn_manifest": turn_manifest,
+                # Worst channel wins: a meeting is only as complete as the
+                # side that lost the most. None when no channel reported a
+                # figure (whisper.cpp, parakeet-mlx, or a file short enough
+                # to need no windowing) -- absence means "unknown", never
+                # "complete", so callers must not read it as a pass.
+                "window_coverage": _worst_window_coverage(mic_result, sys_result),
             }
         finally:
             # Clean up temp channel files

--- a/tests/test_backfill_participants_cli.py
+++ b/tests/test_backfill_participants_cli.py
@@ -57,13 +57,13 @@ class BackfillParticipantsCliTests(unittest.TestCase):
                 "---\ntitle: \"Mtg\"\n---\n\n## Summary\n\nNotes.\n", encoding="utf-8",
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Max", "mtg001")
+            self._confirm(cfg, "Person Gamma", "mtg001")
 
             result = self._run([], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["meetings_updated"], [{"meeting_id": "mtg001", "participants": ["Max"]}])
-            self.assertIn("## Participants\n\nMax", (output_dir / "mtg001_summary.md").read_text())
+            self.assertEqual(data["meetings_updated"], [{"meeting_id": "mtg001", "participants": ["Person Gamma"]}])
+            self.assertIn("## Participants\n\nPerson Gamma", (output_dir / "mtg001_summary.md").read_text())
 
     def test_covers_every_meeting_across_multiple_people(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -74,19 +74,19 @@ class BackfillParticipantsCliTests(unittest.TestCase):
                     json.dumps({"session_info": {}, "participants": []}), encoding="utf-8",
                 )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Max", "mtg001")
-            self._confirm(cfg, "Julian", "mtg002")
+            self._confirm(cfg, "Person Gamma", "mtg001")
+            self._confirm(cfg, "Person Alpha", "mtg002")
 
             result = self._run([], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             by_id = {m["meeting_id"]: m["participants"] for m in data["meetings_updated"]}
-            self.assertEqual(by_id, {"mtg001": ["Max"], "mtg002": ["Julian"]})
+            self.assertEqual(by_id, {"mtg001": ["Person Gamma"], "mtg002": ["Person Alpha"]})
             self.assertEqual(
-                json.loads((output_dir / "mtg001_summary.json").read_text())["participants"], ["Max"],
+                json.loads((output_dir / "mtg001_summary.json").read_text())["participants"], ["Person Gamma"],
             )
             self.assertEqual(
-                json.loads((output_dir / "mtg002_summary.json").read_text())["participants"], ["Julian"],
+                json.loads((output_dir / "mtg002_summary.json").read_text())["participants"], ["Person Alpha"],
             )
 
     def test_no_person_profiles_is_a_noop(self):
@@ -118,7 +118,7 @@ class BackfillParticipantsCliTests(unittest.TestCase):
             original = "Session: mtg001\n\n" + "=" * 60 + "\n\n[00:05] [Speaker 2] hello there"
             transcript_path.write_text(original, encoding="utf-8")
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Max", "mtg001", run_id=self._run_id(tmp))
+            self._confirm(cfg, "Person Gamma", "mtg001", run_id=self._run_id(tmp))
 
             result = self._run([], tmp, cfg)
             data = _last_json(result.output)
@@ -150,14 +150,14 @@ class BackfillParticipantsCliTests(unittest.TestCase):
                 encoding="utf-8",
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Max", "mtg001", run_id=self._run_id(tmp))
+            self._confirm(cfg, "Person Gamma", "mtg001", run_id=self._run_id(tmp))
 
             result = self._run(["--relabel-transcripts"], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertEqual(data["transcripts_relabeled"], {"mtg001": 1})
             text = transcript_path.read_text()
-            self.assertIn("[00:05] [Max] hello there", text)
+            self.assertIn("[00:05] [Person Gamma] hello there", text)
             self.assertIn("[00:20] [You] hi back", text)  # never touches You
 
     def test_relabel_transcripts_uses_exact_matching_when_sidecar_has_manifest(self):
@@ -191,7 +191,7 @@ class BackfillParticipantsCliTests(unittest.TestCase):
                 encoding="utf-8",
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Max", "mtg001", run_id=self._run_id(tmp))
+            self._confirm(cfg, "Person Gamma", "mtg001", run_id=self._run_id(tmp))
 
             result = self._run(["--relabel-transcripts"], tmp, cfg)
             data = _last_json(result.output)
@@ -228,13 +228,13 @@ class BackfillParticipantsCliTests(unittest.TestCase):
                 encoding="utf-8",
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Max", "mtg001", run_id=self._run_id(tmp))
+            self._confirm(cfg, "Person Gamma", "mtg001", run_id=self._run_id(tmp))
 
             result = self._run(["--relabel-transcripts"], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertEqual(data["transcripts_relabeled"], {"mtg001": 1})
-            self.assertIn("[00:05] [Max] hello there", transcript_path.read_text())
+            self.assertIn("[00:05] [Person Gamma] hello there", transcript_path.read_text())
 
     def test_relabel_transcripts_is_idempotent_on_already_relabeled_meeting(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -257,11 +257,11 @@ class BackfillParticipantsCliTests(unittest.TestCase):
             # Already relabeled (e.g. confirmed via the UI, which always
             # passes --relabel-transcript at confirm time already).
             transcript_path.write_text(
-                "Session: mtg001\n\n" + "=" * 60 + "\n\n[00:05] [Max] hello there",
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n[00:05] [Person Gamma] hello there",
                 encoding="utf-8",
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Max", "mtg001", run_id=self._run_id(tmp))
+            self._confirm(cfg, "Person Gamma", "mtg001", run_id=self._run_id(tmp))
 
             result = self._run(["--relabel-transcripts"], tmp, cfg)
             data = _last_json(result.output)
@@ -307,8 +307,8 @@ class BackfillParticipantsCliTests(unittest.TestCase):
                 encoding="utf-8",
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm(cfg, "Valentin Weyer", "mtg001", sid="SPEAKER_00", recording_type="in_person", run_id=self._run_id(tmp))
-            self._confirm(cfg, "Inga Hahn", "mtg001", sid="SPEAKER_00", recording_type="remote", run_id=self._run_id(tmp))
+            self._confirm(cfg, "Person Alpha", "mtg001", sid="SPEAKER_00", recording_type="in_person", run_id=self._run_id(tmp))
+            self._confirm(cfg, "Person Beta", "mtg001", sid="SPEAKER_00", recording_type="remote", run_id=self._run_id(tmp))
 
             result = self._run(["--relabel-transcripts"], tmp, cfg)
             data = _last_json(result.output)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -770,8 +770,8 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_create_person_profile_starts_empty(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            profile = config.create_person_profile("Max")
-            self.assertEqual(profile["display_name"], "Max")
+            profile = config.create_person_profile("Person Gamma")
+            self.assertEqual(profile["display_name"], "Person Gamma")
             self.assertEqual(profile["prototypes"], [])
             self.assertEqual(profile["hard_negatives"], [])
             self.assertIn("person_id", profile)
@@ -780,46 +780,46 @@ class ConfigPersonProfileTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config_path = Path(tmp_dir) / "config.json"
             config = Config(config_path=config_path)
-            config.create_person_profile("Max")
+            config.create_person_profile("Person Gamma")
             reloaded = Config(config_path=config_path)
             names = [p["display_name"] for p in reloaded.get_person_profiles()]
-            self.assertEqual(names, ["Max"])
+            self.assertEqual(names, ["Person Gamma"])
 
     def test_get_person_profile_by_id(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            created = config.create_person_profile("Max")
+            created = config.create_person_profile("Person Gamma")
             fetched = config.get_person_profile(created["person_id"])
-            self.assertEqual(fetched["display_name"], "Max")
+            self.assertEqual(fetched["display_name"], "Person Gamma")
             self.assertIsNone(config.get_person_profile("nonexistent"))
 
     def test_create_person_profile_rejects_exact_duplicate_name(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            config.create_person_profile("Max")
+            config.create_person_profile("Person Gamma")
             with self.assertRaises(ValueError):
-                config.create_person_profile("Max")
+                config.create_person_profile("Person Gamma")
             self.assertEqual(len(config.get_person_profiles()), 1)
 
     def test_create_person_profile_rejects_case_and_whitespace_variant(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            config.create_person_profile("Max")
+            config.create_person_profile("Person Gamma")
             with self.assertRaises(ValueError):
-                config.create_person_profile("  max  ")
+                config.create_person_profile("  person gamma  ")
             self.assertEqual(len(config.get_person_profiles()), 1)
 
     def test_create_person_profile_allows_distinct_names(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            config.create_person_profile("Max")
+            config.create_person_profile("Person Gamma")
             config.create_person_profile("Maxine")
             self.assertEqual(len(config.get_person_profiles()), 2)
 
     def test_rename_person_profile(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            created = config.create_person_profile("Max")
+            created = config.create_person_profile("Person Gamma")
             self.assertTrue(config.rename_person_profile(created["person_id"], "Maximilian"))
             self.assertEqual(
                 config.get_person_profile(created["person_id"])["display_name"],
@@ -834,22 +834,22 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_rename_person_profile_rejects_collision_with_another_person(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            config.create_person_profile("Max")
-            julian = config.create_person_profile("Julian")
+            config.create_person_profile("Person Gamma")
+            person_alpha = config.create_person_profile("Person Alpha")
             with self.assertRaises(ValueError):
-                config.rename_person_profile(julian["person_id"], "max")
-            self.assertEqual(config.get_person_profile(julian["person_id"])["display_name"], "Julian")
+                config.rename_person_profile(person_alpha["person_id"], "person gamma")
+            self.assertEqual(config.get_person_profile(person_alpha["person_id"])["display_name"], "Person Alpha")
 
     def test_rename_person_profile_to_its_own_current_name_is_a_noop_allowed(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            created = config.create_person_profile("Max")
-            self.assertTrue(config.rename_person_profile(created["person_id"], "Max"))
+            created = config.create_person_profile("Person Gamma")
+            self.assertTrue(config.rename_person_profile(created["person_id"], "Person Gamma"))
 
     def test_delete_person_profile(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            created = config.create_person_profile("Max")
+            created = config.create_person_profile("Person Gamma")
             self.assertTrue(config.delete_person_profile(created["person_id"]))
             self.assertEqual(config.get_person_profiles(), [])
 
@@ -860,53 +860,53 @@ class ConfigPersonProfileTests(unittest.TestCase):
 
     def test_delete_person_profile_strips_hard_negatives_derived_from_them_in_other_profiles(self):
         # Mirrors confirm-speaker's mutual-hard-negative shape: confirming
-        # Max next to Julian in the same meeting+channel writes a
-        # hard-negative into Julian's profile whose embedding is literally
-        # Max's own voice sample, tagged with the meeting/channel/sid Max
-        # was confirmed under. Deleting Max must not leave that sample
-        # sitting in Julian's profile forever.
+        # Person Gamma next to Person Alpha in the same meeting+channel writes a
+        # hard-negative into Person Alpha's profile whose embedding is literally
+        # Person Gamma's own voice sample, tagged with the meeting/channel/sid Person Gamma
+        # was confirmed under. Deleting Person Gamma must not leave that sample
+        # sitting in Person Alpha's profile forever.
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            max_p = config.create_person_profile("Max")
-            julian = config.create_person_profile("Julian")
+            person_gamma = config.create_person_profile("Person Gamma")
+            person_alpha = config.create_person_profile("Person Alpha")
 
-            # Max's own positive evidence -- what delete_person_profile reads
+            # Person Gamma's own positive evidence -- what delete_person_profile reads
             # to know which cross-referenced hard negatives to strip.
             config.add_speaker_prototype(
-                max_p["person_id"], [0.1, 0.2, 0.3],
+                person_gamma["person_id"], [0.1, 0.2, 0.3],
                 recording_type="in_person", meeting_id="mtg1",
                 diarization_speaker_id="SPEAKER_0", channel="mic",
                 speech_duration_seconds=30.0, segment_count=5,
                 created_from="user_confirmed",
             )
-            # Julian's hard negative derived from Max's confirmation above.
+            # Person Alpha's hard negative derived from Person Gamma's confirmation above.
             config.add_speaker_prototype(
-                julian["person_id"], [0.1, 0.2, 0.3],
+                person_alpha["person_id"], [0.1, 0.2, 0.3],
                 recording_type="in_person", meeting_id="mtg1",
                 diarization_speaker_id="SPEAKER_0", channel="mic",
                 speech_duration_seconds=30.0, segment_count=5,
                 created_from="user_confirmed", negative=True,
             )
-            # An UNRELATED hard negative on Julian (different meeting) must survive.
+            # An UNRELATED hard negative on Person Alpha (different meeting) must survive.
             config.add_speaker_prototype(
-                julian["person_id"], [0.9, 0.9, 0.9],
+                person_alpha["person_id"], [0.9, 0.9, 0.9],
                 recording_type="in_person", meeting_id="mtg2",
                 diarization_speaker_id="SPEAKER_1", channel="mic",
                 speech_duration_seconds=30.0, segment_count=5,
                 created_from="user_confirmed", negative=True,
             )
 
-            self.assertTrue(config.delete_person_profile(max_p["person_id"]))
+            self.assertTrue(config.delete_person_profile(person_gamma["person_id"]))
 
-            julian_after = config.get_person_profile(julian["person_id"])
-            remaining_meetings = {h["meeting_id"] for h in julian_after["hard_negatives"]}
+            alpha_after = config.get_person_profile(person_alpha["person_id"])
+            remaining_meetings = {h["meeting_id"] for h in alpha_after["hard_negatives"]}
             self.assertNotIn("mtg1", remaining_meetings)
             self.assertIn("mtg2", remaining_meetings)
 
     def test_add_speaker_prototype_appends_positive_evidence(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             prototype = config.add_speaker_prototype(
                 person["person_id"], [0.1, 0.2, 0.3],
                 recording_type="in_person", meeting_id="mtg001",
@@ -923,7 +923,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_add_speaker_prototype_negative_goes_to_hard_negatives(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             config.add_speaker_prototype(
                 person["person_id"], [0.1, 0.2, 0.3],
                 recording_type="in_person", meeting_id="mtg001",
@@ -950,7 +950,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_add_speaker_prototype_rejects_invalid_recording_type(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             with self.assertRaises(ValueError):
                 config.add_speaker_prototype(
                     person["person_id"], [0.1, 0.2],
@@ -963,7 +963,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_add_speaker_prototype_rejects_invalid_created_from(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             with self.assertRaises(ValueError):
                 config.add_speaker_prototype(
                     person["person_id"], [0.1, 0.2],
@@ -976,7 +976,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_add_speaker_prototype_stores_channel_when_given(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             prototype = config.add_speaker_prototype(
                 person["person_id"], [0.1, 0.2],
                 recording_type="in_person", meeting_id="mtg001",
@@ -992,7 +992,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
         # explicitly recorded channel.
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             prototype = config.add_speaker_prototype(
                 person["person_id"], [0.1, 0.2],
                 recording_type="in_person", meeting_id="mtg001",
@@ -1035,7 +1035,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_add_speaker_prototype_rejects_invalid_channel(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             with self.assertRaises(ValueError):
                 config.add_speaker_prototype(
                     person["person_id"], [0.1, 0.2],
@@ -1059,7 +1059,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_remove_speaker_evidence_scopes_to_meeting_and_channel(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             pid = person["person_id"]
             self._add(config, pid, "mtg001", "SPEAKER_00", channel="mic")
             self._add(config, pid, "mtg001", "SPEAKER_00", channel="system", recording_type="remote")
@@ -1078,7 +1078,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_remove_speaker_evidence_sid_restriction_and_negatives(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             pid = person["person_id"]
             self._add(config, pid, "mtg001", "SPEAKER_00", channel="mic", negative=True)
             self._add(config, pid, "mtg001", "SPEAKER_01", channel="mic", negative=True)
@@ -1097,7 +1097,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_remove_speaker_evidence_matches_legacy_entries_via_recording_type(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             pid = person["person_id"]
             self._add(config, pid, "mtg001", "SPEAKER_00")  # legacy: no channel
             removed = config.remove_speaker_evidence(
@@ -1192,7 +1192,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_remove_speaker_evidence_by_ids(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             pid = person["person_id"]
             keep = self._add(config, pid, "mtg001", "SPEAKER_00", channel="mic")
             drop = self._add(config, pid, "mtg002", "SPEAKER_00", channel="mic")
@@ -1204,7 +1204,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_set_speaker_evidence_channels_backfills_and_validates(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             pid = person["person_id"]
             legacy = self._add(config, pid, "mtg001", "SPEAKER_00")
             updated = config.set_speaker_evidence_channels(pid, {legacy["prototype_id"]: "mic"})
@@ -1221,7 +1221,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
     def test_quality_score_rewards_clearing_stability_bar(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = Config(config_path=Path(tmp_dir) / "config.json")
-            person = config.create_person_profile("Max")
+            person = config.create_person_profile("Person Gamma")
             strong = config.add_speaker_prototype(
                 person["person_id"], [0.1, 0.2],
                 recording_type="in_person", meeting_id="mtg001",
@@ -1244,7 +1244,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
             config_path = Path(tmp_dir) / "config.json"
             config_path.write_text(json.dumps({
                 "person_profiles": [
-                    {"person_id": "p1", "display_name": "Max"},
+                    {"person_id": "p1", "display_name": "Person Gamma"},
                     {"display_name": "missing id"},
                     "not even a dict",
                     None,
@@ -1253,7 +1253,7 @@ class ConfigPersonProfileTests(unittest.TestCase):
             config = Config(config_path=config_path)
             profiles = config.get_person_profiles()
             self.assertEqual(len(profiles), 1)
-            self.assertEqual(profiles[0]["display_name"], "Max")
+            self.assertEqual(profiles[0]["display_name"], "Person Gamma")
 
     def test_normalize_person_profiles_handles_non_list(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -49,17 +49,17 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar(tmp)
             result, _ = self._run(
-                ["mtg001", "mic", "SPEAKER_00", "--person-id", "x", "--new-person", "Max"], tmp,
+                ["mtg001", "mic", "SPEAKER_00", "--person-id", "x", "--new-person", "Person Gamma"], tmp,
             )
             self.assertNotEqual(result.exit_code, 0)
 
     def test_new_person_creates_profile_and_prototype(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar(tmp)
-            result, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp)
+            result, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["display_name"], "Max")
+            self.assertEqual(data["display_name"], "Person Gamma")
             self.assertEqual(data["hard_negatives_added_against"], [])
 
             profile = cfg.get_person_profile(data["person_id"])
@@ -74,7 +74,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            existing = cfg.create_person_profile("Max")
+            existing = cfg.create_person_profile("Person Gamma")
             result, cfg = self._run(
                 ["mtg001", "mic", "SPEAKER_00", "--person-id", existing["person_id"]], tmp, cfg=cfg,
             )
@@ -88,9 +88,9 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            cfg.create_person_profile("Max")
+            cfg.create_person_profile("Person Gamma")
             result, cfg = self._run(
-                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp, cfg=cfg,
             )
             self.assertNotEqual(result.exit_code, 0)
             data = _last_json(result.output)
@@ -111,13 +111,13 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
     def test_missing_sidecar_fails(self):
         with tempfile.TemporaryDirectory() as tmp:
             Path(tmp, "output").mkdir(parents=True, exist_ok=True)
-            result, _ = self._run(["mtg_nonexistent", "mic", "SPEAKER_00", "--new-person", "Max"], tmp)
+            result, _ = self._run(["mtg_nonexistent", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp)
             self.assertNotEqual(result.exit_code, 0)
 
     def test_unknown_cluster_id_fails(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar(tmp)
-            result, _ = self._run(["mtg001", "mic", "SPEAKER_99", "--new-person", "Max"], tmp)
+            result, _ = self._run(["mtg001", "mic", "SPEAKER_99", "--new-person", "Person Gamma"], tmp)
             self.assertNotEqual(result.exit_code, 0)
 
     def test_second_confirmation_in_same_meeting_creates_mutual_hard_negatives(self):
@@ -125,18 +125,18 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self._seed_sidecar(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
 
-            result1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg)
+            result1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp, cfg=cfg)
             max_id = _last_json(result1.output)["person_id"]
 
             result2, cfg = self._run(["mtg001", "mic", "SPEAKER_01", "--new-person", "Sarah"], tmp, cfg=cfg)
             data2 = _last_json(result2.output)
             sarah_id = data2["person_id"]
-            self.assertEqual(data2["hard_negatives_added_against"], ["Max"])
+            self.assertEqual(data2["hard_negatives_added_against"], ["Person Gamma"])
 
             max_profile = cfg.get_person_profile(max_id)
             sarah_profile = cfg.get_person_profile(sarah_id)
 
-            # Max has one positive prototype (his own cluster) and one
+            # Person Gamma has one positive prototype (his own cluster) and one
             # hard-negative (Sarah's cluster) -- and vice versa.
             self.assertEqual(len(max_profile["prototypes"]), 1)
             self.assertEqual(max_profile["prototypes"][0]["embedding_mean"], [1.0, 0.0])
@@ -525,7 +525,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 },
             })
             cfg = Config(config_path=Path(tmp) / "config.json")
-            result1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg)
+            result1, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp, cfg=cfg)
             result2, cfg = self._run(["mtg001", "system", "SPEAKER_00", "--new-person", "RemoteGuest"], tmp, cfg=cfg)
             data2 = _last_json(result2.output)
             # Same meeting, but a DIFFERENT channel -- must not be treated
@@ -675,13 +675,13 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 encoding="utf-8",
             )
             result, _ = self._run(
-                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Max", "--relabel-transcript"], tmp,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma", "--relabel-transcript"], tmp,
             )
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertEqual(data["relabeled_lines"], 1)
             text = transcript_path.read_text()
-            self.assertIn("[00:05] [Max] hello there", text)
+            self.assertIn("[00:05] [Person Gamma] hello there", text)
             self.assertIn("[00:20] [You] hi back", text)  # untouched
 
     def test_relabel_transcript_uses_exact_matching_when_sidecar_has_manifest(self):
@@ -717,7 +717,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 encoding="utf-8",
             )
             result, _ = self._run(
-                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Max", "--relabel-transcript"], tmp,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma", "--relabel-transcript"], tmp,
             )
             data = _last_json(result.output)
             self.assertTrue(data["success"])
@@ -752,12 +752,12 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 encoding="utf-8",
             )
             result, _ = self._run(
-                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Max", "--relabel-transcript"], tmp,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma", "--relabel-transcript"], tmp,
             )
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertEqual(data["relabeled_lines"], 1)
-            self.assertIn("[00:05] [Max] hello there", transcript_path.read_text())
+            self.assertIn("[00:05] [Person Gamma] hello there", transcript_path.read_text())
 
     def test_without_relabel_flag_transcript_is_untouched(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -781,7 +781,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 "Session: mtg001\n\n" + "=" * 60 + "\n\n[00:05] [Speaker 2] hello there"
             )
             transcript_path.write_text(original, encoding="utf-8")
-            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp)
+            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertEqual(data["relabeled_lines"], 0)
@@ -805,7 +805,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                     },
                 },
             })
-            result, cfg = self._run(["mtg001", "system", "SPEAKER_2", "--new-person", "Julian"], tmp)
+            result, cfg = self._run(["mtg001", "system", "SPEAKER_2", "--new-person", "Person Alpha"], tmp)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             # SPEAKER_2 has less duration than SPEAKER_0 -> SPEAKER_0 is
@@ -853,13 +853,13 @@ class ConfirmSpeakerUpdatesParticipantsTests(unittest.TestCase):
             summary_path = output_dir / "mtg001_summary.json"
             summary_path.write_text(json.dumps({"session_info": {}, "participants": []}), encoding="utf-8")
 
-            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp)
+            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["participants_updated"], ["Max"])
+            self.assertEqual(data["participants_updated"], ["Person Gamma"])
 
             on_disk = json.loads(summary_path.read_text())
-            self.assertEqual(on_disk["participants"], ["Max"])
+            self.assertEqual(on_disk["participants"], ["Person Gamma"])
 
     def test_inserts_participants_section_into_markdown_summary(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -870,11 +870,11 @@ class ConfirmSpeakerUpdatesParticipantsTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp)
+            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp)
             self.assertTrue(_last_json(result.output)["success"])
 
             text = summary_path.read_text()
-            self.assertIn("## Participants\n\nMax", text)
+            self.assertIn("## Participants\n\nPerson Gamma", text)
             # Inserted after Summary, before Key Points -- and Key Points
             # itself is untouched.
             self.assertLess(text.index("## Summary"), text.index("## Participants"))
@@ -891,12 +891,12 @@ class ConfirmSpeakerUpdatesParticipantsTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp)
+            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp)
             self.assertTrue(_last_json(result.output)["success"])
 
             text = summary_path.read_text()
             self.assertEqual(text.count("## Participants"), 1)
-            self.assertIn("## Participants\n\nMax", text)
+            self.assertIn("## Participants\n\nPerson Gamma", text)
             self.assertNotIn("OldName", text)
             self.assertIn("- a point", text)
 
@@ -907,20 +907,20 @@ class ConfirmSpeakerUpdatesParticipantsTests(unittest.TestCase):
             summary_path.write_text("---\ntitle: \"Mtg\"\n---\n\n## Summary\n\nSome notes.\n", encoding="utf-8")
             cfg = Config(config_path=Path(tmp) / "config.json")
 
-            _, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp, cfg=cfg)
-            result, _ = self._run(["mtg001", "mic", "SPEAKER_01", "--new-person", "Julian"], tmp, cfg=cfg)
+            _, cfg = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp, cfg=cfg)
+            result, _ = self._run(["mtg001", "mic", "SPEAKER_01", "--new-person", "Person Alpha"], tmp, cfg=cfg)
             self.assertTrue(_last_json(result.output)["success"])
 
             text = summary_path.read_text()
-            self.assertIn("## Participants\n\nMax, Julian", text)
+            self.assertIn("## Participants\n\nPerson Gamma, Person Alpha", text)
 
     def test_noops_when_no_summary_file_exists(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar(tmp)  # no _summary.json/.md written at all
-            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Max"], tmp)
+            result, _ = self._run(["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"], tmp)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["participants_updated"], ["Max"])  # computed fine, just nothing to write to
+            self.assertEqual(data["participants_updated"], ["Person Gamma"])  # computed fine, just nothing to write to
 
 
 if __name__ == "__main__":

--- a/tests/test_enroll_self_from_person_cli.py
+++ b/tests/test_enroll_self_from_person_cli.py
@@ -35,46 +35,46 @@ class EnrollSelfFromPersonCliTests(unittest.TestCase):
     def test_happy_path_two_mic_prototypes(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             self._add(cfg, person["person_id"], "mtg001", "SPEAKER_00", "in_person",
                       channel="mic", embedding=[1.0, 0.0])
             self._add(cfg, person["person_id"], "mtg002", "SPEAKER_00", "in_person",
                       channel="mic", embedding=[0.0, 1.0])
-            result = self._run(["Max"], tmp, cfg)
+            result = self._run(["Person Gamma"], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["name"], "Max")
+            self.assertEqual(data["name"], "Person Gamma")
             self.assertEqual(data["prototypes_used"], 2)
             self.assertTrue(data["mic_only"])
             self.assertEqual(data["centroid_sample_count"], 2)
 
-            vp = cfg.get_voiceprint("Max")
+            vp = cfg.get_voiceprint("Person Gamma")
             self.assertTrue(vp["is_self"])
             self.assertEqual(len(vp["embeddings"]), 2)
 
     def test_prefers_mic_prototypes_over_system(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             self._add(cfg, person["person_id"], "mtg001", "SPEAKER_00", "in_person",
                       channel="mic", embedding=[1.0, 0.0])
             self._add(cfg, person["person_id"], "mtg002", "SPEAKER_00", "remote",
                       channel="system", embedding=[0.0, 1.0])
-            result = self._run(["Max"], tmp, cfg)
+            result = self._run(["Person Gamma"], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertEqual(data["prototypes_used"], 1)
             self.assertTrue(data["mic_only"])
-            vp = cfg.get_voiceprint("Max")
+            vp = cfg.get_voiceprint("Person Gamma")
             self.assertEqual(vp["embeddings"], [[1.0, 0.0]])
 
     def test_falls_back_to_all_prototypes_when_no_mic_evidence(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             self._add(cfg, person["person_id"], "mtg001", "SPEAKER_00", "remote",
                       channel="system", embedding=[0.0, 1.0])
-            result = self._run(["Max"], tmp, cfg)
+            result = self._run(["Person Gamma"], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertEqual(data["prototypes_used"], 1)
@@ -83,10 +83,10 @@ class EnrollSelfFromPersonCliTests(unittest.TestCase):
     def test_legacy_prototype_without_channel_matches_via_recording_type(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             self._add(cfg, person["person_id"], "mtg001", "SPEAKER_00", "in_person",
                       embedding=[1.0, 0.0])  # no channel -- legacy shape
-            result = self._run(["Max"], tmp, cfg)
+            result = self._run(["Person Gamma"], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
             self.assertTrue(data["mic_only"])
@@ -95,7 +95,7 @@ class EnrollSelfFromPersonCliTests(unittest.TestCase):
     def test_hard_negatives_never_used(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             cfg.add_speaker_prototype(
                 person["person_id"], [9.0, 9.0],
                 recording_type="in_person", meeting_id="mtg001",
@@ -103,7 +103,7 @@ class EnrollSelfFromPersonCliTests(unittest.TestCase):
                 speech_duration_seconds=25.0, segment_count=4,
                 created_from="user_confirmed", channel="mic", negative=True,
             )
-            result = self._run(["Max"], tmp, cfg)
+            result = self._run(["Person Gamma"], tmp, cfg)
             data = _last_json(result.output)
             self.assertFalse(data["success"])
             self.assertIn("no confirmed prototypes", data["error"])
@@ -119,8 +119,8 @@ class EnrollSelfFromPersonCliTests(unittest.TestCase):
     def test_person_with_no_prototypes_fails_cleanly(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            cfg.create_person_profile("Max")
-            result = self._run(["Max"], tmp, cfg)
+            cfg.create_person_profile("Person Gamma")
+            result = self._run(["Person Gamma"], tmp, cfg)
             self.assertNotEqual(result.exit_code, 0)
             data = _last_json(result.output)
             self.assertFalse(data["success"])
@@ -128,24 +128,24 @@ class EnrollSelfFromPersonCliTests(unittest.TestCase):
     def test_resolves_by_person_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             self._add(cfg, person["person_id"], "mtg001", "SPEAKER_00", "in_person",
                       channel="mic", embedding=[1.0, 0.0])
             result = self._run([person["person_id"]], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["name"], "Max")
+            self.assertEqual(data["name"], "Person Gamma")
 
     def test_rerunning_updates_rather_than_duplicating(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             self._add(cfg, person["person_id"], "mtg001", "SPEAKER_00", "in_person",
                       channel="mic", embedding=[1.0, 0.0])
-            self._run(["Max"], tmp, cfg)
-            self._run(["Max"], tmp, cfg)
+            self._run(["Person Gamma"], tmp, cfg)
+            self._run(["Person Gamma"], tmp, cfg)
             self.assertEqual(len(cfg.get_voiceprints()), 1)
-            self.assertEqual(cfg.get_voiceprint("Max")["is_self"], True)
+            self.assertEqual(cfg.get_voiceprint("Person Gamma")["is_self"], True)
 
 
 if __name__ == "__main__":

--- a/tests/test_full_reprocess_cli.py
+++ b/tests/test_full_reprocess_cli.py
@@ -128,7 +128,7 @@ class FullReprocessCliTests(unittest.TestCase):
                 d.mkdir(parents=True, exist_ok=True)
             (output_dir / "mtg001_summary.json").write_text(json.dumps({
                 "session_info": {"name": "Weekly Sync"},
-                "user_notes": "Remember to follow up with Max.",
+                "user_notes": "Remember to follow up with Person Gamma.",
                 "participants": [],
             }), encoding="utf-8")
             (recordings_dir / "mtg001.wav").write_bytes(b"fake-audio")
@@ -157,7 +157,7 @@ class FullReprocessCliTests(unittest.TestCase):
             self.assertEqual(Path(audio_file), recordings_dir / "mtg001.wav")
             self.assertEqual(name, "Weekly Sync")
             self.assertIsNone(live_transcript)
-            self.assertEqual(seen_notes_text["text"], "Remember to follow up with Max.")
+            self.assertEqual(seen_notes_text["text"], "Remember to follow up with Person Gamma.")
             # The temp notes file is cleaned up after the call.
             self.assertFalse(Path(seen_notes_text["path"]).exists())
 
@@ -223,7 +223,7 @@ class FullReprocessCliTests(unittest.TestCase):
             (recordings_dir / "mtg001.wav").write_bytes(b"fake-audio")
 
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             cfg.add_speaker_prototype(
                 person["person_id"], [1.0, 0.0],
                 recording_type="in_person", meeting_id="mtg001",
@@ -237,8 +237,8 @@ class FullReprocessCliTests(unittest.TestCase):
                 result = self._run(["mtg001"], tmp, cfg)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["participants_restored"], ["Max"])
-            self.assertIn("## Participants\n\nMax", (output_dir / "mtg001_summary.md").read_text())
+            self.assertEqual(data["participants_restored"], ["Person Gamma"])
+            self.assertIn("## Participants\n\nPerson Gamma", (output_dir / "mtg001_summary.md").read_text())
 
     def test_restores_folder_membership(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_parakeet_onnx.py
+++ b/tests/test_parakeet_onnx.py
@@ -234,6 +234,39 @@ class TranscribeWindowsMergeTests(unittest.TestCase):
         merged = onnx_backend._transcribe_windows(model, self._eighty_seconds())
         self.assertEqual(merged.tokens, ["Hello", " world."])
 
+    def test_a_skipped_window_is_reported_not_just_swallowed(self):
+        # Skipping the window keeps the meeting alive, but the transcript now
+        # covers less audio than the recording holds. Downstream has to be
+        # able to see that -- silently handing back a short transcript is how
+        # a half-read file used to beat a complete live transcript.
+        model = _FakeTsModel([
+            (["Hello", " world."], [(0.0, 0.5), (1.0, 1.5)]),
+            RuntimeError("onnx blew up on this window"),
+        ])
+        merged = onnx_backend._transcribe_windows(model, self._eighty_seconds())
+        self.assertEqual(merged.windows_attempted, 2)
+        self.assertEqual(merged.windows_recognized, 1)
+        self.assertEqual(onnx_backend._result_to_dict(merged, language=None)["window_coverage"], 0.5)
+
+    def test_a_clean_run_reports_full_coverage(self):
+        model = _FakeTsModel([
+            (["Hello", " world."], [(0.0, 0.5), (1.0, 1.5)]),
+            ([" Bar."], [(20.0, 20.5)]),
+        ])
+        merged = onnx_backend._transcribe_windows(model, self._eighty_seconds())
+        self.assertEqual(merged.windows_attempted, merged.windows_recognized)
+        self.assertEqual(onnx_backend._result_to_dict(merged, language=None)["window_coverage"], 1.0)
+
+    def test_a_result_that_never_windowed_reports_unknown_not_complete(self):
+        # onnx-asr's own TimestampedResult carries no counters. That must read
+        # as "no figure available", never as a clean bill of health.
+        class _Plain:
+            text = "Hello world."
+            tokens = ["Hello", " world."]
+            timestamps = [(0.0, 0.5), (1.0, 1.5)]
+
+        self.assertIsNone(onnx_backend._result_to_dict(_Plain(), language=None)["window_coverage"])
+
     def test_all_windows_failing_raises_not_empty(self):
         # A broken model/session where EVERY window raises is a real failure,
         # not silence — _transcribe_windows must raise so the caller marks it

--- a/tests/test_person_profile_cli.py
+++ b/tests/test_person_profile_cli.py
@@ -31,18 +31,18 @@ class PersonProfileCliTests(unittest.TestCase):
 
     def test_create_person_profile_succeeds(self):
         with tempfile.TemporaryDirectory() as tmp:
-            result, cfg = self._run(simple_recorder.create_person_profile, ["Max"], tmp)
+            result, cfg = self._run(simple_recorder.create_person_profile, ["Person Gamma"], tmp)
             self.assertEqual(result.exit_code, 0)
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["display_name"], "Max")
+            self.assertEqual(data["display_name"], "Person Gamma")
             self.assertEqual(len(cfg.get_person_profiles()), 1)
 
     def test_create_person_profile_rejects_duplicate_name(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            cfg.create_person_profile("Max")
-            result, cfg = self._run(simple_recorder.create_person_profile, ["Max"], tmp, cfg=cfg)
+            cfg.create_person_profile("Person Gamma")
+            result, cfg = self._run(simple_recorder.create_person_profile, ["Person Gamma"], tmp, cfg=cfg)
             self.assertNotEqual(result.exit_code, 0)
             data = _last_json(result.output)
             self.assertFalse(data["success"])
@@ -52,16 +52,16 @@ class PersonProfileCliTests(unittest.TestCase):
     def test_rename_person_profile_rejects_collision(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            cfg.create_person_profile("Max")
-            julian = cfg.create_person_profile("Julian")
+            cfg.create_person_profile("Person Gamma")
+            person_alpha = cfg.create_person_profile("Person Alpha")
             result, cfg = self._run(
-                simple_recorder.rename_person_profile, [julian["person_id"], "Max"], tmp, cfg=cfg,
+                simple_recorder.rename_person_profile, [person_alpha["person_id"], "Person Gamma"], tmp, cfg=cfg,
             )
             self.assertNotEqual(result.exit_code, 0)
             data = _last_json(result.output)
             self.assertFalse(data["success"])
             self.assertIn("already exists", data["error"])
-            self.assertEqual(cfg.get_person_profile(julian["person_id"])["display_name"], "Julian")
+            self.assertEqual(cfg.get_person_profile(person_alpha["person_id"])["display_name"], "Person Alpha")
 
 
 class PersonProfileParticipantsPropagationTests(unittest.TestCase):
@@ -106,18 +106,18 @@ class PersonProfileParticipantsPropagationTests(unittest.TestCase):
             self.assertIn("## Participants\n\nJulain", summary_path.read_text())
 
             result, cfg = self._run(
-                simple_recorder.rename_person_profile, [person["person_id"], "Julian"], tmp, cfg=cfg,
+                simple_recorder.rename_person_profile, [person["person_id"], "Person Alpha"], tmp, cfg=cfg,
             )
             self.assertTrue(_last_json(result.output)["success"])
             text = summary_path.read_text()
-            self.assertIn("## Participants\n\nJulian", text)
+            self.assertIn("## Participants\n\nPerson Alpha", text)
             self.assertNotIn("Julain", text)
 
     def test_delete_removes_name_from_every_confirmed_meeting(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person, summary_path = self._seed_confirmed_person(tmp, cfg, "Max", "mtg001")
-            self.assertIn("## Participants\n\nMax", summary_path.read_text())
+            person, summary_path = self._seed_confirmed_person(tmp, cfg, "Person Gamma", "mtg001")
+            self.assertIn("## Participants\n\nPerson Gamma", summary_path.read_text())
 
             result, cfg = self._run(
                 simple_recorder.delete_person_profile, [person["person_id"]], tmp, cfg=cfg,
@@ -125,12 +125,12 @@ class PersonProfileParticipantsPropagationTests(unittest.TestCase):
             self.assertTrue(_last_json(result.output)["success"])
             text = summary_path.read_text()
             self.assertNotIn("## Participants", text)
-            self.assertNotIn("Max", text)
+            self.assertNotIn("Person Gamma", text)
 
     def test_rename_of_person_never_confirmed_anywhere_is_a_noop_on_disk(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Max")
+            person = cfg.create_person_profile("Person Gamma")
             result, _ = self._run(
                 simple_recorder.rename_person_profile, [person["person_id"], "Maximilian"], tmp, cfg=cfg,
             )

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -189,7 +189,7 @@ class MarkedClusterIsWithheldTests(unittest.TestCase):
         # The embedding is IDENTICAL to the profile's, so without the
         # marking this is an unambiguous "confirmed". Anything short of
         # status "none" here means the guard is not doing its job.
-        profiles = [_profile("p1", "Julian", [1.0, 0.0])]
+        profiles = [_profile("p1", "Person Alpha", [1.0, 0.0])]
         unmarked = suggest_speaker([1.0, 0.0], _context(), profiles)
         self.assertEqual(unmarked.status, "confirmed")
 
@@ -210,7 +210,7 @@ class MarkedClusterIsWithheldTests(unittest.TestCase):
         # must not be able to do that -- otherwise marking a contaminated
         # cluster would COST the real cluster its correct suggestion,
         # punishing the user for telling the truth.
-        profiles = [_profile("p1", "Julian", [1.0, 0.0])]
+        profiles = [_profile("p1", "Person Alpha", [1.0, 0.0])]
         results = suggest_speakers_for_meeting({
             "system": {
                 "SPEAKER_0": (
@@ -1084,7 +1084,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            pid = cfg.create_person_profile("Julian")["person_id"]
+            pid = cfg.create_person_profile("Person Alpha")["person_id"]
             run1 = self._seeded_run_id(tmp)
             cfg.add_speaker_prototype(
                 pid, [1.0, 0.0], recording_type="remote", meeting_id="mtg001",
@@ -1104,7 +1104,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertTrue(data["success"])
             self.assertEqual(
                 data["cleared_confirmation_from"], [],
-                "the marking describes this run's cluster, not the one Julian was confirmed on",
+                "the marking describes this run's cluster, not the one Person Alpha was confirmed on",
             )
             profile = cfg.get_person_profile(pid)
             self.assertEqual(
@@ -1120,14 +1120,14 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            julian = cfg.create_person_profile("Julian")["person_id"]
+            person_alpha = cfg.create_person_profile("Person Alpha")["person_id"]
             max_id = cfg.create_person_profile("Max")["person_id"]
             run1 = self._seeded_run_id(tmp)
             run2 = self._rediarize(tmp)
 
-            # Julian is the one confirmed on the CURRENT run's SPEAKER_0...
+            # Person Alpha is the one confirmed on the CURRENT run's SPEAKER_0...
             cfg.add_speaker_prototype(
-                julian, [0.0, 1.0], recording_type="remote", meeting_id="mtg001",
+                person_alpha, [0.0, 1.0], recording_type="remote", meeting_id="mtg001",
                 diarization_speaker_id="SPEAKER_0", speech_duration_seconds=55.0,
                 segment_count=9, created_from="user_confirmed", channel="system",
                 diarization_run_id=run2,
@@ -1140,9 +1140,9 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     segment_count=9, created_from="user_confirmed", channel="system",
                     negative=True, diarization_run_id=run_id,
                 )
-            # Julian carries a stale one of his own from before the re-run.
+            # Person Alpha carries a stale one of his own from before the re-run.
             cfg.add_speaker_prototype(
-                julian, [1.0, 0.0], recording_type="remote", meeting_id="mtg001",
+                person_alpha, [1.0, 0.0], recording_type="remote", meeting_id="mtg001",
                 diarization_speaker_id="SPEAKER_0", speech_duration_seconds=60.0,
                 segment_count=10, created_from="user_confirmed", channel="system",
                 negative=True, diarization_run_id=run1,
@@ -1153,10 +1153,10 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 ["mtg001", "system", "SPEAKER_0"], tmp, cfg=cfg,
             )
             data = _last_json(result.output)
-            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
-            self.assertEqual(cfg.get_person_profile(julian)["prototypes"], [])
+            self.assertEqual(data["cleared_confirmation_from"], ["Person Alpha"])
+            self.assertEqual(cfg.get_person_profile(person_alpha)["prototypes"], [])
             self.assertEqual(
-                [n["diarization_run_id"] for n in cfg.get_person_profile(julian)["hard_negatives"]],
+                [n["diarization_run_id"] for n in cfg.get_person_profile(person_alpha)["hard_negatives"]],
                 [run1],
             )
             self.assertEqual(
@@ -1178,7 +1178,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
     def test_marking_one_cluster_keeps_the_negatives_earned_by_the_others(self):
         # From the bot review, and it destroys data. A person's hard
         # negatives are created when OTHER clusters are confirmed as
-        # somebody else -- "this voice is not Julian" is evidence about
+        # somebody else -- "this voice is not Person Alpha" is evidence about
         # THAT cluster. Marking cluster A as mixed cleared every negative
         # the person had in this meeting and channel, including the ones
         # earned by clusters B and C, which are untouched by the marking
@@ -1187,7 +1187,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             pid = person["person_id"]
             # Confirmed on SPEAKER_0 (the cluster about to be marked)...
             run_id = self._seeded_run_id(tmp)
@@ -1247,9 +1247,9 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
     def test_marking_a_confirmed_cluster_takes_the_name_out_of_the_transcript(self):
         # The last of the three P1s from the bot review, and the one a user
         # actually reads. confirm-speaker --relabel-transcript rewrites the
-        # cluster's lines to "Julian". Marking it as more than one person
+        # cluster's lines to "Person Alpha". Marking it as more than one person
         # afterwards withdraws the profile, the prototype and the
-        # participants chip -- but left "Julian" standing in the saved
+        # participants chip -- but left "Person Alpha" standing in the saved
         # transcript, which is what feeds the summary and every export. The
         # app then knows the cluster holds several people while the
         # artefact keeps naming one of them.
@@ -1266,11 +1266,11 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             with mock.patch("src.config.get_config", return_value=cfg), \
                  mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
                 confirmed = CliRunner().invoke(simple_recorder.confirm_speaker, [
-                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Julian",
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
                     "--relabel-transcript",
                 ])
             self.assertTrue(_last_json(confirmed.output)["success"])
-            self.assertIn("[00:05] [Julian] hello there", transcript.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", transcript.read_text())
 
             result = self._run(
                 simple_recorder.mark_speaker_cluster,
@@ -1278,10 +1278,10 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             )
             data = _last_json(result.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+            self.assertEqual(data["cleared_confirmation_from"], ["Person Alpha"])
 
             text = transcript.read_text()
-            self.assertNotIn("Julian", text, "the withdrawn name must leave the transcript too")
+            self.assertNotIn("Person Alpha", text, "the withdrawn name must leave the transcript too")
             self.assertIn(
                 "[00:05] [Speaker 2] hello there", text,
                 "and the label the line carried before the confirmation comes back",
@@ -1295,11 +1295,11 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
         # fallback states exactly what the user just decided.
         with tempfile.TemporaryDirectory() as tmp:
             transcript = self._seed_with_transcript(
-                tmp, "[00:05] [Julian] hello there",
+                tmp, "[00:05] [Person Alpha] hello there",
                 [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             cfg.add_speaker_prototype(
                 person["person_id"], [1.0, 0.0], recording_type="in_person",
                 meeting_id="mtg001", diarization_speaker_id="SPEAKER_00",
@@ -1312,7 +1312,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 ["mtg001", "mic", "SPEAKER_00"], tmp, cfg=cfg,
             )
             data = _last_json(result.output)
-            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+            self.assertEqual(data["cleared_confirmation_from"], ["Person Alpha"])
             self.assertEqual(data["transcript_lines_restored"], 1)
             self.assertIn("[00:05] [Multiple speakers] hello there", transcript.read_text())
 
@@ -1325,12 +1325,12 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
         # cleanup that never happened.
         with tempfile.TemporaryDirectory() as tmp:
             transcript = self._seed_with_transcript(
-                tmp, "[00:05] [Julian] hello there\n\n[00:20] [You] hi back",
+                tmp, "[00:05] [Person Alpha] hello there\n\n[00:20] [You] hi back",
                 # One entry, two diarised lines: cannot be paired.
                 [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             cfg.add_speaker_prototype(
                 person["person_id"], [1.0, 0.0], recording_type="in_person",
                 meeting_id="mtg001", diarization_speaker_id="SPEAKER_00",
@@ -1343,12 +1343,12 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 ["mtg001", "mic", "SPEAKER_00"], tmp, cfg=cfg,
             )
             data = _last_json(result.output)
-            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+            self.assertEqual(data["cleared_confirmation_from"], ["Person Alpha"])
             self.assertEqual(
                 data["transcript_lines_restored"], 0,
                 "a refusal must be reported as zero, not as a silent success",
             )
-            self.assertIn("[00:05] [Julian] hello there", transcript.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", transcript.read_text())
 
     def test_unknown_cluster_fails_loudly_rather_than_marking_nothing(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1363,7 +1363,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             for meeting in ("other1", "other2"):
                 cfg.add_speaker_prototype(
                     person["person_id"], [1.0, 0.0], recording_type="remote",
@@ -1399,7 +1399,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
 
             result = self._run(
                 simple_recorder.confirm_speaker,
-                ["mtg001", "system", "SPEAKER_0", "--new-person", "Julian"], tmp, cfg=cfg,
+                ["mtg001", "system", "SPEAKER_0", "--new-person", "Person Alpha"], tmp, cfg=cfg,
             )
             self.assertEqual(result.exit_code, 1)
             self.assertFalse(_last_json(result.output)["success"])
@@ -1421,11 +1421,11 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
 
             confirmed = self._run(
                 simple_recorder.confirm_speaker,
-                ["mtg001", "system", "SPEAKER_0", "--new-person", "Julian"], tmp, cfg=cfg,
+                ["mtg001", "system", "SPEAKER_0", "--new-person", "Person Alpha"], tmp, cfg=cfg,
             )
             self.assertTrue(_last_json(confirmed.output)["success"])
-            julian = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Julian")
-            self.assertEqual(len(julian["prototypes"]), 1)
+            person_alpha = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Person Alpha")
+            self.assertEqual(len(person_alpha["prototypes"]), 1)
 
             marked = self._run(
                 simple_recorder.mark_speaker_cluster,
@@ -1433,11 +1433,11 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             )
             data = _last_json(marked.output)
             self.assertTrue(data["success"])
-            self.assertEqual(data["cleared_confirmation_from"], ["Julian"])
+            self.assertEqual(data["cleared_confirmation_from"], ["Person Alpha"])
 
-            julian = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Julian")
+            person_alpha = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Person Alpha")
             self.assertEqual(
-                julian["prototypes"], [],
+                person_alpha["prototypes"], [],
                 "a blended two-voice embedding must not stay enrolled as a person",
             )
 
@@ -1462,16 +1462,16 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
 
             self._run(
                 simple_recorder.confirm_speaker,
-                ["mtg001", "system", "SPEAKER_0", "--new-person", "Julian"], tmp, cfg=cfg,
+                ["mtg001", "system", "SPEAKER_0", "--new-person", "Person Alpha"], tmp, cfg=cfg,
             )
-            julian = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Julian")
-            self.assertEqual(len(julian["prototypes"]), 1)
+            person_alpha = next(p for p in cfg.get_person_profiles() if p["display_name"] == "Person Alpha")
+            self.assertEqual(len(person_alpha["prototypes"]), 1)
 
             set_cluster_multi_speaker(output_dir, "mtg001", "system", "SPEAKER_0", True)
 
             result = self._run(
                 simple_recorder.confirm_speaker,
-                ["mtg001", "system", "SPEAKER_1", "--new-person", "Max"], tmp, cfg=cfg,
+                ["mtg001", "system", "SPEAKER_1", "--new-person", "Person Gamma"], tmp, cfg=cfg,
             )
             data = _last_json(result.output)
             self.assertTrue(data["success"])
@@ -1492,7 +1492,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             cfg = Config(config_path=Path(tmp) / "config.json")
             result = self._run(
                 simple_recorder.confirm_speaker,
-                ["mtg001", "system", "SPEAKER_1", "--new-person", "Julian"], tmp, cfg=cfg,
+                ["mtg001", "system", "SPEAKER_1", "--new-person", "Person Alpha"], tmp, cfg=cfg,
             )
             self.assertTrue(_last_json(result.output)["success"])
 
@@ -1540,7 +1540,7 @@ class SpeakerNamingStatusCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             cfg.add_speaker_prototype(
                 person["person_id"], [1.0, 0.0], recording_type="remote",
                 meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
@@ -1564,7 +1564,7 @@ class SpeakerNamingStatusCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             cfg.add_speaker_prototype(
                 person["person_id"], [1.0, 0.0], recording_type="remote",
                 meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
@@ -1841,7 +1841,7 @@ class SetClusterReviewStateCliTests(unittest.TestCase):
                 set_cluster_review_state(output_dir, "mtg001", "system", sid, REVIEW_STATE_GENERIC)
 
             result = self._run(simple_recorder.confirm_speaker,
-                               ["mtg001", "system", "SPEAKER_2", "--new-person", "Julian"],
+                               ["mtg001", "system", "SPEAKER_2", "--new-person", "Person Alpha"],
                                tmp, cfg=cfg)
             self.assertTrue(_last_json(result.output)["success"])
             for sid in ("SPEAKER_0", "SPEAKER_2"):

--- a/tests/test_speaker_suggestions.py
+++ b/tests/test_speaker_suggestions.py
@@ -142,7 +142,7 @@ class BuildClustersFromDiarizationTests(unittest.TestCase):
 
 class ScoreCandidatesTests(unittest.TestCase):
     def test_prefers_same_context_prototypes(self):
-        profiles = [_profile("p1", "Max", prototypes=[
+        profiles = [_profile("p1", "Person Gamma", prototypes=[
             _prototype([1.0, 0.0], recording_type="remote"),   # far from query, wrong context
             _prototype([0.0, 1.0], recording_type="in_person"),  # close to query, right context
         ])]
@@ -151,7 +151,7 @@ class ScoreCandidatesTests(unittest.TestCase):
         self.assertAlmostEqual(candidates[0].distance, 0.0, places=6)
 
     def test_falls_back_to_cross_context_when_none_match(self):
-        profiles = [_profile("p1", "Max", prototypes=[
+        profiles = [_profile("p1", "Person Gamma", prototypes=[
             _prototype([0.0, 1.0], recording_type="remote"),
         ])]
         context = _stable_context(recording_type="in_person")
@@ -160,13 +160,13 @@ class ScoreCandidatesTests(unittest.TestCase):
         self.assertAlmostEqual(candidates[0].distance, 0.0, places=6)
 
     def test_person_with_no_prototypes_at_all_is_skipped(self):
-        profiles = [_profile("p1", "Max", prototypes=[])]
+        profiles = [_profile("p1", "Person Gamma", prototypes=[])]
         candidates = score_candidates([1.0, 0.0], _stable_context(), profiles)
         self.assertEqual(candidates, [])
 
     def test_flags_hard_negative_conflict(self):
         profiles = [_profile(
-            "p1", "Max",
+            "p1", "Person Gamma",
             prototypes=[_prototype([1.0, 0.0])],
             hard_negatives=[_prototype([1.0, 0.0])],  # query will land right on this too
         )]
@@ -175,7 +175,7 @@ class ScoreCandidatesTests(unittest.TestCase):
 
     def test_no_hard_negative_conflict_when_query_far_from_negatives(self):
         profiles = [_profile(
-            "p1", "Max",
+            "p1", "Person Gamma",
             prototypes=[_prototype([1.0, 0.0])],
             hard_negatives=[_prototype([0.0, 1.0])],  # orthogonal, far
         )]
@@ -188,7 +188,7 @@ class ScoreCandidatesTests(unittest.TestCase):
         # an ordinary cross-speaker distance, which every colleague's
         # confirm adds. The old absolute rule suppressed exactly these.
         profiles = [_profile(
-            "p1", "Max",
+            "p1", "Person Gamma",
             prototypes=[_prototype([1.0, 0.0])],
             hard_negatives=[_prototype([0.7, 0.714])],  # distance ~0.3 from query
         )]
@@ -200,7 +200,7 @@ class ScoreCandidatesTests(unittest.TestCase):
         # Positive at ~0.25, negative at ~0.3: the negative evidence rivals
         # the positive (within SUGGESTION_CONFIDENCE_MARGIN), so suppress.
         profiles = [_profile(
-            "p1", "Max",
+            "p1", "Person Gamma",
             prototypes=[_prototype([0.75, 0.661])],   # distance ~0.25 from query
             hard_negatives=[_prototype([0.7, 0.714])],  # distance ~0.3 from query
         )]
@@ -211,7 +211,7 @@ class ScoreCandidatesTests(unittest.TestCase):
         # A negative past HARD_NEGATIVE_DISTANCE_THRESHOLD is not
         # meaningful evidence at all, however weak the positive is.
         profiles = [_profile(
-            "p1", "Max",
+            "p1", "Person Gamma",
             prototypes=[_prototype([0.75, 0.661])],  # distance ~0.25
             hard_negatives=[_prototype([0.5, 0.866])],  # distance ~0.5, beyond 0.40
         )]
@@ -219,7 +219,7 @@ class ScoreCandidatesTests(unittest.TestCase):
         self.assertFalse(candidates[0].hard_negative_conflict)
 
     def test_negative_distance_is_none_without_negatives(self):
-        profiles = [_profile("p1", "Max", prototypes=[_prototype([1.0, 0.0])])]
+        profiles = [_profile("p1", "Person Gamma", prototypes=[_prototype([1.0, 0.0])])]
         candidates = score_candidates([1.0, 0.0], _stable_context(), profiles)
         self.assertIsNone(candidates[0].negative_distance)
 
@@ -232,7 +232,7 @@ class ScoreCandidatesTests(unittest.TestCase):
         self.assertEqual([c.display_name for c in candidates], ["Close", "Far"])
 
     def test_confirmed_meeting_count_counts_distinct_meeting_ids_in_pool(self):
-        profiles = [_profile("p1", "Max", prototypes=[
+        profiles = [_profile("p1", "Person Gamma", prototypes=[
             _prototype([1.0, 0.0], meeting_id="mtg_a"),
             _prototype([0.9, 0.1], meeting_id="mtg_a"),  # same meeting again
             _prototype([0.8, 0.2], meeting_id="mtg_b"),
@@ -243,14 +243,14 @@ class ScoreCandidatesTests(unittest.TestCase):
 
 class SuggestSpeakerTests(unittest.TestCase):
     def test_confirmed_when_threshold_margin_and_stability_all_clear(self):
-        profiles = [_profile("p1", "Max", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.98, 0.01]))]
+        profiles = [_profile("p1", "Person Gamma", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.98, 0.01]))]
         result = suggest_speaker([1.0, 0.0], _stable_context(), profiles)
         self.assertEqual(result.status, "confirmed")
-        self.assertEqual(result.suggested_name, "Max")
+        self.assertEqual(result.suggested_name, "Person Gamma")
         self.assertEqual(result.suggested_person_id, "p1")
 
     def test_possible_when_threshold_clears_but_stability_does_not(self):
-        profiles = [_profile("p1", "Max", prototypes=[_prototype([1.0, 0.0])])]
+        profiles = [_profile("p1", "Person Gamma", prototypes=[_prototype([1.0, 0.0])])]
         weak_context = ClusterContext(
             meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
             recording_type="in_person",
@@ -259,18 +259,18 @@ class SuggestSpeakerTests(unittest.TestCase):
         )
         result = suggest_speaker([1.0, 0.0], weak_context, profiles)
         self.assertEqual(result.status, "possible")
-        self.assertEqual(result.suggested_name, "Max")
+        self.assertEqual(result.suggested_name, "Person Gamma")
 
     def test_possible_when_margin_too_close(self):
         profiles = [
-            _profile("p1", "Max", prototypes=[_prototype([1.0, 0.0])]),
+            _profile("p1", "Person Gamma", prototypes=[_prototype([1.0, 0.0])]),
             _profile("p2", "Sam", prototypes=[_prototype([0.99, 0.02])]),  # near-tie
         ]
         result = suggest_speaker([1.0, 0.0], _stable_context(), profiles)
         self.assertEqual(result.status, "possible")
 
     def test_none_when_below_distance_threshold(self):
-        profiles = [_profile("p1", "Max", prototypes=[_prototype([-1.0, 0.0])])]  # orthogonal/opposite
+        profiles = [_profile("p1", "Person Gamma", prototypes=[_prototype([-1.0, 0.0])])]  # orthogonal/opposite
         result = suggest_speaker([1.0, 0.0], _stable_context(), profiles)
         self.assertEqual(result.status, "none")
         self.assertIsNone(result.suggested_name)
@@ -282,7 +282,7 @@ class SuggestSpeakerTests(unittest.TestCase):
 
     def test_hard_negative_conflict_suppresses_even_strong_match(self):
         profiles = [_profile(
-            "p1", "Max",
+            "p1", "Person Gamma",
             prototypes=[_prototype([1.0, 0.0])],
             hard_negatives=[_prototype([1.0, 0.0])],
         )]
@@ -295,17 +295,17 @@ class SuggestSpeakerTests(unittest.TestCase):
         # "confirmed" even though a stored negative sits at ~0.3 (an
         # ordinary cross-speaker distance).
         profiles = [_profile(
-            "p1", "Max",
+            "p1", "Person Gamma",
             prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.98, 0.01]),
             hard_negatives=[_prototype([0.7, 0.714])],  # distance ~0.3 from query
         )]
         result = suggest_speaker([1.0, 0.0], _stable_context(), profiles)
         self.assertEqual(result.status, "confirmed")
-        self.assertEqual(result.suggested_name, "Max")
+        self.assertEqual(result.suggested_name, "Person Gamma")
 
     def test_never_raises_on_malformed_profile(self):
         # Missing "prototypes" key entirely shouldn't crash scoring.
-        profiles = [{"person_id": "p1", "display_name": "Max"}]
+        profiles = [{"person_id": "p1", "display_name": "Person Gamma"}]
         result = suggest_speaker([1.0, 0.0], _stable_context(), profiles)
         self.assertEqual(result.status, "none")
 
@@ -316,7 +316,7 @@ class SuggestSpeakerTests(unittest.TestCase):
         # real speech -- duration/segment-count gates alone don't catch it.
         # Reproduces the exact shape of a confirmed false positive found
         # this session: 56 turns, 85.4s total, ~1.53s/turn average.
-        profiles = [_profile("p1", "Max", prototypes=[_prototype([1.0, 0.0])])]
+        profiles = [_profile("p1", "Person Gamma", prototypes=[_prototype([1.0, 0.0])])]
         fragmented_context = ClusterContext(
             meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
             recording_type="in_person",
@@ -325,7 +325,7 @@ class SuggestSpeakerTests(unittest.TestCase):
         )
         result = suggest_speaker([1.0, 0.0], fragmented_context, profiles)
         self.assertEqual(result.status, "possible")
-        self.assertEqual(result.suggested_name, "Max")
+        self.assertEqual(result.suggested_name, "Person Gamma")
 
     def test_confirmed_when_avg_turn_clears_threshold_even_with_many_short_turns(self):
         # A real conversation can have many short turns (quick back-and-forth)
@@ -334,7 +334,7 @@ class SuggestSpeakerTests(unittest.TestCase):
         # above SUGGESTION_MIN_SEGMENT_COUNT and total duration well above
         # SUGGESTION_MIN_DURATION_SECONDS so only the avg-turn gate is
         # actually under test here.
-        profiles = [_profile("p1", "Max", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.98, 0.01]))]
+        profiles = [_profile("p1", "Person Gamma", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.98, 0.01]))]
         context = ClusterContext(
             meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
             recording_type="in_person",
@@ -348,17 +348,17 @@ class SuggestSpeakerTests(unittest.TestCase):
         # Even with a perfect distance/margin/duration/avg-turn, a person
         # with evidence from only ONE meeting must not auto-fill -- their
         # profile hasn't demonstrated it generalizes across sessions yet.
-        profiles = [_profile("p1", "Max", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg_only")])]
+        profiles = [_profile("p1", "Person Gamma", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg_only")])]
         result = suggest_speaker([1.0, 0.0], _stable_context(), profiles)
         self.assertEqual(result.status, "possible")
-        self.assertEqual(result.suggested_name, "Max")
+        self.assertEqual(result.suggested_name, "Person Gamma")
 
     def test_possible_when_two_prototypes_are_from_the_same_meeting(self):
         # Two prototypes confirmed from fragments of the SAME meeting (the
         # exact real-world shape found this session: a diarizer-split voice
         # confirmed twice within one call) must NOT count as two distinct
         # confirmed meetings.
-        profiles = [_profile("p1", "Max", prototypes=[
+        profiles = [_profile("p1", "Person Gamma", prototypes=[
             _prototype([1.0, 0.0], meeting_id="mtg_shared"),
             _prototype([0.99, 0.02], meeting_id="mtg_shared"),
         ])]
@@ -366,7 +366,7 @@ class SuggestSpeakerTests(unittest.TestCase):
         self.assertEqual(result.status, "possible")
 
     def test_confirmed_when_two_distinct_meetings_confirmed(self):
-        profiles = [_profile("p1", "Max", prototypes=[
+        profiles = [_profile("p1", "Person Gamma", prototypes=[
             _prototype([1.0, 0.0], meeting_id="mtg_a"),
             _prototype([0.99, 0.02], meeting_id="mtg_b"),
         ])]
@@ -410,10 +410,10 @@ class PrototypeRunMatchesTests(unittest.TestCase):
 
 class SuggestSpeakersForMeetingTests(unittest.TestCase):
     def test_same_person_not_suggested_for_two_clusters(self):
-        # Two clusters both plausibly Max; only the closer one should claim
+        # Two clusters both plausibly Person Gamma; only the closer one should claim
         # the confirmed match — port of the removed auto-matcher's
         # usedNames behaviour.
-        profiles = [_profile("p1", "Max", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.97, 0.03]))]
+        profiles = [_profile("p1", "Person Gamma", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.97, 0.03]))]
         channel_clusters = {"mic": {
             "SPEAKER_0": ([1.0, 0.0], _stable_context(sid="SPEAKER_0")),  # exact match
             "SPEAKER_1": ([0.95, 0.05], _stable_context(sid="SPEAKER_1")),  # also plausible
@@ -422,13 +422,13 @@ class SuggestSpeakersForMeetingTests(unittest.TestCase):
         statuses = {sid: r.status for sid, r in results.items()}
         names = {sid: r.suggested_name for sid, r in results.items()}
         self.assertEqual(statuses["SPEAKER_0"], "confirmed")
-        self.assertEqual(names["SPEAKER_0"], "Max")
-        # SPEAKER_1 can't also claim Max -- no profiles left to match.
-        self.assertNotEqual(names.get("SPEAKER_1"), "Max")
+        self.assertEqual(names["SPEAKER_0"], "Person Gamma")
+        # SPEAKER_1 can't also claim Person Gamma -- no profiles left to match.
+        self.assertNotEqual(names.get("SPEAKER_1"), "Person Gamma")
 
     def test_independent_clusters_each_get_their_own_person(self):
         profiles = [
-            _profile("p1", "Max", prototypes=[_prototype([1.0, 0.0])]),
+            _profile("p1", "Person Gamma", prototypes=[_prototype([1.0, 0.0])]),
             _profile("p2", "Sarah", prototypes=[_prototype([0.0, 1.0])]),
         ]
         channel_clusters = {"mic": {
@@ -436,37 +436,37 @@ class SuggestSpeakersForMeetingTests(unittest.TestCase):
             "SPEAKER_1": ([0.0, 1.0], _stable_context(sid="SPEAKER_1")),
         }}
         results = suggest_speakers_for_meeting(channel_clusters, profiles)["mic"]
-        self.assertEqual(results["SPEAKER_0"].suggested_name, "Max")
+        self.assertEqual(results["SPEAKER_0"].suggested_name, "Person Gamma")
         self.assertEqual(results["SPEAKER_1"].suggested_name, "Sarah")
 
     def test_person_cannot_be_confirmed_on_both_channels(self):
         # Exclusivity is meeting-wide, not per-channel: a cross-channel
         # double match is echo/bleed, not the same person twice. The closer
-        # (system) cluster claims Max; the mic one must not also get him.
-        profiles = [_profile("p1", "Max", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.97, 0.03]))]
+        # (system) cluster claims Person Gamma; the mic one must not also get him.
+        profiles = [_profile("p1", "Person Gamma", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.97, 0.03]))]
         channel_clusters = {
             "mic": {"SPEAKER_0": ([0.95, 0.05], _stable_context(sid="SPEAKER_0"))},
             "system": {"SPEAKER_0": ([1.0, 0.0], _stable_context(sid="SPEAKER_0", recording_type="remote"))},
         }
         results = suggest_speakers_for_meeting(channel_clusters, profiles)
         self.assertEqual(results["system"]["SPEAKER_0"].status, "confirmed")
-        self.assertEqual(results["system"]["SPEAKER_0"].suggested_name, "Max")
-        self.assertNotEqual(results["mic"]["SPEAKER_0"].suggested_name, "Max")
+        self.assertEqual(results["system"]["SPEAKER_0"].suggested_name, "Person Gamma")
+        self.assertNotEqual(results["mic"]["SPEAKER_0"].suggested_name, "Person Gamma")
 
     def test_better_matching_later_cluster_wins_the_person(self):
         # Clusters are assigned in best-distance order, not sorted-id
-        # order: SPEAKER_1 matches Max exactly, so a merely-plausible
+        # order: SPEAKER_1 matches Person Gamma exactly, so a merely-plausible
         # SPEAKER_0 must not claim him first just by sorting earlier
         # (the old per-channel sorted-sid behaviour).
-        profiles = [_profile("p1", "Max", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.97, 0.03]))]
+        profiles = [_profile("p1", "Person Gamma", prototypes=_multi_meeting_prototypes([1.0, 0.0], [0.97, 0.03]))]
         channel_clusters = {"mic": {
             "SPEAKER_0": ([0.8, 0.6], _stable_context(sid="SPEAKER_0")),  # distance ~0.2, would confirm alone
             "SPEAKER_1": ([1.0, 0.0], _stable_context(sid="SPEAKER_1")),  # exact match
         }}
         results = suggest_speakers_for_meeting(channel_clusters, profiles)["mic"]
         self.assertEqual(results["SPEAKER_1"].status, "confirmed")
-        self.assertEqual(results["SPEAKER_1"].suggested_name, "Max")
-        self.assertNotEqual(results["SPEAKER_0"].suggested_name, "Max")
+        self.assertEqual(results["SPEAKER_1"].suggested_name, "Person Gamma")
+        self.assertNotEqual(results["SPEAKER_0"].suggested_name, "Person Gamma")
 
     def test_every_input_cluster_appears_in_results(self):
         channel_clusters = {
@@ -556,7 +556,7 @@ class MergeSameChannelFragmentsTests(unittest.TestCase):
     def test_does_not_merge_deliberately_different_voices(self):
         # Same real person, deliberately different vocal performance --
         # should NOT collapse (that's a human judgment call, not automatic).
-        # Modeled on this session's real "3 Julian voices" finding: distinct
+        # Three distinct voices must not collapse into one person's profile:
         # enough acoustically to sit outside the strict merge threshold.
         clusters = {
             "SPEAKER_0": ([1.0, 0.0], _ctx("SPEAKER_0", 300)),
@@ -690,11 +690,11 @@ class ConfirmedParticipantNamesTests(unittest.TestCase):
         self.assertEqual(confirmed_participant_names("mtg001", []), [])
 
     def test_person_with_prototype_for_meeting_is_included(self):
-        profiles = [_profile("p1", "Julian", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg001")])]
-        self.assertEqual(confirmed_participant_names("mtg001", profiles), ["Julian"])
+        profiles = [_profile("p1", "Person Alpha", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg001")])]
+        self.assertEqual(confirmed_participant_names("mtg001", profiles), ["Person Alpha"])
 
     def test_person_with_prototype_for_different_meeting_is_excluded(self):
-        profiles = [_profile("p1", "Julian", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg002")])]
+        profiles = [_profile("p1", "Person Alpha", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg002")])]
         self.assertEqual(confirmed_participant_names("mtg001", profiles), [])
 
     def test_hard_negative_only_is_excluded(self):
@@ -703,7 +703,7 @@ class ConfirmedParticipantNamesTests(unittest.TestCase):
         # never count as a confirmed participant -- hard_negatives is a
         # structurally separate list from prototypes.
         profiles = [_profile(
-            "p1", "Julian",
+            "p1", "Person Alpha",
             prototypes=[],
             hard_negatives=[_prototype([1.0, 0.0], meeting_id="mtg001")],
         )]
@@ -711,17 +711,17 @@ class ConfirmedParticipantNamesTests(unittest.TestCase):
 
     def test_two_people_confirmed_in_same_meeting_both_included_in_order(self):
         profiles = [
-            _profile("p1", "Julian", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg001")]),
-            _profile("p2", "Christian", prototypes=[_prototype([0.0, 1.0], meeting_id="mtg001")]),
+            _profile("p1", "Person Alpha", prototypes=[_prototype([1.0, 0.0], meeting_id="mtg001")]),
+            _profile("p2", "Person Beta", prototypes=[_prototype([0.0, 1.0], meeting_id="mtg001")]),
         ]
-        self.assertEqual(confirmed_participant_names("mtg001", profiles), ["Julian", "Christian"])
+        self.assertEqual(confirmed_participant_names("mtg001", profiles), ["Person Alpha", "Person Beta"])
 
     def test_multiple_prototypes_same_meeting_counts_person_once(self):
-        profiles = [_profile("p1", "Julian", prototypes=[
+        profiles = [_profile("p1", "Person Alpha", prototypes=[
             _prototype([1.0, 0.0], meeting_id="mtg001"),
             _prototype([0.9, 0.1], meeting_id="mtg001"),
         ])]
-        self.assertEqual(confirmed_participant_names("mtg001", profiles), ["Julian"])
+        self.assertEqual(confirmed_participant_names("mtg001", profiles), ["Person Alpha"])
 
 
 class RelabelTranscriptSpeakerTests(unittest.TestCase):
@@ -736,21 +736,21 @@ class RelabelTranscriptSpeakerTests(unittest.TestCase):
     def test_relabels_line_within_segment_range(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 1)
-            self.assertIn("[00:05] [Julian] hello there", path.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", path.read_text())
 
     def test_does_not_relabel_line_outside_segment_range(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:50] [Speaker 2] hello there")
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 0)
             self.assertIn("[00:50] [Speaker 2] hello there", path.read_text())
 
     def test_never_relabels_you(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [You] hello there")
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 0)
             self.assertIn("[00:05] [You] hello there", path.read_text())
 
@@ -761,31 +761,31 @@ class RelabelTranscriptSpeakerTests(unittest.TestCase):
         # be relabelable, not skipped like "You" is.
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Others] hello there")
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 1)
-            self.assertIn("[00:05] [Julian] hello there", path.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", path.read_text())
 
     def test_tolerance_allows_slight_boundary_mismatch(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:04] [Speaker 2] hello there")
             # Line timestamp (4.0s, from integer-second [MM:SS] truncation)
             # is just outside [4.3, 6.0] but within the 0.5s tolerance.
-            changed = relabel_transcript_speaker(path, [{"start": 4.3, "end": 6.0}], "Julian")
+            changed = relabel_transcript_speaker(path, [{"start": 4.3, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 1)
 
     def test_idempotent_rerun_with_different_name_overwrites(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
-            relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Max")
+            relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Gamma")
             self.assertEqual(changed, 1)
-            self.assertIn("[00:05] [Max] hello there", path.read_text())
+            self.assertIn("[00:05] [Person Gamma] hello there", path.read_text())
 
     def test_rerun_with_same_name_is_a_noop(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
-            relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 0)
 
     def test_multiple_pooled_segments_from_merged_fragments(self):
@@ -795,12 +795,12 @@ class RelabelTranscriptSpeakerTests(unittest.TestCase):
                 "[00:05] [Speaker 2] first fragment\n\n[05:00] [Speaker 3] second fragment",
             )
             changed = relabel_transcript_speaker(
-                path, [{"start": 4.0, "end": 6.0}, {"start": 299.0, "end": 301.0}], "Julian",
+                path, [{"start": 4.0, "end": 6.0}, {"start": 299.0, "end": 301.0}], "Person Alpha",
             )
             self.assertEqual(changed, 2)
             text = path.read_text()
-            self.assertIn("[00:05] [Julian] first fragment", text)
-            self.assertIn("[05:00] [Julian] second fragment", text)
+            self.assertIn("[00:05] [Person Alpha] first fragment", text)
+            self.assertIn("[05:00] [Person Alpha] second fragment", text)
 
     def test_untouched_lines_and_header_preserved(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -808,7 +808,7 @@ class RelabelTranscriptSpeakerTests(unittest.TestCase):
                 tmp, "[00:05] [Speaker 2] hello\n\n[00:10] [You] hi back",
             )
             before = path.read_text()
-            relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             after = path.read_text()
             self.assertIn("Session: mtg001", after)
             self.assertIn("[00:10] [You] hi back", after)
@@ -817,28 +817,28 @@ class RelabelTranscriptSpeakerTests(unittest.TestCase):
     def test_returns_zero_when_transcript_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "nonexistent_transcript.txt"
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 0)
 
     def test_returns_zero_when_no_segments(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
-            changed = relabel_transcript_speaker(path, [], "Julian")
+            changed = relabel_transcript_speaker(path, [], "Person Alpha")
             self.assertEqual(changed, 0)
 
     def test_handles_hour_scale_timestamp(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[1:02:33] [Speaker 2] hello there")
             changed = relabel_transcript_speaker(
-                path, [{"start": 3752.0, "end": 3754.0}], "Julian",
+                path, [{"start": 3752.0, "end": 3754.0}], "Person Alpha",
             )
             self.assertEqual(changed, 1)
-            self.assertIn("[1:02:33] [Julian] hello there", path.read_text())
+            self.assertIn("[1:02:33] [Person Alpha] hello there", path.read_text())
 
     def test_malformed_line_does_not_crash(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "not a diarised line at all")
-            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Julian")
+            changed = relabel_transcript_speaker(path, [{"start": 4.0, "end": 6.0}], "Person Alpha")
             self.assertEqual(changed, 0)
 
 
@@ -862,10 +862,10 @@ class RelabelTranscriptMultiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
             changed, skipped = relabel_transcript_multi(
-                path, [("mic", "Julian", [{"start": 4.0, "end": 6.0}])],
+                path, [("mic", "Person Alpha", [{"start": 4.0, "end": 6.0}])],
             )
             self.assertEqual((changed, skipped), (1, 0))
-            self.assertIn("[00:05] [Julian] hello there", path.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", path.read_text())
 
     def test_skips_line_claimed_by_two_different_channels(self):
         # A mic-channel assignment and a system-channel assignment both
@@ -875,8 +875,8 @@ class RelabelTranscriptMultiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
             changed, skipped = relabel_transcript_multi(path, [
-                ("mic", "Valentin Weyer", [{"start": 4.0, "end": 6.0}]),
-                ("system", "Inga Hahn", [{"start": 4.5, "end": 5.5}]),
+                ("mic", "Person Alpha", [{"start": 4.0, "end": 6.0}]),
+                ("system", "Person Beta", [{"start": 4.5, "end": 5.5}]),
             ])
             self.assertEqual((changed, skipped), (0, 1))
             self.assertIn("[00:05] [Speaker 2] hello there", path.read_text())
@@ -888,19 +888,19 @@ class RelabelTranscriptMultiTests(unittest.TestCase):
         # later assignment (by position in `assignments`, expected to be
         # sorted oldest-first by the caller) must win.
         with tempfile.TemporaryDirectory() as tmp:
-            path = self._write_transcript(tmp, "[00:05] [Julian] hello there")
+            path = self._write_transcript(tmp, "[00:05] [Person Alpha] hello there")
             changed, skipped = relabel_transcript_multi(path, [
-                ("system", "Julian", [{"start": 4.0, "end": 6.0}]),
-                ("system", "Max Prechtl", [{"start": 4.0, "end": 6.0}]),
+                ("system", "Person Alpha", [{"start": 4.0, "end": 6.0}]),
+                ("system", "Person Gamma", [{"start": 4.0, "end": 6.0}]),
             ])
             self.assertEqual((changed, skipped), (1, 0))
-            self.assertIn("[00:05] [Max Prechtl] hello there", path.read_text())
+            self.assertIn("[00:05] [Person Gamma] hello there", path.read_text())
 
     def test_never_relabels_you_even_when_claimed(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [You] hello there")
             changed, skipped = relabel_transcript_multi(
-                path, [("mic", "Julian", [{"start": 4.0, "end": 6.0}])],
+                path, [("mic", "Person Alpha", [{"start": 4.0, "end": 6.0}])],
             )
             self.assertEqual((changed, skipped), (0, 0))
             self.assertIn("[00:05] [You] hello there", path.read_text())
@@ -915,7 +915,7 @@ class RelabelTranscriptMultiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "nonexistent_transcript.txt"
             changed, skipped = relabel_transcript_multi(
-                path, [("mic", "Julian", [{"start": 4.0, "end": 6.0}])],
+                path, [("mic", "Person Alpha", [{"start": 4.0, "end": 6.0}])],
             )
             self.assertEqual((changed, skipped), (0, 0))
 
@@ -923,8 +923,8 @@ class RelabelTranscriptMultiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:50] [Speaker 2] hello there")
             changed, skipped = relabel_transcript_multi(path, [
-                ("mic", "Valentin Weyer", [{"start": 4.0, "end": 6.0}]),
-                ("system", "Inga Hahn", [{"start": 4.0, "end": 6.0}]),
+                ("mic", "Person Alpha", [{"start": 4.0, "end": 6.0}]),
+                ("system", "Person Beta", [{"start": 4.0, "end": 6.0}]),
             ])
             self.assertEqual((changed, skipped), (0, 0))
             self.assertIn("[00:50] [Speaker 2] hello there", path.read_text())
@@ -948,15 +948,15 @@ class RelabelTranscriptExactTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
             manifest = [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_1"}]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Julian")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Person Alpha")
             self.assertEqual(changed, 1)
-            self.assertIn("[00:05] [Julian] hello there", path.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", path.read_text())
 
     def test_does_not_relabel_line_whose_manifest_entry_is_a_different_cluster(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
             manifest = [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"}]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Julian")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Person Alpha")
             self.assertEqual(changed, 0)
             self.assertIn("[00:05] [Speaker 2] hello there", path.read_text())
 
@@ -968,7 +968,7 @@ class RelabelTranscriptExactTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
             manifest = [{"start": 5.2, "channel": "system", "diarization_speaker_id": "SPEAKER_1"}]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Julian")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Person Alpha")
             self.assertEqual(changed, 0)
             self.assertIn("[00:05] [Speaker 2] hello there", path.read_text())
 
@@ -976,7 +976,7 @@ class RelabelTranscriptExactTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [You] hello there")
             manifest = [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_1"}]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Julian")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Person Alpha")
             self.assertEqual(changed, 0)
             self.assertIn("[00:05] [You] hello there", path.read_text())
 
@@ -993,44 +993,44 @@ class RelabelTranscriptExactTests(unittest.TestCase):
                 {"start": 20.4, "channel": "system", "diarization_speaker_id": "SPEAKER_2"},
             ]
             changed = relabel_transcript_exact(
-                path, manifest, {("system", "SPEAKER_0"), ("system", "SPEAKER_2")}, "Julian",
+                path, manifest, {("system", "SPEAKER_0"), ("system", "SPEAKER_2")}, "Person Alpha",
             )
             self.assertEqual(changed, 2)
             text = path.read_text()
-            self.assertIn("[00:05] [Julian] first fragment", text)
-            self.assertIn("[00:20] [Julian] second fragment", text)
+            self.assertIn("[00:05] [Person Alpha] first fragment", text)
+            self.assertIn("[00:20] [Person Alpha] second fragment", text)
 
     def test_returns_zero_when_manifest_empty(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
-            self.assertEqual(relabel_transcript_exact(path, [], {("mic", "SPEAKER_1")}, "Julian"), 0)
+            self.assertEqual(relabel_transcript_exact(path, [], {("mic", "SPEAKER_1")}, "Person Alpha"), 0)
 
     def test_returns_zero_when_target_ids_empty(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
             manifest = [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_1"}]
-            self.assertEqual(relabel_transcript_exact(path, manifest, set(), "Julian"), 0)
+            self.assertEqual(relabel_transcript_exact(path, manifest, set(), "Person Alpha"), 0)
 
     def test_returns_zero_when_transcript_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "nonexistent_transcript.txt"
             manifest = [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_1"}]
-            self.assertEqual(relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Julian"), 0)
+            self.assertEqual(relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Person Alpha"), 0)
 
     def test_idempotent_rerun_with_same_name_is_a_noop(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = self._write_transcript(tmp, "[00:05] [Julian] hello there")
+            path = self._write_transcript(tmp, "[00:05] [Person Alpha] hello there")
             manifest = [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_1"}]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Julian")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Person Alpha")
             self.assertEqual(changed, 0)
 
     def test_rerun_with_different_name_overwrites_a_change_correction(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = self._write_transcript(tmp, "[00:05] [Julian] hello there")
+            path = self._write_transcript(tmp, "[00:05] [Person Alpha] hello there")
             manifest = [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_1"}]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Max Prechtl")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_1")}, "Person Gamma")
             self.assertEqual(changed, 1)
-            self.assertIn("[00:05] [Max Prechtl] hello there", path.read_text())
+            self.assertIn("[00:05] [Person Gamma] hello there", path.read_text())
 
     def test_matches_by_position_not_by_timestamp_collision(self):
         # The real bug found this session in an EARLIER version of this
@@ -1051,11 +1051,11 @@ class RelabelTranscriptExactTests(unittest.TestCase):
                 {"start": 5.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
                 {"start": 5.9, "channel": "system", "diarization_speaker_id": "SPEAKER_0"},
             ]
-            changed = relabel_transcript_exact(path, manifest, {("system", "SPEAKER_0")}, "Inga Hahn")
+            changed = relabel_transcript_exact(path, manifest, {("system", "SPEAKER_0")}, "Person Beta")
             self.assertEqual(changed, 1)
             text = path.read_text()
             self.assertIn("[00:05] [Speaker 2] first", text)  # untouched -- position 0, mic
-            self.assertIn("[00:05] [Inga Hahn] second", text)  # relabeled -- position 1, system
+            self.assertIn("[00:05] [Person Beta] second", text)  # relabeled -- position 1, system
 
     def test_a_stale_manifest_of_the_same_length_refuses_and_returns_zero(self):
         # The length check was the only check, so a manifest describing a
@@ -1074,7 +1074,7 @@ class RelabelTranscriptExactTests(unittest.TestCase):
                 {"start": 5.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
                 {"start": 42.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"},
             ]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_0")}, "Julian")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_0")}, "Person Alpha")
             self.assertEqual(changed, 0)
             text = path.read_text()
             self.assertIn("[00:05] [Speaker 2] first", text)
@@ -1087,7 +1087,7 @@ class RelabelTranscriptExactTests(unittest.TestCase):
         # reaches straight for entry.get(...).
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write_transcript(tmp, "[00:05] [Speaker 2] hello there")
-            changed = relabel_transcript_exact(path, [None], {("mic", "SPEAKER_0")}, "Julian")
+            changed = relabel_transcript_exact(path, [None], {("mic", "SPEAKER_0")}, "Person Alpha")
             self.assertEqual(changed, 0)
             self.assertIn("[00:05] [Speaker 2] hello there", path.read_text())
 
@@ -1097,7 +1097,7 @@ class RelabelTranscriptExactTests(unittest.TestCase):
                 tmp, "[00:05] [Speaker 2] first\n\n[00:10] [Speaker 3] second",
             )
             manifest = [{"start": 5.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_0"}]
-            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_0")}, "Julian")
+            changed = relabel_transcript_exact(path, manifest, {("mic", "SPEAKER_0")}, "Person Alpha")
             self.assertEqual(changed, 0)
             text = path.read_text()
             self.assertIn("[00:05] [Speaker 2] first", text)

--- a/tests/test_suggest_speakers_cli.py
+++ b/tests/test_suggest_speakers_cli.py
@@ -145,7 +145,7 @@ class SuggestSpeakersCliTests(unittest.TestCase):
                 },
             })
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             cfg.add_speaker_prototype(
                 person["person_id"], [1.0, 0.0],
                 recording_type="remote", meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
@@ -158,7 +158,7 @@ class SuggestSpeakersCliTests(unittest.TestCase):
             )
             result = self._run(["mtg001"], tmp, cfg=cfg)
             data = _last_json(result.output)
-            self.assertEqual(data["channels"]["system"]["SPEAKER_0"]["confirmed_by_user"], "Julian")
+            self.assertEqual(data["channels"]["system"]["SPEAKER_0"]["confirmed_by_user"], "Person Alpha")
 
     def test_confirmed_by_user_is_null_when_never_confirmed(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -195,7 +195,7 @@ class SuggestSpeakersCliTests(unittest.TestCase):
                 },
             })
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Valentin")
+            person = cfg.create_person_profile("Person Alpha")
             cfg.add_speaker_prototype(
                 person["person_id"], [1.0, 0.0],
                 recording_type="in_person", meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
@@ -204,7 +204,7 @@ class SuggestSpeakersCliTests(unittest.TestCase):
             )
             result = self._run(["mtg001"], tmp, cfg=cfg)
             data = _last_json(result.output)
-            self.assertEqual(data["channels"]["mic"]["SPEAKER_0"]["confirmed_by_user"], "Valentin")
+            self.assertEqual(data["channels"]["mic"]["SPEAKER_0"]["confirmed_by_user"], "Person Alpha")
             self.assertIsNone(data["channels"]["system"]["SPEAKER_0"]["confirmed_by_user"])
 
     def test_confirmed_by_user_resolves_through_merged_fragments(self):
@@ -225,7 +225,7 @@ class SuggestSpeakersCliTests(unittest.TestCase):
                 },
             })
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = cfg.create_person_profile("Julian")
+            person = cfg.create_person_profile("Person Alpha")
             # Confirmed via the non-primary fragment id (SPEAKER_2) -- same
             # real shape as confirm-speaker's own id-resolution.
             cfg.add_speaker_prototype(
@@ -240,7 +240,7 @@ class SuggestSpeakersCliTests(unittest.TestCase):
             # confirmation must still be found via merged_from.
             merged = data["channels"]["system"]["SPEAKER_0"]
             self.assertEqual(merged["merged_from"], ["SPEAKER_2"])
-            self.assertEqual(merged["confirmed_by_user"], "Julian")
+            self.assertEqual(merged["confirmed_by_user"], "Person Alpha")
 
     def test_sample_text_quotes_the_transcript_at_the_longest_segment(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -632,7 +632,7 @@ class SuggestSpeakersRunScopeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = self._confirm_by_hand(cfg, "Julian", "SPEAKER_0", self._run_id(tmp))
+            person = self._confirm_by_hand(cfg, "Person Alpha", "SPEAKER_0", self._run_id(tmp))
             self._rediarize(tmp)
             data = _last_json(self._run(["mtg001"], tmp, cfg=cfg).output)
             cluster = data["channels"]["system"]["SPEAKER_0"]
@@ -640,17 +640,17 @@ class SuggestSpeakersRunScopeTests(unittest.TestCase):
             self.assertIsNone(cluster["confirmed_person_id"])
             self.assertEqual(
                 data["stale_assignments"],
-                [{"person_id": person["person_id"], "display_name": "Julian"}],
+                [{"person_id": person["person_id"], "display_name": "Person Alpha"}],
             )
 
     def test_a_confirmation_from_this_run_is_reported_and_is_not_stale(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = self._confirm_by_hand(cfg, "Julian", "SPEAKER_0", self._run_id(tmp))
+            person = self._confirm_by_hand(cfg, "Person Alpha", "SPEAKER_0", self._run_id(tmp))
             data = _last_json(self._run(["mtg001"], tmp, cfg=cfg).output)
             cluster = data["channels"]["system"]["SPEAKER_0"]
-            self.assertEqual(cluster["confirmed_by_user"], "Julian")
+            self.assertEqual(cluster["confirmed_by_user"], "Person Alpha")
             self.assertEqual(cluster["confirmed_person_id"], person["person_id"])
             self.assertEqual(data["stale_assignments"], [])
 
@@ -662,10 +662,10 @@ class SuggestSpeakersRunScopeTests(unittest.TestCase):
             self._seed(tmp)
             self._make_legacy(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm_by_hand(cfg, "Julian", "SPEAKER_0", None)
+            self._confirm_by_hand(cfg, "Person Alpha", "SPEAKER_0", None)
             data = _last_json(self._run(["mtg001"], tmp, cfg=cfg).output)
             self.assertEqual(
-                data["channels"]["system"]["SPEAKER_0"]["confirmed_by_user"], "Julian",
+                data["channels"]["system"]["SPEAKER_0"]["confirmed_by_user"], "Person Alpha",
             )
             self.assertEqual(data["stale_assignments"], [])
 
@@ -673,7 +673,7 @@ class SuggestSpeakersRunScopeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            person = self._confirm_by_hand(cfg, "Julian", "SPEAKER_0", self._run_id(tmp))
+            person = self._confirm_by_hand(cfg, "Person Alpha", "SPEAKER_0", self._run_id(tmp))
             cfg.add_speaker_prototype(
                 person["person_id"], [0.0, 1.0], recording_type="remote",
                 meeting_id="mtg001", diarization_speaker_id="SPEAKER_1",
@@ -684,7 +684,7 @@ class SuggestSpeakersRunScopeTests(unittest.TestCase):
             self._rediarize(tmp)
             data = _last_json(self._run(["mtg001"], tmp, cfg=cfg).output)
             self.assertEqual(len(data["stale_assignments"]), 1)
-            self.assertEqual(data["stale_assignments"][0]["display_name"], "Julian")
+            self.assertEqual(data["stale_assignments"][0]["display_name"], "Person Alpha")
 
     def test_a_cluster_someone_has_since_confirmed_reports_no_stale_owner(self):
         # The notice has to be able to go away. Nothing deletes a
@@ -695,7 +695,7 @@ class SuggestSpeakersRunScopeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed(tmp)
             cfg = Config(config_path=Path(tmp) / "config.json")
-            self._confirm_by_hand(cfg, "Julian", "SPEAKER_0", self._run_id(tmp))
+            self._confirm_by_hand(cfg, "Person Alpha", "SPEAKER_0", self._run_id(tmp))
             new_run = self._rediarize(tmp)
             self._confirm_by_hand(cfg, "Sarah", "SPEAKER_0", new_run, embedding=(0.0, 1.0))
             data = _last_json(self._run(["mtg001"], tmp, cfg=cfg).output)

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -46,6 +46,7 @@ from src.transcriber import (
     _tag_channel_segments,
     _token_jaccard,
     _voiceprint_distance,
+    _worst_window_coverage,
 )
 
 
@@ -896,6 +897,28 @@ class MergeCloseDiarSegmentsTests(unittest.TestCase):
         segments = [{"start": 0.0, "end": 1.0, "speaker": "SPEAKER_0"}]
         _merge_close_diar_segments(segments, STENO_DIARIZE_MERGE_GAP_S)
         self.assertEqual(segments, [{"start": 0.0, "end": 1.0, "speaker": "SPEAKER_0"}])
+
+
+class WorstWindowCoverageTests(unittest.TestCase):
+    def test_takes_the_worst_reporting_channel(self):
+        self.assertEqual(
+            _worst_window_coverage({"window_coverage": 1.0}, {"window_coverage": 0.4}), 0.4
+        )
+
+    def test_ignores_channels_that_report_nothing(self):
+        # A silent channel never runs and never reports. It must not drag the
+        # meeting's figure down, and it must not stand in for the other one.
+        self.assertEqual(_worst_window_coverage(None, {"window_coverage": 0.6}), 0.6)
+        self.assertEqual(_worst_window_coverage({}, {"window_coverage": 0.6}), 0.6)
+
+    def test_nothing_reported_is_unknown_not_complete(self):
+        # whisper.cpp and parakeet-mlx do no windowing of their own. Absence
+        # of a figure must never read as a clean bill of health.
+        self.assertIsNone(_worst_window_coverage(None, None))
+        self.assertIsNone(_worst_window_coverage({"window_coverage": None}, {}))
+
+    def test_zero_coverage_is_kept_not_treated_as_missing(self):
+        self.assertEqual(_worst_window_coverage({"window_coverage": 0.0}, None), 0.0)
 
 
 class ClampOverlappingDiarSegmentsTests(unittest.TestCase):

--- a/tests/test_transcriber_failure.py
+++ b/tests/test_transcriber_failure.py
@@ -568,18 +568,43 @@ class LiveTranscriptFallbackTests(unittest.TestCase):
     def test_short_real_transcript_does_not_trigger_fallback(self):
         """Fix 4: a correct-but-short batch transcript (under the 100-char
         live-fallback floor) is a real result and must NOT be replaced. The
-        trigger is batch_failed OR the exact silence sentinel — never length."""
+        trigger is batch_failed OR the exact silence sentinel — never length.
+
+        Calls the production predicate itself. It used to be restated here,
+        which meant this test could stay green while process_streaming
+        changed underneath it."""
         import simple_recorder
         sentinel = simple_recorder._SILENCE_SENTINEL
         short_real = "Quick sync done."  # < 100 chars but genuine speech
+        reason = simple_recorder._unusable_batch_reason
 
-        def should_fall_back(batch_text, batch_failed):
-            # Mirrors the production predicate in process_streaming.
-            return batch_failed or (batch_text.strip() == sentinel)
+        self.assertIsNone(reason(short_real, False, None))
+        self.assertIsNotNone(reason(sentinel, False, None))
+        self.assertIsNotNone(reason("", True, None))  # crash
 
-        self.assertFalse(should_fall_back(short_real, False))
-        self.assertTrue(should_fall_back(sentinel, False))
-        self.assertTrue(should_fall_back("", True))  # crash
+    def test_a_batch_missing_most_of_the_file_loses_to_the_live_transcript(self):
+        """A batch that skipped most of its transcription windows is neither
+        a crash nor silence, so it used to pass the gate and replace a
+        complete live transcript with a full-of-holes one."""
+        import simple_recorder
+        reason = simple_recorder._unusable_batch_reason
+        self.assertIsNotNone(reason("Some words.", False, 0.2))
+        self.assertIn("20%", reason("Some words.", False, 0.2))
+
+    def test_a_batch_missing_only_a_window_or_two_still_wins(self):
+        """The live transcript is complete but lower quality. A meeting that
+        lost a window is still the better transcript, so the swap must not
+        fire on every gap — only when most of the file is gone."""
+        import simple_recorder
+        reason = simple_recorder._unusable_batch_reason
+        self.assertIsNone(reason("Some words.", False, 0.95))
+        self.assertIsNone(reason("Some words.", False, simple_recorder._MIN_BATCH_WINDOW_COVERAGE))
+
+    def test_a_backend_that_cannot_report_coverage_is_not_punished(self):
+        """whisper.cpp and parakeet-mlx do no windowing of their own. Unknown
+        must never be read as bad, or every macOS meeting would be replaced."""
+        import simple_recorder
+        self.assertIsNone(simple_recorder._unusable_batch_reason("Real words.", False, None))
 
     def test_fallback_overwrites_transcript_file(self):
         """Fix 6: when the live fallback fires, the _transcript.txt the batch


### PR DESCRIPTION
## What changed

- report the usable-window coverage of ONNX batch transcription
- keep the complete live transcript when a batch result lost more than half of its windows
- preserve unknown coverage for backends that do not window internally
- anonymize real-person names in speaker unit and E2E fixtures

## Why

The ONNX backend deliberately skips an individual window when recognition fails so one bad window does not abort a whole meeting. Until now, downstream code could not distinguish that partial result from a complete transcript, so a transcript with large gaps could replace the complete live transcript.

The speaker fixtures also contained real-person names. They now use neutral `Person Alpha`, `Person Beta`, and `Person Gamma` labels without changing test behavior.

## Impact

Meetings keep the live transcript when the batch transcript covered less than half of the attempted windows. Short but complete batch transcripts are unchanged, and backends without coverage information are not penalized.

## Verification

- 182 focused transcription and diarization tests
- 446 focused speaker and privacy tests
- Electron and renderer unit tests
- renderer TypeScript typecheck
- backend PyInstaller bundle build
- 19 speaker-review T1 E2E tests
- 9 speaker-naming and multi-marking T2 E2E tests

Renderer lint reports 0 errors and the existing 37 warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents incomplete ONNX batch transcripts from overwriting a complete live transcript by tracking per-channel window coverage and falling back when coverage is low or the batch fails. Surfaces coverage in results and anonymizes person names in tests and UI examples.

- **Bug Fixes**
  - Compute coverage from `windows_attempted`/`windows_recognized` in `_parakeet_onnx`, propagate `window_coverage` through transcription results and `simple_recorder`; use the worst reporting channel, ignoring non-reporting ones.
  - Keep the live transcript when the batch failed, returned the silence sentinel, or `window_coverage` < 0.5; short but complete batch transcripts are unchanged.
  - Backends that don’t window report `null` coverage; treated as unknown, not penalized.

- **Refactors**
  - Anonymized speaker fixtures and UI placeholder text to `Person Alpha/Beta/Gamma`; updated E2E and unit tests accordingly.

<sup>Written for commit d1e7b099ba6217e96351766bdeaced6397bdc82c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

