### PR TITLE
fix: close speaker release blockers

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -128,12 +128,22 @@ jobs:
         # ship users a Rosetta'd helper.
         file bin/mic-monitor | grep -q "arm64"
 
+    - name: Build speaker-diarization sidecar (Swift/Core ML)
+      run: |
+        chmod +x scripts/build-diarize-sidecar.sh
+        ./scripts/build-diarize-sidecar.sh arm64
+        test -x bin/steno-diarize
+        file bin/steno-diarize
+        file bin/steno-diarize | grep -q "arm64"
+
     - name: Build Python backend with PyInstaller
       run: |
         pyinstaller stenoai.spec --noconfirm
         # Verify build and architecture
         ls -la dist/stenoai/
         file dist/stenoai/stenoai
+        test -x dist/stenoai/_internal/steno-diarize
+        file dist/stenoai/_internal/steno-diarize | grep -q "arm64"
         echo "Expected arch: ${{ matrix.arch }}"
         echo "Backend built successfully"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -227,8 +227,16 @@ jobs:
           chmod +x scripts/download-ollama.sh
           ./scripts/download-ollama.sh
 
+      - name: Build speaker-diarization sidecar (Swift/Core ML)
+        run: |
+          chmod +x scripts/build-diarize-sidecar.sh
+          ./scripts/build-diarize-sidecar.sh "$(uname -m)"
+          test -x bin/steno-diarize
+
       - name: Build backend with PyInstaller
-        run: pyinstaller stenoai.spec --noconfirm
+        run: |
+          pyinstaller stenoai.spec --noconfirm
+          test -x dist/stenoai/_internal/steno-diarize
 
       # Guards the Ollama/pip-mlx libmlx.dylib ABI collision (see
       # scripts/verify_mlx_bundle.py). dlopen probes run here too - GitHub's

--- a/e2e/fixtures/user-config.ts
+++ b/e2e/fixtures/user-config.ts
@@ -35,6 +35,14 @@ export function writeUserConfig(
   writeFileSync(cfgPath, JSON.stringify({ ...cfg, ...partial }, null, 2));
 }
 
+/** Explicitly opt a test user into local biometric speaker identification. */
+export function enableSpeakerIdentification(userDataDir: string): void {
+  writeUserConfig(userDataDir, {
+    identity_matching_enabled: true,
+    identity_matching_privacy_default_version: 1,
+  });
+}
+
 /**
  * Configure the app for the renderer-driven capture path (system audio ON) with
  * the Whisper engine, so no Parakeet live-transcribe sidecar spawns. The

--- a/e2e/specs/people-management.t2.spec.ts
+++ b/e2e/specs/people-management.t2.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
 import { makeWav } from '../fixtures/make-wav';
-import { writeSpeakersSidecar } from '../fixtures/user-config';
+import { enableSpeakerIdentification, writeSpeakersSidecar } from '../fixtures/user-config';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
 
@@ -126,6 +126,7 @@ test('People sample playback extracts a current confirmed voice through the bund
   const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf8')) as Record<string, unknown>;
   sidecar.diarization_run = { run_id: 'e2e-person-sample-run', created_at: 1_700_000_000 };
   writeFileSync(sidecarPath, JSON.stringify(sidecar, null, 2));
+  enableSpeakerIdentification(userDataDir);
 
   const { page } = await launchApp();
   const confirmed = await page.evaluate(

--- a/e2e/specs/speaker-multi-marking.t2.spec.ts
+++ b/e2e/specs/speaker-multi-marking.t2.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { writeSpeakersSidecar, writeTranscriptFile, writeMeetingMarkdown } from '../fixtures/user-config';
+import {
+  enableSpeakerIdentification,
+  writeSpeakersSidecar,
+  writeTranscriptFile,
+  writeMeetingMarkdown,
+} from '../fixtures/user-config';
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import path from 'path';
 
@@ -96,6 +101,7 @@ const readJson = (file: string) => JSON.parse(readFileSync(file, 'utf8'));
  * lengths and out of chronological order in the file, so the samples list
  * proves it sorts rather than echoing input order. */
 function seedMeeting(userDataDir: string, stem: string) {
+  enableSpeakerIdentification(userDataDir);
   writeSpeakersSidecar(userDataDir, stem, {
     system: {
       recording_type: 'remote',

--- a/e2e/specs/speaker-naming.t2.spec.ts
+++ b/e2e/specs/speaker-naming.t2.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../fixtures/electron';
 import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
-import { writeSpeakersSidecar, writeTranscriptFile } from '../fixtures/user-config';
+import {
+  enableSpeakerIdentification,
+  readUserConfig,
+  writeSpeakersSidecar,
+  writeTranscriptFile,
+} from '../fixtures/user-config';
 import { makeWav } from '../fixtures/make-wav';
 import { readFileSync, mkdirSync } from 'fs';
 import path from 'path';
@@ -92,6 +97,41 @@ test('a meeting without a speaker sidecar returns an empty result without backen
   expect(fileSig(realUserDataDir())).toBe(realDirBefore);
 });
 
+test('speaker identification stays unavailable until the user opts in', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const stem = 'e2e-speaker-opt-out';
+  writeSpeakersSidecar(userDataDir, stem, {
+    mic: {
+      recording_type: 'in_person',
+      clusters: {
+        SPEAKER_0: {
+          embedding: [1.0, 0.0], speech_duration_seconds: 30.0, segment_count: 5,
+          segments: [{ start: 5.0, end: 7.0 }],
+        },
+      },
+    },
+  });
+
+  const { page } = await launchApp();
+  const suggestions = await page.evaluate(
+    (meetingStem) => (window as StenoWindow).stenoai.speakers.suggestForMeeting(meetingStem),
+    stem,
+  );
+  expect(suggestions).toMatchObject({ success: true, channels: {} });
+
+  const confirm = await page.evaluate(
+    (params) => (window as StenoWindow).stenoai.speakers.confirm(params),
+    { meetingStem: stem, channel: 'mic', diarizationSpeakerId: 'SPEAKER_0', newPersonName: 'Person Alpha' },
+  );
+  expect(confirm).toMatchObject({
+    success: false,
+    error: 'Speaker identification is disabled in settings.',
+  });
+  expect(readUserConfig(userDataDir).person_profiles ?? []).toEqual([]);
+});
+
 test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels the saved transcript', async ({
   launchApp,
   userDataDir,
@@ -117,6 +157,8 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
     stem,
     '[00:05] [Speaker 2] hello there\n\n[00:20] [You] hi back',
   );
+
+  enableSpeakerIdentification(userDataDir);
 
   const { page } = await launchApp();
 
@@ -249,6 +291,8 @@ test('identification aids: sample_text/is_likely_artifact/recording_available an
   // is safely within range (unlike 0s, which would be just outside).
   writeTranscriptFile(userDataDir, stem, '[00:01] [Speaker 2] this is a real substantial turn');
 
+  enableSpeakerIdentification(userDataDir);
+
   const { page } = await launchApp();
 
   const suggestions = await page.evaluate(
@@ -300,6 +344,8 @@ test('duplicate person names are rejected, and delete-person-profile removes a p
       },
     },
   });
+
+  enableSpeakerIdentification(userDataDir);
 
   const { page } = await launchApp();
 

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -56,6 +56,13 @@ echo "Building standalone executable..."
 echo "This may take several minutes..."
 echo ""
 
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "Building required speaker-diarization sidecar..."
+    "$SCRIPT_DIR/build-diarize-sidecar.sh" "$(uname -m)"
+    test -x bin/steno-diarize
+    echo ""
+fi
+
 python3 -m PyInstaller stenoai.spec --noconfirm
 
 # Check if build succeeded

--- a/scripts/diarize_bundle_guard.py
+++ b/scripts/diarize_bundle_guard.py
@@ -1,0 +1,30 @@
+"""Build-time guard for the macOS speaker-diarization sidecar."""
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def require_diarize_sidecar(
+    sidecar_path: Path,
+    *,
+    platform: str = sys.platform,
+) -> Optional[Path]:
+    """Require an executable sidecar for macOS bundles.
+
+    Returning ``None`` on other platforms keeps their existing channel-only
+    speaker labeling path unchanged.
+    """
+    if platform != "darwin":
+        return None
+    if not sidecar_path.is_file():
+        raise FileNotFoundError(
+            f"Missing required macOS diarization sidecar: {sidecar_path}. "
+            "Run scripts/build-diarize-sidecar.sh before PyInstaller."
+        )
+    if not os.access(sidecar_path, os.X_OK):
+        raise PermissionError(
+            f"Required macOS diarization sidecar is not executable: {sidecar_path}"
+        )
+    return sidecar_path

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5057,10 +5057,19 @@ def get_person_sample_audio(person_id):
 def create_person_profile(display_name):
     """Create a new, empty named person profile."""
     from src.config import get_config
+    config = get_config()
+    config.begin_transaction()
     try:
-        profile = get_config().create_person_profile(display_name)
+        profile = config.create_person_profile(display_name)
     except ValueError as e:
+        config.rollback_transaction()
         print(json.dumps({"success": False, "error": str(e)}))
+        sys.exit(1)
+    if not config.commit_transaction():
+        print(json.dumps({
+            "success": False,
+            "error": "Could not save the person profile.",
+        }))
         sys.exit(1)
     print(json.dumps({"success": True, "person_id": profile["person_id"], "display_name": profile["display_name"]}))
 
@@ -5182,6 +5191,14 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
         print(json.dumps({"success": False, "error": "Specify exactly one of --person-id or --new-person"}))
         sys.exit(1)
 
+    config = get_config()
+    if not config.get_identity_matching_enabled():
+        print(json.dumps({
+            "success": False,
+            "error": "Speaker identification is disabled in settings.",
+        }))
+        sys.exit(1)
+
     output_dir = get_data_dirs()["output"]
     sidecar = read_speakers_sidecar(output_dir, meeting_stem)
     if sidecar is None:
@@ -5235,16 +5252,18 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
         }))
         sys.exit(1)
 
-    config = get_config()
+    config.begin_transaction()
     if new_person:
         try:
             person = config.create_person_profile(new_person)
         except ValueError as e:
+            config.rollback_transaction()
             print(json.dumps({"success": False, "error": str(e)}))
             sys.exit(1)
     else:
         person = config.get_person_profile(person_id)
         if person is None:
+            config.rollback_transaction()
             print(json.dumps({"success": False, "error": f"No person profile with id {person_id!r}"}))
             sys.exit(1)
 
@@ -5435,6 +5454,13 @@ def confirm_speaker(meeting_stem, channel, diarization_speaker_id, person_id, ne
             channel=channel, diarization_run_id=run_id,
         )
         hard_negatives_added.append(other_person["display_name"])
+
+    if not config.commit_transaction():
+        print(json.dumps({
+            "success": False,
+            "error": "Could not save the speaker profile.",
+        }))
+        sys.exit(1)
 
     relabeled_lines = 0
     if relabel_transcript:
@@ -5642,15 +5668,19 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
         merge_same_channel_fragments,
         clusters_from_sidecar_channel,
         minimum_speaker_count,
+        read_speakers_sidecar,
         restore_transcript_labels,
         set_cluster_multi_speaker,
     )
 
     output_dir = get_data_dirs()["output"]
-    sidecar = set_cluster_multi_speaker(
-        output_dir, meeting_stem, channel, diarization_speaker_id, multiple,
-    )
-    if sidecar is None:
+    sidecar = read_speakers_sidecar(output_dir, meeting_stem)
+    channels = sidecar.get("channels") if isinstance(sidecar, dict) else None
+    channel_data = channels.get(channel) if isinstance(channels, dict) else None
+    raw_clusters = channel_data.get("clusters") if isinstance(channel_data, dict) else None
+    if not isinstance(raw_clusters, dict) or not isinstance(
+        raw_clusters.get(diarization_speaker_id), dict,
+    ):
         print(json.dumps({
             "success": False,
             "error": f"No cluster {diarization_speaker_id!r} in {channel!r} channel of {meeting_stem!r}",
@@ -5662,7 +5692,6 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
     # reviewed and displayed under its primary's id, so marking any
     # fragment withholds the whole merged cluster. Saying so here keeps
     # the CLI honest about what just happened.
-    channel_data = (sidecar.get("channels") or {}).get(channel) or {}
     channel_recording_type = channel_data.get("recording_type")
     # From the rewritten document set_cluster_multi_speaker returned, which
     # carries the existing run forward -- marking a cluster is an annotation
@@ -5673,13 +5702,11 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
             clusters_from_sidecar_channel(meeting_stem, channel_data)
         )
     except (KeyError, TypeError, ValueError):
-        # Same as set-cluster-review-state: the marking already landed, and
-        # only the reach computation can still fail -- on any OTHER cluster
-        # in this channel with no usable embedding. A traceback here would
-        # claim a marking failed that did not.
+        # Another malformed cluster can prevent merged-reach computation.
+        # The raw target remains safe to withdraw and mark.
         clusters, id_resolution = {}, {}
     resolved_id = id_resolution.get(diarization_speaker_id, diarization_speaker_id)
-    fragment_ids = set()
+    fragment_ids = {diarization_speaker_id}
     if resolved_id in clusters:
         fragment_ids = {resolved_id, *clusters[resolved_id][1].merged_from}
 
@@ -5702,12 +5729,7 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
     cleared_from = []
     restored_lines = 0
     if multiple and fragment_ids:
-        # "A human kept this generic" is superseded by "a human says it is
-        # several people" -- the second is a stronger statement about the
-        # same cluster. Swept across every fragment, because the merged row
-        # reads generic when ANY member carries the key, so a leftover on a
-        # fragment would keep marking a row nobody can click.
-        clear_cluster_review_state(output_dir, meeting_stem, channel, fragment_ids)
+        config.begin_transaction()
         # Run-scoped for the same reason the confirm path is: the cluster
         # this marking describes exists only within this run, so an entry
         # from a superseded run shares nothing with it but a reused id.
@@ -5739,6 +5761,33 @@ def mark_speaker_cluster(meeting_stem, channel, diarization_speaker_id, multiple
                     channel=channel, channel_recording_type=channel_recording_type,
                     sids=fragment_ids, negative=True, diarization_run_id=run_id,
                 )
+        if not config.commit_transaction():
+            print(json.dumps({
+                "success": False,
+                "error": "Could not update the speaker profiles.",
+            }))
+            sys.exit(1)
+
+    # Persist the marking only after the profile cleanup is durable. If the
+    # config write fails, leaving the cluster unmarked is recoverable by a
+    # retry; leaving a poisoned biometric prototype active is not.
+    try:
+        sidecar = set_cluster_multi_speaker(
+            output_dir, meeting_stem, channel, diarization_speaker_id, multiple,
+        )
+    except OSError:
+        sidecar = None
+    if sidecar is None:
+        print(json.dumps({
+            "success": False,
+            "error": "Could not save the speaker marking.",
+        }))
+        sys.exit(1)
+
+    if multiple and fragment_ids:
+        # "A human kept this generic" is superseded by "a human says it is
+        # several people". Clear it only after the stronger marking is safe.
+        clear_cluster_review_state(output_dir, meeting_stem, channel, fragment_ids)
         if cleared_from:
             # The transcript is the artefact a human reads, and the one the
             # summary and every export are built from. Withdrawing the
@@ -5819,6 +5868,14 @@ def speaker_naming_status(meeting_stem):
         read_speakers_sidecar,
     )
 
+    config = get_config()
+    if not config.get_identity_matching_enabled():
+        print(json.dumps({
+            "success": True, "meeting_id": meeting_stem, "has_sidecar": False,
+            "total_clusters": 0, "named_clusters": 0, "unnamed_clusters": 0,
+        }))
+        return
+
     dirs = get_data_dirs()
     sidecar = read_speakers_sidecar(dirs["output"], meeting_stem)
     if sidecar is None:
@@ -5835,7 +5892,7 @@ def speaker_naming_status(meeting_stem):
     # unnamed cluster from the delete warning, and an unnamed cluster cannot
     # be named again once the audio is gone.
     run_id = (sidecar.get("diarization_run") or {}).get("run_id")
-    profiles = get_config().get_person_profiles()
+    profiles = config.get_person_profiles()
     total = 0
     named = 0
     for channel_name, channel_data in (sidecar.get("channels") or {}).items():
@@ -5907,6 +5964,17 @@ def suggest_speakers(meeting_stem):
     from src.config import get_data_dirs
     from src.transcriber import _format_timestamp
 
+    config = get_config()
+    if not config.get_identity_matching_enabled():
+        print(json.dumps({
+            "success": True,
+            "meeting_id": meeting_stem,
+            "recording_available": False,
+            "minimum_speaker_count": 0,
+            "channels": {},
+        }))
+        return
+
     dirs = get_data_dirs()
     sidecar = read_speakers_sidecar(dirs["output"], meeting_stem)
     if sidecar is None:
@@ -5945,7 +6013,7 @@ def suggest_speakers(meeting_stem):
     # both-absent rule keeps every existing confirmation current.
     run_id = (sidecar.get("diarization_run") or {}).get("run_id")
 
-    profiles = get_config().get_person_profiles()
+    profiles = config.get_person_profiles()
     # Merge fragments per channel first, then suggest for ALL channels in
     # one call -- used-person exclusivity is meeting-wide (a person can't
     # be the confirmed suggestion on both mic and system), so suggestion
@@ -6239,26 +6307,26 @@ def get_speaker_sample_audio(meeting_stem, channel, diarization_speaker_id, segm
         Path(tempfile.gettempdir())
         / f"steno_sample_{meeting_stem}_{channel}_{resolved_id}{suffix}.wav"
     )
-    ok = extract_speaker_sample_audio(
-        recording_path, channel, pooled_segments, output_path,
-        segment_index=target,
-    )
-    if not ok:
-        print(json.dumps({"success": False, "error": "could not extract audio sample"}))
-        return
+    try:
+        ok = extract_speaker_sample_audio(
+            recording_path, channel, pooled_segments, output_path,
+            segment_index=target,
+        )
+        if not ok:
+            print(json.dumps({"success": False, "error": "could not extract audio sample"}))
+            return
 
-    # Return the clip's bytes inline (base64), not a filesystem path: the
-    # renderer's strict CSP (media-src 'self' blob:) has no file: allowance,
-    # so a raw path could never actually play in the packaged app -- the
-    # renderer builds a blob: URL from these bytes instead. Clips are short
-    # (a few seconds of 16kHz mono PCM), safely small enough to inline.
-    import base64
-    audio_bytes = output_path.read_bytes()
-    output_path.unlink(missing_ok=True)
-    print(json.dumps({
-        "success": True,
-        "audio_base64": base64.b64encode(audio_bytes).decode("ascii"),
-    }))
+        # Return the clip's bytes inline (base64), not a filesystem path: the
+        # renderer's strict CSP (media-src 'self' blob:) has no file: allowance,
+        # so a raw path could never actually play in the packaged app.
+        import base64
+        audio_bytes = output_path.read_bytes()
+        print(json.dumps({
+            "success": True,
+            "audio_base64": base64.b64encode(audio_bytes).decode("ascii"),
+        }))
+    finally:
+        output_path.unlink(missing_ok=True)
 
 
 def _find_recording_file(recordings_dir, stem, extension=None):

--- a/src/config.py
+++ b/src/config.py
@@ -346,6 +346,12 @@ class Config:
         # back ONLY the keys this process actually changed, so a concurrent
         # writer's unrelated keys aren't clobbered (the lost-update fix).
         self._snapshot: Dict[str, Any] = copy.deepcopy(self._config)
+        # A confirm-speaker operation updates several related profile entries.
+        # Batch their otherwise-independent _save() calls into one atomic
+        # config write so a failed final save cannot leave half a reassignment
+        # on disk or relabel a transcript without the matching profile.
+        self._transaction_backup: Optional[tuple[Dict[str, Any], Dict[str, Any]]] = None
+        self._transaction_dirty = False
         self._migrate_cloud_model_map()
         self._migrate_whisper_model()
         self._migrate_summary_model()
@@ -749,6 +755,10 @@ class Config:
         changed. On lock timeout, degrade to a plain unlocked atomic write of
         our own config — a stuck lock must never block saves or raise.
         """
+        if self._transaction_backup is not None:
+            self._transaction_dirty = True
+            return True
+
         lock_path = str(self.config_path) + ".lock"
         try:
             # filelock is NOT reentrant: _save() must never be called while
@@ -779,6 +789,38 @@ class Config:
         except Exception as e:
             logger.error(f"Error saving config: {e}")
             return False
+
+    def begin_transaction(self) -> None:
+        """Defer saves until ``commit_transaction`` writes once atomically."""
+        if self._transaction_backup is not None:
+            raise RuntimeError("Config transaction already active")
+        self._transaction_backup = (
+            copy.deepcopy(self._config),
+            copy.deepcopy(self._snapshot),
+        )
+        self._transaction_dirty = False
+
+    def commit_transaction(self) -> bool:
+        """Commit a deferred batch, restoring in-memory state on failure."""
+        if self._transaction_backup is None:
+            raise RuntimeError("No Config transaction active")
+        old_config, old_snapshot = self._transaction_backup
+        dirty = self._transaction_dirty
+        self._transaction_backup = None
+        self._transaction_dirty = False
+        if not dirty or self._save():
+            return True
+        self._config = old_config
+        self._snapshot = old_snapshot
+        return False
+
+    def rollback_transaction(self) -> None:
+        """Discard a deferred batch without touching the on-disk config."""
+        if self._transaction_backup is None:
+            return
+        self._config, self._snapshot = self._transaction_backup
+        self._transaction_backup = None
+        self._transaction_dirty = False
 
     def _get_default_config(self) -> Dict[str, Any]:
         """Get default configuration."""

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -654,7 +654,7 @@ def write_speakers_sidecar(
     if turn_manifest:
         payload["transcript_lines"] = turn_manifest
     path = speakers_sidecar_path(output_dir, meeting_stem)
-    path.write_text(json.dumps(payload, indent=2))
+    write_sidecar_document(output_dir, meeting_stem, payload)
     return path
 
 

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -924,29 +924,45 @@ def _run_steno_diarize(
         logger.warning("steno-diarize failed: %s", e)
         return None
 
-    segments = sorted(
-        (
-            {
-                "start": float(s["start"]),
-                "end": float(s["end"]),
-                "speaker": str(s["speakerId"]),
-            }
-            for s in raw_segments
-        ),
-        key=lambda s: s["start"],
-    )
-    # Merge first so a same-speaker overlap (the flicker case) collapses into
-    # one turn instead of being clamped into two touching ones; then clamp
-    # what is left, which is overlap between DIFFERENT speakers; then merge
-    # again, since clamping can leave two same-speaker segments flush.
-    # Clamping only ever moves a start forward, so re-sort before the second
-    # merge -- a segment nested inside a longer one keeps its original start
-    # and can end up out of order.
-    merged = _merge_close_diar_segments(segments, STENO_DIARIZE_MERGE_GAP_S)
-    clamped = sorted(_clamp_overlapping_diar_segments(merged), key=lambda s: s["start"])
-    merged = _merge_close_diar_segments(clamped, STENO_DIARIZE_MERGE_GAP_S)
-    embeddings = {str(k): [float(x) for x in v] for k, v in raw_embeddings.items()}
-    return merged, embeddings
+    try:
+        if not isinstance(raw_segments, list) or not isinstance(raw_embeddings, dict):
+            raise TypeError("segments must be a list and speakers must be an object")
+        segments = []
+        for raw_segment in raw_segments:
+            if not isinstance(raw_segment, dict):
+                raise TypeError("each segment must be an object")
+            start = float(raw_segment["start"])
+            end = float(raw_segment["end"])
+            speaker = raw_segment["speakerId"]
+            if (
+                not math.isfinite(start)
+                or not math.isfinite(end)
+                or end < start
+                or not isinstance(speaker, str)
+                or not speaker
+            ):
+                raise ValueError("invalid segment values")
+            segments.append({"start": start, "end": end, "speaker": speaker})
+        segments.sort(key=lambda segment: segment["start"])
+
+        embeddings = {}
+        for speaker, raw_embedding in raw_embeddings.items():
+            if not isinstance(raw_embedding, list) or not raw_embedding:
+                raise TypeError("each speaker embedding must be a non-empty list")
+            embedding = [float(value) for value in raw_embedding]
+            if not all(math.isfinite(value) for value in embedding):
+                raise ValueError("speaker embedding contains a non-finite value")
+            embeddings[str(speaker)] = embedding
+
+        # Merge first so a same-speaker overlap (the flicker case) collapses
+        # into one turn instead of being clamped into two touching ones.
+        merged = _merge_close_diar_segments(segments, STENO_DIARIZE_MERGE_GAP_S)
+        clamped = sorted(_clamp_overlapping_diar_segments(merged), key=lambda s: s["start"])
+        merged = _merge_close_diar_segments(clamped, STENO_DIARIZE_MERGE_GAP_S)
+        return merged, embeddings
+    except (KeyError, TypeError, ValueError, OverflowError) as e:
+        logger.warning("steno-diarize produced an invalid payload: %s", e)
+        return None
 
 
 def _worst_window_coverage(*results: Optional[dict]) -> Optional[float]:
@@ -1144,19 +1160,18 @@ def _apply_voiceprint_matches(
 
 def _identity_matching_enabled() -> bool:
     """Whether cross-recording speaker identification is enabled (default
-    on, user-configurable). Independent of diarization itself: disabling
+    off, user-configurable). Independent of diarization itself: disabling
     this stops self-voiceprint matching (_apply_voiceprint_matches) and
     per-meeting speaker-embedding persistence (clusters_out), but "Speaker
     N" splitting within a meeting is unaffected, since that only depends on
-    diarizer segments, not embeddings. Defaults to enabled on any
-    config-read failure, matching this file's "never fail a meeting"
-    pattern elsewhere.
+    diarizer segments, not embeddings. A config-read failure must fail
+    closed because no reliable opt-in can be established.
     """
     try:
         from src.config import get_config
         return get_config().get_identity_matching_enabled()
     except Exception:
-        return True
+        return False
 
 
 def _has_spoken_content(text: Optional[str]) -> bool:

--- a/stenoai.spec
+++ b/stenoai.spec
@@ -25,8 +25,11 @@ Usage:
 The bundled executable will be in dist/stenoai/
 """
 
+import os
 import sys
+from pathlib import Path
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs, copy_metadata
+from scripts.diarize_bundle_guard import require_diarize_sidecar
 
 # Apple Silicon uses parakeet-mlx for ASR; Windows / Linux use onnx-asr via
 # ONNX Runtime. The two backends live in src/_parakeet_{mlx,onnx}.py and
@@ -206,8 +209,6 @@ for pkg in _DYLIB_PKGS:
 # Bundle Ollama binary and libraries.
 # Walk bin/ recursively — Ollama for Windows ships its runner libs under
 # lib/ollama/ that must be preserved relative to ollama.exe.
-import os
-
 # Ollama's Windows bundle ships GPU runner libs under lib/ollama/. As of
 # v0.30.8 that's lib/ollama/{cuda_v12,cuda_v13,vulkan} (rocm is no longer
 # shipped). They're NVIDIA-/discrete-GPU-only and add multiple GB
@@ -244,6 +245,10 @@ _OLLAMA_GPU_MARKERS = ('lib/ollama/cuda', 'lib/ollama/rocm', 'lib/ollama/vulkan'
 #   - the GPU runner libs are pruned above and there's no pip-mlx build).
 ollama_datas: list[tuple[str, str, str]] = []
 ollama_bin_dir = os.path.join(SPECPATH, 'bin')
+required_diarize_sidecar = require_diarize_sidecar(
+    Path(ollama_bin_dir) / 'steno-diarize',
+    platform=sys.platform,
+)
 if os.path.exists(ollama_bin_dir):
     for root, _dirs, files in os.walk(ollama_bin_dir):
         for filename in files:
@@ -257,14 +262,16 @@ if os.path.exists(ollama_bin_dir):
             if base in ('ffmpeg', 'ffmpeg.exe'):
                 # Put ffmpeg at the root of the bundle for easy PATH access
                 binaries.append((filepath, '.'))
-            elif base == 'steno-diarize' and _IS_DARWIN:
+            elif (
+                base == 'steno-diarize'
+                and _IS_DARWIN
+                and required_diarize_sidecar is not None
+            ):
                 # macOS-only Swift/CoreML diarization sidecar (built by
-                # scripts/build-diarize-sidecar.sh). Root-level like ffmpeg
-                # since src/transcriber.py resolves it the same way. Gated
-                # on _IS_DARWIN + os.path.exists above so a checkout that
-                # hasn't run the Swift build (or a non-macOS platform) just
-                # skips it — src/transcriber.py falls back to legacy
-                # channel-only labeling when the binary is missing.
+                # scripts/build-diarize-sidecar.sh). It follows ffmpeg into
+                # PyInstaller's _internal directory, which the runtime
+                # resolver probes. The guard above intentionally fails a
+                # macOS build when this required release artifact is absent.
                 binaries.append((filepath, '.'))
             elif _IS_DARWIN:
                 # COLLECT DATA TOC 3-tuple: (dest_path_including_filename,

--- a/stenoai.spec
+++ b/stenoai.spec
@@ -29,6 +29,13 @@ import os
 import sys
 from pathlib import Path
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs, copy_metadata
+
+# PyInstaller does not consistently put the spec directory on sys.path when
+# evaluating a spec on Windows runners. Make the local build guard importable
+# explicitly on every platform.
+if SPECPATH not in sys.path:
+    sys.path.insert(0, SPECPATH)
+
 from scripts.diarize_bundle_guard import require_diarize_sidecar
 
 # Apple Silicon uses parakeet-mlx for ASR; Windows / Linux use onnx-asr via

--- a/tests/test_bundle_mlx.py
+++ b/tests/test_bundle_mlx.py
@@ -9,23 +9,15 @@ matching this repo's skip convention for environment-dependent tests - it never
 fails just because the bundle wasn't built.
 """
 
-import importlib.util
 import os
 import platform
+import subprocess
 import sys
 import unittest
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _SCRIPT = os.path.join(_REPO_ROOT, 'scripts', 'verify_mlx_bundle.py')
 _INTERNAL = os.path.join(_REPO_ROOT, 'dist', 'stenoai', '_internal')
-
-
-def _load_verifier():
-    spec = importlib.util.spec_from_file_location('verify_mlx_bundle', _SCRIPT)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
 
 class BundleMLXCollisionTests(unittest.TestCase):
     def test_no_libmlx_abi_collision_in_bundle(self):
@@ -36,8 +28,21 @@ class BundleMLXCollisionTests(unittest.TestCase):
                 "no PyInstaller bundle at dist/stenoai/_internal - "
                 "run `pyinstaller stenoai.spec --noconfirm` first"
             )
-        rc = _load_verifier().main()
-        self.assertEqual(rc, 0, "verify_mlx_bundle reported failures (see stderr)")
+        # Run in a clean process. Other tests may already have imported the pip
+        # MLX dylib, which changes dyld's resolution for Ollama's incompatible
+        # libmlx build and creates a false collision failure in this process.
+        result = subprocess.run(
+            [sys.executable, _SCRIPT],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "verify_mlx_bundle reported failures:\n"
+            f"{result.stdout}\n{result.stderr}",
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -18,8 +18,9 @@ def _last_json(output):
 
 
 class ConfirmSpeakerCliTests(unittest.TestCase):
-    def _run(self, args, tmp, cfg=None):
+    def _run(self, args, tmp, cfg=None, *, identity_enabled=True):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(identity_enabled)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             result = CliRunner().invoke(simple_recorder.confirm_speaker, args)
@@ -44,6 +45,49 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             result, _ = self._run(["mtg001", "mic", "SPEAKER_00"], tmp)
             self.assertNotEqual(result.exit_code, 0)
             self.assertFalse(_last_json(result.output)["success"])
+
+    def test_disabled_identity_matching_refuses_to_persist_a_profile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_sidecar(tmp)
+            result, cfg = self._run(
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma"],
+                tmp,
+                identity_enabled=False,
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertEqual(_last_json(result.output), {
+                "success": False,
+                "error": "Speaker identification is disabled in settings.",
+            })
+            self.assertEqual(cfg.get_person_profiles(), [])
+
+    def test_config_save_failure_does_not_relabel_or_report_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_sidecar(tmp)
+            transcript_dir = Path(tmp) / "transcripts"
+            transcript_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = transcript_dir / "mtg001_transcript.txt"
+            original = "[00:00] [You] hello\n"
+            transcript_path.write_text(original)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            cfg.set_identity_matching_enabled(True)
+
+            with mock.patch("src.config._atomic_write_json", side_effect=OSError("disk full")), \
+                 mock.patch("src.config.get_config", return_value=cfg), \
+                 mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
+                result = CliRunner().invoke(
+                    simple_recorder.confirm_speaker,
+                    [
+                        "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
+                        "--relabel-transcript",
+                    ],
+                )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertFalse(_last_json(result.output)["success"])
+            self.assertEqual(transcript_path.read_text(), original)
+            self.assertEqual(cfg.get_person_profiles(), [])
 
     def test_rejects_both_person_id_and_new_person(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -828,6 +872,7 @@ class ConfirmSpeakerUpdatesParticipantsTests(unittest.TestCase):
 
     def _run(self, args, tmp, cfg=None):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(True)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             result = CliRunner().invoke(simple_recorder.confirm_speaker, args)

--- a/tests/test_diarize_bundle_guard.py
+++ b/tests/test_diarize_bundle_guard.py
@@ -1,0 +1,43 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.diarize_bundle_guard import require_diarize_sidecar
+
+
+class DiarizeBundleGuardTests(unittest.TestCase):
+    def test_macos_build_fails_when_sidecar_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "steno-diarize"
+
+            with self.assertRaisesRegex(FileNotFoundError, "steno-diarize"):
+                require_diarize_sidecar(missing, platform="darwin")
+
+    def test_macos_build_fails_when_sidecar_is_not_executable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sidecar = Path(tmp) / "steno-diarize"
+            sidecar.write_bytes(b"not executable")
+
+            with self.assertRaisesRegex(PermissionError, "executable"):
+                require_diarize_sidecar(sidecar, platform="darwin")
+
+    def test_macos_build_accepts_executable_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sidecar = Path(tmp) / "steno-diarize"
+            sidecar.write_bytes(b"executable")
+            sidecar.chmod(0o755)
+
+            self.assertEqual(
+                require_diarize_sidecar(sidecar, platform="darwin"),
+                sidecar,
+            )
+
+    def test_other_platforms_do_not_require_the_macos_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "steno-diarize"
+
+            self.assertIsNone(require_diarize_sidecar(missing, platform="win32"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_person_profile_cli.py
+++ b/tests/test_person_profile_cli.py
@@ -49,6 +49,27 @@ class PersonProfileCliTests(unittest.TestCase):
             self.assertIn("already exists", data["error"])
             self.assertEqual(len(cfg.get_person_profiles()), 1)
 
+    def test_create_person_profile_reports_config_save_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            with mock.patch(
+                "src.config._atomic_write_json",
+                side_effect=OSError("disk full"),
+            ):
+                result, cfg = self._run(
+                    simple_recorder.create_person_profile,
+                    ["Person Gamma"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertEqual(_last_json(result.output), {
+                "success": False,
+                "error": "Could not save the person profile.",
+            })
+            self.assertEqual(cfg.get_person_profiles(), [])
+
     def test_rename_person_profile_rejects_collision(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Config(config_path=Path(tmp) / "config.json")

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1047,6 +1047,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
 
     def _run(self, command, args, tmp, cfg=None):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(True)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             return CliRunner().invoke(command, args)
@@ -1263,6 +1264,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 ],
             )
             cfg = Config(config_path=Path(tmp) / "config.json")
+            cfg.set_identity_matching_enabled(True)
             with mock.patch("src.config.get_config", return_value=cfg), \
                  mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
                 confirmed = CliRunner().invoke(simple_recorder.confirm_speaker, [
@@ -1441,6 +1443,42 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 "a blended two-voice embedding must not stay enrolled as a person",
             )
 
+    def test_config_save_failure_keeps_profile_and_sidecar_unmarked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            cfg.set_identity_matching_enabled(True)
+            person = cfg.create_person_profile("Person Alpha")
+            cfg.add_speaker_prototype(
+                person["person_id"], [1.0, 0.0], recording_type="remote",
+                meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
+                speech_duration_seconds=60.0, segment_count=10,
+                created_from="user_confirmed", channel="system",
+                diarization_run_id=self._seeded_run_id(tmp),
+            )
+
+            with mock.patch(
+                "src.config._atomic_write_json",
+                side_effect=OSError("disk full"),
+            ), mock.patch("src.config.get_config", return_value=cfg), \
+                 mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
+                result = CliRunner().invoke(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "system", "SPEAKER_0"],
+                )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertFalse(_last_json(result.output)["success"])
+            stored_cluster = read_speakers_sidecar(
+                output_dir, "mtg001",
+            )["channels"]["system"]["clusters"]["SPEAKER_0"]
+            self.assertNotIn(MULTI_SPEAKER_KEY, stored_cluster)
+            reloaded = Config(config_path=Path(tmp) / "config.json")
+            self.assertEqual(
+                len(reloaded.get_person_profile(person["person_id"])["prototypes"]),
+                1,
+            )
+
     def test_a_marked_cluster_is_not_used_as_hard_negative_evidence(self):
         # "Speaker B is not the person in cluster A" is only meaningful when
         # A is one person. If A is a blend of two voices, the negative is
@@ -1503,8 +1541,9 @@ class SpeakerNamingStatusCliTests(unittest.TestCase):
     meeting); an UNNAMED cluster does not, and cannot be recovered by any
     means once the audio is gone -- naming a voice requires hearing it."""
 
-    def _run(self, args, tmp, cfg=None):
+    def _run(self, args, tmp, cfg=None, *, identity_enabled=True):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(identity_enabled)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             return CliRunner().invoke(simple_recorder.speaker_naming_status, args)
@@ -1535,6 +1574,21 @@ class SpeakerNamingStatusCliTests(unittest.TestCase):
             self.assertTrue(data["has_sidecar"])
             self.assertEqual(data["total_clusters"], 2)
             self.assertEqual(data["unnamed_clusters"], 2)
+
+    def test_disabled_identity_matching_reports_nothing_to_review(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed(tmp)
+            data = _last_json(
+                self._run(["mtg001"], tmp, identity_enabled=False).output
+            )
+            self.assertEqual(data, {
+                "success": True,
+                "meeting_id": "mtg001",
+                "has_sidecar": False,
+                "total_clusters": 0,
+                "named_clusters": 0,
+                "unnamed_clusters": 0,
+            })
 
     def test_a_confirmed_cluster_no_longer_counts_as_unnamed(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1738,6 +1792,7 @@ class SetClusterReviewStateCliTests(unittest.TestCase):
 
     def _run(self, command, args, tmp, cfg=None):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(True)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             return CliRunner().invoke(command, args)

--- a/tests/test_speaker_suggestions.py
+++ b/tests/test_speaker_suggestions.py
@@ -628,6 +628,22 @@ class SpeakersSidecarTests(unittest.TestCase):
             second_run_id = read_speakers_sidecar(output_dir, "mtg001")["diarization_run"]["run_id"]
             self.assertNotEqual(first_run_id, second_run_id)
 
+    def test_failed_replacement_preserves_the_previous_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir)
+            path = output_dir / "mtg001_speakers.json"
+            path.write_text('{"old": true}')
+
+            with mock.patch(
+                "src.speaker_suggestions.os.fsync",
+                side_effect=OSError("disk full"),
+            ):
+                with self.assertRaises(OSError):
+                    write_speakers_sidecar(output_dir, "mtg001", {"mic": {}})
+
+            self.assertEqual(path.read_text(), '{"old": true}')
+            self.assertEqual([p.name for p in output_dir.iterdir()], [path.name])
+
     def test_legacy_sidecar_without_diarization_run_round_trips_unchanged(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_dir = Path(tmp_dir)

--- a/tests/test_suggest_speakers_cli.py
+++ b/tests/test_suggest_speakers_cli.py
@@ -34,12 +34,41 @@ class SuggestSpeakersCliTests(unittest.TestCase):
     go find and listen to that speaker in the recording to figure out who
     they actually are."""
 
-    def _run(self, args, tmp, cfg=None):
+    def _run(self, args, tmp, cfg=None, *, identity_enabled=True):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(identity_enabled)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             result = CliRunner().invoke(simple_recorder.suggest_speakers, args)
         return result
+
+    def test_disabled_identity_matching_hides_retained_speaker_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_0": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                        },
+                    },
+                },
+            })
+
+            result = self._run(["mtg001"], tmp, identity_enabled=False)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(_last_json(result.output), {
+                "success": True,
+                "meeting_id": "mtg001",
+                "recording_available": False,
+                "minimum_speaker_count": 0,
+                "channels": {},
+            })
 
     def test_missing_sidecar_is_an_empty_successful_result(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -419,6 +448,24 @@ class GetSpeakerSampleAudioCliTests(unittest.TestCase):
             self.assertNotIn("audio_path", data)
             self.assertEqual(base64.b64decode(data["audio_base64"]), b"wav-stub-bytes")
 
+    def test_failed_extraction_removes_partial_temp_audio(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_sidecar_and_recording(tmp)
+
+            def leave_partial(_audio_path, _channel, _segments, output_path, segment_index=None):
+                output_path.write_bytes(b"private meeting audio")
+                return False
+
+            with mock.patch("tempfile.gettempdir", return_value=tmp), \
+                 mock.patch(
+                     "src.speaker_suggestions.extract_speaker_sample_audio",
+                     side_effect=leave_partial,
+                 ):
+                result = self._run(["mtg001", "system", "SPEAKER_0"], tmp)
+
+            self.assertFalse(_last_json(result.output)["success"])
+            self.assertEqual(list(Path(tmp).glob("steno_sample_*.wav")), [])
+
     def test_temp_extraction_file_is_cleaned_up_after_reading(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar_and_recording(tmp)
@@ -526,6 +573,7 @@ class SuggestSpeakersReviewStateTests(unittest.TestCase):
 
     def _run(self, args, tmp, cfg=None):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(True)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             return CliRunner().invoke(simple_recorder.suggest_speakers, args)
@@ -588,6 +636,7 @@ class SuggestSpeakersRunScopeTests(unittest.TestCase):
 
     def _run(self, args, tmp, cfg=None):
         cfg = cfg or Config(config_path=Path(tmp) / "config.json")
+        cfg.set_identity_matching_enabled(True)
         with mock.patch("src.config.get_config", return_value=cfg), \
              mock.patch.dict("os.environ", {"STENOAI_USER_DATA_DIR": tmp}):
             return CliRunner().invoke(simple_recorder.suggest_speakers, args)

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -37,6 +37,7 @@ from src.transcriber import (
     _cluster_channel_label_plan,
     _diarised_split_timeout,
     _format_timestamp,
+    _identity_matching_enabled,
     _merge_close_diar_segments,
     _parse_channels_from_ffmpeg_stderr,
     _parse_duration_from_ffmpeg_stderr,
@@ -47,6 +48,12 @@ from src.transcriber import (
     _voiceprint_distance,
     _worst_window_coverage,
 )
+
+
+class IdentityMatchingSettingTests(unittest.TestCase):
+    def test_config_read_failure_disables_identity_matching(self):
+        with patch("src.config.get_config", side_effect=OSError("unreadable config")):
+            self.assertFalse(_identity_matching_enabled())
 
 
 class FormatTimestampTests(unittest.TestCase):
@@ -2015,6 +2022,24 @@ class RunStenoDiarizeTests(unittest.TestCase):
             segments, embeddings = _run_steno_diarize(Path("/fake/mic.wav"), 60)
         self.assertEqual(segments, [{"start": 0.0, "end": 0.9, "speaker": "SPEAKER_0"}])
         self.assertEqual(embeddings, {})
+
+    def test_invalid_segment_shape_falls_back_instead_of_raising(self):
+        payload = json.dumps({
+            "segments": [{"speakerId": "SPEAKER_0", "start": "bad", "end": 0.9}],
+            "speakers": {},
+        }).encode()
+        with patch("src.transcriber._resolve_steno_diarize", return_value="/fake/steno-diarize"), \
+             _patch_popen(stdout=payload, stderr=b"", returncode=0):
+            self.assertIsNone(_run_steno_diarize(Path("/fake/mic.wav"), 60))
+
+    def test_invalid_embedding_shape_falls_back_instead_of_raising(self):
+        payload = json.dumps({
+            "segments": [{"speakerId": "SPEAKER_0", "start": 0.0, "end": 0.9}],
+            "speakers": {"SPEAKER_0": "not-a-vector"},
+        }).encode()
+        with patch("src.transcriber._resolve_steno_diarize", return_value="/fake/steno-diarize"), \
+             _patch_popen(stdout=payload, stderr=b"", returncode=0):
+            self.assertIsNone(_run_steno_diarize(Path("/fake/mic.wav"), 60))
 
     def test_nonzero_exit_returns_none(self):
         with patch("src.transcriber._resolve_steno_diarize", return_value="/fake/steno-diarize"), \


### PR DESCRIPTION
## Summary

- build and require the macOS FluidAudio/Core ML sidecar in release and E2E bundles
- enforce speaker-identification opt-in at backend boundaries and fail closed on config errors
- make profile mutations and mixed-speaker cleanup durable before reporting success
- reject malformed sidecar output safely and keep sidecar/sample writes atomic and clean
- isolate the MLX bundle guard from already-loaded incompatible dylibs

## Verification

- fresh arm64 PyInstaller bundle with executable `_internal/steno-diarize`
- MLX bundle guard: 10/10 passed
- Python: 1,069 passed, 7 skipped
- targeted T2 E2E: 13 passed
- renderer typecheck, unit tests, production build, and lint completed earlier on this patch series
- independent review: Ready, no remaining Critical or Important findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships the macOS Swift/Core ML speaker-diarization sidecar and enforces explicit opt‑in for speaker identification. Hardens writes and validation so builds fail closed when misconfigured and user data stays consistent.

- New Features
  - Build and bundle `steno-diarize` on macOS; `PyInstaller` spec now requires it via `require_diarize_sidecar`, imports the guard portably across platforms, and CI builds/validates arm64.
  - Speaker identification is opt‑in and defaults off; backend/CLI paths return empty results or clear errors until enabled.
  - Config writes use transactions (begin/commit/rollback) for profile creation, confirmations, and mixed‑speaker cleanup to avoid partial saves.
  - Sidecar I/O is atomic and validated; malformed sidecar output is rejected; temp audio clips are always cleaned; MLX bundle guard runs in a subprocess to avoid dylib collisions.

- Migration
  - On macOS, run `scripts/build-diarize-sidecar.sh` before `pyinstaller`; the build fails if `bin/steno-diarize` is missing or not executable.
  - To enable identification locally, set `identity_matching_enabled: true` and `identity_matching_privacy_default_version: 1` in the user config.

<sup>Written for commit 445253037d4bb3f2ebe6a6332c0a5cfed6fe2ec9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

