### PR TITLE
docs: restore release entry separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
-- **2026-08-08** 👥 Individual speakers &mdash; Steno now separates people who share the same microphone or call-audio channel, not just `[You]` and `[Others]`. Review the speaker groups on the transcript, rename them, or mark uncertain groups. Optional recognition across meetings is off by default and currently available on macOS.
-- **2026-08-04** 💎 Sync to Obsidian &mdash; mirror your notes into an Obsidian vault folder as Markdown. Turn it on in Settings → Integrations and pick a vault folder. One-way (Steno → vault); notes you edit in Obsidian are never overwritten.
-- **2026-08-03** 🔔 One-tap meeting notes &mdash; "Take Notes" starts recording instantly, meetings auto-stop when they end, and a single "Summarise?" tap opens the note and generates it. Recordings are transcript-first now. Turn on auto-summarise in Settings → AI for automatic notes.
-- **2026-07-26** 🎙️ System audio without Screen Recording &mdash; record both sides of a call with no Screen Recording permission. Now requires macOS 14.4 or later.
+- **2026-08-08** 👥 Individual speakers — Steno now separates people who share the same microphone or call-audio channel, not just `[You]` and `[Others]`. Review the speaker groups on the transcript, rename them, or mark uncertain groups. Optional recognition across meetings is off by default and currently available on macOS.
+- **2026-08-04** 💎 Sync to Obsidian — mirror your notes into an Obsidian vault folder as Markdown. Turn it on in Settings → Integrations and pick a vault folder. One-way (Steno → vault); notes you edit in Obsidian are never overwritten.
+- **2026-08-03** 🔔 One-tap meeting notes — "Take Notes" starts recording instantly, meetings auto-stop when they end, and a single "Summarise?" tap opens the note and generates it. Recordings are transcript-first now. Turn on auto-summarise in Settings → AI for automatic notes.
+- **2026-07-26** 🎙️ System audio without Screen Recording — record both sides of a call with no Screen Recording permission. Now requires macOS 14.4 or later.
 
 
 ## Features


### PR DESCRIPTION
## Summary

- replace the four HTML dash entities in the README release marquee with the literal separator required by the repository release format

## Why

PR #480 rendered the separators correctly but left the Markdown source inconsistent with `CLAUDE.md` and harder to search mechanically.

## Verification

- `git diff --check`
- verified all four release entries match the documented source pattern
- verified the release entries contain no `&mdash;` entities


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores literal em-dash separators in the README "What's New" release entries, replacing `&mdash;` to match the repository release format and `CLAUDE.md`. This keeps sources consistent and improves mechanical search.

<sup>Written for commit 7b3f5bd7a1743fe00f9d2af937a13aad9d586a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

